### PR TITLE
UX: hide chat header buttons for collapsed drawer chat, change minimize icon

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
@@ -38,7 +38,11 @@ export default class ChatNavbarChannelTitle extends Component {
   }
 
   get showStarButton() {
-    return this.currentUser && this.args.channel?.isFollowing;
+    return (
+      this.currentUser &&
+      this.args.channel?.isFollowing &&
+      !this.chatStateManager.isDrawerCollapsed
+    );
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/filter.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/filter.gjs
@@ -1,15 +1,21 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
-const ChatNavbarFilter = <template>
-  <DButton
-    @icon="discourse-chat-search"
-    @action={{@onToggleFilter}}
-    class={{dConcatClass
-      "btn-transparent c-navbar__filter"
-      (if @isFiltering "active")
-    }}
-  />
-</template>;
+export default class ChatNavbarFilter extends Component {
+  @service chatStateManager;
 
-export default ChatNavbarFilter;
+  <template>
+    {{#unless this.chatStateManager.isDrawerCollapsed}}
+      <DButton
+        @icon="discourse-chat-search"
+        @action={{@onToggleFilter}}
+        class={{dConcatClass
+          "btn-transparent c-navbar__filter"
+          (if @isFiltering "active")
+        }}
+      />
+    {{/unless}}
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
@@ -9,6 +9,7 @@ import { hasPinsDismissal } from "discourse/plugins/chat/discourse/lib/chat-pinn
 export default class ChatNavbarPinnedMessagesButton extends Component {
   @service router;
   @service siteSettings;
+  @service chatStateManager;
 
   pinnedMessagesLabel = i18n("chat.pinned_messages.title");
 
@@ -20,6 +21,7 @@ export default class ChatNavbarPinnedMessagesButton extends Component {
   get showButton() {
     return (
       this.siteSettings.chat_pinned_messages &&
+      !this.chatStateManager.isDrawerCollapsed &&
       this.args.channel?.hasPinnedMessages &&
       !this.args.channel.canManagePins &&
       hasPinsDismissal(this.args.channel) &&

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/threads-list-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/threads-list-button.gjs
@@ -8,12 +8,14 @@ import ThreadHeaderUnreadIndicator from "discourse/plugins/chat/discourse/compon
 
 export default class ChatNavbarThreadsListButton extends Component {
   @service router;
+  @service chatStateManager;
 
   threadsListLabel = i18n("chat.threads.list");
 
   get showThreadsListButton() {
     return (
       this.args.channel?.threadingEnabled &&
+      !this.chatStateManager.isDrawerCollapsed &&
       this.router.currentRoute.name !== "chat.channel.threads" &&
       this.router.currentRoute.name !== "chat.channel.thread" &&
       this.router.currentRoute.name !== "chat.channel.thread.index"

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/toggle-drawer-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/toggle-drawer-button.gjs
@@ -8,11 +8,7 @@ export default class ChatNavbarToggleDrawerButton extends Component {
 
   <template>
     <DButton
-      @icon={{if
-        this.chatStateManager.isDrawerExpanded
-        "angles-down"
-        "angles-up"
-      }}
+      @icon={{if this.chatStateManager.isDrawerExpanded "minus" "angles-up"}}
       @action={{this.chat.toggleDrawer}}
       @title={{if
         this.chatStateManager.isDrawerExpanded

--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -166,6 +166,10 @@ export default class ChatStateManager extends Service {
     return this.isFullPageActive || this.isDrawerActive;
   }
 
+  get isDrawerCollapsed() {
+    return this.isDrawerActive && !this.isDrawerExpanded;
+  }
+
   get isPinnedMessagesPaneOpen() {
     return this.router.currentRouteName === "chat.channel.pins";
   }

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -24,22 +24,20 @@
     }
 
     &__toggle-drawer-button {
-      &::after {
-        @container (inline-size) {
-          content: "";
-          position: absolute;
-          height: 100%;
-          left: -1rem;
-          width: calc(100cqw - 2.3em + 1rem);
-        }
+      // only shown for keyboard nav
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      overflow: hidden;
+      clip-path: inset(50%);
 
-        &:hover {
-          color: var(--tertiary-hover);
-
-          .d-icon {
-            color: inherit;
-          }
-        }
+      &:focus-visible {
+        position: static;
+        width: auto;
+        height: auto;
+        overflow: visible;
+        clip-path: none;
       }
     }
   }

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -157,6 +157,54 @@ RSpec.describe "Drawer" do
     end
   end
 
+  context "when the drawer is collapsed" do
+    fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
+    fab!(:membership) do
+      Fabricate(:user_chat_channel_membership, user: current_user, chat_channel: channel)
+    end
+
+    before { SiteSetting.chat_search_enabled = true }
+
+    it "only keeps the navbar controls which are usable when collapsed" do
+      drawer_page.visit_channel(channel)
+
+      expect(page).to have_selector(".c-navbar__star-channel-button")
+      expect(page).to have_selector(".c-navbar__filter")
+      expect(page).to have_selector(".c-navbar__threads-list-button")
+
+      drawer_page.collapse
+
+      expect(page).to have_selector(".chat-drawer:not(.is-expanded)")
+      expect(page).to have_no_selector(".c-navbar__star-channel-button")
+      expect(page).to have_no_selector(".c-navbar__filter")
+      expect(page).to have_no_selector(".c-navbar__threads-list-button")
+      expect(page).to have_selector(".c-navbar__close-drawer-button")
+
+      drawer_page.expand
+
+      expect(page).to have_selector(".chat-drawer.is-expanded")
+      expect(page).to have_selector(".c-navbar__star-channel-button")
+      expect(page).to have_selector(".c-navbar__filter")
+      expect(page).to have_selector(".c-navbar__threads-list-button")
+    end
+
+    it "can be expanded with the keyboard" do
+      drawer_page.visit_channel(channel)
+      drawer_page.collapse
+
+      expect(page).to have_selector(".chat-drawer:not(.is-expanded)")
+      expect(drawer_page.toggle_button_width).to be <= 1 # not visible to pointer users
+
+      drawer_page.focus_toggle_button
+
+      expect(drawer_page.toggle_button_width).to be > 1
+
+      drawer_page.expand_with_keyboard
+
+      expect(page).to have_selector(".chat-drawer.is-expanded")
+    end
+  end
+
   context "when going from drawer to full page" do
     fab!(:channel_1, :chat_channel)
     fab!(:channel_2, :chat_channel)

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -32,6 +32,38 @@ module PageObjects
         find("#{VISIBLE_DRAWER} .c-navbar__back-button").click
       end
 
+      def collapse
+        mouseout
+        find("#{VISIBLE_DRAWER} .c-navbar__toggle-drawer-button").click
+      end
+
+      def expand
+        mouseout
+        find(".chat-drawer:not(.is-expanded) .c-navbar").click
+      end
+
+      def toggle_button_width
+        page.evaluate_script(<<~JS)
+          document
+            .querySelector(".c-navbar__toggle-drawer-button")
+            .getBoundingClientRect().width
+        JS
+      end
+
+      # while collapsed the toggle button is only revealed to keyboard users
+      def focus_toggle_button
+        page.send_keys(:tab) # so the browser treats the next focus as keyboard driven
+        page.execute_script(<<~JS)
+          document
+            .querySelector(".chat-drawer:not(.is-expanded) .c-navbar__toggle-drawer-button")
+            .focus()
+        JS
+      end
+
+      def expand_with_keyboard
+        find(".c-navbar__toggle-drawer-button:focus").send_keys(:enter)
+      end
+
       def visit_index
         visit("/")
         PageObjects::Pages::Chat.new.open_from_header

--- a/plugins/chat/test/javascripts/components/chat-navbar-channel-title-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-channel-title-test.gjs
@@ -10,6 +10,7 @@ module("Component | ChatNavbar | ChannelTitle", function (hooks) {
 
   hooks.beforeEach(function () {
     this.fabricators = new ChatFabricators(getOwner(this));
+    this.chatStateManager = getOwner(this).lookup("service:chat-state-manager");
   });
 
   test("shows the star button when the user has joined the channel", async function (assert) {
@@ -36,5 +37,33 @@ module("Component | ChatNavbar | ChannelTitle", function (hooks) {
     assert
       .dom(".c-navbar__star-channel-button")
       .doesNotExist("the star button is hidden");
+  });
+
+  test("does not show the star button when the drawer is collapsed", async function (assert) {
+    this.channel = this.fabricators.channel();
+    this.channel.currentUserMembership = { following: true };
+    this.chatStateManager.didCollapseDrawer();
+
+    await render(
+      <template><ChatNavbarChannelTitle @channel={{this.channel}} /></template>
+    );
+
+    assert
+      .dom(".c-navbar__star-channel-button")
+      .doesNotExist("the star button is hidden");
+  });
+
+  test("shows the star button when the drawer is expanded", async function (assert) {
+    this.channel = this.fabricators.channel();
+    this.channel.currentUserMembership = { following: true };
+    this.chatStateManager.didExpandDrawer();
+
+    await render(
+      <template><ChatNavbarChannelTitle @channel={{this.channel}} /></template>
+    );
+
+    assert
+      .dom(".c-navbar__star-channel-button")
+      .exists("the star button is shown");
   });
 });

--- a/plugins/chat/test/javascripts/components/chat-navbar-filter-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-filter-test.gjs
@@ -1,0 +1,58 @@
+import { getOwner } from "@ember/owner";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ChatNavbarFilter from "discourse/plugins/chat/discourse/components/chat/navbar/filter";
+
+module("Component | ChatNavbar | Filter", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.chatStateManager = getOwner(this).lookup("service:chat-state-manager");
+  });
+
+  test("shows the filter button", async function (assert) {
+    await render(<template><ChatNavbarFilter /></template>);
+
+    assert.dom(".c-navbar__filter").exists("the filter button is shown");
+    assert.dom(".c-navbar__filter").doesNotHaveClass("active");
+  });
+
+  test("is active while filtering", async function (assert) {
+    await render(
+      <template><ChatNavbarFilter @isFiltering={{true}} /></template>
+    );
+
+    assert.dom(".c-navbar__filter").hasClass("active");
+  });
+
+  test("toggles the filter when clicked", async function (assert) {
+    this.toggled = false;
+    const onToggleFilter = () => (this.toggled = true);
+
+    await render(
+      <template>
+        <ChatNavbarFilter @onToggleFilter={{onToggleFilter}} />
+      </template>
+    );
+    await click(".c-navbar__filter");
+
+    assert.true(this.toggled, "the filter callback is called");
+  });
+
+  test("does not show the filter button when the drawer is collapsed", async function (assert) {
+    this.chatStateManager.didCollapseDrawer();
+
+    await render(<template><ChatNavbarFilter /></template>);
+
+    assert.dom(".c-navbar__filter").doesNotExist("the filter button is hidden");
+  });
+
+  test("shows the filter button when the drawer is expanded", async function (assert) {
+    this.chatStateManager.didExpandDrawer();
+
+    await render(<template><ChatNavbarFilter /></template>);
+
+    assert.dom(".c-navbar__filter").exists("the filter button is shown");
+  });
+});

--- a/plugins/chat/test/javascripts/components/chat-navbar-pinned-messages-button-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-pinned-messages-button-test.gjs
@@ -1,0 +1,46 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ChatNavbarPinnedMessagesButton from "discourse/plugins/chat/discourse/components/chat/navbar/pinned-messages-button";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module("Component | ChatNavbar | PinnedMessagesButton", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  hooks.beforeEach(function () {
+    this.siteSettings.chat_pinned_messages = true;
+    this.fabricators = new ChatFabricators(getOwner(this));
+    this.chatStateManager = getOwner(this).lookup("service:chat-state-manager");
+    this.channel = this.fabricators.channel();
+    this.channel.pinnedMessagesCount = 1;
+    // the button is only a way back to the pins panel once the bar is dismissed
+    this.channel.pinsDismissedAboveId = 1;
+  });
+
+  test("shows the button when the pinned bar is dismissed", async function (assert) {
+    await render(
+      <template>
+        <ChatNavbarPinnedMessagesButton @channel={{this.channel}} />
+      </template>
+    );
+
+    assert
+      .dom(".c-navbar__pinned-messages-btn")
+      .exists("the pinned messages button is shown");
+  });
+
+  test("does not show the button when the drawer is collapsed", async function (assert) {
+    this.chatStateManager.didCollapseDrawer();
+
+    await render(
+      <template>
+        <ChatNavbarPinnedMessagesButton @channel={{this.channel}} />
+      </template>
+    );
+
+    assert
+      .dom(".c-navbar__pinned-messages-btn")
+      .doesNotExist("the pinned messages button is hidden");
+  });
+});

--- a/plugins/chat/test/javascripts/components/chat-navbar-threads-list-button-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-threads-list-button-test.gjs
@@ -1,0 +1,43 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ChatNavbarThreadsListButton from "discourse/plugins/chat/discourse/components/chat/navbar/threads-list-button";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module("Component | ChatNavbar | ThreadsListButton", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  hooks.beforeEach(function () {
+    this.fabricators = new ChatFabricators(getOwner(this));
+    this.chatStateManager = getOwner(this).lookup("service:chat-state-manager");
+    this.channel = this.fabricators.channel();
+    this.channel.threadingEnabled = true;
+  });
+
+  test("shows the threads list button when threading is enabled", async function (assert) {
+    await render(
+      <template>
+        <ChatNavbarThreadsListButton @channel={{this.channel}} />
+      </template>
+    );
+
+    assert
+      .dom(".c-navbar__threads-list-button")
+      .exists("the threads list button is shown");
+  });
+
+  test("does not show the threads list button when the drawer is collapsed", async function (assert) {
+    this.chatStateManager.didCollapseDrawer();
+
+    await render(
+      <template>
+        <ChatNavbarThreadsListButton @channel={{this.channel}} />
+      </template>
+    );
+
+    assert
+      .dom(".c-navbar__threads-list-button")
+      .doesNotExist("the threads list button is hidden");
+  });
+});

--- a/plugins/chat/test/javascripts/components/chat-navbar-toggle-drawer-button-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-toggle-drawer-button-test.gjs
@@ -1,0 +1,62 @@
+import { getOwner } from "@ember/owner";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+import ChatNavbarToggleDrawerButton from "discourse/plugins/chat/discourse/components/chat/navbar/toggle-drawer-button";
+
+module("Component | ChatNavbar | ToggleDrawerButton", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.chatStateManager = getOwner(this).lookup("service:chat-state-manager");
+  });
+
+  test("shows a collapse button when the drawer is expanded", async function (assert) {
+    this.chatStateManager.didExpandDrawer();
+
+    await render(<template><ChatNavbarToggleDrawerButton /></template>);
+
+    assert
+      .dom(".c-navbar__toggle-drawer-button")
+      .exists("the collapse button is shown")
+      .hasAttribute("title", i18n("chat.collapse"));
+    assert.dom(".c-navbar__toggle-drawer-button .d-icon-minus").exists();
+  });
+
+  test("shows an expand button when the drawer is collapsed", async function (assert) {
+    this.chatStateManager.didCollapseDrawer();
+
+    await render(<template><ChatNavbarToggleDrawerButton /></template>);
+
+    assert
+      .dom(".c-navbar__toggle-drawer-button")
+      .exists("the expand button is shown")
+      .hasAttribute("title", i18n("chat.expand"));
+    assert.dom(".c-navbar__toggle-drawer-button .d-icon-angles-up").exists();
+  });
+
+  test("expands the drawer when clicked", async function (assert) {
+    this.chatStateManager.didCollapseDrawer();
+
+    await render(<template><ChatNavbarToggleDrawerButton /></template>);
+    await click(".c-navbar__toggle-drawer-button");
+
+    assert.true(
+      this.chatStateManager.isDrawerExpanded,
+      "the drawer is expanded"
+    );
+  });
+
+  test("collapses the drawer when clicked", async function (assert) {
+    this.chatStateManager.didExpandDrawer();
+
+    await render(<template><ChatNavbarToggleDrawerButton /></template>);
+    await click(".c-navbar__toggle-drawer-button");
+
+    assert.false(
+      this.chatStateManager.isDrawerExpanded,
+      "the drawer is collapsed"
+    );
+  });
+});

--- a/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
@@ -159,6 +159,27 @@ module("Unit | Service | chat-state-manager", function (hooks) {
     sinon.assert.calledTwice(stub);
   });
 
+  test("isDrawerCollapsed", function (assert) {
+    assert.false(
+      this.subject.isDrawerCollapsed,
+      "is false when the drawer is not active"
+    );
+
+    this.subject.didCollapseDrawer();
+
+    assert.true(
+      this.subject.isDrawerCollapsed,
+      "is true when the drawer is active and not expanded"
+    );
+
+    this.subject.didExpandDrawer();
+
+    assert.false(
+      this.subject.isDrawerCollapsed,
+      "is false when the drawer is expanded"
+    );
+  });
+
   test("callbacks", function (assert) {
     this.state = null;
     addChatDrawerStateCallback((state) => {


### PR DESCRIPTION
This simplifies the appearance of the drawer by hiding the header buttons when collapsed, some of them didn't even work in this state


before
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/ec542d3c-8a9b-47e3-9a83-1ed86826de5c" />


after
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/5dd2ebe8-0ea7-4987-b37d-42d4280afa6c" />

clicking anywhere other than the x will expand the chat again, and when using keyboard nav we still show the expand button as an accessibility affordance: 

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/9d40b834-c47b-48ec-b312-3d8241e39969" />

the minimize icon change is similar to what we did for the composer in https://github.com/discourse/discourse/issues/42017
