### PR TITLE
FIX: Enforce `skip_review_media_groups` when an edit adds media

### DIFF
--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -63,6 +63,7 @@ class Admin::EmailTemplatesController < Admin::AdminController
         system_messages.pending_users_reminder
         system_messages.post_hidden
         system_messages.post_hidden_again
+        system_messages.post_hidden_media_pending_review
         system_messages.queued_by_staff
         system_messages.queued_posts_reminder
         system_messages.restore_failed

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -758,7 +758,7 @@ class PostsController < ApplicationController
     guardian.ensure_can_unhide!(post)
 
     post.acting_user = current_user
-    post.unhide!
+    post.unhide!(force: true)
 
     render body: nil
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -176,6 +176,7 @@ class Post < ActiveRecord::Base
         flagged_by_tl4_user: 6,
         email_authentication_result_header: 7,
         imported_as_unlisted: 8,
+        media_pending_review: 9,
       )
   end
 
@@ -643,7 +644,12 @@ class Post < ActiveRecord::Base
       topic_including_deleted.read_restricted_category?
   end
 
-  def hide!(post_action_type_id, reason = nil, custom_message: nil)
+  def hide!(
+    post_action_type_id,
+    reason = nil,
+    custom_message: nil,
+    visibility_reason_id: Topic.visibility_reasons[:op_flag_threshold_reached]
+  )
     return if hidden?
 
     reason ||=
@@ -667,13 +673,8 @@ class Post < ActiveRecord::Base
       any_visible_posts_in_topic =
         Post.exists?(topic_id: topic_id, hidden: false, post_type: Post.types[:regular])
 
-      if is_first_post? || !any_visible_posts_in_topic
-        topic.update_status(
-          "visible",
-          false,
-          Discourse.system_user,
-          { visibility_reason_id: Topic.visibility_reasons[:op_flag_threshold_reached] },
-        )
+      if (is_first_post? || !any_visible_posts_in_topic) && topic.visible
+        topic.update_status("visible", false, Discourse.system_user, { visibility_reason_id: })
         should_update_user_stat = false
       end
 
@@ -684,17 +685,16 @@ class Post < ActiveRecord::Base
 
     # inform user
     if user.present?
-      options = {
-        url: url,
-        edit_delay: SiteSetting.cooldown_minutes_after_hiding_posts,
-        flag_reason:
-          I18n.t(
-            "flag_reasons.#{post_action_type_view.types[post_action_type_id]}",
-            locale: SiteSetting.default_locale,
-            base_path: Discourse.base_path,
-            default: PostActionType.names[post_action_type_id],
-          ),
-      }
+      options = { url:, edit_delay: SiteSetting.cooldown_minutes_after_hiding_posts }
+
+      if post_action_type_id.present?
+        options[:flag_reason] = I18n.t(
+          "flag_reasons.#{post_action_type_view.types[post_action_type_id]}",
+          locale: SiteSetting.default_locale,
+          base_path: Discourse.base_path,
+          default: PostActionType.names[post_action_type_id],
+        )
+      end
 
       message = custom_message
       message = hiding_again ? :post_hidden_again : :post_hidden if message.nil?
@@ -711,7 +711,28 @@ class Post < ActiveRecord::Base
     topic.reset_bumped_at if should_reset_bumped_at
   end
 
-  def unhide!
+  def awaiting_media_review?
+    return true if hidden_reason_id == Post.hidden_reasons[:media_pending_review]
+
+    ReviewablePost
+      .pending
+      .where(target: self)
+      .joins(:reviewable_scores)
+      .where(reviewable_scores: { reason: "contains_media" })
+      .exists?
+  end
+
+  def hidden_notice_key(for_author: false)
+    if hidden_reason_id == Post.hidden_reasons[:media_pending_review]
+      for_author ? "media_review.post_hidden_yours" : "media_review.post_hidden"
+    else
+      for_author ? "flagging.you_must_edit" : "flagging.user_must_edit"
+    end
+  end
+
+  def unhide!(force: false)
+    return if !force && awaiting_media_review?
+
     Post.transaction do
       update!(hidden: false)
       should_update_user_stat = true
@@ -719,11 +740,14 @@ class Post < ActiveRecord::Base
       # NOTE: We have to consider `nil` a valid reason here because historically
       # topics didn't have a visibility_reason_id, if we didn't do this we would
       # break backwards compat since we cannot backfill data.
-      hidden_because_of_op_flagging =
-        topic.visibility_reason_id == Topic.visibility_reasons[:op_flag_threshold_reached] ||
-          topic.visibility_reason_id.nil?
+      hidden_because_op_was_hidden =
+        topic.visibility_reason_id.nil? ||
+          [
+            Topic.visibility_reasons[:op_flag_threshold_reached],
+            Topic.visibility_reasons[:media_pending_review],
+          ].include?(topic.visibility_reason_id)
 
-      if is_first_post? && hidden_because_of_op_flagging
+      if is_first_post? && hidden_because_op_was_hidden
         topic.update_status(
           "visible",
           true,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -305,6 +305,7 @@ class Post < ActiveRecord::Base
     raw_mentions
     linked_hosts
     embedded_media_count
+    embedded_media_keys
     attachment_count
     link_count
     raw_links

--- a/app/models/post_analyzer.rb
+++ b/app/models/post_analyzer.rb
@@ -56,17 +56,19 @@ class PostAnalyzer
 
   # How many images are present in the post
   def embedded_media_count
-    return 0 if @raw.blank?
+    embedded_media_elements.count
+  end
 
-    # TODO - do we need to look for tags other than img, video and audio?
-    cooked_stripped
-      .css("img", "video", "audio")
-      .reject do |t|
-        if dom_class = t["class"]
-          (Post.allowed_image_classes & dom_class.split).count > 0
-        end
-      end
-      .count
+  def embedded_media_keys
+    embedded_media_elements.map do |element|
+      element = element.parent if element.parent&.name == "picture"
+
+      srcs =
+        [element, *element.css("*")].flat_map(&:attribute_nodes)
+          .filter_map { |attr| attr.value if attr.name.match?(/src|poster/) }
+
+      srcs.empty? ? element.to_html : srcs.sort.join(" ")
+    end
   end
 
   # How many attachments are present in the post
@@ -151,6 +153,19 @@ class PostAnalyzer
   end
 
   private
+
+  def embedded_media_elements
+    return [] if @raw.blank?
+
+    # TODO - do we need to look for tags other than img, video and audio?
+    cooked_stripped
+      .css("img", "video", "audio")
+      .reject do |t|
+        if dom_class = t["class"]
+          (Post.allowed_image_classes & dom_class.split).count > 0
+        end
+      end
+  end
 
   def link_is_a_mention?(l)
     href = l["href"].to_s

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -263,7 +263,7 @@ class ReviewableFlaggedPost < Reviewable
     end
 
     # Undo hide/silence if applicable
-    if post&.hidden?
+    if post&.hidden? && !post.awaiting_media_review?
       notify_poster(performed_by)
       post.acting_user = performed_by
       post.unhide!

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -19,7 +19,6 @@ class ReviewablePost < Reviewable
     return if edited_by.staff? || edited_by.bot?
     return if post.post_type != Post.types[:regular] || post.topic.private_message?
     return if edited_by.in_any_groups?(SiteSetting.skip_review_media_groups_map)
-    return if pending.where(target: post).exists?
 
     media = post.embedded_media_keys
     return if media.empty?
@@ -27,7 +26,15 @@ class ReviewablePost < Reviewable
     previous_media = Post.new(raw: previous_raw, topic_id: post.topic_id).embedded_media_keys
     return if (media - previous_media).empty?
 
-    queue_for_review(post, reason: :contains_media)
+    queue_for_review(post, reason: :contains_media) unless pending.where(target: post).exists?
+
+    post.hide!(
+      nil,
+      Post.hidden_reasons[:media_pending_review],
+      custom_message: :post_hidden_media_pending_review,
+      visibility_reason_id: Topic.visibility_reasons[:media_pending_review],
+    )
+    post.publish_change_to_clients!(:acted)
   end
 
   def self.queue_for_review(post, reason: nil)
@@ -116,7 +123,7 @@ class ReviewablePost < Reviewable
 
   def perform_approve_and_unhide(performed_by, _args)
     post.acting_user = performed_by
-    post.unhide!
+    post.unhide!(force: true)
 
     create_result(:success, :approved, [created_by_id], false)
   end

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -14,7 +14,23 @@ class ReviewablePost < Reviewable
     queue_for_review(post)
   end
 
-  def self.queue_for_review(post)
+  def self.queue_for_media_review_if_possible(post, edited_by, previous_raw:)
+    return if post.raw == previous_raw
+    return if edited_by.staff? || edited_by.bot?
+    return if post.post_type != Post.types[:regular] || post.topic.private_message?
+    return if edited_by.in_any_groups?(SiteSetting.skip_review_media_groups_map)
+    return if pending.where(target: post).exists?
+
+    media = post.embedded_media_keys
+    return if media.empty?
+
+    previous_media = Post.new(raw: previous_raw, topic_id: post.topic_id).embedded_media_keys
+    return if (media - previous_media).empty?
+
+    queue_for_review(post, reason: :contains_media)
+  end
+
+  def self.queue_for_review(post, reason: nil)
     system_user = Discourse.system_user
 
     needs_review!(
@@ -24,7 +40,12 @@ class ReviewablePost < Reviewable
       reviewable_by_moderator: true,
       potential_spam: false,
     ).tap do |reviewable|
-      reviewable.add_score(system_user, ReviewableScore.types[:needs_approval], force_review: true)
+      reviewable.add_score(
+        system_user,
+        ReviewableScore.types[:needs_approval],
+        reason:,
+        force_review: true,
+      )
     end
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -48,6 +48,7 @@ class Topic < ActiveRecord::Base
         manually_unlisted: 3,
         manually_relisted: 4,
         bulk_action: 5,
+        media_pending_review: 6,
         unknown: 99,
       )
   end

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -28,11 +28,9 @@ class BasicPostSerializer < ApplicationSerializer
 
   def cooked
     if cooked_hidden
-      if scope.current_user && object.user_id == scope.current_user.id
-        I18n.t("flagging.you_must_edit", path: "/my/messages")
-      else
-        I18n.t("flagging.user_must_edit")
-      end
+      yours = scope.current_user && object.user_id == scope.current_user.id
+
+      I18n.t(object.hidden_notice_key(for_author: yours), path: "/my/messages")
     else
       cooked = object.filter_quotes(@parent_post)
 

--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -35,7 +35,7 @@ class ReviewableScoreSerializer < ApplicationSerializer
     invite_only: "invite_only",
     email_spam: "email_in_spam_header",
     suspect_user: "approve_suspect_users",
-    contains_media: "skip_media_review_groups",
+    contains_media: "skip_review_media_groups",
   }
 
   attributes :id,

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -111,7 +111,7 @@
               </span>
             </div>
             <div class='post' <%= tag.attributes(itemprop: "text") if emit_md %>>
-              <%= post.hidden ? t('flagging.user_must_edit').html_safe : post.cooked.html_safe %>
+              <%= post.hidden ? t(post.hidden_notice_key).html_safe : post.cooked.html_safe %>
             </div>
 
             <% unless crawler_post_schema_overridden?(post, @topic_view.topic) %>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -6,7 +6,8 @@
     <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
     <title><%= @topic_view.title %></title>
     <link><%= topic_url %></link>
-    <description><%= @topic_view.posts.first.raw %></description>
+    <% first_post = @topic_view.posts.first %>
+    <description><%= first_post.hidden ? t(first_post.hidden_notice_key) : first_post.raw %></description>
     <% if lang %><language><%= lang.sub('_', '-')%></language><% end %>
     <lastBuildDate><%= @topic_view.topic.bumped_at.rfc2822 %></lastBuildDate>
     <category><%= @topic_view.topic.category.name %></category>
@@ -19,7 +20,7 @@
         <description><![CDATA[
           <% post_url = Discourse.base_url + post.url %>
           <% if post.hidden %>
-            <%= t('flagging.user_must_edit').html_safe %>
+            <%= t(post.hidden_notice_key).html_safe %>
           <% else %>
             <%= PrettyText.format_for_email(post.cooked, post).html_safe %>
           <% end %>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5601,6 +5601,7 @@ en:
         manually_unlisted: "This topic was manually unlisted by an admin or moderator"
         manually_relisted: "This topic was manually relisted by an admin or moderator"
         bulk_action: "This topic's visibility was changed because of a bulk action performed by a user"
+        media_pending_review: "This topic was automatically unlisted because a recent edit added media that is awaiting staff review"
     posts: "Posts"
     pending_posts:
       label: "Pending"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1263,6 +1263,10 @@ en:
     you_must_edit: '<p>Your post was flagged by the community. Please <a href="%{path}">see your messages</a>.</p>'
     user_must_edit: "<p>This post was flagged by the community and is temporarily hidden.</p>"
 
+  media_review:
+    post_hidden_yours: '<p>Your post is temporarily hidden because a recent edit added media that requires staff approval. Please <a href="%{path}">see your messages</a>.</p>'
+    post_hidden: "<p>This post is temporarily hidden because a recent edit added media that is awaiting staff review.</p>"
+
   ignored:
     hidden_content: "<p>Ignored content</p>"
 
@@ -3732,6 +3736,21 @@ en:
         However, if the post is hidden by the community a second time, it will remain hidden until handled by staff.
 
         For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
+
+    post_hidden_media_pending_review:
+      title: "Post Hidden Pending Media Review"
+      preview: "Post hidden while media added by an edit awaits staff review."
+      subject_template: "Post hidden pending media review"
+      text_body_template: |
+        Hello,
+
+        This is an automated message from %{site_name} to let you know that your post was hidden.
+
+        <%{base_url}%{url}>
+
+        A recent edit added images or other media, which on this site must be approved by a staff member before they are visible to others.
+
+        No action is needed from you. Your post will be visible again once the media has been approved.
 
     reviewable_queued_post_revise_and_reject_edit_post: "You can edit your original post below and re-submit to make the suggested changes, or reply to this message if you have any questions."
     reviewable_queued_post_revise_and_reject_edit_post_no_reply: "You can edit your original post below and re-submit to make the suggested changes."

--- a/frontend/discourse/app/lib/constants.js
+++ b/frontend/discourse/app/lib/constants.js
@@ -64,6 +64,7 @@ export const TOPIC_VISIBILITY_REASONS = {
   manually_unlisted: 3,
   manually_relisted: 4,
   bulk_action: 5,
+  media_pending_review: 6,
   unknown: 99,
 };
 

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -207,6 +207,7 @@ module PostGuardian
 
   def can_edit_hidden_post?(post)
     return false if post.nil?
+    return true if post.hidden_reason_id == Post.hidden_reasons[:media_pending_review]
     post.hidden_at.nil? ||
       post.hidden_at < SiteSetting.cooldown_minutes_after_hiding_posts.minutes.ago
   end

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -302,7 +302,12 @@ class PostDestroyer
     # has internal transactions, if we nest then there are some very high risk deadlocks
     last_revision = @post.revisions.last
     if last_revision.present? && last_revision.modifications["raw"].present?
-      @post.revise(@user, { raw: last_revision.modifications["raw"][0] }, force_new_version: true)
+      @post.revise(
+        @user,
+        { raw: last_revision.modifications["raw"][0] },
+        force_new_version: true,
+        recovering_post: true,
+      )
     end
 
     restore_reviewables_for_author_recovery if @user.id == @post.user_id

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -425,7 +425,7 @@ class PostRevisor
     publish_changes
     grant_badge
 
-    unless @opts[:recovering_post]
+    unless @opts[:recovering_post] || @opts[:skip_validations]
       ReviewablePost.queue_for_media_review_if_possible(@post, @editor, previous_raw: old_raw)
     end
     ReviewablePost.queue_for_review_if_possible(@post, @editor) if should_create_new_version?
@@ -673,6 +673,7 @@ class PostRevisor
   def remove_flags_and_unhide_post
     return if @opts[:deleting_post]
     return unless editing_a_flagged_and_hidden_post?
+    return if @post.awaiting_media_review?
 
     flaggers = []
     @post

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -276,8 +276,13 @@ class PostRevisor
   # @option opts [Boolean] :bypass_rate_limiter Bypass the max limits per day rate limiter
   # @option opts [Boolean] :bypass_bump Do not bump the topic. Takes precedence over should_bump_topic plugin modifier, and any other should_bump? logic
   # @option opts [Boolean] :skip_validations Ask ActiveRecord to skip validations
+  # @option opts [Boolean] :validate_post Validate the post, unless :skip_validations says otherwise
+  # @option opts [Boolean] :validate_topic Validate the topic, unless :skip_validations says otherwise
   # @option opts [Boolean] :skip_revision Do not create a new PostRevision record
   # @option opts [Boolean] :skip_staff_log Skip creating an entry in the staff action log
+  # @option opts [Boolean] :keep_existing_draft Do not advance the draft sequence, keeping any open draft
+  # @option opts [Boolean] :deleting_post Blanking content the author deleted, not a new edit
+  # @option opts [Boolean] :recovering_post Restoring content the author had deleted, not a new edit
   # @option opts [Boolean] :silent Don't send notifications to user
   # @option opts [Boolean] :hidden Force the created revision to be hidden from non-staff users
   # @return [Boolean] Returns true if the revision was successful, false otherwise
@@ -420,6 +425,9 @@ class PostRevisor
     publish_changes
     grant_badge
 
+    unless @opts[:recovering_post]
+      ReviewablePost.queue_for_media_review_if_possible(@post, @editor, previous_raw: old_raw)
+    end
     ReviewablePost.queue_for_review_if_possible(@post, @editor) if should_create_new_version?
 
     successfully_saved_post_and_topic

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -457,6 +457,8 @@ class TopicView
   end
 
   def image_url
+    return if desired_post&.hidden
+
     if @post_number == 1
       @topic.image_url || og_image_url
     else
@@ -465,6 +467,8 @@ class TopicView
   end
 
   def image_upload
+    return if desired_post&.hidden
+
     @image_upload ||=
       if @post_number == 1
         @topic.image_upload || og_image_upload

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -606,6 +606,16 @@ RSpec.describe PostGuardian do
 
       expect(Guardian.new(user).can_edit_hidden_post?(post)).to be_falsey
     end
+
+    it "returns true within the cooldown when the post is hidden pending media review" do
+      post.update!(
+        hidden: true,
+        hidden_at: 1.minute.ago,
+        hidden_reason_id: Post.hidden_reasons[:media_pending_review],
+      )
+
+      expect(Guardian.new(user).can_edit_hidden_post?(post)).to be_truthy
+    end
   end
 
   describe "#can_change_post_owner?" do

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -525,6 +525,19 @@ RSpec.describe PostDestroyer do
       expect(history.created_by).to eq(Discourse.system_user)
     end
 
+    it "does not queue the restored post for media review" do
+      SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_3]
+      reply = create_post(topic: post.topic, raw: "look: ![image](upload://sherlock.jpeg)")
+
+      PostDestroyer.new(reply.user, reply).destroy
+
+      expect { PostDestroyer.new(reply.user, reply.reload).recover }.not_to change(
+        ReviewablePost,
+        :count,
+      )
+      expect(reply.reload.raw).to include("upload://sherlock.jpeg")
+    end
+
     it "does not restore reviewable when manually ignored by moderator" do
       reply = create_post(topic: post.topic)
       result = PostActionCreator.spam(coding_horror, reply)

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1905,6 +1905,51 @@ describe PostRevisor do
         revisor.revise!(post.user, { raw: raw_with_image }, recovering_post: true)
       }.not_to change(ReviewablePost, :count)
     end
+
+    it "does not queue the post when the revision skips validations" do
+      expect {
+        revisor.revise!(
+          post.user,
+          { raw: raw_with_image },
+          revised_at: post.updated_at + 10.seconds,
+          skip_validations: true,
+        )
+      }.not_to change(ReviewablePost, :count)
+    end
+
+    it "hides the post until staff review the added media" do
+      revisor.revise!(post.user, { raw: raw_with_image }, revised_at: post.updated_at + 10.seconds)
+
+      expect(post.reload.hidden).to eq(true)
+      expect(post.hidden_reason_id).to eq(Post.hidden_reasons[:media_pending_review])
+      expect(post.topic.reload.visible).to eq(false)
+    end
+
+    it "keeps the post hidden when a follow-up edit does not add new media" do
+      revisor.revise!(post.user, { raw: raw_with_image }, revised_at: post.updated_at + 10.seconds)
+      expect(post.reload.hidden).to eq(true)
+
+      PostRevisor.new(post).revise!(
+        post.user,
+        { raw: "#{raw_with_image}\n\nsome more text" },
+        revised_at: post.updated_at + 20.seconds,
+      )
+
+      expect(post.reload.hidden).to eq(true)
+    end
+
+    it "does not unhide a flag-hidden post while a media review is pending" do
+      revisor.revise!(post.user, { raw: raw_with_image }, revised_at: post.updated_at + 10.seconds)
+      post.reload.update!(hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached])
+
+      PostRevisor.new(post).revise!(
+        post.user,
+        { raw: "#{raw_with_image}\n\nedited to address feedback" },
+        revised_at: post.updated_at + 20.seconds,
+      )
+
+      expect(post.reload.hidden).to eq(true)
+    end
   end
 
   describe "topic bumping" do

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1876,6 +1876,37 @@ describe PostRevisor do
     end
   end
 
+  context "when skip_review_media_groups requires media review" do
+    fab!(:post) { Fabricate(:post, user:, raw: "this is a plain text post") }
+
+    let(:revisor) { PostRevisor.new(post) }
+    let(:raw_with_image) { "#{post.raw}\n\n![image](upload://sherlock.jpeg)" }
+
+    before do
+      SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_3]
+      SiteSetting.editing_grace_period = 1.minute
+    end
+
+    it "queues the post for review when a grace period edit adds media" do
+      expect {
+        revisor.revise!(
+          post.user,
+          { raw: raw_with_image },
+          revised_at: post.updated_at + 10.seconds,
+        )
+      }.to change(ReviewablePost, :count).by(1)
+
+      expect(post.reload.revisions).to be_empty
+      expect(ReviewablePost.last.reviewable_scores.last.reason).to eq("contains_media")
+    end
+
+    it "does not queue the post when the revision restores content the author deleted" do
+      expect {
+        revisor.revise!(post.user, { raw: raw_with_image }, recovering_post: true)
+      }.not_to change(ReviewablePost, :count)
+    end
+  end
+
   describe "topic bumping" do
     subject(:post_revisor) { PostRevisor.new(post) }
 

--- a/spec/models/post_analyzer_spec.rb
+++ b/spec/models/post_analyzer_spec.rb
@@ -216,6 +216,54 @@ RSpec.describe PostAnalyzer do
     end
   end
 
+  describe "embedded_media_keys" do
+    it "is empty without media" do
+      post_analyzer = PostAnalyzer.new("hello :wink: world", default_topic_id)
+      expect(post_analyzer.embedded_media_keys).to be_empty
+    end
+
+    it "keys media on its source" do
+      raw = "<video><source src='http://bbc.co.uk/sherlock.mp4'></video>"
+      post_analyzer = PostAnalyzer.new(raw, default_topic_id)
+
+      expect(post_analyzer.embedded_media_keys).to eq(["http://bbc.co.uk/sherlock.mp4"])
+    end
+
+    it "keys an upload on its source, scaled or not" do
+      plain = PostAnalyzer.new("![sherlock](upload://sherlock.jpeg)", default_topic_id)
+      scaled = PostAnalyzer.new("![sherlock|500x500](upload://sherlock.jpeg)", default_topic_id)
+
+      expect(plain.embedded_media_keys).to eq(["/images/transparent.png upload://sherlock.jpeg"])
+      expect(scaled.embedded_media_keys).to eq(plain.embedded_media_keys)
+    end
+
+    it "keys a picture on both its source and its image" do
+      raw =
+        "<picture><source srcset='http://bbc.co.uk/a.png'><img src='http://bbc.co.uk/sherlock.png'></picture>"
+      post_analyzer = PostAnalyzer.new(raw, default_topic_id)
+
+      expect(post_analyzer.embedded_media_keys).to eq(
+        ["http://bbc.co.uk/a.png http://bbc.co.uk/sherlock.png"],
+      )
+    end
+
+    it "keys a video on both its poster and its source" do
+      raw =
+        "<video poster='http://bbc.co.uk/sherlock.png'><source src='http://bbc.co.uk/a.mp4'></video>"
+      post_analyzer = PostAnalyzer.new(raw, default_topic_id)
+
+      expect(post_analyzer.embedded_media_keys).to eq(
+        ["http://bbc.co.uk/a.mp4 http://bbc.co.uk/sherlock.png"],
+      )
+    end
+
+    it "falls back to the markup for media without a source" do
+      post_analyzer = PostAnalyzer.new("<img alt='sherlock'>", default_topic_id)
+
+      expect(post_analyzer.embedded_media_keys).to eq(['<img alt="sherlock">'])
+    end
+  end
+
   describe "link_count" do
     let(:raw_post_one_link_md) { "[sherlock](http://www.bbc.co.uk/programmes/b018ttws)" }
     let(:raw_post_two_links_html) do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1823,6 +1823,17 @@ RSpec.describe Post do
     end
   end
 
+  it "does not unhide a post awaiting media review unless forced" do
+    post = Fabricate(:post)
+    post.hide!(nil, Post.hidden_reasons[:media_pending_review])
+
+    post.unhide!
+    expect(post.reload.hidden).to eq(true)
+
+    post.unhide!(force: true)
+    expect(post.reload.hidden).to eq(false)
+  end
+
   it "will unhide the post but will keep the topic invisible/unlisted" do
     hidden_topic = Fabricate(:topic, visible: false)
     create_post(topic: hidden_topic)

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -590,6 +590,19 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(flagged_post.reload.hidden).to eq(false)
       expect(flagged_post.topic.reload.visible).to eq(true)
     end
+
+    it "keeps the post hidden when it is awaiting media review" do
+      reviewable = Fabricate(:reviewable_flagged_post)
+      reviewable.post.update!(
+        hidden: true,
+        hidden_at: Time.zone.now,
+        hidden_reason_id: Post.hidden_reasons[:media_pending_review],
+      )
+
+      reviewable.perform(moderator, :disagree)
+
+      expect(reviewable.post.reload.hidden).to eq(true)
+    end
   end
 
   describe "#perform_disagree_and_restore" do

--- a/spec/models/reviewable_post_spec.rb
+++ b/spec/models/reviewable_post_spec.rb
@@ -99,6 +99,57 @@ RSpec.describe ReviewablePost do
         described_class.queue_for_media_review_if_possible(pm_post, author, previous_raw:)
       }.not_to change(ReviewablePost, :count)
     end
+
+    it "hides the post and unlists the topic until staff review the media" do
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.to change { post.reload.hidden }.to(
+        true,
+      ).and change { post.topic.reload.visible }.to(false)
+
+      expect(post.hidden_reason_id).to eq(Post.hidden_reasons[:media_pending_review])
+      expect(post.topic.visibility_reason_id).to eq(Topic.visibility_reasons[:media_pending_review])
+    end
+
+    it "hides the post even when a media reviewable is already pending" do
+      described_class.queue_for_review(post)
+
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.to change { post.reload.hidden }.to(true)
+    end
+
+    it "notifies the author that their post is hidden" do
+      expect_enqueued_with(
+        job: :send_system_message,
+        args: {
+          user_id: author.id,
+          message_type: "post_hidden_media_pending_review",
+        },
+      ) { queue("#{post.raw}\n\n#{image_markdown}") }
+    end
+
+    it "does not unlist the topic when the hidden post is a reply" do
+      reply = Fabricate(:post, topic: post.topic, user: author)
+      reply.raw = "#{reply.raw}\n\n#{image_markdown}"
+
+      described_class.queue_for_media_review_if_possible(reply, author, previous_raw: "reply")
+
+      expect(reply.reload.hidden).to eq(true)
+      expect(reply.topic.reload.visible).to eq(true)
+    end
+
+    it "does not overwrite the visibility reason of a manually unlisted topic" do
+      post.topic.update_status(
+        "visible",
+        false,
+        admin,
+        { visibility_reason_id: Topic.visibility_reasons[:manually_unlisted] },
+      )
+
+      queue("#{post.raw}\n\n#{image_markdown}")
+
+      expect(post.reload.hidden).to eq(true)
+      expect(post.topic.reload.visibility_reason_id).to eq(
+        Topic.visibility_reasons[:manually_unlisted],
+      )
+    end
   end
 
   describe "#build_actions" do
@@ -231,11 +282,38 @@ RSpec.describe ReviewablePost do
         expect(result.transition_to).to eq :approved
         expect(post.reload.hidden).to eq(false)
       end
+
+      it "relists the topic when the post was hidden pending media review" do
+        post.hide!(
+          nil,
+          Post.hidden_reasons[:media_pending_review],
+          visibility_reason_id: Topic.visibility_reasons[:media_pending_review],
+        )
+
+        result = reviewable.reload.perform admin, :approve_and_unhide
+
+        expect(result.transition_to).to eq :approved
+        expect(post.reload.hidden).to eq(false)
+        expect(post.topic.reload.visible).to eq(true)
+      end
     end
 
     describe "#perform_reject_and_delete" do
       it "transitions to the rejected state and deletes the post" do
         result = reviewable.perform admin, :reject_and_delete
+
+        expect(result.transition_to).to eq :rejected
+        expect(Post.where(id: post.id).exists?).to eq(false)
+      end
+
+      it "deletes a post that was hidden pending media review" do
+        post.hide!(
+          nil,
+          Post.hidden_reasons[:media_pending_review],
+          visibility_reason_id: Topic.visibility_reasons[:media_pending_review],
+        )
+
+        result = reviewable.reload.perform admin, :reject_and_delete
 
         expect(result.transition_to).to eq :rejected
         expect(Post.where(id: post.id).exists?).to eq(false)

--- a/spec/models/reviewable_post_spec.rb
+++ b/spec/models/reviewable_post_spec.rb
@@ -3,6 +3,104 @@
 RSpec.describe ReviewablePost do
   fab!(:admin)
 
+  describe ".queue_for_media_review_if_possible" do
+    fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:post) { Fabricate(:post, user: author, raw: "this is a plain text post") }
+
+    let(:image_markdown) { "![image](upload://sherlock.jpeg)" }
+    let(:other_image_markdown) { "![image](upload://moriarty.jpeg)" }
+
+    before { SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_3] }
+
+    def queue(raw, editor: author, previous_raw: post.raw)
+      post.raw = raw
+      described_class.queue_for_media_review_if_possible(post, editor, previous_raw:)
+    end
+
+    it "queues the post when an edit adds media" do
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.to change(ReviewablePost, :count).by(1)
+
+      reviewable = ReviewablePost.last
+      expect(reviewable.target).to eq(post)
+      expect(reviewable).to be_pending
+      expect(reviewable.reviewable_scores.last.reason).to eq("contains_media")
+    end
+
+    it "queues the post when an edit replaces the media" do
+      expect { queue(other_image_markdown, previous_raw: image_markdown) }.to change(
+        ReviewablePost,
+        :count,
+      ).by(1)
+    end
+
+    it "queues the post even when a flag is already pending" do
+      Fabricate(:reviewable_flagged_post, target: post, topic: post.topic)
+
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.to change(ReviewablePost, :count).by(1)
+    end
+
+    it "does not queue the post when the raw is unchanged" do
+      expect { queue(post.raw) }.not_to change(ReviewablePost, :count)
+    end
+
+    it "does not queue the post when the edit leaves the media alone" do
+      expect {
+        queue("behold: #{image_markdown}", previous_raw: "look: #{image_markdown}")
+      }.not_to change(ReviewablePost, :count)
+    end
+
+    it "does not queue the post when the edit removes the media" do
+      expect { queue("no more media", previous_raw: image_markdown) }.not_to change(
+        ReviewablePost,
+        :count,
+      )
+    end
+
+    it "does not queue the post when the editor is a staff member" do
+      expect { queue("#{post.raw}\n\n#{image_markdown}", editor: admin) }.not_to change(
+        ReviewablePost,
+        :count,
+      )
+    end
+
+    it "does not queue the post when the editor is a bot" do
+      expect { queue("#{post.raw}\n\n#{image_markdown}", editor: Fabricate(:bot)) }.not_to change(
+        ReviewablePost,
+        :count,
+      )
+    end
+
+    it "does not queue the post when the editor is in a skip group" do
+      SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_1]
+
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.not_to change(ReviewablePost, :count)
+    end
+
+    it "does not score the post again when a media reviewable is already pending" do
+      reviewable = described_class.queue_for_review(post)
+
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.not_to change {
+        reviewable.reload.reviewable_scores.count
+      }
+    end
+
+    it "does not queue the post when it is not a regular post" do
+      post.update!(post_type: Post.types[:whisper])
+
+      expect { queue("#{post.raw}\n\n#{image_markdown}") }.not_to change(ReviewablePost, :count)
+    end
+
+    it "does not queue the post when it is in a private message" do
+      pm_post = Fabricate(:private_message_post, user: author)
+      previous_raw = pm_post.raw
+      pm_post.raw = "#{previous_raw}\n\n#{image_markdown}"
+
+      expect {
+        described_class.queue_for_media_review_if_possible(pm_post, author, previous_raw:)
+      }.not_to change(ReviewablePost, :count)
+    end
+  end
+
   describe "#build_actions" do
     let(:post) { Fabricate.build(:post) }
     let(:reviewable) { ReviewablePost.new(target: post, target_created_by: post.user) }

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -297,6 +297,44 @@ RSpec.describe PostSerializer do
     end
   end
 
+  describe "#cooked for a post hidden pending media review" do
+    fab!(:author, :user)
+    fab!(:post) do
+      Fabricate(
+        :post,
+        user: author,
+        hidden: true,
+        hidden_reason_id: Post.hidden_reasons[:media_pending_review],
+      )
+    end
+
+    def cooked_for(user)
+      PostSerializer.new(post, scope: Guardian.new(user), root: false).as_json[:cooked]
+    end
+
+    it "explains the pending review to the author" do
+      expect(cooked_for(author)).to eq(
+        I18n.t("media_review.post_hidden_yours", path: "/my/messages"),
+      )
+    end
+
+    it "shows a generic notice to other users" do
+      expect(cooked_for(Fabricate(:user))).to eq(I18n.t("media_review.post_hidden"))
+      expect(cooked_for(nil)).to eq(I18n.t("media_review.post_hidden"))
+    end
+
+    it "shows the real content to staff" do
+      expect(cooked_for(Fabricate(:admin))).to eq(post.cooked)
+    end
+
+    it "keeps the flag copy for flag-hidden posts" do
+      post.update!(hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached])
+
+      expect(cooked_for(author)).to eq(I18n.t("flagging.you_must_edit", path: "/my/messages"))
+      expect(cooked_for(Fabricate(:user))).to eq(I18n.t("flagging.user_must_edit"))
+    end
+  end
+
   context "with a post with notices" do
     fab!(:user) { Fabricate(:user, trust_level: 1) }
     fab!(:user_tl1) { Fabricate(:user, trust_level: 1) }


### PR DESCRIPTION
Previously, the `skip_review_media_groups` check only ran when a post was created, so a user could publish plain text and then edit an image in without the post ever reaching the review queue — and inside `editing_grace_period` that edit creates no revision, so it left no trace in the UI either.

This change runs the same check on edits, queueing a `ReviewablePost` when an edit introduces media the post did not already have, comparing media by its sources rather than its markup so that rescaling an image is not mistaken for adding one.

Reported in [meta t/408899](https://meta.discourse.org/t/grace-period-edits-bypass-skip-review-media-groups-media-review/408899).
