### PR TITLE
FIX: Enforce edit_reason 1,000-char limit on staff small-action post edits

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -71,7 +71,10 @@ class Post < ActiveRecord::Base
   has_many :reviewables, as: :target, dependent: :destroy
 
   validates_with PostValidator, unless: :skip_validation
-  validates :edit_reason, length: { maximum: 1000 }
+  MAX_EDIT_REASON_LENGTH = 1000
+  validates :edit_reason, length: { maximum: MAX_EDIT_REASON_LENGTH }
+
+  before_save :ensure_edit_reason_length
 
   after_commit :index_search
 
@@ -1222,6 +1225,13 @@ class Post < ActiveRecord::Base
   end
 
   private
+
+  def ensure_edit_reason_length
+    return if edit_reason.blank? || edit_reason.length <= MAX_EDIT_REASON_LENGTH
+
+    errors.add(:edit_reason, :too_long, count: MAX_EDIT_REASON_LENGTH)
+    throw :abort
+  end
 
   def access_control_post_id_for_upload
     id

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -55,7 +55,17 @@ RSpec.describe Post do
   end
 
   it { is_expected.to validate_presence_of :raw }
-  it { is_expected.to validate_length_of(:edit_reason).is_at_most(1000) }
+  it { is_expected.to validate_length_of(:edit_reason).is_at_most(Post::MAX_EDIT_REASON_LENGTH) }
+
+  it "rejects oversized edit reasons when validations are skipped" do
+    post = Fabricate(:post)
+    post.edit_reason = "a" * (Post::MAX_EDIT_REASON_LENGTH + 1)
+
+    expect(post.save(validate: false)).to be_falsey
+    expect(post.errors.full_messages).to include(
+      "Edit reason is too long (maximum is #{Post::MAX_EDIT_REASON_LENGTH} characters)",
+    )
+  end
 
   # Min/max body lengths, respecting padding
   it { is_expected.not_to allow_value("x").for(:raw) }

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -773,6 +773,39 @@ RSpec.describe PostsController do
     describe "when logged in as staff" do
       before { sign_in(moderator) }
 
+      it "limits edit reasons while allowing staff to edit small action content" do
+        small_action = Fabricate(:small_action, user: user)
+        oversized_edit_reason = "a" * 1001
+
+        put "/posts/#{small_action.id}.json",
+            params: {
+              post: {
+                raw: "x",
+                edit_reason: oversized_edit_reason,
+              },
+            }
+
+        aggregate_failures do
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to include(
+            "Edit reason is too long (maximum is 1000 characters)",
+          )
+          expect(small_action.reload.edit_reason).not_to eq(oversized_edit_reason)
+        end
+
+        put "/posts/#{small_action.id}.json",
+            params: {
+              post: {
+                raw: "x",
+                edit_reason: "a" * 1000,
+              },
+            }
+
+        expect(response.status).to eq(200), response.body
+        expect(response.parsed_body["post"]["raw"]).to eq("x")
+        expect(small_action.reload.edit_reason).to eq("a" * 1000)
+      end
+
       it "supports updating posts in deleted topics" do
         first_post = post.topic.ordered_posts.first
         PostDestroyer.new(moderator, first_post).destroy


### PR DESCRIPTION
## Summary

Staff edits of small-action posts previously bypassed all model validations, allowing oversized `edit_reason` values to be persisted despite the explicit 1,000-character invariant. The patch now enforces that length limit before every save, including validation-skipping saves, while preserving the special body-editing behavior for small-action posts. The reported availability impact remains unconfirmed.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1587

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>