### PR TITLE
Revert "FIX: Enforce per-section sidebar link cap on partial sidebar section updates (#42277)

### DIFF
--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -32,7 +32,6 @@ class SidebarSection < ActiveRecord::Base
             }
 
   validates :locale, presence: true, length: { maximum: 20 }
-  validate :sidebar_urls_count_within_limit
 
   scope :public_sections, -> { where("public") }
   scope :custom_sections, -> { where(section_type: nil) }
@@ -74,14 +73,6 @@ class SidebarSection < ActiveRecord::Base
   end
 
   private
-
-  def sidebar_urls_count_within_limit
-    count = sidebar_urls.reject(&:marked_for_destruction?).size
-    limit = SiteSetting.max_sidebar_section_links
-    return if count <= limit
-
-    errors.add(:base, "Maximum #{limit} records are allowed. Got #{count} records instead.")
-  end
 
   def set_system_user_for_public_section
     self.user_id = Discourse.system_user.id if public

--- a/app/services/sidebar_section_updater.rb
+++ b/app/services/sidebar_section_updater.rb
@@ -13,7 +13,7 @@ class SidebarSectionUpdater
   end
 
   def update!
-    @sidebar_section.with_lock do
+    ActiveRecord::Base.transaction do
       @sidebar_section.update!(@section_params.merge(sidebar_urls_attributes: @links_params))
       @sidebar_section.sidebar_section_links.update_all(user_id: @sidebar_section.user_id)
       update_link_order

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -629,28 +629,6 @@ RSpec.describe SidebarSectionsController do
       expect(SidebarUrlLocalization.exists?(url_localization.id)).to eq(false)
     end
 
-    it "enforces the total link limit when adding links" do
-      SiteSetting.max_sidebar_section_links = 5
-      sign_in(user)
-
-      put "/sidebar_sections/#{sidebar_section.id}.json",
-          params: {
-            title: "custom section",
-            links: [
-              { icon: "link", name: "latest", value: "/latest" },
-              { icon: "link", name: "new", value: "/new" },
-              { icon: "link", name: "top", value: "/top" },
-              { icon: "link", name: "hot", value: "/hot" },
-            ],
-          }
-
-      expect(response.status).to eq(422)
-      expect(response.parsed_body["errors"]).to eq(
-        ["Maximum 5 records are allowed. Got 6 records instead."],
-      )
-      expect(sidebar_section.reload.sidebar_urls.count).to eq(2)
-    end
-
     it "validates limit of links" do
       SiteSetting.max_sidebar_section_links = 5
 


### PR DESCRIPTION
This reverts commit d041a4538ce0c235c90676bf38703b9c601895dc.

Build is broken:

```
Failures:

  1) Editing Sidebar Community Section allows admin to edit community section and reset to default
     Failure/Error:
       expect(sidebar.primary_section_links("community")).to eq(
         ["Topics", "My posts", "My messages", "Review", "Admin", "Invite", "More"],
       )
     
       expected: ["Topics", "My posts", "My messages", "Review", "Admin", "Invite", "More"]
            got: ["My posts", "My messages", "Topics", "Review", "Admin", "Invite", "More"]
     
       (compared using ==)
     
     [Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_editing_sidebar_community_section_allows_admin_to_edit_community_section_and_reset_to_default_413.png

     ~~~~~~~ JS LOGS ~~~~~~~
     DEBUG: For more advanced debugging, install the Ember Inspector from https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi
     DEBUG: -------------------------------
     DEBUG: Ember : 6.10.1
     DEBUG: -------------------------------
     ℹ️ Discourse v2026.8.0-latest.1 — https://github.com/discourse/discourse/commits/d041a4538c — Ember v6.10.1
     Service Worker registration blocked by Playwright
     DEBUG: For more advanced debugging, install the Ember Inspector from https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi
     DEBUG: -------------------------------
     DEBUG: Ember : 6.10.1
     DEBUG: -------------------------------
     ℹ️ Discourse v2026.8.0-latest.1 — https://github.com/discourse/discourse/commits/d041a4538c — Ember v6.10.1
     Service Worker registration blocked by Playwright
     ~~~~~ END JS LOGS ~~~~~
     
     # ./spec/system/editing_sidebar_community_section_spec.rb:50:in 'block (2 levels) in <main>'
     # ./spec/support/discourse_event_helper.rb:42:in 'block (2 levels) in <main>'
     # ./spec/support/ci.rb:64:in 'block (3 levels) in <main>'
     # ./spec/support/ci.rb:54:in 'block (2 levels) in <main>'
```