### PR TITLE
DEV: Fix const redefine warning in topic voting

### DIFF
--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_query_extension.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_query_extension.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module DiscourseTopicVoting
-  TRENDING_SCORE_SQL = <<~SQL.squish
-    COALESCE((
-      SELECT SUM(1.0 / (EXTRACT(EPOCH FROM (NOW() - tv.created_at)) / 3600.0 + 2.0))
-      FROM topic_voting_votes tv
-      WHERE tv.topic_id = topics.id
-    ), 0)
-  SQL
-
   module TopicQueryExtension
+    TRENDING_SCORE_SQL = <<~SQL.squish
+      COALESCE((
+        SELECT SUM(1.0 / (EXTRACT(EPOCH FROM (NOW() - tv.created_at)) / 3600.0 + 2.0))
+        FROM topic_voting_votes tv
+        WHERE tv.topic_id = topics.id
+      ), 0)
+    SQL
+
     def list_voted_by(user)
       create_list(:user_topics) do |topics|
         topics.joins(
@@ -34,7 +34,7 @@ module DiscourseTopicVoting
           topics.joins(
             "LEFT JOIN topic_voting_topic_vote_count dvtvc ON dvtvc.topic_id = topics.id",
           ).order(
-            "#{DiscourseTopicVoting::TRENDING_SCORE_SQL} DESC, COALESCE(dvtvc.votes_count, 0) DESC, topics.bumped_at DESC",
+            "#{TRENDING_SCORE_SQL} DESC, COALESCE(dvtvc.votes_count, 0) DESC, topics.bumped_at DESC",
           )
         end
       else


### PR DESCRIPTION
Fixes this console error:

```
 [rails] /Users/mb/repos/discourse/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_query_extension.rb:4: warning: already initialized constant DiscourseTopicVoting::TRENDING_SCORE_SQL
  [rails] /Users/mb/repos/discourse/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_query_extension.rb:4: warning: previous definition of TRENDING_SCORE_SQL was here
```
