### PR TITLE
DEV: Return false not nil for Acl::Target group + user checks

### DIFF
--- a/lib/acl/target.rb
+++ b/lib/acl/target.rb
@@ -32,9 +32,8 @@ module Acl
     end
 
     def group_has_permission?(group_or_id, permission)
-      @group_lookup[group_or_id.is_a?(Numeric) ? group_or_id : group_or_id&.id]&.include?(
-        permission,
-      )
+      group_permissions = @group_lookup[group_or_id.is_a?(Numeric) ? group_or_id : group_or_id&.id]
+      (group_permissions || []).include?(permission)
     end
 
     def group_has_any_permission?(group_or_id, permissions)
@@ -51,7 +50,8 @@ module Acl
     end
 
     def user_has_permission?(user_or_id, permission)
-      @user_lookup[user_or_id.is_a?(Numeric) ? user_or_id : user_or_id&.id]&.include?(permission)
+      user_permissions = @user_lookup[user_or_id.is_a?(Numeric) ? user_or_id : user_or_id&.id]
+      (user_permissions || []).include?(permission)
     end
 
     def user_has_any_permission?(user_or_id, permissions)

--- a/spec/fabricators/access_control_list_fabricator.rb
+++ b/spec/fabricators/access_control_list_fabricator.rb
@@ -9,17 +9,17 @@ Fabricator(:access_control_list) do
 end
 
 Fabricator(:access_control_list_with_users, from: :access_control_list) do
-  transient :users
-  allowed_user_ids { |attrs| attrs[:users].map(&:id) }
+  transient :users, :user_ids
+  allowed_user_ids { |attrs| (attrs[:users] || []).map(&:id) + (attrs[:user_ids] || []) }
 end
 
 Fabricator(:access_control_list_with_groups, from: :access_control_list) do
-  transient :groups
-  allowed_group_ids { |attrs| attrs[:groups].map(&:id) }
+  transient :groups, :group_ids
+  allowed_group_ids { |attrs| (attrs[:groups] || []).map(&:id) + (attrs[:group_ids] || []) }
 end
 
 Fabricator(:access_control_list_with_users_and_groups, from: :access_control_list) do
-  transient :users, :groups
-  allowed_user_ids { |attrs| attrs[:users].map(&:id) }
-  allowed_group_ids { |attrs| attrs[:groups].map(&:id) }
+  transient :users, :user_ids, :groups, :group_ids
+  allowed_user_ids { |attrs| (attrs[:users] || []).map(&:id) + (attrs[:user_ids] || []) }
+  allowed_group_ids { |attrs| (attrs[:groups] || []).map(&:id) + (attrs[:group_ids] || []) }
 end

--- a/spec/lib/acl/target_spec.rb
+++ b/spec/lib/acl/target_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe Acl::Target do
       expect(target_acl.group_has_permission?(22, "edit")).to eq(false)
     end
 
-    it "returns nil for a group not present in the list" do
-      expect(target_acl.group_has_permission?(123_456, "view")).to be_nil
+    it "returns false for a group not present in the list" do
+      expect(target_acl.group_has_permission?(123_456, "view")).to eq(false)
     end
 
     it "does not grant group permissions from non-group entries" do
-      expect(target_acl.group_has_permission?(99, "manage")).to be_nil
+      expect(target_acl.group_has_permission?(99, "manage")).to eq(false)
     end
   end
 
@@ -99,12 +99,12 @@ RSpec.describe Acl::Target do
       expect(target_acl.user_has_permission?(99, "manage")).to eq(false)
     end
 
-    it "returns nil for a user not present in the list" do
-      expect(target_acl.user_has_permission?(123_456, "view")).to be_nil
+    it "returns false for a user not present in the list" do
+      expect(target_acl.user_has_permission?(123_456, "view")).to eq(false)
     end
 
     it "does not grant user permissions from non-user entries" do
-      expect(target_acl.user_has_permission?(group.id, "edit")).to be_nil
+      expect(target_acl.user_has_permission?(group.id, "edit")).to eq(false)
     end
   end
 


### PR DESCRIPTION
The methods group_has_permission? and user_has_permission? were
returning nil, not false, if the entity did not have permission even
though they are framed as questions. Let's return false as expected,
which is also what we do for the multiple versions of these which
are group_has_any_permission? and user_has_any_permission?
