### PR TITLE
FIX: Ensure language header selections do not silently get added to 'Languages I understand'

### DIFF
--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -191,11 +191,12 @@ class UserUpdater
         attributes[:text_size]
     end
 
-    if attributes.key?(:locale) || attributes.key?(:understood_languages)
-      understood_languages =
-        attributes.fetch(:understood_languages) { user.user_option.understood_languages }
+    if attributes.key?(:understood_languages)
       interface_locale = user.effective_locale
-      attributes[:understood_languages] = [interface_locale, *understood_languages].compact.uniq
+      attributes[:understood_languages] = Array(attributes[:understood_languages])
+        .compact
+        .uniq
+        .reject { |locale| LocaleNormalizer.is_same?(locale, interface_locale) }
     end
 
     OPTION_ATTR.each do |attribute|

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -191,14 +191,6 @@ class UserUpdater
         attributes[:text_size]
     end
 
-    if attributes.key?(:understood_languages)
-      interface_locale = user.effective_locale
-      attributes[:understood_languages] = Array(attributes[:understood_languages])
-        .compact
-        .uniq
-        .reject { |locale| LocaleNormalizer.is_same?(locale, interface_locale) }
-    end
-
     OPTION_ATTR.each do |attribute|
       if attributes.key?(attribute)
         save_options = true

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2720,7 +2720,7 @@ RSpec.describe UsersController do
             ).pluck(:tag_id),
           ).to contain_exactly(tags[0].id, tags[1].id)
           expect(user.user_option.automatically_translate).to eq(false)
-          expect(user.user_option.understood_languages).to contain_exactly("en", "ja")
+          expect(user.user_option.understood_languages).to contain_exactly("ja")
 
           theme = Fabricate(:theme, user_selectable: true)
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -46,14 +46,13 @@ RSpec.describe UserUpdater do
       expect(user.reload.name).to eq "Jim Tom"
     end
 
-    it "keeps the interface locale separate from the user's understood languages" do
+    it "preserves explicitly submitted understood languages when the interface locale changes" do
       user.update!(locale: "en")
-      user.user_option.update!(understood_languages: ["de"])
 
       UserUpdater.new(user, user).update(locale: "ja", understood_languages: %w[ja de])
 
       expect(user.reload.locale).to eq("ja")
-      expect(user.user_option.understood_languages).to eq(["de"])
+      expect(user.user_option.understood_languages).to eq(%w[ja de])
     end
 
     it "preserves understood languages when only the interface locale changes" do
@@ -66,14 +65,14 @@ RSpec.describe UserUpdater do
       expect(user.user_option.understood_languages).to eq(["de"])
     end
 
-    it "uses the effective interface locale when user locales are disabled" do
+    it "preserves explicitly submitted understood languages when user locales are disabled" do
       SiteSetting.default_locale = "en"
       SiteSetting.allow_user_locale = false
       user.update!(locale: "fr")
 
       UserUpdater.new(user, user).update(understood_languages: %w[en ja])
 
-      expect(user.user_option.understood_languages).to eq(["ja"])
+      expect(user.user_option.understood_languages).to eq(%w[en ja])
     end
 
     it "adapts legacy show-original updates to the positive preference" do

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -46,14 +46,24 @@ RSpec.describe UserUpdater do
       expect(user.reload.name).to eq "Jim Tom"
     end
 
-    it "keeps the interface locale among the user's understood languages" do
+    it "keeps the interface locale separate from the user's understood languages" do
       user.update!(locale: "en")
-      user.user_option.update!(understood_languages: ["en"])
+      user.user_option.update!(understood_languages: ["de"])
 
-      UserUpdater.new(user, user).update(locale: "ja", understood_languages: [])
+      UserUpdater.new(user, user).update(locale: "ja", understood_languages: %w[ja de])
 
       expect(user.reload.locale).to eq("ja")
-      expect(user.user_option.understood_languages).to eq(["ja"])
+      expect(user.user_option.understood_languages).to eq(["de"])
+    end
+
+    it "preserves understood languages when only the interface locale changes" do
+      user.update!(locale: "en")
+      user.user_option.update!(understood_languages: ["de"])
+
+      UserUpdater.new(user, user).update(locale: "ja")
+
+      expect(user.reload.locale).to eq("ja")
+      expect(user.user_option.understood_languages).to eq(["de"])
     end
 
     it "uses the effective interface locale when user locales are disabled" do
@@ -61,9 +71,9 @@ RSpec.describe UserUpdater do
       SiteSetting.allow_user_locale = false
       user.update!(locale: "fr")
 
-      UserUpdater.new(user, user).update(understood_languages: [])
+      UserUpdater.new(user, user).update(understood_languages: %w[en ja])
 
-      expect(user.user_option.understood_languages).to eq(["en"])
+      expect(user.user_option.understood_languages).to eq(["ja"])
     end
 
     it "adapts legacy show-original updates to the positive preference" do

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -118,11 +118,11 @@ describe "Content Localization" do
       preferences_interface_page.enable_automatic_translation.save_changes
       page.refresh
       expect(preferences_interface_page).to be_automatic_translation_enabled
-      expect(preferences_interface_page).to have_understood_language("en")
+      expect(preferences_interface_page).to have_no_understood_language("en")
 
       topic_page.visit_topic(topic)
-      expect(topic_page).to have_topic_title("Life strategies from The Art of War")
-      expect(post_1_obj).to have_cooked_content(post_1.raw)
+      expect(topic_page).to have_topic_title("孫子兵法からの人生戦略")
+      expect(post_1_obj).to have_cooked_content("傑作は単なる軍事戦略についてではありません")
       expect(post_3_obj).to have_cooked_content(post_3.raw)
       expect(topic_page).to have_topic_tag("戦略")
       expect(sidebar).to have_section_link("戦略")

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -70,6 +70,16 @@ module PageObjects
         result
       end
 
+      def has_no_understood_language?(locale)
+        understood_languages_dropdown.expand
+        result =
+          page.has_no_css?(
+            "#understood-languages-selector .selected-choice[data-value='#{locale}']",
+          )
+        understood_languages_dropdown.collapse
+        result
+      end
+
       def has_understood_language_option?(locale)
         understood_languages_dropdown.expand
         result =


### PR DESCRIPTION
This involves this header and this setting:


1. <img width="200" alt="Screenshot 2026-08-04 at 2 08 37 PM" src="https://github.com/user-attachments/assets/f7f96692-958d-4099-ba2a-ab3b4e3bc0f4" />
2. <img width="400" alt="Screenshot 2026-08-04 at 2 08 55 PM" src="https://github.com/user-attachments/assets/0713d25f-3e1c-428d-9b82-938b3706de79" />

Changing the interface language from the header was also adding that locale to “Languages I understand”. Switching through multiple locales meant all of them stayed selected and content in those languages was no longer translated.

This PR keeps the interface locale and understood languages separate. Header selection no longer modifies `understood_languages`, while explicit language updates store only the additional languages a user understands..