### PR TITLE
FIX: Don't hide OP avatar when RSVPing to a livestream event

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/livestream.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/livestream.scss
@@ -1,14 +1,4 @@
 body.chat-enabled.livestream-topic.confirmed-event-assistance {
-  #post_1 {
-    .topic-avatar {
-      display: none;
-    }
-
-    .topic-meta-data {
-      margin: 0;
-    }
-  }
-
   .topic-navigation {
     display: none;
   }
@@ -17,7 +7,7 @@ body.chat-enabled.livestream-topic.confirmed-event-assistance {
     width: 100%;
 
     .topic-body {
-      width: 100%;
+      flex: 1;
       margin-right: 1em;
     }
   }


### PR DESCRIPTION
Previously, RSVPing "Going" to a livestream event hid the first post's avatar — a leftover from the original theater-mode design carried over when the standalone livestream plugin was folded into discourse-calendar.

This change keeps the avatar visible and swaps the post body's `width: 100%` for `flex: 1`, so the body still fills the remaining width in theater mode without squeezing avatars (the post row is a flex container) or overriding the narrower width embedded posts expect.

Internal ref - t/188846