### PR TITLE
FIX: Ensure the language dropdowns from the frontend does not add interface language to understood languages

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1827,7 +1827,7 @@ en:
       content_languages:
         title: "Content languages"
         understood: "Languages I understand"
-        understood_description: "Topics and posts in these languages won’t be translated. Your interface language is always included."
+        understood_description: "Topics and posts in these languages won’t be translated. Your interface language is always considered understood."
       experimental_sidebar:
         enable: "Enable sidebar"
         options: "Options"
@@ -5218,7 +5218,6 @@ en:
       preferences:
         title: "Content language preferences"
         login_to_set_languages: "Log in to set more languages"
-        interface_language_mandatory: "Your interface language is always included."
 
     category:
       none: "(no category)"

--- a/frontend/discourse/app/components/modal/content-language-preferences.gjs
+++ b/frontend/discourse/app/components/modal/content-language-preferences.gjs
@@ -104,7 +104,8 @@ export default class ContentLanguagePreferencesModal extends Component {
 
         await ajax(`/u/${this.currentUser.username}.json`, {
           type: "PUT",
-          data: preferences,
+          contentType: "application/json",
+          data: JSON.stringify(preferences),
         });
         if (this.canChangeInterfaceLanguage) {
           this.currentUser.set("locale", data.interfaceLanguage);

--- a/frontend/discourse/app/components/modal/content-language-preferences.gjs
+++ b/frontend/discourse/app/components/modal/content-language-preferences.gjs
@@ -35,8 +35,7 @@ export default class ContentLanguagePreferencesModal extends Component {
     return {
       interfaceLanguage,
       understoodLanguages: normalizeUnderstoodLanguages(
-        this.currentUser?.user_option?.understood_languages,
-        interfaceLanguage
+        this.currentUser?.user_option?.understood_languages
       ),
       automaticallyTranslate: automaticallyTranslate(this.currentUser),
     };
@@ -76,23 +75,13 @@ export default class ContentLanguagePreferencesModal extends Component {
   }
 
   @action
-  async setInterfaceLanguage(value, { set }) {
-    await set("interfaceLanguage", value);
-    await set(
-      "understoodLanguages",
-      normalizeUnderstoodLanguages(
-        this.formApi.get("understoodLanguages"),
-        value
-      )
-    );
+  setInterfaceLanguage(value, { set }) {
+    return set("interfaceLanguage", value);
   }
 
   @action
   setUnderstoodLanguages(value, { set }) {
-    return set(
-      "understoodLanguages",
-      normalizeUnderstoodLanguages(value, this.formApi.get("interfaceLanguage"))
-    );
+    return set("understoodLanguages", normalizeUnderstoodLanguages(value));
   }
 
   @action
@@ -102,8 +91,7 @@ export default class ContentLanguagePreferencesModal extends Component {
     try {
       if (this.currentUser) {
         const understoodLanguages = normalizeUnderstoodLanguages(
-          data.understoodLanguages,
-          data.interfaceLanguage
+          data.understoodLanguages
         );
 
         const preferences = {
@@ -159,7 +147,7 @@ export default class ContentLanguagePreferencesModal extends Component {
           @data={{this.data}}
           @onSubmit={{this.save}}
           @onRegisterApi={{this.registerFormApi}}
-          as |form transientData|
+          as |form|
         >
           <form.Field
             @name="interfaceLanguage"
@@ -200,10 +188,6 @@ export default class ContentLanguagePreferencesModal extends Component {
                   @content={{this.interfaceLanguageOptions}}
                   @value={{field.value}}
                   @onChange={{field.set}}
-                  @mandatoryValues={{transientData.interfaceLanguage}}
-                  @mandatoryValueTitle={{i18n
-                    "content_localization.preferences.interface_language_mandatory"
-                  }}
                   @options={{hash filterable=true}}
                 />
               </field.Control>

--- a/frontend/discourse/app/controllers/preferences/interface.js
+++ b/frontend/discourse/app/controllers/preferences/interface.js
@@ -29,7 +29,7 @@ import {
 } from "discourse/lib/utilities";
 import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 import { PLATFORM_KEY_MODIFIER } from "discourse/services/keyboard-shortcuts";
-import I18n, { i18n } from "discourse-i18n";
+import { i18n } from "discourse-i18n";
 
 // same as UserOption::HOMEPAGES
 const USER_HOMES = {
@@ -108,20 +108,10 @@ export default class InterfaceController extends Controller {
     });
   }
 
-  @computed("model.locale")
-  get interfaceLanguage() {
-    if (!this.siteSettings.allow_user_locale) {
-      return this.siteSettings.default_locale ?? I18n.locale;
-    }
-
-    return this.model.locale ?? this.siteSettings.default_locale ?? I18n.locale;
-  }
-
-  @computed("model.locale", "model.user_option.understood_languages.[]")
+  @computed("model.user_option.understood_languages.[]")
   get understoodLanguages() {
     return normalizeUnderstoodLanguages(
-      this.model.user_option.understood_languages,
-      this.interfaceLanguage
+      this.model.user_option.understood_languages
     );
   }
 
@@ -136,14 +126,13 @@ export default class InterfaceController extends Controller {
   @action
   setInterfaceLanguage(locale) {
     this.model.set("locale", locale);
-    this.setUnderstoodLanguages(this.model.user_option.understood_languages);
   }
 
   @action
   setUnderstoodLanguages(locales) {
     this.model.set(
       "user_option.understood_languages",
-      normalizeUnderstoodLanguages(locales, this.interfaceLanguage)
+      normalizeUnderstoodLanguages(locales)
     );
   }
 

--- a/frontend/discourse/app/lib/content-localization.js
+++ b/frontend/discourse/app/lib/content-localization.js
@@ -3,10 +3,8 @@ import cookie from "discourse/lib/cookie";
 export const AUTOMATICALLY_TRANSLATE_COOKIE = "automatically_translate";
 export const AUTOMATICALLY_TRANSLATE_COOKIE_EXPIRY = 30;
 
-export function normalizeUnderstoodLanguages(languages, interfaceLanguage) {
-  return [
-    ...new Set([interfaceLanguage, ...(languages ?? [])].filter(Boolean)),
-  ];
+export function normalizeUnderstoodLanguages(languages) {
+  return [...new Set((languages ?? []).filter(Boolean))];
 }
 
 export function automaticallyTranslate(currentUser) {

--- a/frontend/discourse/app/templates/preferences/interface.gjs
+++ b/frontend/discourse/app/templates/preferences/interface.gjs
@@ -180,10 +180,6 @@ export default <template>
           @content={{@controller.availableLocales}}
           @value={{@controller.understoodLanguages}}
           @onChange={{@controller.setUnderstoodLanguages}}
-          @mandatoryValues={{@controller.interfaceLanguage}}
-          @mandatoryValueTitle={{i18n
-            "content_localization.preferences.interface_language_mandatory"
-          }}
           @options={{hash filterable=true}}
         />
         <div class="instructions">

--- a/frontend/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -1,5 +1,7 @@
-import { click, find, visit } from "@ember/test-helpers";
+import { getOwner } from "@ember/owner";
+import { click, find, settled, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import ContentLanguagePreferencesModal from "discourse/components/modal/content-language-preferences";
 import cookie, { removeCookie } from "discourse/lib/cookie";
 import Session from "discourse/models/session";
 import Site from "discourse/models/site";
@@ -81,6 +83,57 @@ acceptance("User Preferences - Interface", function (needs) {
       seen_popups: "",
       skip_new_user_tips: "false",
     });
+  });
+});
+
+acceptance("Content language preferences", function (needs) {
+  needs.user();
+  needs.settings({
+    allow_user_locale: true,
+    available_locales: [
+      { name: "English", value: "en" },
+      { name: "Japanese (日本語)", value: "ja" },
+    ],
+  });
+
+  test("keeps interface and understood languages independent", async function (assert) {
+    await visit("/");
+
+    const owner = getOwner(this);
+    const currentUser = owner.lookup("service:current-user");
+    currentUser.setProperties({
+      effective_locale: "ja",
+      locale: "ja",
+      user_option: {
+        automatically_translate: true,
+        understood_languages: ["en"],
+      },
+    });
+
+    const modalService = owner.lookup("service:modal");
+    modalService.show(ContentLanguagePreferencesModal);
+    await settled();
+
+    await selectKit(
+      ".form-kit__field[data-name='understoodLanguages'] .multi-select"
+    ).expand();
+
+    assert
+      .dom(".form-kit__field[data-name='understoodLanguages']")
+      .exists("the understood languages field is shown");
+    assert
+      .dom(
+        ".form-kit__field[data-name='understoodLanguages'] .selected-choice[data-value='en']"
+      )
+      .exists("the explicitly understood language is selected")
+      .isEnabled("the explicitly understood language can be removed");
+    assert
+      .dom(
+        ".form-kit__field[data-name='understoodLanguages'] .select-kit-row[data-value='ja']"
+      )
+      .exists(
+        "the interface language remains available as an understood language"
+      );
   });
 });
 

--- a/frontend/discourse/tests/unit/lib/content-localization-test.js
+++ b/frontend/discourse/tests/unit/lib/content-localization-test.js
@@ -50,7 +50,7 @@ module("Unit | Lib | content-localization", function (hooks) {
     );
   });
 
-  test("keeps the interface language first in understood languages", function (assert) {
+  test("normalizes understood languages independently from the interface language", function (assert) {
     assert.deepEqual(
       normalizeUnderstoodLanguages(["en", "de", "de"], "en"),
       ["en", "de"],
@@ -58,8 +58,8 @@ module("Unit | Lib | content-localization", function (hooks) {
     );
     assert.deepEqual(
       normalizeUnderstoodLanguages(["en"], "ja"),
-      ["ja", "en"],
-      "it inserts a missing interface language"
+      ["en"],
+      "the interface language does not change explicit selections"
     );
   });
 });

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -162,6 +162,20 @@ describe "Content Localization" do
       expect(preferences_interface_page).to have_understood_language_option("ja")
     end
 
+    it "lets users remove their last understood language from the modal" do
+      site_local_user.user_option.update!(understood_languages: ["en"])
+
+      sign_in(site_local_user)
+      topic_page.visit_topic(topic)
+
+      modal = topic_page.open_content_language_preferences
+      expect(modal).to have_removable_understood_language("en")
+      modal.remove_understood_language("en").save
+
+      modal = topic_page.open_content_language_preferences
+      expect(modal).to have_understood_language_option("en")
+    end
+
     it "allows users to set their post's locale when posting" do
       sign_in(japanese_user)
 

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -94,7 +94,7 @@ describe "Content Localization" do
       preferences_interface_page.visit(japanese_user)
       expect(preferences_interface_page).to have_interface_language_section
       expect(preferences_interface_page).to have_content_languages_section
-      expect(preferences_interface_page).to have_locked_understood_language
+      expect(preferences_interface_page).to have_understood_language_option("ja")
       expect(preferences_interface_page).to have_understood_language_option("de")
       expect(preferences_interface_page).to be_automatic_translation_enabled
 
@@ -130,7 +130,7 @@ describe "Content Localization" do
       modal = topic_page.open_content_language_preferences
       expect(modal).to be_open
       expect(modal).to have_logged_in_language_controls
-      expect(modal).to have_locked_understood_language
+      expect(modal).to have_understood_language_option("ja")
       expect(modal).to have_understood_language_option("de")
       expect(modal).to be_automatic_translation_enabled
       modal.close
@@ -143,7 +143,23 @@ describe "Content Localization" do
 
       preferences_interface_page.visit(japanese_user)
       expect(preferences_interface_page).to have_no_interface_language_section
-      expect(preferences_interface_page).to have_locked_understood_language("English")
+      expect(preferences_interface_page).to have_understood_language_option("en")
+    end
+
+    it "keeps header and understood language selections independent" do
+      SiteSetting.set_locale_from_cookie = true
+      SiteSetting.content_localization_language_switcher = "all"
+      site_local_user.user_option.update!(understood_languages: ["en"])
+
+      sign_in(site_local_user)
+      visit("/")
+
+      language_switcher.select_language("ja")
+      expect(page.find(switcher_selector)).to have_content("JA")
+
+      preferences_interface_page.visit(site_local_user)
+      expect(preferences_interface_page).to have_removable_understood_language("en")
+      expect(preferences_interface_page).to have_understood_language_option("ja")
     end
 
     it "allows users to set their post's locale when posting" do

--- a/spec/system/page_objects/modals/content_language_preferences.rb
+++ b/spec/system/page_objects/modals/content_language_preferences.rb
@@ -42,18 +42,6 @@ module PageObjects
         result
       end
 
-      def has_locked_understood_language?
-        understood_languages_dropdown.expand
-        result =
-          body.has_css?(
-            ".form-kit__field[data-name='understoodLanguages'] " \
-              ".selected-content .tag-choice.disabled",
-            count: 1,
-          )
-        understood_languages_dropdown.collapse
-        result
-      end
-
       def automatic_translation_enabled?
         body.has_css?("[data-test-automatically-translate]:checked", visible: :all)
       end

--- a/spec/system/page_objects/modals/content_language_preferences.rb
+++ b/spec/system/page_objects/modals/content_language_preferences.rb
@@ -42,6 +42,27 @@ module PageObjects
         result
       end
 
+      def has_removable_understood_language?(locale)
+        understood_languages_dropdown.expand
+        result =
+          body.has_css?(
+            ".form-kit__field[data-name='understoodLanguages'] " \
+              "button.selected-choice[data-value='#{locale}']:not(:disabled)",
+          )
+        understood_languages_dropdown.collapse
+        result
+      end
+
+      def remove_understood_language(locale)
+        understood_languages_dropdown.expand
+        body.find(
+          ".form-kit__field[data-name='understoodLanguages'] " \
+            "button.selected-choice[data-value='#{locale}']",
+        ).click
+        understood_languages_dropdown.collapse
+        self
+      end
+
       def automatic_translation_enabled?
         body.has_css?("[data-test-automatically-translate]:checked", visible: :all)
       end

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -62,10 +62,13 @@ module PageObjects
         self
       end
 
-      def has_understood_language?(locale)
+      def has_removable_understood_language?(locale)
         understood_languages_dropdown.expand
         result =
-          page.has_css?("#understood-languages-selector .selected-choice[data-value='#{locale}']")
+          page.has_css?(
+            "#understood-languages-selector button.selected-choice" \
+              "[data-value='#{locale}']:not(:disabled)",
+          )
         understood_languages_dropdown.collapse
         result
       end
@@ -84,18 +87,6 @@ module PageObjects
         understood_languages_dropdown.expand
         result =
           page.has_css?("#understood-languages-selector .select-kit-row[data-value='#{locale}']")
-        understood_languages_dropdown.collapse
-        result
-      end
-
-      def has_locked_understood_language?(language = nil)
-        understood_languages_dropdown.expand
-        result =
-          page.has_css?(
-            "#understood-languages-selector .selected-content .tag-choice.disabled",
-            count: 1,
-            text: language,
-          )
         understood_languages_dropdown.collapse
         result
       end


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/42294


https://github.com/user-attachments/assets/a76ea5fa-8c88-45a6-993a-060a156e7054

