### PR TITLE
FIX: Restore pinch-zoom over the mobile composer editor and inputs

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -818,8 +818,9 @@ html.composer-open:not(.has-full-page-chat) {
 
       .submit-panel,
       .composer-fields {
-        // this prevents touch events (i.e. accidental scrolls) from bubbling up
-        touch-action: none;
+        // prevents accidental scroll-panning from bubbling up while still
+        // allowing the browser's pinch-zoom gesture
+        touch-action: pinch-zoom;
       }
     }
 

--- a/frontend/discourse/app/lib/composer/composer-position.js
+++ b/frontend/discourse/app/lib/composer/composer-position.js
@@ -78,6 +78,11 @@ export function setupComposerPosition(
   }
 
   function editorTouchMove(event) {
+    // Multi-touch gestures (e.g. pinch-zoom) must be left to the browser
+    if (event.touches.length > 1) {
+      return;
+    }
+
     // This is an alternative to locking up the body
     // It stops scrolling in the given element from bubbling up to the body
     // when the editor does not have any content to scroll


### PR DESCRIPTION
Previously, the mobile composer swallowed pinch-zoom (and scroll) gestures because `editorTouchMove` called `preventDefault()` on every touch gesture and .composer-fields/.submit-panel used `touch-action: none`.

This caused issues when the composer was zoomed in, it was nearly impossible to zoom back out, resulting in elements not being reachable. 

Meta `t/408540`

This change makes editorTouchMove ignore **multi-touch gestures** and switches those regions to touch-action: pinch-zoom, so the browser's native zoom works over the composer while accidental scroll-panning is still blocked.