### PR TITLE
UX: allow overflow for group-add-members-modal

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -267,6 +267,12 @@
 }
 
 .d-modal.group-add-members-modal {
+  @include viewport.until(sm) {
+    .d-modal__body {
+      overflow-y: visible;
+    }
+  }
+
   .input-group {
     margin-bottom: 0.5em;
 


### PR DESCRIPTION
Add an overrule to allow the `group-add-members-modal` to overflow, to fix its use of the dropdown.

| Then | Now |
|--------|--------|
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/cb812b8b-1029-4094-8aa5-5a8bedacf773" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/5503ff33-6286-4227-a7cb-31de5c952244" /> | 

