### PR TITLE
UX: fix selectkit overflow on dashboard

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/engagement.scss
+++ b/app/assets/stylesheets/admin/dashboard/engagement.scss
@@ -1,7 +1,26 @@
+@use "lib/container";
+
 .db-activity {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  container-type: inline-size;
+  container-name: db-activity;
+
+  .db-section__row-block-header {
+    align-items: center;
+    gap: var(--space-2);
+
+    @include container.until(sm, db-activity) {
+      flex-direction: column;
+      align-items: flex-start;
+
+      .select-kit.multi-select.multiple-categories-selector {
+        max-width: none;
+        width: 100%;
+      }
+    }
+  }
 
   th,
   td {
@@ -94,7 +113,10 @@
   container-name: db-whos-posting;
 
   .db-section__row-block-header {
-    @container db-whos-posting (width < 22rem) {
+    align-items: center;
+    gap: var(--space-2);
+
+    @include container.until(sm, db-whos-posting) {
       flex-direction: column;
       align-items: flex-start;
     }
@@ -108,11 +130,13 @@
     flex-grow: 1;
     min-width: 0;
 
-    @container db-whos-posting (width < 22rem) {
+    @include container.until(sm, db-whos-posting) {
       width: 100%;
+      align-items: flex-start;
 
       .select-kit.multi-select.multiple-categories-selector {
         max-width: none;
+        width: 100%;
       }
     }
   }
@@ -263,13 +287,5 @@
     &.--demoted {
       background: var(--danger);
     }
-  }
-}
-
-.db-whos-posting,
-.db-activity {
-  .db-section__row-block-header {
-    align-items: center;
-    gap: var(--space-2);
   }
 }


### PR DESCRIPTION
https://meta.discourse.org/t/activity-by-category-section-overflows-with-long-category-names/409202

Change to using the new container lib for more surgical responsive scaling to prevent the selectkit from overflowing on narrow screens.