### PR TITLE
FIX: Enforce per-section sidebar link cap on partial updates

### DIFF
--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -32,6 +32,7 @@ class SidebarSection < ActiveRecord::Base
             }
 
   validates :locale, presence: true, length: { maximum: 20 }
+  validate :sidebar_urls_count_within_limit, on: :sidebar_section_update
 
   scope :public_sections, -> { where("public") }
   scope :custom_sections, -> { where(section_type: nil) }
@@ -73,6 +74,15 @@ class SidebarSection < ActiveRecord::Base
   end
 
   private
+
+  def sidebar_urls_count_within_limit
+    count = sidebar_urls.reject(&:marked_for_destruction?).size
+    persisted_count = sidebar_urls.count(&:persisted?)
+    limit = SiteSetting.max_sidebar_section_links
+    return if count <= [limit, persisted_count].max
+
+    errors.add(:base, :too_many_sidebar_urls, limit:, count:)
+  end
 
   def set_system_user_for_public_section
     self.user_id = Discourse.system_user.id if public

--- a/app/services/sidebar_section_updater.rb
+++ b/app/services/sidebar_section_updater.rb
@@ -13,8 +13,11 @@ class SidebarSectionUpdater
   end
 
   def update!
-    ActiveRecord::Base.transaction do
-      @sidebar_section.update!(@section_params.merge(sidebar_urls_attributes: @links_params))
+    @sidebar_section.with_lock do
+      @sidebar_section.assign_attributes(
+        @section_params.merge(sidebar_urls_attributes: @links_params),
+      )
+      @sidebar_section.save!(context: :sidebar_section_update)
       @sidebar_section.sidebar_section_links.update_all(user_id: @sidebar_section.user_id)
       update_link_order
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -872,6 +872,10 @@ en:
           attributes:
             linkable_type:
               invalid: "is not valid"
+        sidebar_section:
+          attributes:
+            base:
+              too_many_sidebar_urls: "Maximum %{limit} records are allowed. Got %{count} records instead."
         api_key:
           base:
             at_least_one_granular_scope: "at least one must be selected"

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -651,6 +651,44 @@ RSpec.describe SidebarSectionsController do
       )
     end
 
+    it "enforces the total link limit when adding links" do
+      SiteSetting.max_sidebar_section_links = 5
+      sign_in(user)
+
+      put "/sidebar_sections/#{sidebar_section.id}.json",
+          params: {
+            title: "custom section",
+            links: [
+              { icon: "link", name: "latest", value: "/latest" },
+              { icon: "link", name: "new", value: "/new" },
+              { icon: "link", name: "top", value: "/top" },
+              { icon: "link", name: "hot", value: "/hot" },
+            ],
+          }
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body["errors"]).to eq(
+        ["Maximum 5 records are allowed. Got 6 records instead."],
+      )
+      expect(sidebar_section.reload.sidebar_urls.count).to eq(2)
+    end
+
+    it "allows an existing over-limit section to remove links" do
+      SiteSetting.max_sidebar_section_links = 1
+      sign_in(user)
+
+      put "/sidebar_sections/#{sidebar_section.id}.json",
+          params: {
+            title: "custom section",
+            links: [
+              { id: sidebar_url_2.id, icon: "link", name: "tags", value: "/tags", _destroy: "1" },
+            ],
+          }
+
+      expect(response.status).to eq(200)
+      expect(sidebar_section.reload.sidebar_urls).to contain_exactly(sidebar_url_1)
+    end
+
     it "returns 404 when updating a non-existent section" do
       sign_in(user)
 


### PR DESCRIPTION
## Summary

- enforce the resulting active-link count while holding the sidebar section row lock
- scope the validation to sidebar updates so Community reset and unrelated model saves do not load or retain stale link associations
- allow existing over-limit sections to make non-growing and deletion-based repairs
- use a translatable ActiveRecord error key

This replaces #42277 after its revert in #42287.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1583