### PR TITLE
FIX: Default AI translation backfill start date when translations are enabled

### DIFF
--- a/plugins/discourse-ai/lib/translation/entry_point.rb
+++ b/plugins/discourse-ai/lib/translation/entry_point.rb
@@ -31,6 +31,13 @@ module DiscourseAi
             Jobs.enqueue_in(grace, :detect_translate_post, post_id: post.id) if raw_changed
           end
         end
+
+        plugin.on(:site_setting_changed) do |name, _old_value, new_value|
+          if name == :ai_translation_enabled && new_value &&
+               SiteSetting.ai_translation_backfill_start_date.blank?
+            SiteSetting.ai_translation_backfill_start_date = 5.days.ago.utc.to_date.iso8601
+          end
+        end
       end
     end
   end

--- a/plugins/discourse-ai/spec/lib/translation/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/entry_point_spec.rb
@@ -124,6 +124,29 @@ describe DiscourseAi::Translation::EntryPoint do
     end
   end
 
+  describe "upon enabling ai_translation_enabled" do
+    before do
+      SiteSetting.ai_translation_enabled = false
+      SiteSetting.ai_translation_backfill_start_date = ""
+    end
+
+    it "sets the backfill start date to 5 days ago when it is at the default value" do
+      freeze_time
+
+      SiteSetting.ai_translation_enabled = true
+
+      expect(SiteSetting.ai_translation_backfill_start_date).to eq(5.days.ago.utc.to_date.iso8601)
+    end
+
+    it "keeps an existing backfill start date" do
+      SiteSetting.ai_translation_backfill_start_date = "2026-07-01"
+
+      SiteSetting.ai_translation_enabled = true
+
+      expect(SiteSetting.ai_translation_backfill_start_date).to eq("2026-07-01")
+    end
+  end
+
   describe "upon post edited" do
     it "enqueues detect translate post job in grace period" do
       freeze_time


### PR DESCRIPTION
Previously, #42082 converted `ai_translation_backfill_max_age_days` (default: 5 days) into the blank-by-default `ai_translation_backfill_start_date`, which had the unintended side effect of leaving post/topic backfill disabled when automatic translations were enabled.

This change sets `ai_translation_backfill_start_date` to 5 days ago whenever `ai_translation_enabled` is turned on and the date is still at its default, restoring the original out-of-the-box backfill behavior without overriding an explicitly configured date.