### PR TITLE
FIX: Stop hiding workflow fields gated on an expression

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/node-issues.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/node-issues.js
@@ -1,6 +1,6 @@
 import {
+  fieldDefinitelyVisible,
   fieldType,
-  fieldVisible,
   fixedCollectionGroups,
   fixedCollectionRows,
   normalizePropertyOptions,
@@ -44,7 +44,7 @@ function walk(schema, config, pathPrefix, issues) {
   const effective = applyDefaults(schema, config);
 
   for (const [name, field] of Object.entries(schema)) {
-    if (!fieldVisible(field, effective)) {
+    if (!fieldDefinitelyVisible(field, effective)) {
       continue;
     }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
@@ -425,32 +425,60 @@ export function credentialSlotAnchorField(slot = {}) {
   return fields.size === 1 ? [...fields][0] : null;
 }
 
-export function fieldVisible(schema = {}, configuration = {}) {
+/**
+ * "visible" | "hidden" | "indeterminate". A rule anchored to an
+ * expression-valued parameter cannot be settled in the editor, so the target
+ * stays visible rather than vanishing along with its validations.
+ */
+export function fieldDisplayState(schema = {}, configuration = {}) {
   if (fieldUi(schema).hidden) {
-    return false;
+    return "hidden";
   }
 
   const display_options = schema.display_options;
-  if (
-    display_options?.show &&
-    !matchesRules(display_options.show, configuration)
-  ) {
-    return false;
+  let indeterminate = false;
+
+  if (display_options?.show) {
+    const outcome = rulesOutcome(display_options.show, configuration);
+    if (outcome === false) {
+      return "hidden";
+    }
+    indeterminate ||= outcome === "unknown";
   }
-  if (
-    display_options?.hide &&
-    matchesRules(display_options.hide, configuration)
-  ) {
-    return false;
+  if (display_options?.hide) {
+    const outcome = rulesOutcome(display_options.hide, configuration);
+    if (outcome === true) {
+      return "hidden";
+    }
+    indeterminate ||= outcome === "unknown";
   }
 
-  return true;
+  return indeterminate ? "indeterminate" : "visible";
 }
 
-function matchesRules(rules, configuration) {
-  return Object.entries(rules).every(([fieldName, expected]) =>
-    matchesRule(expected, configuration[fieldName])
-  );
+export function fieldVisible(schema = {}, configuration = {}) {
+  return fieldDisplayState(schema, configuration) !== "hidden";
+}
+
+export function fieldDefinitelyVisible(schema = {}, configuration = {}) {
+  return fieldDisplayState(schema, configuration) === "visible";
+}
+
+function rulesOutcome(rules, configuration) {
+  let unknown = false;
+
+  for (const [fieldName, expected] of Object.entries(rules)) {
+    const value = configuration?.[fieldName];
+    if (isExpression(value)) {
+      unknown = true;
+      continue;
+    }
+    if (!matchesRule(expected, value)) {
+      return false;
+    }
+  }
+
+  return unknown ? "unknown" : true;
 }
 
 function matchesRule(expected, value) {

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/schema-graph.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/schema-graph.js
@@ -3,7 +3,7 @@ import {
   normalizeTargetInputIndex,
 } from "./graph-constants";
 import { resolveNodeTypeVersion, typeVersionForNode } from "./node-types";
-import { fieldVisible } from "./property-engine";
+import { fieldDisplayState, fieldVisible } from "./property-engine";
 
 const DRAFT_URI = "https://json-schema.org/draft/2020-12/schema";
 
@@ -115,20 +115,38 @@ function contractDefinition(contract = {}) {
   };
 }
 
-function activeOutputContract(contract, configuration) {
-  const variant = (contract.variants || []).find((candidate) =>
-    fieldVisible({ display_options: candidate.display_options }, configuration)
-  );
-  if (variant) {
-    return variant;
+function activeOutputContracts(contract, configuration) {
+  const candidates = [];
+
+  for (const variant of contract.variants || []) {
+    const state = fieldDisplayState(
+      { display_options: variant.display_options },
+      configuration
+    );
+    if (state === "hidden") {
+      continue;
+    }
+
+    candidates.push(contractDefinition(variant));
+    // Nothing after a definite match can be picked at runtime.
+    if (state === "visible") {
+      return candidates;
+    }
   }
 
-  return fieldVisible(
-    { display_options: contract.display_options },
-    configuration
-  )
-    ? contract
-    : {};
+  if (
+    fieldVisible({ display_options: contract.display_options }, configuration)
+  ) {
+    candidates.push(contractDefinition(contract));
+  }
+
+  // An unknown schema absorbs the union of everything it contends with, so drop
+  // it rather than let it erase what the others declare.
+  const contenders = candidates.filter(
+    ({ mode, schema }) => !(mode === "replace" && isUnknown(schema))
+  );
+
+  return contenders.length ? contenders : [contractDefinition({})];
 }
 
 function nodeTypeDefinitionForNode(node, graph) {
@@ -146,7 +164,7 @@ function nodeTypeDefinitionForNode(node, graph) {
 function ownOutputContracts(node, graph, configuration) {
   const definition = nodeTypeDefinitionForNode(node, graph);
   if (!definition) {
-    return [{ mode: "replace", schema: {} }];
+    return [[{ mode: "replace", schema: {} }]];
   }
 
   const currentConfiguration = configuration ?? node.configuration ?? {};
@@ -159,9 +177,7 @@ function ownOutputContracts(node, graph, configuration) {
     (definition.outputs || definition.ports || [null]).length;
 
   return Array.from({ length: outputCount }, (_, index) =>
-    contractDefinition(
-      activeOutputContract(contracts[index] || {}, currentConfiguration)
-    )
+    activeOutputContracts(contracts[index] || {}, currentConfiguration)
   );
 }
 
@@ -254,15 +270,19 @@ export function resolveDeclaredOutputSchemas(
         const contracts = contractsByKey.get(key);
         let inputSchema = {};
 
-        if (contracts.some(({ mode }) => mode !== "replace")) {
+        if (
+          contracts.some((port) => port.some(({ mode }) => mode !== "replace"))
+        ) {
           inputSchema = inputSchemaFor(key);
           if (inputSchema === undefined) {
             continue;
           }
         }
 
-        const resolved = contracts.map((contract) =>
-          resolvedOutputSchema(contract, inputSchema)
+        const resolved = contracts.map((port) =>
+          unionSchemas(
+            port.map((contract) => resolvedOutputSchema(contract, inputSchema))
+          )
         );
         if (
           !outputSchemas.has(key) ||

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -524,7 +524,7 @@ module DiscourseWorkflows
 
         raw_value = get_node_parameter(field, item_index || 0, options: { raw_expressions: true })
         return :default if raw_value.nil?
-        return :expression if raw_value.is_a?(String) && raw_value.start_with?("=")
+        return :expression if Schema.expression_value?(raw_value)
 
         :static_config
       end

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_data.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_data.rb
@@ -113,44 +113,7 @@ module DiscourseWorkflows
     end
 
     def credential_slot_visible?(definition, parameters)
-      display_options = definition["display_options"] || {}
-
-      visible_for_conditions?(display_options["show"], parameters) &&
-        !hidden_by_conditions?(display_options["hide"], parameters)
-    end
-
-    def visible_for_conditions?(conditions, parameters)
-      return true if conditions.blank?
-
-      conditions.all? { |key, expected| matches_display_rule?(expected, parameters[key]) }
-    end
-
-    def hidden_by_conditions?(conditions, parameters)
-      conditions.present? && visible_for_conditions?(conditions, parameters)
-    end
-
-    def matches_display_rule?(expected, value)
-      return false unless expected.is_a?(Array)
-
-      expected.any? { |condition| matches_display_condition?(condition, value) }
-    end
-
-    def matches_display_condition?(condition, value)
-      operator = condition.is_a?(Hash) ? condition["condition"] : nil
-      return condition == value if operator.blank?
-
-      return value != operator["not"] if operator.key?("not")
-      if operator.key?("exists")
-        return operator["exists"] ? !empty_display_value?(value) : empty_display_value?(value)
-      end
-
-      false
-    end
-
-    def empty_display_value?(value)
-      return true if value.nil? || value == ""
-      return value.empty? if value.is_a?(Array)
-      false
+      Schema.visible?(definition["display_options"] || {}, parameters)
     end
 
     def node_class(node_type)

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_issues.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_issues.rb
@@ -17,7 +17,7 @@ module DiscourseWorkflows
         issues = []
 
         schema.each do |name, field|
-          next unless field_visible?(field, effective)
+          next unless field_definitely_visible?(field, effective)
 
           name_s = name.to_s
           path = path_prefix.empty? ? name_s : "#{path_prefix}.#{name_s}"
@@ -98,46 +98,10 @@ module DiscourseWorkflows
         result
       end
 
-      def field_visible?(field, config)
-        ui = field[:ui] || {}
-        return false if ui[:hidden]
-        display_options = field[:display_options] || {}
-        return false if display_options[:show] && !matches_rules?(display_options[:show], config)
-        return false if display_options[:hide] && matches_rules?(display_options[:hide], config)
-        true
-      end
+      def field_definitely_visible?(field, config)
+        return false if (field[:ui] || {})[:hidden]
 
-      def matches_rules?(rules, config)
-        rules.all? { |field_name, expected| matches_rule?(expected, config[field_name.to_s]) }
-      end
-
-      def matches_rule?(expected, value)
-        return false unless expected.is_a?(Array)
-
-        expected.any? { |condition| matches_condition?(condition, value) }
-      end
-
-      def matches_condition?(condition, value)
-        operator = condition.is_a?(Hash) ? condition[:condition] || condition["condition"] : nil
-        return condition == value if operator.blank?
-
-        if operator.key?(:not) || operator.key?("not")
-          expected = operator.key?(:not) ? operator[:not] : operator["not"]
-          return value != expected
-        end
-
-        if operator.key?(:exists) || operator.key?("exists")
-          exists = operator.key?(:exists) ? operator[:exists] : operator["exists"]
-          return exists ? !empty_value?(value) : empty_value?(value)
-        end
-
-        false
-      end
-
-      def empty_value?(value)
-        return true if value.nil? || value == ""
-        return value.empty? if value.is_a?(Array)
-        false
+        Schema.definitely_visible?(field[:display_options] || {}, config)
       end
 
       def blank_value?(value)

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -123,8 +123,12 @@ module DiscourseWorkflows
     def self.output_schemas(configuration = {}, input_schemas: [])
       input_schema = Schema.union(*input_schemas.compact)
 
-      active_output_contracts(configuration).map do |contract|
-        Schema.resolve(contract.fetch(:schema), mode: contract.fetch(:mode), input_schema:)
+      active_output_contracts(configuration).map do |candidates|
+        Schema.union(
+          *candidates.map do |contract|
+            Schema.resolve(contract.fetch(:schema), mode: contract.fetch(:mode), input_schema:)
+          end,
+        )
       end
     end
 
@@ -146,18 +150,38 @@ module DiscourseWorkflows
     EMPTY_OUTPUT_CONTRACT = { schema: {}, mode: :replace, display_options: {} }.freeze
 
     def self.active_output_contracts(configuration = {})
-      output_contracts.map do |contract|
-        active =
-          contract
-            .fetch(:variants)
-            .find { |variant| Schema.visible?(variant.fetch(:display_options), configuration) }
-        active ||= contract.except(:variants) if Schema.visible?(
-          contract.fetch(:display_options),
-          configuration,
-        )
-        active || EMPTY_OUTPUT_CONTRACT
-      end
+      output_contracts.map { |contract| contract_candidates(contract, configuration) }
     end
+
+    def self.contract_candidates(contract, configuration)
+      candidates = []
+
+      contract
+        .fetch(:variants)
+        .each do |variant|
+          state = Schema.display_state(variant.fetch(:display_options), configuration)
+          next if state == :hidden
+
+          candidates << variant
+          # Nothing after a definite match can be picked at runtime.
+          return candidates if state == :visible
+        end
+
+      if Schema.visible?(contract.fetch(:display_options), configuration)
+        candidates << contract.except(:variants)
+      end
+      # An unknown schema absorbs the union of everything it contends with, so
+      # drop it rather than let it erase what the others declare.
+      candidates.reject! { |candidate| unknown_contract?(candidate) }
+
+      candidates.presence || [EMPTY_OUTPUT_CONTRACT]
+    end
+    private_class_method :contract_candidates
+
+    def self.unknown_contract?(contract)
+      contract.fetch(:mode) == :replace && Schema.unknown?(contract.fetch(:schema))
+    end
+    private_class_method :unknown_contract?
 
     def self.event_name
       Array(description[:events]).first
@@ -252,7 +276,7 @@ module DiscourseWorkflows
     end
 
     def self.expression_value?(value)
-      value.is_a?(String) && value.start_with?("=")
+      Schema.expression_value?(value)
     end
 
     def self.validate_timezone_configuration(configuration, errors)

--- a/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
@@ -288,9 +288,13 @@ module DiscourseWorkflows
         schemas.reduce({}) { |combined, schema| merge_pair(combined, schema) }
       end
 
+      def unknown?(schema)
+        stringify(schema).empty?
+      end
+
       def union(*schemas)
         schemas = schemas.flatten.map { |schema| stringify(schema) }
-        return {} if schemas.empty? || schemas.any?(&:empty?)
+        return {} if schemas.empty? || schemas.any? { |schema| unknown?(schema) }
 
         branches = schemas.flat_map { |schema| union_branches(schema) }.uniq
         return branches.first if branches.one?
@@ -324,16 +328,42 @@ module DiscourseWorkflows
         infer_value(value)
       end
 
-      def visible?(display_options, configuration)
+      def expression_value?(value)
+        value.is_a?(String) && value.start_with?("=")
+      end
+
+      # :indeterminate means a rule is anchored to an expression-valued parameter,
+      # so the target must neither be dropped nor have its requirements enforced.
+      def display_state(display_options, configuration)
         display_options = normalize_options(display_options)
-        configuration = normalize_options(configuration)
         show_rules = display_options["show"]
         hide_rules = display_options["hide"]
+        return :visible if show_rules.blank? && hide_rules.blank?
 
-        return false if show_rules.present? && !matches_rules?(show_rules, configuration)
-        return false if hide_rules.present? && matches_rules?(hide_rules, configuration)
+        configuration = normalize_configuration(configuration)
+        indeterminate = false
 
-        true
+        if show_rules.present?
+          outcome = rules_outcome(show_rules, configuration)
+          return :hidden if outcome == false
+          indeterminate ||= outcome == :unknown
+        end
+
+        if hide_rules.present?
+          outcome = rules_outcome(hide_rules, configuration)
+          return :hidden if outcome == true
+          indeterminate ||= outcome == :unknown
+        end
+
+        indeterminate ? :indeterminate : :visible
+      end
+
+      def visible?(display_options, configuration)
+        display_state(display_options, configuration) != :hidden
+      end
+
+      def definitely_visible?(display_options, configuration)
+        display_state(display_options, configuration) == :visible
       end
 
       private
@@ -431,10 +461,28 @@ module DiscourseWorkflows
         options.to_h.deep_stringify_keys
       end
 
-      def matches_rules?(rules, configuration)
-        rules.all? do |field_name, expected|
-          matches_rule?(expected, configuration[field_name.to_s])
+      # Rules only anchor on top-level keys, so a shallow pass avoids deep-copying
+      # the whole configuration on every visibility check.
+      def normalize_configuration(configuration)
+        return {} if configuration.blank?
+
+        configuration.to_h.stringify_keys
+      end
+
+      def rules_outcome(rules, configuration)
+        unknown = false
+
+        rules.each do |field_name, expected|
+          value = configuration[field_name.to_s]
+          if expression_value?(value)
+            unknown = true
+            next
+          end
+
+          return false unless matches_rule?(expected, value)
         end
+
+        unknown ? :unknown : true
       end
 
       def matches_rule?(expected, value)

--- a/plugins/discourse-workflows/lib/discourse_workflows/schema/graph_resolver.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/schema/graph_resolver.rb
@@ -127,7 +127,9 @@ module DiscourseWorkflows
 
         node_class
           .active_output_contracts(NodeData.parameters(@nodes_by_id.fetch(node_id)))
-          .all? { |contract| contract.fetch(:mode).to_sym == :replace }
+          .all? do |candidates|
+            candidates.all? { |contract| contract.fetch(:mode).to_sym == :replace }
+          end
       end
 
       def output_count(node_id)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_data_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_data_spec.rb
@@ -58,6 +58,29 @@ RSpec.describe DiscourseWorkflows::NodeData do
       expect(split["credentials"]).to eq({})
     end
 
+    it "keeps stored credentials when the controlling parameter is an expression" do
+      split =
+        described_class.split(
+          node_type: "action:http_request",
+          parameters: {
+            "authentication" => "={{ $json.auth }}",
+          },
+          credentials: {
+            "auth" => {
+              "id" => 12,
+              "credential_type" => "basic_auth",
+            },
+          },
+        )
+
+      expect(split["credentials"]).to eq(
+        "auth" => {
+          "id" => "12",
+          "credential_type" => "basic_auth",
+        },
+      )
+    end
+
     it "removes credentials from node types without credential declarations" do
       split =
         described_class.split(

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_issues_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_issues_spec.rb
@@ -124,6 +124,50 @@ RSpec.describe DiscourseWorkflows::NodeIssues do
         expect(issues.size).to eq(1)
       end
     end
+
+    context "when the controlling parameter is an expression" do
+      let(:configuration) { { "page_type" => "={{ $json.kind }}" } }
+
+      it "does not report the blank required field" do
+        expect(issues).to be_empty
+      end
+    end
+  end
+
+  context "with a collection behind an expression-valued anchor" do
+    let(:schema) do
+      {
+        mode: {
+          type: :options,
+        },
+        columns: {
+          type: :fixed_collection,
+          display_options: {
+            show: {
+              mode: %w[manual],
+            },
+          },
+          options: [{ name: "values", values: { header: { type: :string, required: true } } }],
+        },
+      }
+    end
+    let(:configuration) do
+      { "mode" => "={{ $json.mode }}", "columns" => { "values" => [{ "header" => "" }] } }
+    end
+
+    it "suppresses issues for the whole subtree" do
+      expect(issues).to be_empty
+    end
+
+    context "when the anchor is a literal" do
+      let(:configuration) do
+        { "mode" => "manual", "columns" => { "values" => [{ "header" => "" }] } }
+      end
+
+      it "still reports the nested blank required field" do
+        expect(issues.map { |issue| issue[:path] }).to eq(["columns.values.0.header"])
+      end
+    end
   end
 
   context "when a required field has a default" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_output_contracts_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_output_contracts_spec.rb
@@ -81,6 +81,62 @@ RSpec.describe DiscourseWorkflows::NodeType do
     )
   end
 
+  it "unions the group variants in contention when the operation is an expression" do
+    node_class = DiscourseWorkflows::Nodes::Group::V1
+    add_remove_schema =
+      DiscourseWorkflows::Schema.merge(
+        DiscourseWorkflows::Schema::GROUP_SCHEMA,
+        DiscourseWorkflows::Schema::BASIC_USER_SCHEMA,
+      )
+
+    expect(
+      node_class.output_schemas({ "operation" => "add" }, input_schemas: [input_schema]),
+    ).to eq([add_remove_schema])
+
+    expect(
+      node_class.output_schemas(
+        { "operation" => "={{ $json.op }}" },
+        input_schemas: [input_schema],
+      ),
+    ).to eq(
+      [
+        DiscourseWorkflows::Schema.union(
+          add_remove_schema,
+          DiscourseWorkflows::Schema::GROUP_SCHEMA,
+          DiscourseWorkflows::Schema.resolve(
+            DiscourseWorkflows::Schema::GROUP_MEMBERSHIP_SCHEMA,
+            mode: :merge,
+            input_schema: input_schema,
+          ),
+        ),
+      ],
+    )
+  end
+
+  it "keeps the fallbacks that declare something and drops the ones that do not",
+     :aggregate_failures do
+    expect(
+      DiscourseWorkflows::Nodes::Wait::V1.output_schemas(
+        { "resume" => "={{ $json.kind }}" },
+        input_schemas: [input_schema],
+      ),
+    ).to eq(
+      [
+        DiscourseWorkflows::Schema.union(
+          DiscourseWorkflows::Schema::WEBHOOK_REQUEST_SCHEMA,
+          input_schema,
+        ),
+      ],
+    )
+
+    expect(
+      DiscourseWorkflows::Nodes::Merge::V1.output_schemas(
+        { "mode" => "={{ $json.mode }}", "resolve_clash" => "add_suffix" },
+        input_schemas: [input_schema],
+      ),
+    ).to eq([input_schema])
+  end
+
   it "accepts every JSON body shape produced by webhook requests" do
     request =
       DiscourseWorkflows::WebhookRequest.new(

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_spec.rb
@@ -329,6 +329,36 @@ RSpec.describe DiscourseWorkflows::Schema do
         false,
       )
     end
+
+    it "keeps targets visible when a controlling parameter is an expression" do
+      display_options = { show: { operation: %w[add remove] } }
+
+      expect(described_class.visible?(display_options, operation: "={{ $json.op }}")).to eq(true)
+    end
+  end
+
+  describe ".display_state" do
+    let(:expression) { "={{ $json.op }}" }
+
+    it "treats an expression anchor as indeterminate rather than a failed rule",
+       :aggregate_failures do
+      shown = { show: { operation: %w[add remove] } }
+
+      expect(described_class.display_state(shown, operation: "add")).to eq(:visible)
+      expect(described_class.display_state(shown, operation: "get")).to eq(:hidden)
+      expect(described_class.display_state(shown, operation: expression)).to eq(:indeterminate)
+
+      hidden = { hide: { operation: %w[get] } }
+      expect(described_class.display_state(hidden, operation: expression)).to eq(:indeterminate)
+
+      two_rules = { show: { operation: %w[add], source: %w[csv] } }
+      expect(described_class.display_state(two_rules, operation: expression, source: "json")).to eq(
+        :hidden,
+      )
+      expect(described_class.display_state(two_rules, operation: expression, source: "csv")).to eq(
+        :indeterminate,
+      )
+    end
   end
 
   describe ".resolve_graph" do

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-issues-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-issues-test.js
@@ -96,6 +96,27 @@ module("Unit | lib | discourse-workflows | node-issues", function () {
     );
   });
 
+  test("waives required issues while the gate holds an expression", function (assert) {
+    const schema = {
+      operation: { type: "options", default: "add" },
+      username: {
+        type: "string",
+        required: true,
+        display_options: { show: { operation: ["add", "remove"] } },
+      },
+    };
+
+    assert.deepEqual(
+      getNodeIssues({ operation: "={{ $json.op }}" }, schema),
+      []
+    );
+
+    assert.deepEqual(
+      getNodeIssues({ operation: "add" }, schema).map((i) => i.path),
+      ["username"]
+    );
+  });
+
   test("walks optional fields inside fixed collections", function (assert) {
     const schema = {
       form_fields: {

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
@@ -4,6 +4,7 @@ import {
   collectionAddLabel,
   emptyCollectionItem,
   fieldControl,
+  fieldDisplayState,
   fieldFormat,
   fieldSupportsExpression,
   fieldValue,
@@ -374,6 +375,51 @@ module("Unit | Utility | workflows property engine", function () {
     );
     assert.false(
       fieldVisible(combined, { method: "POST", content_type: "raw" })
+    );
+  });
+
+  test("treats an expression anchor as indeterminate rather than a failed rule", function (assert) {
+    const expression = "={{ $json.op }}";
+    const state = fieldDisplayState;
+
+    const shown = {
+      display_options: { show: { operation: ["add", "remove"] } },
+    };
+    assert.strictEqual(state(shown, { operation: "add" }), "visible");
+    assert.strictEqual(state(shown, { operation: "get" }), "hidden");
+    assert.strictEqual(
+      state(shown, { operation: expression }),
+      "indeterminate"
+    );
+    assert.true(
+      fieldVisible(shown, { operation: expression }),
+      "an indeterminate field is still rendered"
+    );
+
+    const hidden = { display_options: { hide: { operation: ["get"] } } };
+    assert.strictEqual(
+      state(hidden, { operation: expression }),
+      "indeterminate",
+      "an expression anchor does not trigger a hide rule either"
+    );
+
+    const twoRules = {
+      display_options: { show: { operation: ["add"], source: ["csv"] } },
+    };
+    assert.strictEqual(
+      state(twoRules, { operation: expression, source: "json" }),
+      "hidden",
+      "a rule that definitely fails settles the field despite the expression"
+    );
+    assert.strictEqual(
+      state(twoRules, { operation: expression, source: "csv" }),
+      "indeterminate"
+    );
+
+    assert.strictEqual(
+      state({ ...shown, ui: { hidden: true } }, { operation: expression }),
+      "hidden",
+      "ui.hidden is not a rule and stays definite"
     );
   });
 

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-schema-graph-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-schema-graph-test.js
@@ -225,9 +225,14 @@ module("Unit | lib | discourse-workflows | schema-graph", function () {
       configuration: { resume: "time" },
     });
     const chooser = node("chooser", "action:chooser");
+    const blender = node("blender", "flow:blender");
     const graph = {
-      nodes: [node("source", "trigger:source"), wait, chooser],
-      connections: [conn("source", "wait"), conn("source", "chooser")],
+      nodes: [node("source", "trigger:source"), wait, chooser, blender],
+      connections: [
+        conn("source", "wait"),
+        conn("source", "chooser"),
+        conn("source", "blender"),
+      ],
       nodeTypes: [
         triggerType("trigger:source", src),
         nodeType("flow:wait", [
@@ -255,6 +260,12 @@ module("Unit | lib | discourse-workflows | schema-graph", function () {
                 display_options: { show: { mode: ["variant"] } },
               },
             ],
+          },
+        ]),
+        nodeType("flow:blender", [
+          {
+            mode: "passthrough",
+            variants: [{ display_options: { show: { mode: ["combine"] } } }],
           },
         ]),
       ],
@@ -288,6 +299,27 @@ module("Unit | lib | discourse-workflows | schema-graph", function () {
       out(chooser, { configuration: { mode: "other" } }),
       {},
       "no matching contract resolves to unknown without passing the input through"
+    );
+
+    assert.deepEqual(
+      out(wait, { configuration: { resume: "={{ $json.kind }}" } }),
+      { $schema: DRAFT_URI, anyOf: [src, hook] },
+      "an expression-valued controlling parameter unions the variants in contention, leaving out an empty-replace fallback"
+    );
+    assert.deepEqual(
+      out(chooser, { configuration: { mode: "={{ $json.mode }}" } }),
+      { $schema: DRAFT_URI, anyOf: [variant, base] },
+      "the declared fallback contract stays in contention alongside indeterminate variants"
+    );
+    assert.deepEqual(
+      out(blender, { configuration: { mode: "={{ $json.mode }}" } }),
+      src,
+      "a schema-less variant leaves contention rather than collapsing the union"
+    );
+    assert.deepEqual(
+      out(blender, { configuration: { mode: "combine" } }),
+      {},
+      "a schema-less variant that definitely matches still resolves to unknown"
     );
   });
 


### PR DESCRIPTION
Display rules compare the parameter they are anchored on against the literals they expect, which an expression can never equal. Everything gated on a dynamic parameter therefore behaved as if the gate had definitely failed: the field disappeared from the configurator, so a value the node still needs at runtime could no longer be entered, and its required-field check disappeared with it instead of being waived on purpose. Output contracts were chosen the same way, so the node ended up declaring no schema at all and downstream nodes had nothing to pick from.

An anchor holding an expression is not a rule that failed, it is a rule that cannot be answered yet, and that deserves a state of its own: the target stays visible with its hard requirements suspended until the gate is known, and every variant still in contention contributes to the output schema rather than none of them.

The editor and the server judged all of this independently, so the two drew different conclusions from the same workflow — and the server did not even agree with itself, carrying three copies of the matching. Sharing one is also what stops a credential slot gated on an expression from being discarded on save while the editor still shows it.

All of that because I wanted the `operation` parameter of a "add user to group" node to be dynamic, and when doing that, it would hide the `user` parameter 😅

<img width="1372" height="720" alt="before-after" src="https://github.com/user-attachments/assets/ff854611-c809-421a-a904-b40ccb91ede4" />

