### PR TITLE
SECURITY: Escape embed URL for HTML attribute context in footer

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -36,7 +36,7 @@ class TopicEmbed < ActiveRecord::Base
   end
 
   def self.imported_from_html(url)
-    url = UrlHelper.normalized_encode(url)
+    url = ERB::Util.html_escape(UrlHelper.normalized_encode(url))
     I18n.with_locale(SiteSetting.default_locale) do
       "\n<hr>\n<small>#{I18n.t("embed.imported_from", link: "<a href='#{url}'>#{url}</a>")}</small>\n"
     end

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -832,6 +832,15 @@ RSpec.describe TopicEmbed do
         "\n<hr>\n<small>This is a companion discussion topic for the original entry at <a href='http://www.discourse.org/%23%3C/a%3E%3Cimg%20src=x%20onerror=alert(%22document.domain%22);%3E'>http://www.discourse.org/%23%3C/a%3E%3Cimg%20src=x%20onerror=alert(%22document.domain%22);%3E</a></small>\n"
       expect(html).to eq(expected_html)
     end
+
+    it "escapes the URL in the raw HTML footer" do
+      url = "http://eviltrout.com/'onmouseover='window.topicEmbedXssExecuted=true"
+      link = Nokogiri::HTML5.fragment(TopicEmbed.imported_from_html(url)).at_css("a")
+
+      expect(link["href"]).to eq(url)
+      expect(link["onmouseover"]).to be_nil
+      expect(link.text).to eq(url)
+    end
   end
 
   describe ".expanded_for" do

--- a/spec/system/topic_embed_spec.rb
+++ b/spec/system/topic_embed_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "Imported topic embeds" do
+  fab!(:embeddable_host) { Fabricate(:embeddable_host, host: "eviltrout.com") }
+
+  let(:embed_url) { "http://eviltrout.com/'onmouseover='window.topicEmbedXssExecuted=true" }
+
+  before do
+    SiteSetting.content_security_policy = false
+    SiteSetting.import_embed_unlisted = false
+    Jobs.run_immediately!
+    stub_request(:get, embed_url).to_return(
+      status: 200,
+      body: "<html><title>Embedded article</title><body><p>Article content</p></body></html>",
+    )
+  end
+
+  it "does not execute JavaScript from an imported URL" do
+    visit("/embed/comments?#{{ embed_url: embed_url }.to_query}")
+    expect(page).to have_content(I18n.t("embed.loading"))
+
+    visit(TopicEmbed.last.post.topic.url)
+    link = find("#post_1 .cooked a", text: embed_url)
+
+    page.execute_script("window.topicEmbedXssExecuted = false")
+    link.hover
+
+    expect(page.evaluate_script("window.topicEmbedXssExecuted")).to eq(false)
+    expect(link["onmouseover"]).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

TopicEmbed.imported_from_html interpolated a URL-normalized value directly into a single-quoted href attribute and display text. URL normalization preserves apostrophes, allowing a crafted embed URL to inject an HTML event-handler attribute into the companion footer. The fix applies HTML escaping after URL normalization, preventing the value from breaking out of its attribute or text contexts. Both the import and expand embed paths are covered because they share the same generated footer.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1544

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>