### PR TITLE
FIX: Ensure email_verified is properly checked for true values in OAuth2 Basic

### DIFF
--- a/plugins/discourse-oauth2-basic/lib/oauth2_basic_authenticator.rb
+++ b/plugins/discourse-oauth2-basic/lib/oauth2_basic_authenticator.rb
@@ -255,10 +255,9 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
 
   def primary_email_verified?(auth)
     return true if SiteSetting.oauth2_email_verified
-    verified = auth["info"]["email_verified"]
-    verified = true if verified == "true"
-    verified = false if verified == "false"
-    verified
+
+    email_verified = auth["info"]["email_verified"]
+    email_verified == true || (email_verified.is_a?(String) && email_verified.downcase == "true")
   end
 
   def always_update_user_email?

--- a/plugins/discourse-oauth2-basic/spec/integration/overrides_email_spec.rb
+++ b/plugins/discourse-oauth2-basic/spec/integration/overrides_email_spec.rb
@@ -36,6 +36,30 @@ describe "OAuth2 Overrides Email", type: :request do
     expect(user.reload.email).to eq(initial_email)
   end
 
+  it "doesn't link an unverified provider account to a matching email" do
+    SiteSetting.oauth2_email_verified = false
+    OmniAuth.config.mock_auth[:oauth2_basic] = OmniAuth::AuthHash.new(
+      provider: "oauth2_basic",
+      uid: "unverified-provider-uid",
+      info: OmniAuth::AuthHash::InfoHash.new(email: user.email, email_verified: "pending"),
+      extra: OmniAuth::AuthHash.new,
+      credentials: OmniAuth::AuthHash.new,
+    )
+
+    get "/auth/oauth2_basic/callback"
+
+    expect(response.status).to eq(302)
+    expect(response.body).to be_blank
+    expect(session[:current_user_id]).to be_nil
+    expect(
+      UserAssociatedAccount.exists?(
+        provider_name: "oauth2_basic",
+        provider_uid: "unverified-provider-uid",
+        user: user,
+      ),
+    ).to eq(false)
+  end
+
   it "updates user email if enabled" do
     SiteSetting.oauth2_overrides_email = true
 

--- a/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
+++ b/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
@@ -62,6 +62,22 @@ describe OAuth2BasicAuthenticator do
       expect(result.email_valid).to eq(false)
     end
 
+    it "only accepts explicit verified email values" do
+      SiteSetting.oauth2_email_verified = false
+
+      [true, "true", "True", "TRUE"].each do |email_verified|
+        expect(
+          authenticator.primary_email_verified?(auth.deep_merge(info: { email_verified: })),
+        ).to eq(true)
+      end
+
+      [false, nil, "false", "pending", 0, [], {}].each do |email_verified|
+        expect(
+          authenticator.primary_email_verified?(auth.deep_merge(info: { email_verified: })),
+        ).to eq(false)
+      end
+    end
+
     describe "fetch_user_details" do
       before(:each) do
         SiteSetting.oauth2_fetch_user_details = true


### PR DESCRIPTION
## Summary

Correctly treat only Boolean true or the string "true" (case-insensitively) as an email-verified claim in the OAuth2 Basic authenticator. Previously any truthy non-boolean value (e.g., "pending", 0, arrays) was accepted as verified, which allowed external provider identities with non-verified email states to auto-link to existing Discourse accounts. The fix applies a strict whitelist matching the pattern used by the sibling OpenID Connect authenticator.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1505

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>