### PR TITLE
FIX: Stop Admin Assistant chain at pending approval

### DIFF
--- a/plugins/discourse-ai/lib/agents/agent.rb
+++ b/plugins/discourse-ai/lib/agents/agent.rb
@@ -268,6 +268,10 @@ module DiscourseAi
         []
       end
 
+      def stop_chain_on_pending_approval?
+        false
+      end
+
       def temperature
         nil
       end

--- a/plugins/discourse-ai/lib/agents/bot.rb
+++ b/plugins/discourse-ai/lib/agents/bot.rb
@@ -207,19 +207,26 @@ module DiscourseAi
                   needs_newlines = false
                 end
 
-                process_tool(
-                  tool: tool,
-                  raw_context: raw_context,
-                  current_llm: current_llm,
-                  update_blk: update_blk,
-                  prompt: prompt,
-                  context: context,
-                  current_thinking: current_thinking,
-                )
+                tool_result =
+                  process_tool(
+                    tool: tool,
+                    raw_context: raw_context,
+                    current_llm: current_llm,
+                    update_blk: update_blk,
+                    prompt: prompt,
+                    context: context,
+                    current_thinking: current_thinking,
+                  )
 
-                ongoing_chain &&= tool.chain_next_response?
+                chain_next_response =
+                  tool.chain_next_response? &&
+                    !(
+                      agent.stop_chain_on_pending_approval? && tool_result.is_a?(Hash) &&
+                        tool_result[:status] == "pending_approval"
+                    )
+                ongoing_chain &&= chain_next_response
 
-                tool_halted = true if !tool.chain_next_response?
+                tool_halted = true if !chain_next_response
               else
                 next if tool_halted
                 needs_newlines = true
@@ -406,7 +413,8 @@ module DiscourseAi
         current_thinking:
       )
         tool_call_id = tool.tool_call_id
-        invocation_result_json = invoke_tool(tool, context, &update_blk).to_json
+        invocation_result = invoke_tool(tool, context, &update_blk)
+        invocation_result_json = invocation_result.to_json
 
         tool_call_message = {
           type: :tool_call,
@@ -454,6 +462,7 @@ module DiscourseAi
           tool.provider_data.presence,
         ]
         raw_context << [invocation_result_json, tool_call_id, "tool", tool.name]
+        invocation_result
       end
 
       def invoke_tool(tool, context, &update_blk)

--- a/plugins/discourse-ai/lib/agents/discourse_admin_assistant.rb
+++ b/plugins/discourse-ai/lib/agents/discourse_admin_assistant.rb
@@ -7,6 +7,10 @@ module DiscourseAi
         "low"
       end
 
+      def stop_chain_on_pending_approval?
+        true
+      end
+
       def tools
         [
           Tools::DiscourseMetaSearch,
@@ -46,7 +50,10 @@ module DiscourseAi
           - You are able to find information about site settings, request context for a specific setting, and look up the current value of a site setting.
           - Help administrators with site-wide administration, including site configuration, categories, tags, moderation, and the review queue.
           - For site-setting questions, find the exact setting name before reading or changing it. Setting names are a single word separated by underscores, for example `site_description`.
-          - Only change site settings, categories, tags, reviewable content, topics, posts, or users when an administrator explicitly asks you to do so. Before requesting a change, clearly state the affected item, the proposed action, its expected effect, and the reason for the change.
+          - Only change site settings, categories, tags, reviewable content, topics, posts, or users when an administrator explicitly asks you to do so.
+          - When an administrator explicitly requests a change and provides the required details, invoke the corresponding write tool before writing any response. If required details are missing, ask for them. Never merely describe or simulate a submitted change.
+          - Invoke a separate write tool call for every requested change, including repeated requests and multiple changes in the same message. Previous tool calls never apply to later requests.
+          - Only say that a change is pending approval when the write tool returned a pending approval result in the current turn.
           - Every change requires human approval. Never imply that a pending change has been applied.
           - Be a helpful teacher and explain the trade-offs of each setting.
 

--- a/plugins/discourse-ai/spec/lib/agents/discourse_admin_assistant_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/discourse_admin_assistant_spec.rb
@@ -37,12 +37,21 @@ RSpec.describe DiscourseAi::Agents::DiscourseAdminAssistant do
   it "requires an administrator request and approval before changing settings" do
     expect(assistant.system_prompt).to include(
       "Only change site settings, categories, tags, reviewable content, topics, posts, or users when an administrator explicitly asks you to do so.",
+      "When an administrator explicitly requests a change and provides the required details, invoke the corresponding write tool before writing any response.",
+      "If required details are missing, ask for them.",
+      "Invoke a separate write tool call for every requested change, including repeated requests and multiple changes in the same message.",
+      "Previous tool calls never apply to later requests.",
+      "Only say that a change is pending approval when the write tool returned a pending approval result in the current turn.",
       "Every change requires human approval.",
     )
   end
 
   it "is registered as a system agent with a deterministic id" do
     expect(DiscourseAi::Agents::Agent.system_agents[described_class]).to eq(-39)
+  end
+
+  it "stops tool chains while an action is pending approval" do
+    expect(assistant.stop_chain_on_pending_approval?).to eq(true)
   end
 
   it "is only available to administrators" do

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
@@ -710,6 +710,10 @@ RSpec.describe DiscourseAi::AiBot::Playground do
         first_target = Fabricate(:user)
         second_target = Fabricate(:user)
         agent.update!(tools: ["SuspendUser"], require_approval: true)
+        DiscourseAi::Agents::Agent
+          .any_instance
+          .stubs(:stop_chain_on_pending_approval?)
+          .returns(true)
 
         first_tool_call =
           DiscourseAi::Completions::ToolCall.new(
@@ -742,6 +746,13 @@ RSpec.describe DiscourseAi::AiBot::Playground do
           Chat::Message.where(chat_channel: dm_channel).where.not(blocks: nil).order(:id)
         reviewable_ids = ReviewableAiToolAction.order(:id).last(2).map(&:id)
 
+        expect(approval_messages.count).to eq(2)
+        expect(
+          Chat::Message.exists?(
+            chat_channel: dm_channel,
+            message: "Both actions are awaiting approval.",
+          ),
+        ).to eq(false)
         expect(
           approval_messages.map do |approval_message|
             approval_message.blocks.first["elements"].map { |element| element["action_id"] }


### PR DESCRIPTION
Previously, approval-required Admin Assistant tools chained into another model response, which could replace the interactive approval card with a non-interactive pending-approval summary.

This change adds a default-off `stop_chain_on_pending_approval?` agent capability, enables it for the Admin Assistant, processes every tool call in the current response, and then leaves the approval cards as the authoritative result.