### PR TITLE
SECURITY: Enforce first-post visibility for topic bookmarks

### DIFF
--- a/app/services/topic_bookmarkable.rb
+++ b/app/services/topic_bookmarkable.rb
@@ -25,22 +25,22 @@ class TopicBookmarkable < BaseBookmarkable
   def self.list_query(user, guardian)
     topics = Topic.listable_topics.secured(guardian)
     pms = Topic.private_messages_for_user(user)
+    first_posts = guardian.filter_hidden_posts(Post.secured(guardian).where(deleted_at: nil))
     topic_bookmarks =
       user
         .bookmarks_of_type("Topic")
         .joins(
           "INNER JOIN topics ON topics.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Topic'",
         )
+        .joins("INNER JOIN posts ON posts.topic_id = topics.id AND posts.post_number = 1")
         .joins("LEFT JOIN topic_users ON topic_users.topic_id = topics.id")
         .where("topic_users.user_id = ?", user.id)
-    guardian.filter_allowed_categories(topic_bookmarks.merge(topics.or(pms)))
+    guardian.filter_allowed_categories(topic_bookmarks.merge(topics.or(pms)).merge(first_posts))
   end
 
   def self.search_query(bookmarks, query, ts_query, &bookmarkable_search)
     bookmarkable_search.call(
-      bookmarks.joins(
-        "LEFT JOIN posts ON posts.topic_id = topics.id AND posts.post_number = 1",
-      ).joins("LEFT JOIN post_search_data ON post_search_data.post_id = posts.id"),
+      bookmarks.joins("LEFT JOIN post_search_data ON post_search_data.post_id = posts.id"),
       "#{ts_query} @@ post_search_data.search_data",
     )
   end
@@ -66,7 +66,7 @@ class TopicBookmarkable < BaseBookmarkable
   end
 
   def self.can_see_bookmarkable?(guardian, bookmarkable)
-    guardian.can_see_topic?(bookmarkable)
+    guardian.can_see_post?(bookmarkable&.first_post)
   end
 
   def self.bookmark_metadata(bookmark, user)
@@ -74,7 +74,7 @@ class TopicBookmarkable < BaseBookmarkable
   end
 
   def self.validate_before_create(guardian, bookmarkable)
-    raise Discourse::InvalidAccess if bookmarkable.blank? || !guardian.can_see_topic?(bookmarkable)
+    raise Discourse::InvalidAccess if !can_see_bookmarkable?(guardian, bookmarkable)
   end
 
   def self.after_create(guardian, bookmark, opts)

--- a/spec/lib/bookmark_query_spec.rb
+++ b/spec/lib/bookmark_query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BookmarkQuery do
 
   describe "#count_all" do
     fab!(:post_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:post)) }
-    fab!(:topic_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:topic)) }
+    fab!(:topic_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:topic_with_op)) }
 
     before do
       Fabricate(:topic_user, user:, topic: post_bookmark.bookmarkable.topic)
@@ -44,7 +44,7 @@ RSpec.describe BookmarkQuery do
 
   describe "#list_all" do
     fab!(:post_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:post)) }
-    fab!(:topic_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:topic)) }
+    fab!(:topic_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:topic_with_op)) }
 
     let(:user_bookmark) do
       Fabricate(:bookmark, user:, bookmarkable: Fabricate(:user, username: "bookmarkqueen"))

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -363,10 +363,10 @@ RSpec.describe TopicsFilter do
     end
 
     describe "when filtering with the `in` filter" do
-      fab!(:topic)
+      fab!(:topic, :topic_with_op)
 
       fab!(:pinned_topic) do
-        Fabricate(:topic, pinned_at: Time.zone.now, pinned_until: 1.hour.from_now)
+        Fabricate(:topic_with_op, pinned_at: Time.zone.now, pinned_until: 1.hour.from_now)
       end
 
       fab!(:expired_pinned_topic) do

--- a/spec/models/user_bookmark_list_spec.rb
+++ b/spec/models/user_bookmark_list_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserBookmarkList do
   after { DiscoursePluginRegistry.reset! }
 
   let(:post_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:post)) }
-  let(:topic_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:topic)) }
+  let(:topic_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:topic_with_op)) }
   let(:user_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:user)) }
 
   it "returns all types of bookmarks" do

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe UserSummary do
   describe "#bookmark_count" do
     fab!(:user)
     fab!(:post_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:post)) }
-    fab!(:topic_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:topic)) }
+    fab!(:topic_bookmark) { Fabricate(:bookmark, user:, bookmarkable: Fabricate(:topic_with_op)) }
 
     let(:summary) { UserSummary.new(user, Guardian.new(user)) }
 

--- a/spec/requests/bookmarks_controller_spec.rb
+++ b/spec/requests/bookmarks_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BookmarksController do
   let(:user_2) { Fabricate(:user) }
   let(:bookmark_post) { Fabricate(:post) }
   let(:bookmark_post_2) { Fabricate(:post) }
-  let(:bookmark_topic) { Fabricate(:topic) }
+  let(:bookmark_topic) { Fabricate(:topic_with_op) }
   let(:bookmark_user) { current_user }
 
   describe "#create" do

--- a/spec/requests/bookmarks_controller_spec.rb
+++ b/spec/requests/bookmarks_controller_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe BookmarksController do
         )
       end
     end
+
+    it "returns a 403 when the first post of a topic is hidden" do
+      hidden_topic = Fabricate(:topic_with_op)
+      hidden_topic.first_post.update!(hidden: true)
+
+      post "/bookmarks.json",
+           params: {
+             bookmarkable_id: hidden_topic.id,
+             bookmarkable_type: "Topic",
+           }
+
+      expect(response.status).to eq(403)
+      expect(Bookmark.find_by(user: current_user, bookmarkable: hidden_topic)).to be_nil
+    end
   end
 
   describe "#destroy" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7909,14 +7909,14 @@ RSpec.describe UsersController do
   describe "#bookmarks excerpts" do
     fab!(:user)
     let!(:topic) { Fabricate(:topic, user: user) }
-    let!(:post) { Fabricate(:post, topic: topic) }
+    let!(:topic_post) { Fabricate(:post, topic: topic) }
     let!(:bookmark) { Fabricate(:bookmark, name: "Test", user: user, bookmarkable: topic) }
 
     it "uses the first post of the topic for the bookmarks excerpt" do
       TopicUser.change(
         user.id,
         bookmark.bookmarkable.id,
-        { last_read_post_number: post.post_number },
+        { last_read_post_number: topic_post.post_number },
       )
 
       sign_in(user)
@@ -7928,19 +7928,13 @@ RSpec.describe UsersController do
       expect(bookmark_list.first["excerpt"]).to eq(expected_excerpt)
     end
 
-    it "does not expose excerpts for hidden bookmarked posts the user cannot see" do
+    it "does not expose excerpts for hidden post bookmarks the user cannot see" do
       hidden_post_raw = "hidden post bookmark secret " * 20
-      hidden_topic_raw = "hidden topic bookmark secret " * 20
       hidden_post = Fabricate(:post, raw: hidden_post_raw)
-      hidden_topic = Fabricate(:topic)
-      hidden_first_post = Fabricate(:post, topic: hidden_topic, raw: hidden_topic_raw)
       hidden_post_bookmark = Fabricate(:bookmark, user: user, bookmarkable: hidden_post)
-      hidden_topic_bookmark = Fabricate(:bookmark, user: user, bookmarkable: hidden_topic)
 
       TopicUser.change(user.id, hidden_post.topic_id, total_msecs_viewed: 1)
-      TopicUser.change(user.id, hidden_topic.id, total_msecs_viewed: 1)
       hidden_post.update!(hidden: true)
-      hidden_first_post.update!(hidden: true)
 
       sign_in(user)
 
@@ -7948,18 +7942,70 @@ RSpec.describe UsersController do
       expect(response.status).to eq(200)
       bookmark_list = response.parsed_body["user_bookmark_list"]["bookmarks"]
       hidden_post_response = bookmark_list.find { |item| item["id"] == hidden_post_bookmark.id }
-      hidden_topic_response = bookmark_list.find { |item| item["id"] == hidden_topic_bookmark.id }
 
       expect(hidden_post_response).to be_present
       expect(hidden_post_response).not_to have_key("excerpt")
       expect(hidden_post_response).not_to have_key("truncated")
       expect(hidden_post_response).not_to have_key("cooked")
-      expect(hidden_topic_response).to be_present
-      expect(hidden_topic_response).not_to have_key("excerpt")
-      expect(hidden_topic_response).not_to have_key("truncated")
-      expect(hidden_topic_response).not_to have_key("cooked")
-      expect(response.body).not_to include("hidden post bookmark secret")
-      expect(response.body).not_to include("hidden topic bookmark secret")
+      expect(response.body).not_to include(hidden_post.raw)
+    end
+
+    it "prevents hidden first posts from being bookmarked, listed, or searched" do
+      SearchIndexer.enable
+      hidden_topic =
+        Fabricate(:topic, title: "Hidden topic bookmark secret title", user: Fabricate(:user))
+      hidden_first_post =
+        Fabricate(
+          :post,
+          topic: hidden_topic,
+          user: hidden_topic.user,
+          raw: "hidden topic bookmark secret body",
+        )
+
+      sign_in(user)
+      post "/bookmarks.json",
+           params: {
+             bookmarkable_id: hidden_topic.id,
+             bookmarkable_type: "Topic",
+           }
+      expect(response.status).to eq(200)
+      hidden_topic_bookmark = Bookmark.last
+
+      hidden_first_post.update!(hidden: true)
+
+      get "/u/#{user.username}/bookmarks.json"
+      expect(response.status).to eq(200)
+      bookmark_list = response.parsed_body.dig("user_bookmark_list", "bookmarks") || []
+      expect(bookmark_list.map { |bookmark_response| bookmark_response["id"] }).not_to include(
+        hidden_topic_bookmark.id,
+      )
+      expect(response.body).not_to include(hidden_topic.title)
+
+      get "/u/#{user.username}/bookmarks.json", params: { q: "hidden topic bookmark secret body" }
+      expect(response.status).to eq(200)
+      bookmark_list = response.parsed_body.dig("user_bookmark_list", "bookmarks") || []
+      expect(bookmark_list.map { |bookmark_response| bookmark_response["id"] }).not_to include(
+        hidden_topic_bookmark.id,
+      )
+
+      hidden_topic_to_bookmark =
+        Fabricate(:topic, title: "Unbookmarked hidden topic secret title", user: Fabricate(:user))
+      Fabricate(
+        :post,
+        topic: hidden_topic_to_bookmark,
+        user: hidden_topic_to_bookmark.user,
+        raw: "unbookmarked hidden topic secret body",
+        hidden: true,
+      )
+
+      post "/bookmarks.json",
+           params: {
+             bookmarkable_id: hidden_topic_to_bookmark.id,
+             bookmarkable_type: "Topic",
+           }
+      expect(response.status).to eq(403)
+      expect(Bookmark.find_by(user: user, bookmarkable: hidden_topic_to_bookmark)).to be_nil
+      expect(response.body).not_to include(hidden_topic_to_bookmark.title)
     end
 
     describe "bookmarkable_url" do
@@ -7968,7 +8014,7 @@ RSpec.describe UsersController do
           TopicUser.change(
             user.id,
             bookmark.bookmarkable.id,
-            { last_read_post_number: post.post_number },
+            { last_read_post_number: topic_post.post_number },
           )
 
           sign_in(user)
@@ -7978,7 +8024,7 @@ RSpec.describe UsersController do
           bookmark_list = response.parsed_body["bookmarks"]
 
           expect(bookmark_list.first["bookmarkable_url"]).to end_with(
-            "/t/#{topic.slug}/#{topic.id}/#{post.post_number + 1}",
+            "/t/#{topic.slug}/#{topic.id}/#{topic_post.post_number + 1}",
           )
         end
 
@@ -7986,7 +8032,7 @@ RSpec.describe UsersController do
           TopicUser.change(
             user.id,
             bookmark.bookmarkable.id,
-            { last_read_post_number: post.post_number },
+            { last_read_post_number: topic_post.post_number },
           )
 
           sign_in(user)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7950,7 +7950,7 @@ RSpec.describe UsersController do
       expect(response.body).not_to include(hidden_post.raw)
     end
 
-    it "prevents hidden first posts from being bookmarked, listed, or searched" do
+    it "prevents hidden first posts from being listed or searched" do
       SearchIndexer.enable
       hidden_topic =
         Fabricate(:topic, title: "Hidden topic bookmark secret title", user: Fabricate(:user))
@@ -7961,16 +7961,9 @@ RSpec.describe UsersController do
           user: hidden_topic.user,
           raw: "hidden topic bookmark secret body",
         )
+      hidden_topic_bookmark = Fabricate(:bookmark, user: user, bookmarkable: hidden_topic)
 
       sign_in(user)
-      post "/bookmarks.json",
-           params: {
-             bookmarkable_id: hidden_topic.id,
-             bookmarkable_type: "Topic",
-           }
-      expect(response.status).to eq(200)
-      hidden_topic_bookmark = Bookmark.last
-
       hidden_first_post.update!(hidden: true)
 
       get "/u/#{user.username}/bookmarks.json"
@@ -7987,25 +7980,6 @@ RSpec.describe UsersController do
       expect(bookmark_list.map { |bookmark_response| bookmark_response["id"] }).not_to include(
         hidden_topic_bookmark.id,
       )
-
-      hidden_topic_to_bookmark =
-        Fabricate(:topic, title: "Unbookmarked hidden topic secret title", user: Fabricate(:user))
-      Fabricate(
-        :post,
-        topic: hidden_topic_to_bookmark,
-        user: hidden_topic_to_bookmark.user,
-        raw: "unbookmarked hidden topic secret body",
-        hidden: true,
-      )
-
-      post "/bookmarks.json",
-           params: {
-             bookmarkable_id: hidden_topic_to_bookmark.id,
-             bookmarkable_type: "Topic",
-           }
-      expect(response.status).to eq(403)
-      expect(Bookmark.find_by(user: user, bookmarkable: hidden_topic_to_bookmark)).to be_nil
-      expect(response.body).not_to include(hidden_topic_to_bookmark.title)
     end
 
     describe "bookmarkable_url" do

--- a/spec/serializers/user_bookmark_list_serializer_spec.rb
+++ b/spec/serializers/user_bookmark_list_serializer_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe UserBookmarkListSerializer do
     after { DiscoursePluginRegistry.reset_register!(:bookmarkables) }
 
     let(:post_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:post)) }
-    let(:topic_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:topic)) }
+    let(:topic_bookmark) do
+      Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:topic_with_op))
+    end
     let(:user_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:user)) }
 
     def run_serializer

--- a/spec/services/topic_bookmarkable_spec.rb
+++ b/spec/services/topic_bookmarkable_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TopicBookmarkable do
   let!(:topic1) { Fabricate(:topic) }
   let!(:topic2) { Fabricate(:topic) }
   let!(:post) { Fabricate(:post, topic: topic1) }
+  let!(:post2) { Fabricate(:post, topic: topic2) }
   let!(:bookmark1) do
     Fabricate(:bookmark, user: user, bookmarkable: topic1, name: "something i gotta do")
   end
@@ -93,6 +94,12 @@ RSpec.describe TopicBookmarkable do
       expect(registered_bookmarkable.can_send_reminder?(bookmark1)).to eq(true)
       bookmark1.bookmarkable.trash!
       bookmark1.reload
+      expect(registered_bookmarkable.can_send_reminder?(bookmark1)).to eq(false)
+    end
+
+    it "cannot send a reminder if the first post is hidden" do
+      expect(registered_bookmarkable.can_send_reminder?(bookmark1)).to eq(true)
+      bookmark1.bookmarkable.first_post.update!(hidden: true)
       expect(registered_bookmarkable.can_send_reminder?(bookmark1)).to eq(false)
     end
 


### PR DESCRIPTION
## Summary

Topic bookmark creation, listing, search, and reminder eligibility now require the first post to be visible to the user. The fix adds an inner join on the first post with hidden-post filtering to the list query and delegates creation and visibility checks to `guardian.can_see_post?` on the first post, preventing an authenticated user from bookmarking a topic or searching its metadata after the first post is hidden.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1530

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>