### PR TITLE
FIX: Whisper access bypass for removed users on single-post endpoints

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -183,6 +183,7 @@ module PostGuardian
     return false if !trusted_with_post_edits?
 
     if is_my_own?(post)
+      return false if !is_staff? && !Topic.visible_post_types(@user).include?(post.post_type)
       return false if @user.silenced?
 
       return can_edit_hidden_post?(post) if post.hidden?
@@ -310,7 +311,7 @@ module PostGuardian
     return false if post.blank?
     return true if is_admin?
     return false unless can_see_post_topic?(post)
-    return false unless is_my_own?(post) || Topic.visible_post_types(@user).include?(post.post_type)
+    return false if Topic.visible_post_types(@user).exclude?(post.post_type)
     return true if is_moderator? || is_category_group_moderator?(post.topic.category)
     if (!post.trashed? || can_see_deleted_post?(post)) &&
          (!post.hidden? || can_see_hidden_post?(post))

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -1123,7 +1123,7 @@ RSpec.describe PostGuardian do
       expect(Guardian.new(user2).can_see?(post)).to eq(false)
     end
 
-    it "respects whispers" do
+    it "requires current whisper group membership" do
       SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{group.id}"
 
       regular_post = post
@@ -1138,9 +1138,8 @@ RSpec.describe PostGuardian do
       expect(regular_guardian.can_see?(regular_post)).to eq(true)
       expect(regular_guardian.can_see?(whisper_post)).to eq(false)
 
-      # can see your own whispers
       regular_whisper = Fabricate(:post, post_type: Post.types[:whisper], user: regular_user)
-      expect(regular_guardian.can_see?(regular_whisper)).to eq(true)
+      expect(regular_guardian.can_see?(regular_whisper)).to eq(false)
 
       mod_guardian = Guardian.new(Fabricate(:moderator))
       expect(mod_guardian.can_see?(regular_post)).to eq(true)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -228,6 +228,47 @@ RSpec.describe PostsController do
     end
   end
 
+  describe "whisper visibility" do
+    it "blocks removed whisperers from their own whisper", :aggregate_failures do
+      whisper_group = Fabricate(:group)
+      whisper_author = Fabricate(:user, trust_level: TrustLevel[1])
+      topic = Fabricate(:topic)
+      Fabricate(:post, topic: topic)
+      original_raw = "staff-only whisper body"
+      edited_raw = "edited whisper body"
+      whisper =
+        Fabricate(
+          :post,
+          topic: topic,
+          user: whisper_author,
+          post_type: Post.types[:whisper],
+          raw: original_raw,
+        )
+
+      SiteSetting.whispers_allowed_groups = whisper_group.id.to_s
+      whisper_group.add(whisper_author)
+      whisper_group.remove(whisper_author)
+      sign_in(User.find(whisper_author.id))
+
+      get "/posts/#{whisper.id}.json"
+      expect(response).to be_forbidden
+      expect(response.body).not_to include(whisper.raw)
+
+      get "/posts/by_number/#{topic.id}/#{whisper.post_number}.json"
+      expect(response).to be_forbidden
+      expect(response.body).not_to include(whisper.raw)
+
+      get "/raw/#{topic.id}/#{whisper.post_number}"
+      expect(response.status).to eq(404)
+      expect(response.body).not_to include(whisper.raw)
+
+      put "/posts/#{whisper.id}.json", params: { post: { raw: edited_raw } }
+      expect(response).to be_forbidden
+      expect(response.body).not_to include(edited_raw)
+      expect(whisper.reload.raw).to eq(original_raw)
+    end
+  end
+
   describe "#by_date" do
     include_examples "finding and showing post" do
       let(:url) { "/posts/by-date/#{post.topic_id}/#{post.created_at.strftime("%Y-%m-%d")}.json" }


### PR DESCRIPTION
## Summary

Prevent users removed from whisper-allowed groups from accessing or modifying their own whisper posts via single-post endpoints. The fix ensures that post-type visibility requirements are enforced in the Guardian even for post owners, preventing unauthorized read and write access to the staff-only whisper stream.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1316

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>