### PR TITLE
FIX: updates workflow plugin URL

### DIFF
--- a/plugins/discourse-workflows/config/settings.yml
+++ b/plugins/discourse-workflows/config/settings.yml
@@ -6,7 +6,7 @@ plugins:
     upcoming_change:
       status: "experimental"
       impact: "feature,admins"
-      learn_more_url: "https://meta.discourse.org/t/-/406990"
+      learn_more_url: "https://meta.discourse.org/t/-/407100"
       allow_enabled_for:
         - everyone
       requires_plugin_enabled: false

--- a/plugins/discourse-workflows/plugin.rb
+++ b/plugins/discourse-workflows/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-workflows
 # about: Workflow automation system for Discourse
-# meta_topic_id: 406990
+# meta_topic_id: 407100
 # version: 0.1
 # authors: Discourse
 # url: https://github.com/discourse/discourse-workflows


### PR DESCRIPTION
It was previously using the initial announcement as reference topic.