### PR TITLE
FIX: Authorize Retried AI Bot Replies Against Topic Creator

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/bot_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/bot_controller.rb
@@ -79,12 +79,16 @@ module DiscourseAi
 
         agent_id = retry_agent_id(post, prompt_post)
         llm_model_id = post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD]
+        authorization_user_id =
+          post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD].presence
+        authorization_user_id = authorization_user_id.to_i if authorization_user_id
+        authorization_user_id ||= prompt_post.topic.user_id
 
         args = {
           post_id: prompt_post.id,
           bot_user_id: post.user_id,
           agent_id: agent_id,
-          agent_user_id: prompt_post.topic.user_id,
+          authorization_user_id: authorization_user_id,
           reply_post_id: post.id,
         }
 

--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/bot_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/bot_controller.rb
@@ -83,6 +83,7 @@ module DiscourseAi
           post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD].presence
         authorization_user_id = authorization_user_id.to_i if authorization_user_id
         authorization_user_id ||= prompt_post.topic.user_id
+        raise Discourse::InvalidAccess if authorization_user_id.blank?
 
         args = {
           post_id: prompt_post.id,

--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/bot_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/bot_controller.rb
@@ -84,6 +84,7 @@ module DiscourseAi
           post_id: prompt_post.id,
           bot_user_id: post.user_id,
           agent_id: agent_id,
+          agent_user_id: prompt_post.topic.user_id,
           reply_post_id: post.id,
         }
 

--- a/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
+++ b/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
@@ -34,14 +34,8 @@ module Jobs
             post,
             feature_name: "bot",
             existing_reply_post: reply_post,
+            authorization_user_id: authorization_user.id,
           )
-
-        if reply_post
-          reply_post.custom_fields[
-            DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD
-          ] = authorization_user.id
-          reply_post.save_custom_fields
-        end
       rescue DiscourseAi::Agents::Bot::BOT_NOT_FOUND
         Rails.logger.warn(
           "Bot not found for post #{post.id} - perhaps agent was deleted or bot was disabled",

--- a/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
+++ b/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
@@ -12,9 +12,10 @@ module Jobs
       return if reply_post && reply_post.topic_id != post.topic_id
       agent_id = args[:agent_id]
       authorization_user =
-        if args[:authorization_user_id].present?
+        if args.key?(:authorization_user_id)
           User.find_by(id: args[:authorization_user_id])
         else
+          # jobs enqueued before authorization provenance was recorded
           post.user
         end
       return if authorization_user.nil?

--- a/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
+++ b/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
@@ -11,28 +11,36 @@ module Jobs
       return if args[:reply_post_id].present? && reply_post.nil?
       return if reply_post && reply_post.topic_id != post.topic_id
       agent_id = args[:agent_id]
-      agent_user =
-        if args[:agent_user_id].present?
-          User.find_by(id: args[:agent_user_id])
+      authorization_user =
+        if args[:authorization_user_id].present?
+          User.find_by(id: args[:authorization_user_id])
         else
           post.user
         end
-      return if agent_user.nil?
+      return if authorization_user.nil?
 
       llm_model_id = args[:llm_model_id]
 
       begin
-        agent = DiscourseAi::Agents::Agent.find_by(user: agent_user, id: agent_id)
+        agent = DiscourseAi::Agents::Agent.find_by(user: authorization_user, id: agent_id)
         raise DiscourseAi::Agents::Bot::BOT_NOT_FOUND if agent.nil?
 
         llm_model = LlmModel.find_by(id: llm_model_id.to_i) if !llm_model_id.to_i.zero?
         bot = DiscourseAi::Agents::Bot.as(bot_user, agent: agent.new, model: llm_model)
 
-        DiscourseAi::AiBot::Playground.new(bot).reply_to(
-          post,
-          feature_name: "bot",
-          existing_reply_post: reply_post,
-        )
+        reply_post =
+          DiscourseAi::AiBot::Playground.new(bot).reply_to(
+            post,
+            feature_name: "bot",
+            existing_reply_post: reply_post,
+          )
+
+        if reply_post
+          reply_post.custom_fields[
+            DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD
+          ] = authorization_user.id
+          reply_post.save_custom_fields
+        end
       rescue DiscourseAi::Agents::Bot::BOT_NOT_FOUND
         Rails.logger.warn(
           "Bot not found for post #{post.id} - perhaps agent was deleted or bot was disabled",

--- a/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
+++ b/plugins/discourse-ai/app/jobs/regular/create_ai_reply.rb
@@ -11,10 +11,18 @@ module Jobs
       return if args[:reply_post_id].present? && reply_post.nil?
       return if reply_post && reply_post.topic_id != post.topic_id
       agent_id = args[:agent_id]
+      agent_user =
+        if args[:agent_user_id].present?
+          User.find_by(id: args[:agent_user_id])
+        else
+          post.user
+        end
+      return if agent_user.nil?
+
       llm_model_id = args[:llm_model_id]
 
       begin
-        agent = DiscourseAi::Agents::Agent.find_by(user: post.user, id: agent_id)
+        agent = DiscourseAi::Agents::Agent.find_by(user: agent_user, id: agent_id)
         raise DiscourseAi::Agents::Bot::BOT_NOT_FOUND if agent.nil?
 
         llm_model = LlmModel.find_by(id: llm_model_id.to_i) if !llm_model_id.to_i.zero?

--- a/plugins/discourse-ai/lib/ai_bot.rb
+++ b/plugins/discourse-ai/lib/ai_bot.rb
@@ -7,6 +7,7 @@ module DiscourseAi
     POST_AI_LLM_NAME_FIELD = "ai_llm_name"
     POST_AI_LLM_MODEL_ID_FIELD = "ai_llm_model_id"
     POST_AI_AGENT_ID_FIELD = "ai_agent_id"
+    POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD = "ai_agent_authorization_user_id"
     TOPIC_AI_AGENT_ID_FIELD = "ai_agent_id"
     TOPIC_AI_AGENT_ID_MAX_LENGTH = 20
     PERSONAL_MESSAGE_CONTEXT = "discourse_ai.ai_bot_personal_message"

--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -147,11 +147,18 @@ module DiscourseAi
           topic_agent_id = post.topic.custom_fields["ai_agent_id"]
           topic_agent_id = topic_agent_id.to_i if topic_agent_id.present?
 
-          agent_id = mentioned&.dig(:id) || topic_agent_id
+          agent_user = post.user
+          if mentioned
+            agent_id = mentioned[:id]
+          else
+            agent_id = topic_agent_id
+            agent_user = post.topic.user if topic_agent_id
+          end
 
           agent = nil
 
-          agent = DiscourseAi::Agents::Agent.find_by(user: post.user, id: agent_id.to_i) if agent_id
+          agent =
+            DiscourseAi::Agents::Agent.find_by(user: agent_user, id: agent_id.to_i) if agent_id
 
           if !agent && (agent_name = post.topic.custom_fields["ai_agent"])
             agent = DiscourseAi::Agents::Agent.find_by(user: post.user, name: agent_name)
@@ -175,7 +182,7 @@ module DiscourseAi
           bot_user = User.find(agent.user_id) if agent && agent.force_default_llm
 
           bot = DiscourseAi::Agents::Bot.as(bot_user, agent: agent.new)
-          new(bot).update_playground_with(post)
+          new(bot).update_playground_with(post, agent_user: agent_user)
         end
       end
 
@@ -222,8 +229,8 @@ module DiscourseAi
         @bot = bot
       end
 
-      def update_playground_with(post)
-        schedule_bot_reply(post) if can_attach?(post)
+      def update_playground_with(post, agent_user: post.user)
+        schedule_bot_reply(post, agent_user: agent_user) if can_attach?(post)
       end
 
       def title_playground(post, user)
@@ -860,13 +867,14 @@ module DiscourseAi
         true
       end
 
-      def schedule_bot_reply(post)
+      def schedule_bot_reply(post, agent_user: post.user)
         agent_id = DiscourseAi::Agents::Agent.system_agents[bot.agent.class] || bot.agent.class.id
         ::Jobs.enqueue(
           :create_ai_reply,
           post_id: post.id,
           bot_user_id: bot.bot_user.id,
           agent_id: agent_id,
+          agent_user_id: agent_user&.id,
         )
       end
 

--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -147,21 +147,29 @@ module DiscourseAi
           topic_agent_id = post.topic.custom_fields["ai_agent_id"]
           topic_agent_id = topic_agent_id.to_i if topic_agent_id.present?
 
-          agent_user = post.user
+          authorization_user = post.user
           if mentioned
             agent_id = mentioned[:id]
           else
             agent_id = topic_agent_id
-            agent_user = post.topic.user if topic_agent_id
+            authorization_user = post.topic.user if topic_agent_id
           end
 
           agent = nil
 
           agent =
-            DiscourseAi::Agents::Agent.find_by(user: agent_user, id: agent_id.to_i) if agent_id
+            DiscourseAi::Agents::Agent.find_by(
+              user: authorization_user,
+              id: agent_id.to_i,
+            ) if agent_id && authorization_user
 
           if !agent && (agent_name = post.topic.custom_fields["ai_agent"])
-            agent = DiscourseAi::Agents::Agent.find_by(user: post.user, name: agent_name)
+            authorization_user = post.topic.user
+            agent =
+              DiscourseAi::Agents::Agent.find_by(
+                user: authorization_user,
+                name: agent_name,
+              ) if authorization_user
           end
 
           # edge case, llm was mentioned in an ai agent conversation
@@ -182,7 +190,7 @@ module DiscourseAi
           bot_user = User.find(agent.user_id) if agent && agent.force_default_llm
 
           bot = DiscourseAi::Agents::Bot.as(bot_user, agent: agent.new)
-          new(bot).update_playground_with(post, agent_user: agent_user)
+          new(bot).update_playground_with(post, authorization_user: authorization_user)
         end
       end
 
@@ -229,8 +237,8 @@ module DiscourseAi
         @bot = bot
       end
 
-      def update_playground_with(post, agent_user: post.user)
-        schedule_bot_reply(post, agent_user: agent_user) if can_attach?(post)
+      def update_playground_with(post, authorization_user: post.user)
+        schedule_bot_reply(post, authorization_user: authorization_user) if can_attach?(post)
       end
 
       def title_playground(post, user)
@@ -867,14 +875,14 @@ module DiscourseAi
         true
       end
 
-      def schedule_bot_reply(post, agent_user: post.user)
+      def schedule_bot_reply(post, authorization_user: post.user)
         agent_id = DiscourseAi::Agents::Agent.system_agents[bot.agent.class] || bot.agent.class.id
         ::Jobs.enqueue(
           :create_ai_reply,
           post_id: post.id,
           bot_user_id: bot.bot_user.id,
           agent_id: agent_id,
-          agent_user_id: agent_user&.id,
+          authorization_user_id: authorization_user&.id,
         )
       end
 

--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -185,7 +185,10 @@ module DiscourseAi
             end
           end
 
-          agent ||= DiscourseAi::Agents::General
+          if !agent
+            agent = DiscourseAi::Agents::General
+            authorization_user = post.user
+          end
 
           bot_user = User.find(agent.user_id) if agent && agent.force_default_llm
 

--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -480,6 +480,7 @@ module DiscourseAi
         cancel_manager: nil,
         attributed_user: nil,
         feature_context: nil,
+        authorization_user_id: nil,
         &blk
       )
         # this is a multithreading issue
@@ -578,15 +579,11 @@ module DiscourseAi
                 skip_jobs: true,
                 post_type: post_type,
                 skip_guardian: true,
-                custom_fields: {
-                  DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD => bot.llm.llm_model.display_name,
-                  DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD => bot.llm.llm_model.id,
-                  DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD => bot.agent.id,
-                },
+                custom_fields: ai_custom_fields(authorization_user_id: authorization_user_id),
               )
           end
 
-          save_ai_custom_fields(reply_post)
+          save_ai_custom_fields(reply_post, authorization_user_id: authorization_user_id)
 
           stream_user_ids = reply_post.topic.allowed_users.pluck(:id)
           stream_group_ids = reply_post.topic.allowed_groups.pluck(:id)
@@ -695,7 +692,7 @@ module DiscourseAi
             skip_validations: true,
             force_new_version: true,
           )
-          save_ai_custom_fields(reply_post)
+          save_ai_custom_fields(reply_post, authorization_user_id: authorization_user_id)
         else
           reply_post =
             PostCreator.create!(
@@ -705,11 +702,7 @@ module DiscourseAi
               skip_validations: true,
               post_type: post_type,
               skip_guardian: true,
-              custom_fields: {
-                DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD => bot.llm.llm_model.display_name,
-                DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD => bot.llm.llm_model.id,
-                DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD => bot.agent.id,
-              },
+              custom_fields: ai_custom_fields(authorization_user_id: authorization_user_id),
             )
         end
 
@@ -747,6 +740,7 @@ module DiscourseAi
             raw: error_message,
             skip_validations: true,
             skip_guardian: true,
+            custom_fields: ai_custom_fields(authorization_user_id: authorization_user_id),
           )
         end
 
@@ -805,16 +799,22 @@ module DiscourseAi
 
       private
 
-      def save_ai_custom_fields(reply_post)
-        reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD] = bot
-          .llm
-          .llm_model
-          .display_name
-        reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD] = bot
-          .llm
-          .llm_model
-          .id
-        reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD] = bot.agent.id
+      def ai_custom_fields(authorization_user_id: nil)
+        fields = {
+          DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD => bot.llm.llm_model.display_name,
+          DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD => bot.llm.llm_model.id,
+          DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD => bot.agent.id,
+        }
+        if authorization_user_id
+          fields[
+            DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD
+          ] = authorization_user_id
+        end
+        fields
+      end
+
+      def save_ai_custom_fields(reply_post, authorization_user_id: nil)
+        reply_post.custom_fields.merge!(ai_custom_fields(authorization_user_id:))
         reply_post.save_custom_fields
       end
 

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -23,13 +23,28 @@ RSpec.describe Jobs::CreateAiReply do
 
     it "adds a reply from the bot" do
       agent_id = AiAgent.find_by(name: "Forum Helper").id
-
       bot_user = DiscourseAi::AiBot::EntryPoint.find_user_from_model("gpt-3.5-turbo")
+      authorization_user = topic.first_post.user
+
       DiscourseAi::Completions::Llm.with_prepared_responses([expected_response]) do
-        job.execute(post_id: topic.first_post.id, bot_user_id: bot_user.id, agent_id: agent_id)
+        job.execute(
+          post_id: topic.first_post.id,
+          bot_user_id: bot_user.id,
+          agent_id: agent_id,
+          authorization_user_id: authorization_user.id,
+        )
       end
 
-      expect(topic.posts.last.raw).to eq(expected_response)
+      bot_reply = topic.posts.last
+
+      aggregate_failures do
+        expect(bot_reply.raw).to eq(expected_response)
+        expect(
+          bot_reply.custom_fields[
+            DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD
+          ].to_i,
+        ).to eq(authorization_user.id)
+      end
     end
   end
 end

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -46,5 +46,32 @@ RSpec.describe Jobs::CreateAiReply do
         ).to eq(authorization_user.id)
       end
     end
+
+    it "does not reply when an explicit authorization user is missing" do
+      agent_id = AiAgent.find_by(name: "Forum Helper").id
+      bot_user = DiscourseAi::AiBot::EntryPoint.find_user_from_model("gpt-3.5-turbo")
+
+      expect {
+        DiscourseAi::Completions::Llm.with_prepared_responses([expected_response]) do
+          job.execute(
+            post_id: topic.first_post.id,
+            bot_user_id: bot_user.id,
+            agent_id: agent_id,
+            authorization_user_id: nil,
+          )
+        end
+      }.not_to change { topic.posts.count }
+    end
+
+    it "falls back to the post author for jobs enqueued without authorization provenance" do
+      agent_id = AiAgent.find_by(name: "Forum Helper").id
+      bot_user = DiscourseAi::AiBot::EntryPoint.find_user_from_model("gpt-3.5-turbo")
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([expected_response]) do
+        job.execute(post_id: topic.first_post.id, bot_user_id: bot_user.id, agent_id: agent_id)
+      end
+
+      expect(topic.posts.last.raw).to eq(expected_response)
+    end
   end
 end

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -73,5 +73,30 @@ RSpec.describe Jobs::CreateAiReply do
 
       expect(topic.posts.last.raw).to eq(expected_response)
     end
+
+    it "records authorization provenance before streaming generation fails" do
+      agent_id = AiAgent.find_by(name: "Forum Helper").id
+      bot_user = DiscourseAi::AiBot::EntryPoint.find_user_from_model("gpt-3.5-turbo")
+      authorization_user = Fabricate(:user, refresh_auto_groups: true)
+      pm_topic = Fabricate(:private_message_topic, user: authorization_user, recipient: bot_user)
+      prompt_post = Fabricate(:post, topic: pm_topic, user: authorization_user)
+
+      expect {
+        DiscourseAi::Completions::Llm.with_prepared_responses([]) do
+          job.execute(
+            post_id: prompt_post.id,
+            bot_user_id: bot_user.id,
+            agent_id: agent_id,
+            authorization_user_id: authorization_user.id,
+          )
+        end
+      }.to raise_error(DiscourseAi::Completions::Endpoints::CannedResponse::CANNED_RESPONSE_ERROR)
+
+      bot_reply = pm_topic.posts.order(:post_number).last
+
+      expect(
+        bot_reply.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD].to_i,
+      ).to eq(authorization_user.id)
+    end
   end
 end

--- a/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
@@ -517,6 +517,31 @@ RSpec.describe DiscourseAi::AiBot::BotController do
       end
     end
 
+    it "fails closed when a legacy retry has no topic creator to authorize against" do
+      admin = Fabricate(:admin, refresh_auto_groups: true)
+      restricted_agent =
+        Fabricate(
+          :ai_agent,
+          user: bot_user,
+          default_llm_id: llm_model.id,
+          allowed_group_ids: [Group::AUTO_GROUPS[:admins]],
+        )
+      topic = Fabricate(:private_message_topic, user: user, recipient: bot_user)
+      topic.topic_allowed_users.create!(user: admin)
+      prompt_post = Fabricate(:post, topic: topic, user: admin, raw: "Use the restricted agent")
+      reply_post = Fabricate(:post, topic: topic, user: bot_user, raw: "original reply")
+      reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD] = restricted_agent.id
+      reply_post.save_custom_fields
+      topic.update_columns(user_id: nil)
+      AiAgent.agent_cache.flush!
+
+      expect_not_enqueued_with(job: :create_ai_reply) do
+        post "/discourse-ai/ai-bot/post/#{reply_post.id}/retry"
+      end
+
+      expect(response.status).to eq(403)
+    end
+
     it "streams a replacement into the existing bot reply" do
       retry_text = "second attempt"
       messages = nil

--- a/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
@@ -446,6 +446,41 @@ RSpec.describe DiscourseAi::AiBot::BotController do
       expect(response.status).to eq(403)
     end
 
+    it "uses the topic creator to authorize a legacy restricted agent retry" do
+      admin = Fabricate(:admin, refresh_auto_groups: true)
+      restricted_agent =
+        Fabricate(
+          :ai_agent,
+          user: bot_user,
+          default_llm_id: llm_model.id,
+          allowed_group_ids: [Group::AUTO_GROUPS[:admins]],
+        )
+      topic = Fabricate(:private_message_topic, user: user, recipient: bot_user)
+      topic.topic_allowed_users.create!(user: admin)
+      prompt_post =
+        Fabricate(:post, topic: topic, user: admin, raw: "Please use the restricted agent")
+      reply_post = Fabricate(:post, topic: topic, user: bot_user, raw: "original restricted reply")
+      reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD] = restricted_agent.id
+      reply_post.save_custom_fields
+      AiAgent.agent_cache.flush!
+
+      DiscourseAi::Completions::Llm.with_prepared_responses(
+        ["restricted retry response", "restricted retry title"],
+      ) do
+        post "/discourse-ai/ai-bot/post/#{reply_post.id}/retry"
+
+        job_args = Jobs::CreateAiReply.jobs.last["args"].first.symbolize_keys
+        Jobs::CreateAiReply.new.execute(job_args)
+      end
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq("success" => "OK")
+        expect(Jobs::CreateAiReply.jobs.last["args"].first["agent_user_id"]).to eq(user.id)
+        expect(reply_post.reload.raw).to eq("original restricted reply")
+      end
+    end
+
     it "streams a replacement into the existing bot reply" do
       retry_text = "second attempt"
       messages = nil

--- a/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
@@ -476,8 +476,44 @@ RSpec.describe DiscourseAi::AiBot::BotController do
       aggregate_failures do
         expect(response.status).to eq(200)
         expect(response.parsed_body).to eq("success" => "OK")
-        expect(Jobs::CreateAiReply.jobs.last["args"].first["agent_user_id"]).to eq(user.id)
+        expect(Jobs::CreateAiReply.jobs.last["args"].first["authorization_user_id"]).to eq(user.id)
         expect(reply_post.reload.raw).to eq("original restricted reply")
+      end
+    end
+
+    it "reuses the recorded authorization user when retrying" do
+      admin = Fabricate(:admin, refresh_auto_groups: true)
+      restricted_agent =
+        Fabricate(
+          :ai_agent,
+          user: bot_user,
+          default_llm_id: llm_model.id,
+          allowed_group_ids: [Group::AUTO_GROUPS[:admins]],
+        )
+      topic = Fabricate(:private_message_topic, user: user, recipient: bot_user)
+      topic.topic_allowed_users.create!(user: admin)
+      prompt_post = Fabricate(:post, topic: topic, user: admin, raw: "Use the restricted agent")
+      reply_post = Fabricate(:post, topic: topic, user: bot_user, raw: "original reply")
+      reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD] = restricted_agent.id
+      reply_post.custom_fields[
+        DiscourseAi::AiBot::POST_AI_AGENT_AUTHORIZATION_USER_ID_FIELD
+      ] = admin.id
+      reply_post.save_custom_fields
+      AiAgent.agent_cache.flush!
+
+      DiscourseAi::Completions::Llm.with_prepared_responses(
+        ["retried response", "retried title"],
+      ) do
+        post "/discourse-ai/ai-bot/post/#{reply_post.id}/retry"
+
+        job_args = Jobs::CreateAiReply.jobs.last["args"].first.symbolize_keys
+        Jobs::CreateAiReply.new.execute(job_args)
+      end
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(Jobs::CreateAiReply.jobs.last["args"].first["authorization_user_id"]).to eq(admin.id)
+        expect(reply_post.reload.raw).to eq("retried response")
       end
     end
 

--- a/plugins/discourse-ai/spec/requests/ai_bot/posts_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/posts_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe PostsController do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+  fab!(:llm_model)
+
+  let(:bot_user) { llm_model.reload.user }
+
+  fab!(:restricted_agent) do
+    Fabricate(
+      :ai_agent,
+      allowed_group_ids: [Group::AUTO_GROUPS[:admins]],
+      allow_personal_messages: true,
+    )
+  end
+
+  before do
+    enable_current_plugin
+    toggle_enabled_bots(bots: [llm_model])
+    SiteSetting.ai_bot_allowed_groups = Group::AUTO_GROUPS[:trust_level_0].to_s
+    SiteSetting.min_personal_message_post_length = 5
+  end
+
+  describe "#create" do
+    it "uses the topic creator permissions for stored agent ids" do
+      sign_in(user)
+
+      post "/posts.json",
+           params: {
+             archetype: Archetype.private_message,
+             raw: "Can you help me with this?",
+             target_recipients: "#{admin.username},#{bot_user.username}",
+             title: "AI agent escalation attempt",
+             topic_custom_fields: {
+               ai_agent_id: restricted_agent.id,
+             },
+           }
+
+      topic_id = response.parsed_body["topic_id"]
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(topic_id).to be_present
+      end
+
+      sign_in(admin)
+
+      expect_not_enqueued_with(job: :create_ai_reply, args: { agent_id: restricted_agent.id }) do
+        post "/posts.json", params: { raw: "I'll look into this.", topic_id: topic_id }
+      end
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_id"]).to eq(topic_id)
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/requests/ai_bot/posts_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/posts_controller_spec.rb
@@ -24,35 +24,54 @@ RSpec.describe PostsController do
 
   describe "#create" do
     it "uses the topic creator permissions for stored agent ids" do
-      sign_in(user)
-
-      post "/posts.json",
-           params: {
-             archetype: Archetype.private_message,
-             raw: "Can you help me with this?",
-             target_recipients: "#{admin.username},#{bot_user.username}",
-             title: "AI agent escalation attempt",
-             topic_custom_fields: {
-               ai_agent_id: restricted_agent.id,
-             },
-           }
-
-      topic_id = response.parsed_body["topic_id"]
-
-      aggregate_failures do
-        expect(response.status).to eq(200)
-        expect(topic_id).to be_present
-      end
-
+      topic = Fabricate(:private_message_topic, user: user, recipient: bot_user)
+      topic.topic_allowed_users.create!(user: admin)
+      topic.custom_fields["ai_agent_id"] = restricted_agent.id
+      topic.save_custom_fields
       sign_in(admin)
 
       expect_not_enqueued_with(job: :create_ai_reply, args: { agent_id: restricted_agent.id }) do
-        post "/posts.json", params: { raw: "I'll look into this.", topic_id: topic_id }
+        post "/posts.json", params: { raw: "I'll look into this.", topic_id: topic.id }
       end
 
       aggregate_failures do
         expect(response.status).to eq(200)
-        expect(response.parsed_body["topic_id"]).to eq(topic_id)
+        expect(response.parsed_body["topic_id"]).to eq(topic.id)
+      end
+    end
+
+    it "uses the topic creator permissions for legacy stored agent names" do
+      topic = Fabricate(:private_message_topic, user: user, recipient: bot_user)
+      topic.topic_allowed_users.create!(user: admin)
+      topic.custom_fields["ai_agent"] = restricted_agent.name
+      topic.save_custom_fields
+      sign_in(admin)
+
+      expect_not_enqueued_with(job: :create_ai_reply, args: { agent_id: restricted_agent.id }) do
+        post "/posts.json", params: { raw: "I'll look into this.", topic_id: topic.id }
+      end
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_id"]).to eq(topic.id)
+      end
+    end
+
+    it "fails closed when the topic creator no longer exists" do
+      topic = Fabricate(:private_message_topic, user: user, recipient: bot_user)
+      topic.topic_allowed_users.create!(user: admin)
+      topic.custom_fields["ai_agent_id"] = restricted_agent.id
+      topic.save_custom_fields
+      topic.update_columns(user_id: nil)
+      sign_in(admin)
+
+      expect_not_enqueued_with(job: :create_ai_reply, args: { agent_id: restricted_agent.id }) do
+        post "/posts.json", params: { raw: "I'll look into this.", topic_id: topic.id }
+      end
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_id"]).to eq(topic.id)
       end
     end
   end


### PR DESCRIPTION
## Summary

Previously, AI bot replies checked agent access against the author of the latest post, which meant a more privileged participant could unintentionally unlock a restricted agent for a conversation; retries could also lose the original authorization context, especially after a failed response.

This change keeps topic-selected agents tied to the topic creator’s permissions, records the exact authorizing user before response generation begins, and reuses that information for retries. Explicit agent mentions still use the mentioning user’s permissions, while legacy conversations and missing users fail closed rather than guessing or inheriting access from another participant.
## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1180

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>