### PR TITLE
FIX: Validate and safely handle malformed embed allowlist regexes

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -2,6 +2,7 @@
 
 class EmbeddableHost < ActiveRecord::Base
   validate :host_must_be_valid
+  validate :allowed_paths_must_be_valid
   belongs_to :category
   belongs_to :user, optional: true
   has_many :embeddable_host_tags
@@ -35,8 +36,12 @@ class EmbeddableHost < ActiveRecord::Base
     where("lower(host) = ?", host).each do |eh|
       return eh if eh.allowed_paths.blank?
 
-      path_regexp = Regexp.new(eh.allowed_paths)
-      return eh if path_regexp.match(path) || path_regexp.match(UrlHelper.unencode(path))
+      begin
+        path_regexp = Regexp.new(eh.allowed_paths)
+        return eh if path_regexp.match(path) || path_regexp.match(UrlHelper.unencode(path))
+      rescue RegexpError
+        next
+      end
     end
 
     nil
@@ -60,6 +65,14 @@ class EmbeddableHost < ActiveRecord::Base
     unless EmbeddableHost.exists?
       Embedding.settings.each { |s| SiteSetting.set(s.to_s, SiteSetting.defaults[s]) }
     end
+  end
+
+  def allowed_paths_must_be_valid
+    return if allowed_paths.blank?
+
+    Regexp.new(allowed_paths)
+  rescue RegexpError
+    errors.add(:allowed_paths, I18n.t("errors.messages.invalid"))
   end
 
   def host_must_be_valid

--- a/spec/requests/admin/embeddable_hosts_controller_spec.rb
+++ b/spec/requests/admin/embeddable_hosts_controller_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Admin::EmbeddableHostsController do
         ).to eq(true)
       end
 
+      it "rejects invalid path allowlists" do
+        post "/admin/embeddable_hosts.json",
+             params: {
+               embeddable_host: {
+                 host: "example.com",
+                 allowed_paths: "[invalid",
+               },
+             }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          "#{EmbeddableHost.human_attribute_name(:allowed_paths)} #{I18n.t("errors.messages.invalid")}",
+        )
+        expect(EmbeddableHost.where(host: "example.com")).not_to exist
+      end
+
       it "creates an embeddable host with associated tags" do
         tag1 = Fabricate(:tag)
         tag2 = Fabricate(:tag)

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -113,6 +113,19 @@ RSpec.describe EmbedController do
         expect(response.body).to match("data-referer=\"https://example.com/evil-trout\"")
       end
 
+      it "ignores invalid path allowlists from legacy hosts" do
+        embeddable_host = Fabricate(:embeddable_host, allowed_paths: "/articles/.*")
+        embeddable_host.update_column(:allowed_paths, "[invalid")
+
+        get "/embed/topics?discourse_embed_id=de-1234",
+            headers: {
+              "REFERER" => "https://#{embeddable_host.host}/articles/test",
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.body).to match("data-embed-id=\"de-1234\"")
+      end
+
       it "returns a list of top topics" do
         good_topic = Fabricate(:topic, like_count: 1000, posts_count: 100)
         TopTopic.refresh!


### PR DESCRIPTION
## Summary

EmbeddableHost allowed_paths values are stored as regular expression source and compiled during request handling without validation or error handling. Now new or updated allowlists are validated on save, and legacy invalid or timed-out patterns are safely skipped as non-matches rather than causing HTTP 500 errors on public embed endpoints. This prevents an administrator from accidentally breaking embed functionality across their site.

## Source

- Patch Triage: `patch-triage/1556`

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>