### PR TITLE
FIX: Surface S3 errors when listing backups

### DIFF
--- a/lib/backup_restore/s3_backup_store.rb
+++ b/lib/backup_restore/s3_backup_store.rb
@@ -115,13 +115,9 @@ module BackupRestore
     def unsorted_files
       objects = []
 
-      begin
-        s3_helper.list.each do |obj|
-          objects << create_file_from_object(obj) if obj.key.match?(file_regex)
-        end
-      rescue StandardError
-        NoMethodError
-      end #fired when s3_helper.list is nil - wont respond to .nil?
+      s3_helper.list.each do |obj|
+        objects << create_file_from_object(obj) if obj.key.match?(file_regex)
+      end
 
       objects
     rescue Aws::Errors::ServiceError => e

--- a/spec/lib/backup_restore/s3_backup_store_spec.rb
+++ b/spec/lib/backup_restore/s3_backup_store_spec.rb
@@ -114,6 +114,26 @@ RSpec.describe BackupRestore::S3BackupStore do
         expect(store.stats[:free_bytes]).to be_nil
       end
     end
+
+    describe "#files" do
+      # Regression: the listing was wrapped in a bare `rescue StandardError`
+      # whose body was the constant `NoMethodError` - it caught everything and
+      # did nothing, so an AccessDenied returned an empty list. A site whose
+      # IAM policy did not cover its backup prefix showed "no backups", and the
+      # restore then failed with "Failed to download archive to tmp directory."
+      # instead of naming the permission that was actually missing.
+      it "raises StorageError when S3 denies the listing" do
+        @s3_client.stub_responses(:list_objects_v2, "AccessDenied")
+
+        expect { store.files }.to raise_error(BackupRestore::BackupStore::StorageError)
+      end
+
+      it "still returns an empty list when the bucket genuinely has no backups" do
+        remove_backups
+
+        expect(store.files).to eq([])
+      end
+    end
   end
 
   def objects_with_prefix(context)

--- a/spec/lib/backup_restore/shared_examples_for_backup_store.rb
+++ b/spec/lib/backup_restore/shared_examples_for_backup_store.rb
@@ -172,9 +172,22 @@ RSpec.shared_examples "backup store" do
 
       it "runs if SiteSetting.backup_frequency is configured" do
         base_backup_s3_url = "https://s3-backup-bucket.s3.dualstack.us-west-1.amazonaws.com"
+        # An empty listing from S3 is a valid ListBucketResult with no
+        # <Contents>, not an empty body. Returning an empty body makes the SDK
+        # raise "Empty or incomplete response body", which used to be hidden by
+        # a bare `rescue StandardError` in S3BackupStore#unsorted_files.
         stub_request(:get, "#{base_backup_s3_url}/?list-type=2&prefix=default/").to_return(
           status: 200,
-          body: "",
+          body: <<~XML,
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+              <Name>s3-backup-bucket</Name>
+              <Prefix>default/</Prefix>
+              <KeyCount>0</KeyCount>
+              <MaxKeys>1000</MaxKeys>
+              <IsTruncated>false</IsTruncated>
+            </ListBucketResult>
+          XML
           headers: {
           },
         )
@@ -188,9 +201,22 @@ RSpec.shared_examples "backup store" do
 
       it "doesn't run if SiteSetting.backup_frequency is set to 0" do
         base_backup_s3_url = "https://s3-backup-bucket.s3.dualstack.us-west-1.amazonaws.com"
+        # An empty listing from S3 is a valid ListBucketResult with no
+        # <Contents>, not an empty body. Returning an empty body makes the SDK
+        # raise "Empty or incomplete response body", which used to be hidden by
+        # a bare `rescue StandardError` in S3BackupStore#unsorted_files.
         stub_request(:get, "#{base_backup_s3_url}/?list-type=2&prefix=default/").to_return(
           status: 200,
-          body: "",
+          body: <<~XML,
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+              <Name>s3-backup-bucket</Name>
+              <Prefix>default/</Prefix>
+              <KeyCount>0</KeyCount>
+              <MaxKeys>1000</MaxKeys>
+              <IsTruncated>false</IsTruncated>
+            </ListBucketResult>
+          XML
           headers: {
           },
         )


### PR DESCRIPTION
S3BackupStore#unsorted_files wrapped the listing in a bare `rescue StandardError` whose body was the constant `NoMethodError` - it caught everything and did nothing, so any failure produced an empty backup list. The `rescue Aws::Errors::ServiceError` below it, which raises StorageError for the admin controller to render, was unreachable.

So a site whose IAM policy missed its backup prefix reported "no backups" and failed the restore with "Failed to download archive to tmp directory." instead of naming the missing permission.

The comment claimed the guard fired when s3_helper.list is nil; it returns a lazy collection that is never nil.

Removing it exposed two shared examples stubbing an empty HTTP body to mean "no backups". Real S3 returns a ListBucketResult with no <Contents>, so those now return valid XML.