### PR TITLE
UX: prevent cloak on livestream post

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -399,7 +399,7 @@ export default class DiscoursePostEvent extends Component {
               {{/if}}
 
               {{#unless @hideLivestreamVideo}}
-                <Livestream @event={{event}} />
+                <Livestream @event={{event}} @post={{@post}} />
               {{/unless}}
             </PluginOutlet>
           {{/if}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/livestream.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/livestream.gjs
@@ -1,7 +1,9 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { optionalRequire } from "discourse/lib/utilities";
 import { eventHasLivestream } from "../../lib/livestream-utils";
 import LivestreamZoomEntry from "../livestream/zoom-entry";
@@ -65,6 +67,17 @@ export default class Livestream extends Component {
       : trustHTML(this.args.event?.livestreamOnebox ?? "");
   }
 
+  // Once playing, the post has to stay rendered: scrolling far enough away
+  // would otherwise cloak it and tear the player out of the DOM.
+  @action
+  preventCloak() {
+    const postId = this.args.post?.id;
+
+    if (postId) {
+      withPluginApi((api) => api.preventCloak(postId));
+    }
+  }
+
   <template>
     {{#if this.show}}
       <section class="event__section event-livestream">
@@ -72,7 +85,10 @@ export default class Livestream extends Component {
           <LivestreamZoomEntry @event={{@event}} />
         {{else if this.hasLivestreamOnebox}}
           {{#if this.videoAttributes}}
-            <this.lazyVideo @videoAttributes={{this.videoAttributes}} />
+            <this.lazyVideo
+              @videoAttributes={{this.videoAttributes}}
+              @onLoadedVideo={{this.preventCloak}}
+            />
           {{else}}
             {{this.oneboxHtml}}
           {{/if}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/livestream.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/livestream.gjs
@@ -67,8 +67,8 @@ export default class Livestream extends Component {
       : trustHTML(this.args.event?.livestreamOnebox ?? "");
   }
 
-  // Once playing, the post has to stay rendered: scrolling far enough away
-  // would otherwise cloak it and tear the player out of the DOM.
+  // Once playback starts the post has to stay rendered: cloaking it tears down
+  // the component holding the stream, taking any joined Zoom session with it.
   @action
   preventCloak() {
     const postId = this.args.post?.id;
@@ -82,7 +82,10 @@ export default class Livestream extends Component {
     {{#if this.show}}
       <section class="event__section event-livestream">
         {{#if this.isZoomLivestream}}
-          <LivestreamZoomEntry @event={{@event}} />
+          <LivestreamZoomEntry
+            @event={{@event}}
+            @onJoined={{this.preventCloak}}
+          />
         {{else if this.hasLivestreamOnebox}}
           {{#if this.videoAttributes}}
             <this.lazyVideo

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/livestream/zoom-entry.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/livestream/zoom-entry.gjs
@@ -24,6 +24,7 @@ export default class LivestreamZoomEntry extends Component {
     topicId: this.topic.id,
     canJoin: () => this.canJoinNow,
     onBeforeJoinAttempt: this.markAsGoing,
+    onJoined: () => this.args.onJoined?.(),
   });
 
   willDestroy() {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/zoom-meeting-session.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/zoom-meeting-session.js
@@ -35,11 +35,12 @@ export default class ZoomMeetingSession {
 
   #tornDown = false;
 
-  constructor(owner, { topicId, canJoin, onBeforeJoinAttempt }) {
+  constructor(owner, { topicId, canJoin, onBeforeJoinAttempt, onJoined }) {
     setOwner(this, owner);
     this.topicId = topicId;
     this.canJoin = canJoin;
     this.onBeforeJoinAttempt = onBeforeJoinAttempt;
+    this.onJoined = onJoined;
   }
 
   teardown() {
@@ -95,6 +96,7 @@ export default class ZoomMeetingSession {
       }
 
       this.isJoined = true;
+      this.onJoined?.();
       this.stopRetrying();
     } catch (err) {
       const serializedError = serializeZoomError(err);

--- a/plugins/discourse-calendar/test/javascripts/integration/components/livestream-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/livestream-test.gjs
@@ -1,11 +1,20 @@
+import { on } from "@ember/modifier";
 import { getOwner } from "@ember/owner";
-import { render } from "@ember/test-helpers";
+import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import sinon from "sinon";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import Livestream from "../../discourse/components/discourse-post-event/livestream";
 
 const ZOOM_URL = "https://us06web.zoom.us/j/123456789?pwd=secret";
 const ZOOM_ENTRY_SELECTOR = ".discourse-calendar-livestream-zoom-entry";
+
+const FakeLazyVideo = <template>
+  <button type="button" class="fake-lazy-video" {{on "click" @onLoadedVideo}}>
+    play
+  </button>
+</template>;
 
 module(
   "Integration | Component | DiscoursePostEvent::Livestream",
@@ -89,6 +98,61 @@ module(
 
       assert.dom(".event-livestream").exists();
       assert.dom(".event-livestream aside.onebox").doesNotExist();
+    });
+
+    module("with a playable video", function (nestedHooks) {
+      let preventCloak;
+
+      nestedHooks.beforeEach(function () {
+        this.event.isZoomLivestream = false;
+        this.event.livestreamUrl =
+          "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+        this.event.livestreamOnebox =
+          "<div class='lazy-video-container'></div>";
+
+        sinon.stub(Livestream.prototype, "lazyVideo").get(() => FakeLazyVideo);
+        sinon
+          .stub(Livestream.prototype, "videoAttributes")
+          .get(() => ({ providerName: "youtube", id: "dQw4w9WgXcQ" }));
+
+        withPluginApi((api) => {
+          preventCloak = sinon.stub(api, "preventCloak");
+        });
+      });
+
+      test("keeps the post rendered once the video is playing", async function (assert) {
+        this.post = { id: 42 };
+
+        await render(
+          <template>
+            <Livestream @event={{this.event}} @post={{this.post}} />
+          </template>
+        );
+
+        assert.dom(".event-livestream .fake-lazy-video").exists();
+        assert.false(
+          preventCloak.called,
+          "cloaking is still allowed before playback starts"
+        );
+
+        await click(".fake-lazy-video");
+
+        assert.true(
+          preventCloak.calledWith(42),
+          "prevents the post holding the player from being cloaked"
+        );
+      });
+
+      test("does not prevent cloaking when rendered without a post", async function (assert) {
+        await render(<template><Livestream @event={{this.event}} /></template>);
+
+        await click(".fake-lazy-video");
+
+        assert.false(
+          preventCloak.called,
+          "no post to keep rendered, e.g. in the calendar or onebox preview"
+        );
+      });
     });
   }
 );

--- a/plugins/discourse-calendar/test/javascripts/integration/components/livestream-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/livestream-test.gjs
@@ -6,6 +6,7 @@ import sinon from "sinon";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import Livestream from "../../discourse/components/discourse-post-event/livestream";
+import ZoomMeetingSession from "../../discourse/lib/zoom-meeting-session";
 
 const ZOOM_URL = "https://us06web.zoom.us/j/123456789?pwd=secret";
 const ZOOM_ENTRY_SELECTOR = ".discourse-calendar-livestream-zoom-entry";
@@ -151,6 +152,52 @@ module(
         assert.false(
           preventCloak.called,
           "no post to keep rendered, e.g. in the calendar or onebox preview"
+        );
+      });
+    });
+
+    module("with a Zoom livestream", function (nestedHooks) {
+      let preventCloak;
+
+      nestedHooks.beforeEach(function () {
+        const owner = getOwner(this);
+        owner.unregister("service:discourse-post-event-api");
+        owner.register(
+          "service:discourse-post-event-api",
+          { joinEvent: () => Promise.resolve() },
+          { instantiate: false }
+        );
+
+        this.event.id = 7;
+        this.event.currentlyWithinEventTimeframe = true;
+        this.event.canUpdateAttendance = false;
+
+        sinon.stub(ZoomMeetingSession.prototype, "performJoin").resolves();
+
+        withPluginApi((api) => {
+          preventCloak = sinon.stub(api, "preventCloak");
+        });
+      });
+
+      test("keeps the post rendered once the webinar has joined", async function (assert) {
+        this.post = { id: 42 };
+
+        await render(
+          <template>
+            <Livestream @event={{this.event}} @post={{this.post}} />
+          </template>
+        );
+
+        assert.false(
+          preventCloak.called,
+          "cloaking is still allowed before the user joins"
+        );
+
+        await click(".discourse-calendar-livestream-zoom-entry .btn-primary");
+
+        assert.true(
+          preventCloak.calledWith(42),
+          "prevents the post holding the Zoom session from being cloaked"
         );
       });
     });

--- a/plugins/discourse-calendar/test/javascripts/integration/components/zoom-entry-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/zoom-entry-test.gjs
@@ -251,6 +251,88 @@ module("Integration | Component | LivestreamZoomEntry", function (hooks) {
     assert.dom(`${AUDIO_HINT_SELECTOR} .d-icon-zoom-join-audio`).exists();
   });
 
+  test("notifies once the desktop session has joined", async function (assert) {
+    stubCapabilities(getOwner(this), { lg: true });
+    const performJoin = sinon.stub(ZoomMeetingSession.prototype, "performJoin");
+    const join = deferred();
+    performJoin.returns(join.promise);
+    this.onJoined = sinon.fake();
+
+    await render(
+      <template>
+        <LivestreamZoomEntry
+          @event={{this.event}}
+          @onJoined={{this.onJoined}}
+        />
+      </template>
+    );
+
+    await click(JOIN_BUTTON_SELECTOR);
+
+    assert.false(
+      this.onJoined.called,
+      "does not notify while the join is still in flight"
+    );
+
+    join.resolve();
+    await settled();
+
+    assert.strictEqual(
+      this.onJoined.callCount,
+      1,
+      "notifies once the session is joined"
+    );
+  });
+
+  test("does not notify when the join fails", async function (assert) {
+    stubCapabilities(getOwner(this), { lg: true });
+    sinon
+      .stub(ZoomMeetingSession.prototype, "performJoin")
+      .rejects(new Error("nope"));
+    this.onJoined = sinon.fake();
+
+    await render(
+      <template>
+        <LivestreamZoomEntry
+          @event={{this.event}}
+          @onJoined={{this.onJoined}}
+        />
+      </template>
+    );
+
+    await click(JOIN_BUTTON_SELECTOR);
+
+    assert.false(this.onJoined.called);
+  });
+
+  test("does not notify when the component is torn down mid-join", async function (assert) {
+    stubCapabilities(getOwner(this), { lg: true });
+    const performJoin = sinon.stub(ZoomMeetingSession.prototype, "performJoin");
+    const join = deferred();
+    performJoin.returns(join.promise);
+    this.onJoined = sinon.fake();
+
+    await render(
+      <template>
+        <LivestreamZoomEntry
+          @event={{this.event}}
+          @onJoined={{this.onJoined}}
+        />
+      </template>
+    );
+
+    await click(JOIN_BUTTON_SELECTOR);
+    await clearRender();
+
+    join.resolve();
+    await settled();
+
+    assert.false(
+      this.onJoined.called,
+      "the session was torn down before it could join"
+    );
+  });
+
   test("hides the audio hint once the user connects audio", async function (assert) {
     stubCapabilities(getOwner(this), { lg: true });
     const captured = captureSession();


### PR DESCRIPTION
When in a livestream topic, the video in the first post should continue playing regardless of how far you've scrolled within the topic. This change uses `api.preventCloak(postId)` to prevent the first post from cloaking, which will allow the video to play regardless of how far away I've scrolled from it. 