### PR TITLE
FIX: clear patreon warning on successful response

### DIFF
--- a/plugins/discourse-patreon/lib/api.rb
+++ b/plugins/discourse-patreon/lib/api.rb
@@ -54,6 +54,11 @@ module Patreon
 
       case response.status
       when 200
+        # An inline check is never re-evaluated elsewhere, so a successful
+        # response is the only thing that can resolve it.
+        tracker = ProblemCheckTracker[:access_token_invalid]
+        tracker.no_problem! if tracker.failing?
+
         return JSON.parse response.body
       when 401
         ProblemCheckTracker[:access_token_invalid].problem!

--- a/plugins/discourse-patreon/spec/lib/api_spec.rb
+++ b/plugins/discourse-patreon/spec/lib/api_spec.rb
@@ -56,7 +56,23 @@ RSpec.describe Patreon::Api do
 
     it "should not add admin warning message for valid api response" do
       stub_url(200, url)
+      described_class.campaign_data
+
       expect(ProblemCheckTracker[:access_token_invalid].blips).to eq(0)
+      expect(AdminNotice.find_by(identifier: :access_token_invalid)).to eq(nil)
+    end
+
+    it "should clear an existing admin warning message once the api responds again" do
+      stub_url(401, url)
+      described_class.campaign_data
+      expect(AdminNotice.find_by(identifier: :access_token_invalid)).to be_present
+
+      stub_url(200, url)
+      described_class.campaign_data
+
+      expect(ProblemCheckTracker[:access_token_invalid].blips).to eq(0)
+      expect(ProblemCheckTracker[:access_token_invalid]).to be_passing
+      expect(AdminNotice.find_by(identifier: :access_token_invalid)).to eq(nil)
     end
 
     it "should add warning log" do


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/dashboard-advice-regarding-patreon-persists-after-issue-is-fixed/389807/

A 401 response from the Patreon plugin permanently sets a dashboard warning that can not be cleared. This removes the message the next time the API has a successful response. The spec for this also couldn't fail, so that has been corrected. 