### PR TITLE
FIX: count self-replied topics as in progress in Topic outcomes

### DIFF
--- a/plugins/discourse-solved/lib/discourse_solved/admin_dashboard_support.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/admin_dashboard_support.rb
@@ -226,7 +226,6 @@ module DiscourseSolved
                   AND p.post_number > 1
                   AND p.post_type = :post_type
                   AND p.deleted_at IS NULL
-                  AND p.user_id <> t.user_id
               ) AS has_reply
             FROM topics t
             LEFT JOIN discourse_solved_solved_topics st ON st.topic_id = t.id

--- a/plugins/discourse-solved/spec/lib/discourse_solved/admin_dashboard_support_spec.rb
+++ b/plugins/discourse-solved/spec/lib/discourse_solved/admin_dashboard_support_spec.rb
@@ -80,12 +80,12 @@ RSpec.describe DiscourseSolved::AdminDashboardSupport do
       expect(dashboard[:topic_outcomes]).to eq(resolved: 1, in_progress: 1, unanswered: 1)
     end
 
-    it "treats a topic where only the author replied as unanswered, not in progress" do
+    it "treats a topic where only the author replied as in progress, not unanswered" do
       topic = Fabricate(:topic, category: support_category, user: author)
       Fabricate(:post, topic: topic, user: author)
       Fabricate(:post, topic: topic, user: author)
 
-      expect(dashboard[:topic_outcomes]).to eq(resolved: 0, in_progress: 0, unanswered: 1)
+      expect(dashboard[:topic_outcomes]).to eq(resolved: 0, in_progress: 1, unanswered: 0)
     end
 
     it "serves cached data for the same scope and window within the TTL" do


### PR DESCRIPTION
A topic where only the original poster replied to themselves was counted as unanswered in the Support section's Topic outcomes, but showed up as in progress when you clicked through to the topic list. It's now counted as in progress in both places.