### PR TITLE
FIX: Classify automation user agents as crawler traffic

### DIFF
--- a/lib/crawler_scorer.rb
+++ b/lib/crawler_scorer.rb
@@ -3,8 +3,6 @@
 class CrawlerScorer
   BOT_SCORE_THRESHOLD = 55
 
-  AUTOMATION_UA_SCORE = 100
-
   KNOWN_ASN_SCORE = 30
   DATACENTER_ASN_SCORE = 10
   SINGLE_REQUEST_NO_REFERRER_SCORE = 10
@@ -54,11 +52,9 @@ class CrawlerScorer
         SQL,
         window_start: window_start,
         window_end: window_end,
-        ua_regex: SiteSetting.crawler_automation_user_agents,
         crawler_asns: crawler_asns,
         crawler_detection_datacenter_asns: crawler_detection_datacenter_asns,
         hostname: Discourse.current_hostname,
-        automation_ua_score: AUTOMATION_UA_SCORE,
         known_asn_score: KNOWN_ASN_SCORE,
         datacenter_asn_score: DATACENTER_ASN_SCORE,
         single_request_no_referrer_score: SINGLE_REQUEST_NO_REFERRER_SCORE,
@@ -197,10 +193,7 @@ class CrawlerScorer
     breakdown AS (
       SELECT
         e.id,
-        CASE
-          WHEN :ua_regex <> '' AND e.user_agent ~* :ua_regex THEN :automation_ua_score
-          ELSE 0
-        END AS automation_ua_score,
+        0 AS automation_ua_score,
         CASE
           WHEN e.asn = ANY(ARRAY[:crawler_asns]::int[]) THEN :known_asn_score
           ELSE 0
@@ -295,11 +288,11 @@ class CrawlerScorer
         engagement_score,
         GREATEST(
           0,
-          automation_ua_score + known_asn_score + datacenter_asn_score + single_request_no_referrer_score + stale_browser_score + velocity_score + churn_score
+          known_asn_score + datacenter_asn_score + single_request_no_referrer_score + stale_browser_score + velocity_score + churn_score
             + rapid_nav_score + ip_rotation_score + referrer_score + engagement_score
         ) AS score
       FROM breakdown
-      WHERE automation_ua_score + known_asn_score + datacenter_asn_score + single_request_no_referrer_score + stale_browser_score + velocity_score + churn_score
+      WHERE known_asn_score + datacenter_asn_score + single_request_no_referrer_score + stale_browser_score + velocity_score + churn_score
         + rapid_nav_score + ip_rotation_score + referrer_score > 0
     ),
 

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -226,7 +226,7 @@ class Middleware::RequestTracker
 
     request_data = {
       status: status,
-      is_crawler: helper.is_crawler?,
+      is_crawler: helper.is_crawler? || automation_user_agent?(helper.crawler_identifier),
       has_auth_cookie: has_auth_cookie,
       current_user_id: current_user_id,
       current_username: current_username,
@@ -266,6 +266,18 @@ class Middleware::RequestTracker
 
     request_data
   end
+
+  def self.automation_user_agent?(user_agent)
+    automation_user_agents = SiteSetting.crawler_automation_user_agents
+    return false if user_agent.blank? || automation_user_agents.blank?
+
+    @automation_user_agent_matchers ||= {}
+    matcher =
+      (@automation_user_agent_matchers[automation_user_agents] ||=
+        Regexp.new(automation_user_agents, Regexp::IGNORECASE))
+    user_agent.match?(matcher)
+  end
+  private_class_method :automation_user_agent?
 
   def log_request_info(env, result, info, request = nil)
     # We've got to skip this on error ... its just logging

--- a/spec/lib/crawler_scorer_spec.rb
+++ b/spec/lib/crawler_scorer_spec.rb
@@ -19,10 +19,13 @@ RSpec.describe CrawlerScorer do
     described_class.score!(window_start: 1.hour.ago, window_end: Time.now)
   end
 
-  it "scores automation user agents at +100" do
+  it "does not score automation user agents" do
     event = make_event(user_agent: "Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/120.0.0.0")
+
     score!
-    expect(event.reload.score).to eq(140)
+
+    expect(event.reload.score).to be_nil
+    expect(event.browser_pageview_event_score).to be_nil
   end
 
   it "writes the score breakdown per heuristic to the side table" do
@@ -35,9 +38,9 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(170)
+    expect(event.reload.score).to eq(70)
     breakdown = event.browser_pageview_event_score
-    expect(breakdown.automation_ua_score).to eq(100)
+    expect(breakdown.automation_ua_score).to eq(0)
     expect(breakdown.known_asn_score).to eq(30)
     expect(breakdown.datacenter_asn_score).to eq(0)
     expect(breakdown.single_request_no_referrer_score).to eq(0)
@@ -273,12 +276,14 @@ RSpec.describe CrawlerScorer do
   end
 
   it "also scores logged-in events" do
+    SiteSetting.crawler_asns = "12345"
     user = Fabricate(:user)
-    event = make_event(user_id: user.id, user_agent: "Mozilla/5.0 HeadlessChrome/120.0.0.0")
+    event = make_event(user_id: user.id, asn: 12_345)
 
     score!
 
-    expect(event.reload.score).to eq(140)
+    expect(event.reload.score).to eq(70)
+    expect(event.browser_pageview_event_score.known_asn_score).to eq(30)
   end
 
   it "ignores events outside the window" do
@@ -290,7 +295,8 @@ RSpec.describe CrawlerScorer do
   end
 
   it "does not penalise events whose session shows human interaction" do
-    event = make_event(user_agent: "Mozilla/5.0 HeadlessChrome/120.0.0.0")
+    SiteSetting.crawler_asns = "12345"
+    event = make_event(asn: 12_345)
     Fabricate(
       :browser_pageview_session_engagement,
       session_id: event.session_id,
@@ -300,8 +306,10 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(100)
-    expect(event.browser_pageview_event_score.engagement_score).to eq(0)
+    expect(event.reload.score).to eq(30)
+    breakdown = event.browser_pageview_event_score
+    expect(breakdown.known_asn_score).to eq(30)
+    expect(breakdown.engagement_score).to eq(0)
   end
 
   it "never scores an event below its bot signals" do
@@ -319,7 +327,8 @@ RSpec.describe CrawlerScorer do
   end
 
   it "treats any engagement row as engagement, since the client only beacons on activity" do
-    event = make_event(user_agent: "Mozilla/5.0 HeadlessChrome/120.0.0.0")
+    SiteSetting.crawler_asns = "12345"
+    event = make_event(asn: 12_345)
     Fabricate(
       :browser_pageview_session_engagement,
       session_id: event.session_id,
@@ -328,8 +337,10 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(100)
-    expect(event.browser_pageview_event_score.engagement_score).to eq(0)
+    expect(event.reload.score).to eq(30)
+    breakdown = event.browser_pageview_event_score
+    expect(breakdown.known_asn_score).to eq(30)
+    expect(breakdown.engagement_score).to eq(0)
   end
 
   it "lowers the score when an engagement beacon arrives after an earlier run" do

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -872,6 +872,29 @@ RSpec.describe Middleware::RequestTracker do
 
           expect(events.length).to eq(0)
         end
+
+        it "does not emit or persist events for automation user agent page views" do
+          SiteSetting.crawler_automation_user_agents = "TestingAgent"
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_USER_AGENT" => "testingagent/1.0",
+                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
+                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
+              ),
+              ["200", { "Content-Type" => "text/html" }],
+              0.2,
+            )
+
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
+
+          expect(events).to be_empty
+
+          SiteSetting.persist_browser_pageview_events = true
+
+          expect { log_browser_pageview(data) }.not_to change { BrowserPageviewEvent.count }
+        end
       end
 
       context "when SiteSetting.trigger_browser_pageview_events is false" do

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -80,9 +80,8 @@ describe "Request tracking" do
       expect(event_2[:session_id]).to eq(event[:session_id])
     end
 
-    it "tracks a crawler visit correctly" do
-      # Can't change playwright user agent for now... so change site settings to make Discourse detect chrome as a crawler
-      SiteSetting.crawler_user_agents += "|chrome"
+    it "counts an automated browser visit as crawler traffic" do
+      SiteSetting.crawler_automation_user_agents += "|Chrome"
 
       events =
         DiscourseEvent.track_events(:browser_pageview) do


### PR DESCRIPTION
Automation user agents previously entered browser traffic and received a crawler score later. This classified them as likely crawlers instead of known crawlers.

This commit classifies matching requests at the request tracker boundary. These requests increment known-crawler traffic and do not create browser-pageview events. It removes the automation score while keeping its breakdown column for schema compatibility.

Global crawler rendering, rate limits, and access controls stay unchanged.