### PR TITLE
FIX: Ignore pending reviewables when their target user is deleted

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -53,7 +53,9 @@ class ReviewableQueuedPost < Reviewable
         )
 
       build_action(actions, :reject_post, bundle: reject_bundle, icon: "xmark")
-      build_action(actions, :revise_and_reject_post, bundle: reject_bundle, icon: "envelope")
+      if target_created_by.present?
+        build_action(actions, :revise_and_reject_post, bundle: reject_bundle, icon: "envelope")
+      end
 
       build_penalty_actions(
         actions,

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -46,6 +46,8 @@ class UserDestroyer
         delete_posts(user, category_topic_ids, opts)
       end
 
+      resolve_reviewables_targeting(user)
+
       user.post_actions.find_each { |post_action| post_action.remove_act!(Discourse.system_user) }
 
       # Add info about the user to staff action logs
@@ -165,6 +167,19 @@ class UserDestroyer
         if reviewable.actions_for(@guardian).has?(:reject_post)
           reviewable.perform(@actor, :reject_post)
         end
+      end
+  end
+
+  def resolve_reviewables_targeting(user)
+    Reviewable
+      .pending
+      .where(target_created_by: user)
+      .find_each do |reviewable|
+        reviewable.reviewable_notes.create!(
+          user: Discourse.system_user,
+          content: I18n.t("reviewables.target_user_deleted"),
+        )
+        reviewable.transition_to(:ignored, Discourse.system_user)
       end
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6107,6 +6107,7 @@ en:
     post_restored_by_author: "Post was restored by the author"
     post_deleted_by_author_after_penalty: >-
       Post was deleted by the author after the user was penalized for it. Review the penalty without restoring the post.
+    target_user_deleted: "Automatically ignored because the user account was deleted."
     priorities:
       low: "Low"
       medium: "Medium"

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -455,6 +455,20 @@ RSpec.describe ReviewableQueuedPost, type: :model do
     end
   end
 
+  describe "actions when the author no longer exists" do
+    fab!(:reviewable, :reviewable_queued_post)
+
+    it "only offers rejecting the post" do
+      reviewable.update_column(:target_created_by_id, nil)
+
+      actions = reviewable.actions_for(Guardian.new(moderator))
+      bundle = actions.bundles.find { |bundle| bundle.id == "#{reviewable.id}-reject-post" }
+
+      expect(actions.has?(:approve_post)).to eq(false)
+      expect(bundle.actions.map(&:server_action)).to eq(%w[reject_post])
+    end
+  end
+
   describe "penalty actions" do
     fab!(:reviewable, :reviewable_queued_post)
 

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -149,6 +149,36 @@ RSpec.describe UserDestroyer do
       end
     end
 
+    context "with a pending reviewable targeting the user" do
+      fab!(:queued_post) { Fabricate(:reviewable_queued_post, target_created_by: user) }
+      fab!(:flagged_post) do
+        Fabricate(
+          :reviewable_flagged_post,
+          target_created_by: user,
+          target: Fabricate(:post, user: user),
+        )
+      end
+
+      it "ignores them and notes why" do
+        UserDestroyer.new(admin).destroy(user, delete_posts: true)
+
+        expect(queued_post.reload).to be_ignored
+        expect(flagged_post.reload).to be_ignored
+        expect(queued_post.reviewable_notes.last.content).to eq(
+          I18n.t("reviewables.target_user_deleted"),
+        )
+      end
+
+      it "leaves reviewables that were already handled alone" do
+        queued_post.update!(status: :approved)
+
+        UserDestroyer.new(admin).destroy(user, delete_posts: true)
+
+        expect(queued_post.reload).to be_approved
+        expect(queued_post.reviewable_notes).to be_empty
+      end
+    end
+
     context "with a reviewable user" do
       let(:reviewable) { Fabricate(:reviewable, created_by: admin) }
 


### PR DESCRIPTION
Deleting a user left any reviewable they authored in the pending queue. Reviewing one afterwards was either pointless or broken: the revise and reject action tries to message the author, who no longer exists.

`UserDestroyer` now transitions pending reviewables targeting the user to ignored and adds a reviewable note explaining why, so the queue reflects reality and staff can see what happened. Already handled reviewables are untouched.

`ReviewableQueuedPost` also stops offering the revise and reject action when `target_created_by` is missing, which covers records ignored before this change.