### PR TITLE
DEV: cleanup post reply count position change

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -12,8 +12,8 @@ import ReactionsActionSummary from "../components/discourse-reactions-actions-su
 
 replaceIcon("notification.reaction", "bell");
 
-function initializeDiscourseReactions(api, siteSettings) {
-  customizePostMenu(api, siteSettings);
+function initializeDiscourseReactions(api) {
+  customizePostMenu(api);
 
   api.addKeyboardShortcut("l", null, {
     click: ".topic-post.selected .discourse-reactions-reaction-button",
@@ -157,18 +157,14 @@ function initializeDiscourseReactions(api, siteSettings) {
   }
 }
 
-function customizePostMenu(api, siteSettings) {
+function customizePostMenu(api) {
   api.registerValueTransformer(
     "post-menu-buttons",
     ({ value: dag, context: { buttonKeys } }) => {
       dag.replace(buttonKeys.LIKE, ReactionsActionButton);
-      dag.add(
-        "discourse-reactions-actions",
-        ReactionsActionSummary,
-        siteSettings.enable_new_post_reply_count_position
-          ? { before: buttonKeys.REPLIES }
-          : { after: buttonKeys.REPLIES }
-      );
+      dag.add("discourse-reactions-actions", ReactionsActionSummary, {
+        before: buttonKeys.REPLIES,
+      });
     }
   );
 }
@@ -180,7 +176,7 @@ export default {
     const siteSettings = container.lookup("service:site-settings");
 
     if (siteSettings.discourse_reactions_enabled) {
-      withPluginApi((api) => initializeDiscourseReactions(api, siteSettings));
+      withPluginApi(initializeDiscourseReactions);
     }
   },
 


### PR DESCRIPTION
In #41797 we bumped the status of the upcoming change to `permanent`, however the code branching was left intact. This change cleans up after the status change — we are intentionally keeping the site setting for some time so that it appears within the admin dashboard as a recent change.