### PR TITLE
UX: set max width on feature feed image

### DIFF
--- a/app/assets/stylesheets/admin/dashboard.scss
+++ b/app/assets/stylesheets/admin/dashboard.scss
@@ -783,7 +783,7 @@
 
 .admin-new-feature-item__screenshot {
   margin-bottom: 1em;
-  width: 100%;
+  max-width: 100%;
 }
 
 .admin-new-feature-item__tooltip-header {


### PR DESCRIPTION
Prevents stretching small preview images in the admin new feature feed.