### PR TITLE
FIX: Escape `|` when generating markdown table cells

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -199,7 +199,9 @@ class InlineUploads
         has_attachment = node.attributes["class"]&.value
         index = $~.offset(0)[0]
         text = match[2].strip.gsub("\n", "").gsub(/ +/, " ").gsub(/[\[\]\|]/, "")
-        text = "#{text}|attachment" if has_attachment
+        # a bare `|` would end the cell if this lands in a table row, and the
+        # escape is inert anywhere else since the destination is an upload label
+        text = "#{text}\\|attachment" if has_attachment
 
         yield(match[0], href, +"[#{text}](#{PLACEHOLDER})", index) if block_given?
       end

--- a/frontend/discourse/app/lib/markdown-image-builder.js
+++ b/frontend/discourse/app/lib/markdown-image-builder.js
@@ -30,23 +30,14 @@ export function extensionFromUrl(url) {
 }
 
 export function buildImageMarkdown(imageData) {
-  const {
-    src,
-    alt,
-    width,
-    height,
-    title,
-    escapeTablePipe = false,
-    fallbackAlt,
-  } = imageData;
+  const { src, alt, width, height, title, fallbackAlt } = imageData;
 
   if (!src) {
     return "";
   }
 
   const altText = sanitizeAlt(alt, { fallback: fallbackAlt });
-  const pipe = escapeTablePipe ? "\\|" : "|";
-  const suffix = width && height ? `${pipe}${width}x${height}` : "";
+  const suffix = width && height ? `|${width}x${height}` : "";
   const titleSuffix = title ? ` "${title}"` : "";
 
   return `![${altText}${suffix}](${src}${titleSuffix})`;

--- a/frontend/discourse/app/lib/utilities.js
+++ b/frontend/discourse/app/lib/utilities.js
@@ -698,6 +698,14 @@ export function getCaretPosition(element, options) {
   return adjustedPosition;
 }
 
+// a bare `|` ends the cell early, and in a header it changes the column count,
+// which drops the whole table
+function escapeTableCell(value) {
+  return String(value ?? "")
+    .replace(/\r?\n|\r/g, " ")
+    .replaceAll("|", "\\|");
+}
+
 /**
  * Generate markdown table from an array of objects
  * Inspired by https://github.com/Ygilany/array-to-table
@@ -714,7 +722,7 @@ export function arrayToTable(array, cols, colPrefix = "col", alignments) {
 
   // Generate table headers
   table += "|";
-  table += cols.join(" | ");
+  table += cols.map(escapeTableCell).join(" | ");
   table += "|\n|";
 
   const alignMap = {
@@ -736,9 +744,7 @@ export function arrayToTable(array, cols, colPrefix = "col", alignments) {
     table +=
       cols
         .map(function (_key, index) {
-          return String(item[`${colPrefix}${index}`] || "")
-            .replace(/\r?\n|\r/g, " ")
-            .replaceAll("|", "\\|");
+          return escapeTableCell(item[`${colPrefix}${index}`] || "");
         })
         .join(" | ") + "|\n";
   });

--- a/frontend/discourse/app/static/prosemirror/extensions/table.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/table.js
@@ -131,7 +131,6 @@ const extension = {
     },
   },
   serializeNode: {
-    // TODO(renato): state.renderInline should escape `|` if `state.inTable`
     table(state, node) {
       state.flushClose(1);
 
@@ -170,7 +169,11 @@ const extension = {
             }
             state.out += cellIndex === 0 ? "| " : " | ";
 
+            const cellStart = state.out.length;
             state.renderInline(cell);
+            state.out =
+              state.out.slice(0, cellStart) +
+              escapeCellPipes(state.out.slice(cellStart));
 
             if (headerBuffer !== undefined) {
               if (cell.attrs.alignment === "center") {
@@ -246,6 +249,12 @@ const extension = {
     });
   },
 };
+
+// rows are split into cells before any inline rule runs, and the splitter drops
+// exactly one backslash per pipe it keeps — so this must escape unconditionally
+function escapeCellPipes(cell) {
+  return cell.replace(/\|/g, "\\|");
+}
 
 function findMaxColumns(tbody) {
   let maxColumns = 0;

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/table-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/table-test.js
@@ -28,9 +28,62 @@ module(
         `<div class="md-table"><table><thead><tr><th>Line1<br>Line2</th><th>Cell 2</th></tr></thead><tbody><tr><td>Cell 3</td><td>Cell 4</td></tr></tbody></table></div>`,
         `| Line1<br>Line2 | Cell 2 |\n|----|----|\n| Cell 3 | Cell 4 |\n\n`,
       ],
+      "image dimensions in a cell": [
+        `| Sign | Note |\n| --- | --- |\n| ![Rocket\\|500x500](https://example.com/r.png) | ok |`,
+        (assert) => {
+          assert.dom(".ProseMirror td img").hasAttribute("alt", "Rocket");
+          assert.dom(".ProseMirror td img").hasAttribute("width", "500");
+        },
+        `| Sign | Note |\n|----|----|\n| ![Rocket\\|500x500](https://example.com/r.png) | ok |\n\n`,
+      ],
+      "attachment link in a cell": [
+        `| File |\n| --- |\n| [notes.pdf\\|attachment](https://example.com/notes.pdf) |`,
+        (assert) => {
+          assert.dom(".ProseMirror td a").hasText("notes.pdf");
+        },
+        `| File |\n|----|\n| [notes.pdf\\|attachment](https://example.com/notes.pdf) |\n\n`,
+      ],
+      "literal pipe in cell text": [
+        `| A |\n| --- |\n| x \\| y |`,
+        `<div class="md-table"><table><thead><tr><th>A</th></tr></thead><tbody><tr><td>x | y</td></tr></tbody></table></div>`,
+        `| A |\n|----|\n| x \\| y |\n\n`,
+      ],
+      "literal pipe in a header cell": [
+        `| a \\| b |\n| --- |\n| c |`,
+        `<div class="md-table"><table><thead><tr><th>a | b</th></tr></thead><tbody><tr><td>c</td></tr></tbody></table></div>`,
+        `| a \\| b |\n|----|\n| c |\n\n`,
+      ],
+      "pipe inside an inline code span": [
+        `| A |\n| --- |\n| \`x \\| y\` |`,
+        `<div class="md-table"><table><thead><tr><th>A</th></tr></thead><tbody><tr><td><code>x | y</code></td></tr></tbody></table></div>`,
+        `| A |\n|----|\n| \`x \\| y\` |\n\n`,
+      ],
+      // markdown-it percent-encodes link destinations on parse, in and out of
+      // tables alike, so the destination holds no pipe left to escape
+      "pipe inside a link destination": [
+        `| A |\n| --- |\n| [t](https://example.com/a\\|b) |`,
+        (assert) => {
+          assert.dom(".ProseMirror td a").hasText("t");
+        },
+        `| A |\n|----|\n| [t](https://example.com/a%7Cb) |\n\n`,
+      ],
+      "escaped pipe in a table inside a quote": [
+        `> \n> | A |\n> | --- |\n> | x \\| y |\n`,
+        `<blockquote><div class="md-table"><table><thead><tr><th>A</th></tr></thead><tbody><tr><td>x | y</td></tr></tbody></table></div></blockquote>`,
+        `> \n> | A |\n> |----|\n> | x \\| y |\n\n`,
+      ],
+      "literal backslash before a pipe": [
+        `| A |\n| --- |\n| x \\\\\\| y |`,
+        `<div class="md-table"><table><thead><tr><th>A</th></tr></thead><tbody><tr><td>x \\| y</td></tr></tbody></table></div>`,
+        `| A |\n|----|\n| x \\\\\\| y |\n\n`,
+      ],
     }).forEach(([name, [markdown, html, expectedMarkdown]]) => {
       test(name, async function (assert) {
         await testMarkdown(assert, markdown, html, expectedMarkdown);
+      });
+
+      test(`${name} - stable across repeated round-trips`, async function (assert) {
+        await testMarkdown(assert, markdown, html, expectedMarkdown, true);
       });
     });
   }

--- a/frontend/discourse/tests/unit/lib/markdown-image-builder-test.js
+++ b/frontend/discourse/tests/unit/lib/markdown-image-builder-test.js
@@ -115,19 +115,6 @@ module("Unit | Lib | markdown-image-builder", function () {
       );
     });
 
-    test("escapes pipe in dimensions for table context", function (assert) {
-      assert.strictEqual(
-        buildImageMarkdown({
-          src: "/uploads/image.png",
-          alt: "test",
-          width: 640,
-          height: 480,
-          escapeTablePipe: true,
-        }),
-        "![test\\|640x480](/uploads/image.png)"
-      );
-    });
-
     test("sanitizes alt text", function (assert) {
       assert.strictEqual(
         buildImageMarkdown({

--- a/frontend/discourse/tests/unit/lib/to-markdown-test.js
+++ b/frontend/discourse/tests/unit/lib/to-markdown-test.js
@@ -165,7 +165,7 @@ module("Unit | Utility | to-markdown", function (hooks) {
               <tr><th>Heading 1</th><th>Head 2</th></tr>
               <tr><td><a href="http://example.com"><img src="http://example.com/image.png" alt="Lorem" width="45" height="45"></a></td><td>ipsum</td></tr>
             </table>`;
-    markdown = `| Heading 1 | Head 2 |\n|----|----|\n| [![Lorem|45x45](http://example.com/image.png)](http://example.com) | ipsum |`;
+    markdown = `| Heading 1 | Head 2 |\n|----|----|\n| [![Lorem\\|45x45](http://example.com/image.png)](http://example.com) | ipsum |`;
     assert.strictEqual(await toMarkdown(html), markdown);
   });
 

--- a/frontend/discourse/tests/unit/lib/utilities-test.js
+++ b/frontend/discourse/tests/unit/lib/utilities-test.js
@@ -624,6 +624,14 @@ module("Unit | Utilities | table-builder", function (hooks) {
     );
   });
 
+  test("arrayToTable should escape `|` in headings", function (assert) {
+    assert.strictEqual(
+      arrayToTable([{ col0: "x", col1: "y" }], ["a|b", "Model"]),
+      "|a\\|b | Model|\n|--- | ---|\n|x | y|\n",
+      "an unescaped heading pipe would change the column count and drop the table"
+    );
+  });
+
   test("replaceTableRaw", function (assert) {
     const raw = "Some text\n\nMaterial | Value\n--- | ---\nA | 1\n\nMore text";
     const result = replaceTableRaw(

--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe InlineUploads do
         expect(InlineUploads.process(md)).to eq(<<~MD)
         ![](#{upload.short_url})
         <img src="#{upload2.short_url}">
-        [Text|attachment](#{upload3.short_url})
+        [Text\\|attachment](#{upload3.short_url})
         MD
       end
 
@@ -539,7 +539,7 @@ RSpec.describe InlineUploads do
 
         > some quote
 
-        [test2|attachment](#{upload2.short_url})
+        [test2\\|attachment](#{upload2.short_url})
         MD
       end
 
@@ -561,7 +561,7 @@ RSpec.describe InlineUploads do
 
         <a href="https://some.external.com/link">test</a>
 
-        [test2|attachment](#{upload2.short_url})
+        [test2\\|attachment](#{upload2.short_url})
         MD
       end
 
@@ -579,7 +579,7 @@ RSpec.describe InlineUploads do
 
         [some complicated.doc %50](#{upload3.short_url})
 
-        [test2|attachment](#{upload2.short_url})
+        [test2\\|attachment](#{upload2.short_url})
         MD
       end
 
@@ -604,16 +604,16 @@ RSpec.describe InlineUploads do
         MD
 
         expect(InlineUploads.process(md)).to eq(<<~MD)
-        [this is some attachment|attachment](#{upload.short_url})
+        [this is some attachment\\|attachment](#{upload.short_url})
 
-        - [test2|attachment](#{upload.short_url})
-          - [test2|attachment](#{upload2.short_url})
-            - [test2|attachment](#{upload3.short_url})
+        - [test2\\|attachment](#{upload.short_url})
+          - [test2\\|attachment](#{upload2.short_url})
+            - [test2\\|attachment](#{upload3.short_url})
 
-        [test3|attachment](#{upload.short_url})
-        [test3|attachment](#{upload2.short_url})[test3|attachment](#{upload3.short_url})
+        [test3\\|attachment](#{upload.short_url})
+        [test3\\|attachment](#{upload2.short_url})[test3\\|attachment](#{upload3.short_url})
 
-        [This is some _test_ here|attachment](#{upload3.short_url})
+        [This is some _test_ here\\|attachment](#{upload3.short_url})
         MD
       end
 
@@ -623,8 +623,35 @@ RSpec.describe InlineUploads do
         MD
 
         expect(InlineUploads.process(md)).to eq(<<~MD)
-        [abc_d|attachment](#{upload.short_url})
+        [abc_d\\|attachment](#{upload.short_url})
         MD
+      end
+
+      it "keeps a table row intact when the attachment sits in a cell" do
+        md = <<~MD
+        | file | desc |
+        | --- | --- |
+        | <a class="attachment" href="#{upload.url}">test2</a> | hello |
+
+        | file |
+        | --- |
+        <a class="attachment" href="#{upload2.url}">test3</a>
+        MD
+
+        processed = InlineUploads.process(md)
+
+        expect(processed).to eq(<<~MD)
+        | file | desc |
+        | --- | --- |
+        | [test2\\|attachment](#{upload.short_url}) | hello |
+
+        | file |
+        | --- |
+        [test3\\|attachment](#{upload2.short_url})
+        MD
+
+        cooked = Nokogiri::HTML5.fragment(PrettyText.cook(processed))
+        expect(cooked.css("tbody td").map(&:text)).to eq(%w[test2 hello test3])
       end
 
       it "should correct full upload url to the shorter version" do
@@ -655,7 +682,7 @@ RSpec.describe InlineUploads do
         ![test](#{upload.short_url})
         [test|attachment](#{upload.short_url})
 
-        [test|attachment](#{upload.short_url})
+        [test\\|attachment](#{upload.short_url})
 
         `<a class="attachment" href="#{upload2.url}">In Code Block</a>`
 


### PR DESCRIPTION
Previously, nothing escaped the `|` when generating a markdown table cell, so a pipe in the cell's content ended the cell early — an uploaded image round-tripped through the rich editor lost its backslash and `![img|500x500](upload://…)` split across two columns, and a pipe in a heading changed the column count, dropping the table entirely.

This change escapes every `|` in a generated cell, the exact inverse of the row splitter, so the cell's content survives the round-trip byte-identical.
