### PR TITLE
FIX: Assign group-member search no longer matches disabled full names

### DIFF
--- a/plugins/discourse-assign/app/controllers/discourse_assign/assign_controller.rb
+++ b/plugins/discourse-assign/app/controllers/discourse_assign/assign_controller.rb
@@ -156,12 +156,12 @@ module DiscourseAssign
           .limit(limit)
           .offset(offset)
 
-      users_with_assignments_count =
-        users_with_assignments_count.where(<<~SQL, pattern: "%#{params[:filter]}%") if params[
-          users.name ILIKE :pattern OR users.username_lower ILIKE :pattern
-        SQL
-        :filter
-      ]
+      if params[:filter]
+        filter_query = "users.username_lower ILIKE :pattern"
+        filter_query = "users.name ILIKE :pattern OR #{filter_query}" if SiteSetting.enable_names?
+        users_with_assignments_count =
+          users_with_assignments_count.where(filter_query, pattern: "%#{params[:filter]}%")
+      end
       group_assignments_count = Assignment.active_for_group(group).count
       users_assignments_count =
         users_with_assignments_count.reduce(0) do |sum, assignment|

--- a/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
@@ -660,6 +660,40 @@ RSpec.describe DiscourseAssign::AssignController do
       end
 
       describe "with filter" do
+        it "does not disclose hidden name matches while filtering usernames" do
+          hidden_name_member =
+            Fabricate(
+              :user,
+              username: "opaque-assignee",
+              name: "Confidential Name Token",
+              groups: [allowed_group],
+            )
+          Fabricate(:topic_assignment, assigned_to: hidden_name_member, assigned_by_user: admin)
+          SiteSetting.enable_names = false
+          sign_in(allowed_user)
+
+          get "/assign/members/#{allowed_group.name}.json",
+              params: {
+                filter: hidden_name_member.name,
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["members"].map { |member| member["id"] }).not_to include(
+            hidden_name_member.id,
+          )
+          expect(response.body).not_to include(hidden_name_member.name)
+
+          get "/assign/members/#{allowed_group.name}.json",
+              params: {
+                filter: hidden_name_member.username,
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["members"].map { |member| member["id"] }).to contain_exactly(
+            hidden_name_member.id,
+          )
+        end
+
         it "returns members as according to filter" do
           sign_in(admin)
 


### PR DESCRIPTION
## Summary

The Assign group-member search now respects the enable_names setting. Full names are included in filtering only when names are enabled; otherwise, searches match usernames only. Username filtering remains available in both configurations.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1581

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>