### PR TITLE
FIX: Render hashtag slugs as text nodes in Email::Styles

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -472,9 +472,7 @@ module Email
         .search(".hashtag-cooked")
         .each do |hashtag|
           hashtag.children.each(&:remove)
-          hashtag.add_child(<<~HTML)
-          <span>##{hashtag["data-slug"]}</span>
-        HTML
+          hashtag.add_child(hashtag.document.create_text_node("##{hashtag["data-slug"]}"))
         end
     end
 

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -586,14 +586,14 @@ RSpec.describe Email::Sender do
       )
     end
 
-    it "changes the hashtags to the slug with a # symbol beforehand rather than the full name of the resource" do
+    it "changes hashtags to their slug with a # symbol rather than the full resource name" do
       category = Fabricate(:category, slug: "dev")
       reply.update!(raw: reply.raw + "\n wow this is #dev")
       reply.rebake!
       Email::Sender.new(message, :valid_type).send
       expected = <<~HTML
-      <a class="hashtag-cooked" href=\"#{Discourse.base_url}#{category.url}\" data-type=\"category\" data-slug=\"dev\" data-id=\"#{category.id}\" data-style-type=\"square\" style=\"text-decoration:none;font-weight:bold;color:#006699\"><span>#dev</span>
-      HTML
+          <a class="hashtag-cooked" href="#{Discourse.base_url}#{category.url}" data-type="category" data-slug="dev" data-id="#{category.id}" data-style-type="square" style="text-decoration:none;font-weight:bold;color:#006699">#dev</a>
+        HTML
       expect(message.html_part.body.to_s).to include(expected.chomp)
     end
 

--- a/spec/requests/admin/email_controller_spec.rb
+++ b/spec/requests/admin/email_controller_spec.rb
@@ -201,6 +201,29 @@ RSpec.describe Admin::EmailController do
             }
         expect(response.status).to eq(200)
       end
+
+      it "does not turn a post attribute into executable HTML" do
+        attacker = Fabricate(:user, trust_level: TrustLevel[1])
+        payload =
+          '<a class="hashtag-cooked" data-slug="&lt;img src=x onerror=alert(1)&gt;">ignored</a>'
+
+        freeze_time 1.day.ago do
+          sign_in(attacker)
+          post "/posts.json", params: { title: "Attacker-created topic", raw: payload }
+          expect(response.status).to eq(200)
+        end
+
+        sign_in(admin)
+        get "/admin/email/preview-digest.json",
+            params: {
+              last_seen_at: 1.week.ago,
+              username: admin.username,
+            }
+
+        expect(response.status).to eq(200)
+        preview = Nokogiri::HTML5.parse(response.parsed_body["html_content"])
+        expect(preview.at_css("img[onerror='alert(1)']")).to be_nil
+      end
     end
 
     shared_examples "preview digest inaccessible" do


### PR DESCRIPTION
## Summary

Email::Styles now appends hashtag slugs as Nokogiri text nodes instead of interpolating them into an HTML string that is re-parsed. This prevents an entity-decoded data-slug attribute from being turned back into executable markup when the admin digest preview renders the resulting email HTML in an unsandboxed iframe. The fix also updates the sender expectation to reflect the intentional removal of the cosmetic inner span while preserving the plain hashtag text.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1608

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>