### PR TITLE
UX: composer redesign > adapt composer outlets

### DIFF
--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -52,11 +52,12 @@
     }
   }
 
-  .title-and-category {
+  #reply-control .title-and-category {
     padding: 0 !important;
     width: 100% !important;
     gap: 0 !important;
     border-bottom: 1px solid var(--primary-low);
+    flex-wrap: nowrap !important;
 
     .user-selector {
       margin: 0 !important;
@@ -73,6 +74,10 @@
   }
 
   .tags-input {
+    &:not(:last-child) {
+      border-right: 1px solid var(--primary-low);
+    }
+
     @include viewport.until(sm) {
       flex-grow: 0 !important;
     }

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -568,14 +568,6 @@ export default class ComposerContainer extends Component {
                         }}
                       />
                     </div>
-
-                    {{#if this.composerRedesign}}
-                      <ComposerTitle
-                        @composer={{this.composer.model}}
-                        @lastValidatedAt={{this.composer.lastValidatedAt}}
-                        @focusTarget={{this.composer.focusTarget}}
-                      />
-                    {{/if}}
                   {{/if}}
 
                   <span>
@@ -588,6 +580,16 @@ export default class ComposerContainer extends Component {
                       }}
                     />
                   </span>
+
+                  {{#if this.composerRedesign}}
+                    {{#if this.composer.model.canEditTitle}}
+                      <ComposerTitle
+                        @composer={{this.composer.model}}
+                        @lastValidatedAt={{this.composer.lastValidatedAt}}
+                        @focusTarget={{this.composer.focusTarget}}
+                      />
+                    {{/if}}
+                  {{/if}}
                 {{/unless}}
               </div>
             </ComposerEditor>

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -82,7 +82,7 @@ module PageObjects
       end
 
       def has_title_below_category_row?
-        page.has_css?("#{@composer_id} .title-and-category + .title-input")
+        page.has_css?("#{@composer_id} .title-and-category ~ .title-input")
       end
 
       def has_pm_recipients_in_category_row?


### PR DESCRIPTION
Under the `enable_composer_redesign` the order of the composer fields block is changed, with title below category/tags, and visually made part of the document.
As a consequence, the `composer-field` outlet has to move so it lands after category/tags, but _before_ the title element, as it would otherwise be between title and content in the document.
The commit also adjusts the styling for `title-and-category` to make sure the `after-title-and-category` (needs a rename later) neatly parks any connectors on the same row, not wraps below.