### PR TITLE
FEATURE: Add configurable DiscourseConnect Provider claims

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2175,6 +2175,7 @@ en:
     discourse_connect_url: "URL of DiscourseConnect endpoint (must include http:// or https://, and must not include a trailing slash)"
     discourse_connect_secret: "Secret string used to cryptographically authenticate DiscourseConnect information, be sure it is 10 characters or longer"
     discourse_connect_provider_secrets: "A list of domain-secret pairs that are using DiscourseConnect. Make sure DiscourseConnect secret is 10 characters or longer. Wildcard symbol * can be used to match any domain or only a part of it (e.g. *.example.com)."
+    discourse_connect_provider_claims: "When {{setting:enable_discourse_connect_provider}} is enabled, choose which optional user claims are included in Provider responses. Payloads are signed but not encrypted. The stable external ID and username are always included. All claims are selected by default for compatibility; removing claims may break relying sites that use them for account linking, authorization, or profile synchronization."
     discourse_connect_overrides_bio: "Overrides user bio in user profile and prevents user from changing it"
     discourse_connect_overrides_groups: "Synchronize all manual group membership with groups specified in the groups attribute (WARNING: if you do not specify groups all manual group membership will be cleared for user)"
     auth_overrides_email: "Overrides local email with external site email on every login, and prevent local changes. Applies to all authentication providers. (WARNING: discrepancies can occur due to normalization of local emails)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -955,6 +955,21 @@ login:
       key: "sso_provider.key_placeholder"
       value: "sso_provider.value_placeholder"
     area: "discourseconnect"
+  discourse_connect_provider_claims:
+    default: "name|email|admin|moderator|groups|avatar_url|profile_background_url|card_background_url"
+    type: list
+    list_type: compact
+    allow_any: false
+    choices:
+      - name
+      - email
+      - admin
+      - moderator
+      - groups
+      - avatar_url
+      - profile_background_url
+      - card_background_url
+    area: "discourseconnect"
   blocked_email_domains:
     default: "mailinator.com"
     type: host_list

--- a/lib/second_factor/actions/discourse_connect_provider.rb
+++ b/lib/second_factor/actions/discourse_connect_provider.rb
@@ -72,24 +72,28 @@ module SecondFactor::Actions
     end
 
     def populate_user_data(sso)
-      sso.name = current_user.name
-      sso.username = current_user.username
-      sso.email = current_user.email
-      sso.external_id = current_user.id.to_s
-      sso.admin = current_user.admin?
-      sso.moderator = current_user.moderator?
-      sso.groups = current_user.groups.pluck(:name).join(",")
-      sso.avatar_url =
-        GlobalPath.full_cdn_url(
-          current_user.uploaded_avatar.url,
-        ) if current_user.uploaded_avatar.present?
+      claims = SiteSetting.discourse_connect_provider_claims_map
 
-      if current_user.user_profile.profile_background_upload.present?
+      sso.name = current_user.name if claims.include?("name")
+      sso.username = current_user.username
+      sso.email = current_user.email if claims.include?("email")
+      sso.external_id = current_user.id.to_s
+      sso.admin = current_user.admin? if claims.include?("admin")
+      sso.moderator = current_user.moderator? if claims.include?("moderator")
+      sso.groups = current_user.groups.pluck(:name).join(",") if claims.include?("groups")
+
+      if claims.include?("avatar_url") && current_user.uploaded_avatar.present?
+        sso.avatar_url = GlobalPath.full_cdn_url(current_user.uploaded_avatar.url)
+      end
+
+      if claims.include?("profile_background_url") &&
+           current_user.user_profile.profile_background_upload.present?
         sso.profile_background_url =
           GlobalPath.full_cdn_url(current_user.user_profile.profile_background_upload.url)
       end
 
-      if current_user.user_profile.card_background_upload.present?
+      if claims.include?("card_background_url") &&
+           current_user.user_profile.card_background_upload.present?
         sso.card_background_url =
           GlobalPath.full_cdn_url(current_user.user_profile.card_background_upload.url)
       end

--- a/spec/lib/second_factor/actions/discourse_connect_provider_spec.rb
+++ b/spec/lib/second_factor/actions/discourse_connect_provider_spec.rb
@@ -258,5 +258,25 @@ RSpec.describe SecondFactor::Actions::DiscourseConnectProvider do
         GlobalPath.full_cdn_url(user.user_profile.card_background_upload.url),
       )
     end
+
+    it "includes only the configured optional claims" do
+      SiteSetting.discourse_connect_provider_claims = "email|groups|avatar_url"
+      user.update!(uploaded_avatar: Fabricate(:upload))
+      user.user_profile.update!(
+        profile_background_upload: Fabricate(:upload),
+        card_background_upload: Fabricate(:upload),
+      )
+
+      expect(response_payload.email).to eq(user.email)
+      expect(response_payload.groups).to eq(user.groups.pluck(:name).join(","))
+      expect(response_payload.avatar_url).to eq(GlobalPath.full_cdn_url(user.uploaded_avatar.url))
+      expect(response_payload.name).to be_nil
+      expect(response_payload.admin).to be_nil
+      expect(response_payload.moderator).to be_nil
+      expect(response_payload.profile_background_url).to be_nil
+      expect(response_payload.card_background_url).to be_nil
+      expect(response_payload.external_id).to eq(user.id.to_s)
+      expect(response_payload.username).to eq(user.username)
+    end
   end
 end

--- a/spec/lib/second_factor/actions/discourse_connect_provider_spec.rb
+++ b/spec/lib/second_factor/actions/discourse_connect_provider_spec.rb
@@ -259,24 +259,46 @@ RSpec.describe SecondFactor::Actions::DiscourseConnectProvider do
       )
     end
 
-    it "includes only the configured optional claims" do
-      SiteSetting.discourse_connect_provider_claims = "email|groups|avatar_url"
+    it "evaluates every configured optional claim independently" do
       user.update!(uploaded_avatar: Fabricate(:upload))
       user.user_profile.update!(
         profile_background_upload: Fabricate(:upload),
         card_background_upload: Fabricate(:upload),
       )
 
-      expect(response_payload.email).to eq(user.email)
-      expect(response_payload.groups).to eq(user.groups.pluck(:name).join(","))
-      expect(response_payload.avatar_url).to eq(GlobalPath.full_cdn_url(user.uploaded_avatar.url))
-      expect(response_payload.name).to be_nil
-      expect(response_payload.admin).to be_nil
-      expect(response_payload.moderator).to be_nil
-      expect(response_payload.profile_background_url).to be_nil
-      expect(response_payload.card_background_url).to be_nil
-      expect(response_payload.external_id).to eq(user.id.to_s)
-      expect(response_payload.username).to eq(user.username)
+      optional_claims = {
+        "name" => user.name,
+        "email" => user.email,
+        "admin" => user.admin?,
+        "moderator" => user.moderator?,
+        "groups" => user.groups.pluck(:name).join(","),
+        "avatar_url" => GlobalPath.full_cdn_url(user.uploaded_avatar.url),
+        "profile_background_url" =>
+          GlobalPath.full_cdn_url(user.user_profile.profile_background_upload.url),
+        "card_background_url" =>
+          GlobalPath.full_cdn_url(user.user_profile.card_background_upload.url),
+      }
+
+      optional_claims.each do |claim, expected_value|
+        SiteSetting.discourse_connect_provider_claims = claim
+        request = create_request("")
+        action = create_instance(user, request)
+        redirect_url = action.second_factor_auth_completed!(payload: sso.payload)[:sso_redirect_url]
+        response_payload = ::DiscourseConnectProvider.parse(URI(redirect_url).query)
+
+        actual_claims =
+          optional_claims.keys.index_with do |optional_claim|
+            response_payload.public_send(optional_claim)
+          end
+        expected_claims = optional_claims.keys.index_with(nil)
+        expected_claims[claim] = expected_value
+
+        expect(actual_claims).to eq(expected_claims)
+        expect(response_payload).to have_attributes(
+          external_id: user.id.to_s,
+          username: user.username,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, DiscourseConnect Provider responses included every optional user claim even when relying sites only needed a stable identity, increasing the privacy risk described in [the Meta discussion](https://meta.discourse.org/t/security-privacy-concern-email-exposed-in-discourseconnect-provider-redirect-url/397980) and partially addressed by #38382.

This change adds a fixed `discourse_connect_provider_claims` allowlist, keeps all claims enabled by default for compatibility, and always includes `external_id` and `username`.

### Testing

- `bin/rspec spec/lib/second_factor/actions/discourse_connect_provider_spec.rb` — 24 examples, 0 failures
- Targeted lint — passed
- Manually verified the setting description, defaults, and claim selection in the admin UI
- Verified the live HTTPS flow with claims limited to `name|groups`: login returned 200, the Provider returned a signed 302 callback, the callback returned 200, and the decoded response contained only `external_id`, `username`, `name`, and `groups`

### Screenshots

<img width="2782" height="1386" alt="image" src="https://github.com/user-attachments/assets/0e599787-4e0a-46b1-93a0-4f3219913aa9" />

<img width="1616" height="422" alt="image" src="https://github.com/user-attachments/assets/e72748ca-c85a-479f-b5b1-47818fa7aae7" />

<img width="1514" height="774" alt="image" src="https://github.com/user-attachments/assets/45f8f750-5d63-4bad-9c84-d948028e9a2f" />
