### PR TITLE
FIX: show category selector on the accepted solutions report

### DIFF
--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -167,17 +167,19 @@ after_initialize do
         .where.not(topics: { archetype: Archetype.private_message })
 
     raw_ids = report.filters[:category_ids]
-    if raw_ids.present?
-      parsed_ids = Array(raw_ids.is_a?(String) ? raw_ids.split(",") : raw_ids).map(&:to_i)
-      requested_ids =
+    filter_requested = raw_ids.present?
+    requested_ids =
+      if filter_requested
+        parsed_ids = Array(raw_ids.is_a?(String) ? raw_ids.split(",") : raw_ids).map(&:to_i)
         Category
-          .where(id: parsed_ids)
+          .in_order_of(:id, parsed_ids)
           .limit(DiscourseSolved::MAX_ACCEPTED_SOLUTIONS_CATEGORY_IDS)
           .pluck(:id)
-      report.add_filter("category_ids", type: "category_list", default: requested_ids)
+      end
+    report.add_filter("category_ids", type: "category_list", default: requested_ids)
 
-      accepted_solutions = accepted_solutions.where("topics.category_id" => requested_ids)
-    end
+    accepted_solutions =
+      accepted_solutions.where("topics.category_id" => requested_ids) if filter_requested
 
     accepted_solutions
       .where("discourse_solved_solved_topics.created_at >= ?", report.start_date)

--- a/plugins/discourse-solved/spec/reports/accepted_solutions_spec.rb
+++ b/plugins/discourse-solved/spec/reports/accepted_solutions_spec.rb
@@ -21,6 +21,14 @@ describe "accepted_solutions report" do # rubocop:disable RSpec/DescribeClass
     expect(build.total).to eq(2)
   end
 
+  it "registers the category_ids filter even when no filter is given" do
+    report = build
+
+    filter = report.available_filters["category_ids"]
+    expect(filter).to be_present
+    expect(filter[:type]).to eq("category_list")
+  end
+
   it "filters by category when the category_ids filter is provided" do
     target_category = Fabricate(:category)
     other_category = Fabricate(:category)
@@ -56,6 +64,17 @@ describe "accepted_solutions report" do # rubocop:disable RSpec/DescribeClass
     report = build(filters: { category_ids: "#{first_category.id},#{second_category.id}" })
 
     expect(report.total).to eq(2)
+  end
+
+  it "preserves the requested category order in the filter default" do
+    first_category = Fabricate(:category)
+    second_category = Fabricate(:category)
+
+    report = build(filters: { category_ids: [second_category.id, first_category.id] })
+
+    expect(report.available_filters["category_ids"][:default]).to eq(
+      [second_category.id, first_category.id],
+    )
   end
 
   it "strips category ids that don't correspond to an existing category" do


### PR DESCRIPTION
The categories filter never appeared on the accepted solutions report until a category was already selected in the URL, so there was no way to actually select one. It now shows up right away.