### PR TITLE
FIX: Bound user-actions index limit at 100

### DIFF
--- a/app/controllers/user_actions_controller.rb
+++ b/app/controllers/user_actions_controller.rb
@@ -11,7 +11,7 @@ class UserActionsController < ApplicationController
       )
     offset = [0, user_actions_params[:offset].to_i].max
     action_types = (user_actions_params[:filter] || "").split(",").map(&:to_i)
-    limit = user_actions_params.fetch(:limit, 30).to_i
+    limit = [user_actions_params.fetch(:limit, 30).to_i, 100].min
 
     ensure_user_actions_visible!(user, action_types)
 

--- a/spec/requests/user_actions_controller_spec.rb
+++ b/spec/requests/user_actions_controller_spec.rb
@@ -13,6 +13,36 @@ RSpec.describe UserActionsController do
       end
     end
 
+    context "when requesting more actions than the maximum page size" do
+      fab!(:user)
+
+      let(:params) { { username: user.username, filter: UserAction::REPLY, limit: 200 } }
+
+      before do
+        topic = Fabricate(:topic, user: user)
+
+        101.times do
+          post = Fabricate(:post, topic: topic, user: user)
+          UserAction.create!(
+            action_type: UserAction::REPLY,
+            user: user,
+            acting_user: user,
+            target_topic: topic,
+            target_post: post,
+          )
+        end
+
+        user.user_stat.update!(post_count: 101)
+      end
+
+      it "returns no more than 100 actions" do
+        user_actions
+
+        expect(response).to have_http_status :ok
+        expect(response.parsed_body["user_actions"].length).to eq(100)
+      end
+    end
+
     context "when 'username' is specified" do
       let(:username) { post.user.username }
       let(:params) { { username: username } }


### PR DESCRIPTION
## Summary

The public `GET /user_actions.json` endpoint accepted an unbounded client-supplied `limit` and forwarded it directly into the activity query, allowing an anonymous request to materialize and serialize an arbitrarily large number of actions. The controller now caps the effective limit at 100 while preserving the default of 30 and smaller caller-requested values, so oversized requests return a bounded page without excessive resource use. Public-action visibility and authorization filtering are unchanged.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1588

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>