### PR TITLE
FIX: Prevent flagging inaccessible topics

### DIFF
--- a/app/controllers/post_actions_controller.rb
+++ b/app/controllers/post_actions_controller.rb
@@ -66,11 +66,13 @@ class PostActionsController < ApplicationController
 
     post_id =
       if flag_topic
-        begin
-          Topic.find(params[:id]).posts.first.id
-        rescue StandardError
-          raise Discourse::NotFound
-        end
+        topic = Topic.find_by(id: params[:id])
+        raise Discourse::NotFound unless guardian.can_see_topic?(topic)
+
+        post = topic.posts.first
+        raise Discourse::NotFound if post.blank?
+
+        post.id
       else
         params[:id]
       end

--- a/spec/requests/post_actions_controller_spec.rb
+++ b/spec/requests/post_actions_controller_spec.rb
@@ -116,6 +116,26 @@ RSpec.describe PostActionsController do
       expect(response.status).to eq(403)
     end
 
+    it "returns 404 when flagging a hidden topic" do
+      sign_in(user)
+      SiteSetting.detailed_404 = false
+      pm = Fabricate(:private_message_post, user: coding_horror)
+
+      get "/t/#{pm.topic.id}.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["errors"].first).to include(I18n.t("not_found"))
+
+      post "/post_actions.json",
+           params: {
+             id: pm.topic.id,
+             flag_topic: "true",
+             post_action_type_id: PostActionType.types[:inappropriate],
+           }
+
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["errors"].first).to include(I18n.t("not_found"))
+    end
+
     it "fails when the user tries to notify user that has disabled PM" do
       sign_in(user)
       user2 = Fabricate(:user)


### PR DESCRIPTION
## Summary

Refactors the `flag_topic` branch of `PostActionsController#fetch_post_from_params` (`app/controllers/post_actions_controller.rb:68`) to replace broad exception handling with explicit topic lookup, visibility, and first-post checks. Topics that are unavailable to the current user now follow the standard not-found response path. Adds request coverage for flagging an inaccessible topic.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1325

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>