### PR TITLE
FIX: Respect read-only permissions for chat message interactions

### DIFF
--- a/plugins/chat/app/services/chat/create_message_interaction.rb
+++ b/plugins/chat/app/services/chat/create_message_interaction.rb
@@ -50,7 +50,7 @@ module Chat
     end
 
     def can_interact_with_message(guardian:, message:)
-      guardian.can_preview_chat_channel?(message.chat_channel)
+      guardian.can_join_chat_channel?(message.chat_channel)
     end
 
     def fetch_interaction(guardian:, message:, action:)

--- a/plugins/chat/spec/requests/chat/api/channels_messages_interactions_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_messages_interactions_controller_spec.rb
@@ -105,6 +105,58 @@ RSpec.describe Chat::Api::ChannelsMessagesInteractionsController do
       end
     end
 
+    context "when user has read-only access to the category channel" do
+      fab!(:read_only_group, :group)
+      fab!(:read_only_category) do
+        Fabricate(
+          :private_category,
+          group: read_only_group,
+          permission_type: CategoryGroup.permission_types[:readonly],
+        )
+      end
+      fab!(:read_only_channel) { Fabricate(:category_channel, chatable: read_only_category) }
+      fab!(:read_only_message) do
+        Fabricate(
+          :chat_message,
+          chat_channel: read_only_channel,
+          user: Discourse.system_user,
+          blocks: [
+            {
+              type: "actions",
+              elements: [
+                {
+                  action_id: "xxx",
+                  value: "foo",
+                  type: "button",
+                  text: {
+                    type: "plain_text",
+                    text: "Click Me",
+                  },
+                },
+              ],
+            },
+          ],
+        )
+      end
+
+      before { read_only_group.add(current_user) }
+
+      it "returns 404 and does not create an interaction" do
+        expect do
+          post "/chat/api/channels/#{read_only_channel.id}/messages/#{read_only_message.id}/interactions",
+               params: {
+                 action_id: "xxx",
+               }
+        end.not_to change(Chat::MessageInteraction, :count)
+
+        expect(response.status).to eq(404)
+        expect(response.parsed_body).to include(
+          "errors" => [I18n.t("not_found")],
+          "error_type" => "not_found",
+        )
+      end
+    end
+
     context "when user is not logged in" do
       before { sign_out }
 

--- a/plugins/chat/spec/services/chat/create_message_interaction_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_interaction_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Chat::CreateMessageInteraction do
     end
     let(:dependencies) { { guardian: } }
 
+    before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone] }
+
     context "when all steps pass" do
       before { message.chat_channel.add(current_user) }
 


### PR DESCRIPTION
## Summary

Chat message buttons and other interactive actions are write operations, but users with read-only category access could previously trigger them. This change updates `Chat::CreateMessageInteraction` in `plugins/chat/app/services/chat/create_message_interaction.rb:53` to require permission to join the channel rather than permission to preview it. Attempts from read-only users now return a not-found response without creating a `Chat::MessageInteraction`. Request coverage has been added for read-only category channels.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1324

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>