### PR TITLE
FIX: Consistently exclude synonyms and hidden tags from tag lists

### DIFF
--- a/app/controllers/tag_groups_controller.rb
+++ b/app/controllers/tag_groups_controller.rb
@@ -90,7 +90,7 @@ class TagGroupsController < ApplicationController
   end
 
   def search
-    matches = TagGroup.includes(:tags).visible(guardian).all
+    matches = TagGroup.visible(guardian).includes(:base_tags)
 
     matches = matches.where("lower(name) ILIKE ?", "%#{params[:q].strip}%") if params[:q].present?
 
@@ -98,28 +98,26 @@ class TagGroupsController < ApplicationController
       matches = matches.where("lower(NAME) in (?)", params[:names].map(&:downcase))
     end
 
-    matches =
-      matches.order("name").limit(
-        fetch_limit_from_params(
-          default: SiteSetting.max_tag_search_results,
-          max: MAX_TAG_GROUPS_SEARCH_RESULTS,
-        ),
+    limit =
+      fetch_limit_from_params(
+        default: SiteSetting.max_tag_search_results,
+        max: MAX_TAG_GROUPS_SEARCH_RESULTS,
       )
 
-    render json: {
-             results:
-               matches.map do |x|
-                 {
-                   name: x.name,
-                   tags:
-                     x
-                       .tags
-                       .base_tags
-                       .pluck(:id, :name, :slug)
-                       .map { |id, name, slug| { id:, name:, slug: } },
-                 }
-               end,
-           }
+    matches = matches.order("name").limit(limit).to_a
+    visible_tag_ids = DiscourseTagging.visible_tag_ids(matches.flat_map(&:base_tags), guardian)
+
+    results =
+      matches.map do |tag_group|
+        tags = tag_group.base_tags.select { |tag| visible_tag_ids.include?(tag.id) }
+
+        {
+          name: tag_group.name,
+          tags: tags.map { |tag| { id: tag.id, name: tag.name, slug: tag.slug } },
+        }
+      end
+
+    render json: { results: }
   end
 
   private

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -49,40 +49,29 @@ class TagsController < ::ApplicationController
     @title = @description_meta
 
     preload_localizations = SiteSetting.content_localization_enabled
+    base_tags_includes = preload_localizations ? { base_tags: :localizations } : :base_tags
 
     if SiteSetting.tags_listed_by_group
-      ungrouped_tags = Tag.where("tags.id NOT IN (SELECT tag_id FROM tag_group_memberships)")
+      ungrouped_tags =
+        Tag.browsable(guardian).where("tags.id NOT IN (SELECT tag_id FROM tag_group_memberships)")
       ungrouped_tags = ungrouped_tags.used_tags_in_regular_topics(guardian) unless show_all_tags?
       ungrouped_tags = ungrouped_tags.order(:id)
       ungrouped_tags = ungrouped_tags.includes(:localizations) if preload_localizations
 
-      tag_group_includes =
-        preload_localizations ? { none_synonym_tags: :localizations } : :none_synonym_tags
+      tag_groups = TagGroup.visible(guardian).order("name ASC").includes(base_tags_includes).to_a
 
       grouped_tag_counts =
-        TagGroup
-          .visible(guardian)
-          .order("name ASC")
-          .includes(tag_group_includes)
-          .map do |tag_group|
-            {
-              id: tag_group.id,
-              name: tag_group.name,
-              tags:
-                self.class.tag_counts_json(browsable_tags(tag_group.none_synonym_tags), guardian),
-            }
-          end
+        tag_counts_json_per_owner(tag_groups).map do |tag_group, group_tags|
+          { id: tag_group.id, name: tag_group.name, tags: group_tags }
+        end
 
       @tags = self.class.tag_counts_json(ungrouped_tags, guardian)
       @extras = { tag_groups: grouped_tag_counts }
     else
-      tags = show_all_tags? ? Tag.all : Tag.used_tags_in_regular_topics(guardian)
+      tags = Tag.browsable(guardian)
+      tags = tags.used_tags_in_regular_topics(guardian) unless show_all_tags?
       tags = tags.order(:id)
-      unrestricted_tags = DiscourseTagging.filter_visible(tags.where(target_tag_id: nil), guardian)
-      unrestricted_tags = unrestricted_tags.includes(:localizations) if preload_localizations
-
-      category_includes =
-        preload_localizations ? { none_synonym_tags: :localizations } : :none_synonym_tags
+      tags = tags.includes(:localizations) if preload_localizations
 
       categories =
         Category
@@ -90,23 +79,16 @@ class TagsController < ::ApplicationController
             "id IN (SELECT category_id FROM category_tags WHERE category_id IN (?))",
             guardian.allowed_category_ids,
           )
-          .includes(category_includes)
+          .includes(base_tags_includes)
           .order(:id)
+          .to_a
 
       category_tag_counts =
-        categories
-          .map do |c|
-            visible_category_tags =
-              browsable_tags(DiscourseTagging.filter_visible(c.none_synonym_tags, guardian))
-            category_tags = self.class.tag_counts_json(visible_category_tags, guardian)
+        tag_counts_json_per_owner(categories).filter_map do |category, category_tags|
+          { id: category.id, tags: category_tags } if category_tags.present?
+        end
 
-            next if category_tags.empty?
-
-            { id: c.id, tags: category_tags }
-          end
-          .compact
-
-      @tags = self.class.tag_counts_json(unrestricted_tags, guardian)
+      @tags = self.class.tag_counts_json(tags, guardian)
       @extras = { categories: category_tag_counts }
     end
 
@@ -121,7 +103,10 @@ class TagsController < ::ApplicationController
 
   def list
     offset = params[:offset].to_i || 0
-    tags = guardian.can_admin_tags? ? Tag.all : Tag.visible(guardian)
+    only_tags = params[:only_tags]
+
+    tags = only_tags.present? ? Tag.visible(guardian) : Tag.browsable(guardian)
+    tags = tags.without_pm_only_tags(guardian) unless show_all_tags?
 
     load_more_query_params = { offset: offset + 1 }
 
@@ -130,7 +115,7 @@ class TagsController < ::ApplicationController
       load_more_query_params[:filter] = filter
     end
 
-    if only_tags = params[:only_tags]
+    if only_tags
       tags = tags.where("LOWER(tags.name) IN (?)", only_tags.split(",").map(&:downcase))
       load_more_query_params[:only_tags] = only_tags
     end
@@ -497,9 +482,18 @@ class TagsController < ::ApplicationController
     guardian.can_admin_tags? && guardian.is_admin?
   end
 
-  def browsable_tags(tags)
+  def without_pm_only_tags(tags)
     return tags if show_all_tags?
     DiscourseTagging.without_pm_only_tags(tags, guardian)
+  end
+
+  def tag_counts_json_per_owner(owners)
+    visible_tag_ids = DiscourseTagging.visible_tag_ids(owners.flat_map(&:base_tags), guardian)
+
+    owners.map do |owner|
+      tags = owner.base_tags.select { |tag| visible_tag_ids.include?(tag.id) }
+      [owner, self.class.tag_counts_json(without_pm_only_tags(tags), guardian)]
+    end
   end
 
   def fetch_tag(raise_not_found: true)
@@ -576,11 +570,13 @@ class TagsController < ::ApplicationController
 
   def self.tag_counts_json(tags, guardian)
     show_pm_tags = guardian.can_tag_pms?
+    target_tag_ids = tags.filter_map(&:target_tag_id).uniq
     target_tags =
-      Tag
-        .visible(guardian)
-        .where(id: tags.filter_map(&:target_tag_id).uniq)
-        .select(:id, :name, :slug)
+      if target_tag_ids.present?
+        Tag.visible(guardian).where(id: target_tag_ids).select(:id, :name, :slug)
+      else
+        []
+      end
 
     tags.map do |t|
       topic_count = t.public_send(Tag.topic_count_column(guardian))

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -187,10 +187,7 @@ class Category < ActiveRecord::Base
 
   has_many :category_tags, dependent: :destroy
   has_many :tags, through: :category_tags
-  has_many :none_synonym_tags,
-           -> { where(target_tag_id: nil) },
-           through: :category_tags,
-           source: :tag
+  has_many :base_tags, -> { where(target_tag_id: nil) }, through: :category_tags, source: :tag
   has_many :category_tag_groups, dependent: :destroy
   has_many :tag_groups, through: :category_tag_groups
 

--- a/app/models/form_template.rb
+++ b/app/models/form_template.rb
@@ -27,7 +27,7 @@ class FormTemplate < ActiveRecord::Base
 
     tag_groups =
       TagGroup
-        .includes(:tags)
+        .includes(:base_tags)
         .visible(guardian)
         .where("lower(name) IN (?)", tag_group_names)
         .index_by { |tg| tg.name }
@@ -36,7 +36,7 @@ class FormTemplate < ActiveRecord::Base
       next form_field unless form_field["tag_group"]
 
       tag_group_name = form_field["tag_group"]
-      tags = tag_groups[tag_group_name].tags.reject { |tag| tag.target_tag_id.present? }
+      tags = tag_groups[tag_group_name].base_tags
       ordered_field = {}
 
       tags =

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,12 +27,13 @@ class Tag < ActiveRecord::Base
           where("lower(tags.name) IN (?)", name)
         end
 
-  # tags that have never been used and don't belong to a tag group
+  # base tags that have never been used and don't belong to a tag group
   scope :unused,
         -> do
-          where(staff_topic_count: 0, pm_topic_count: 0, target_tag_id: nil).joins(
-            "LEFT JOIN tag_group_memberships tgm ON tags.id = tgm.tag_id",
-          ).where("tgm.tag_id IS NULL")
+          base_tags
+            .where(staff_topic_count: 0, pm_topic_count: 0)
+            .joins("LEFT JOIN tag_group_memberships tgm ON tags.id = tgm.tag_id")
+            .where("tgm.tag_id IS NULL")
         end
 
   scope :used_tags_in_regular_topics,
@@ -40,6 +41,14 @@ class Tag < ActiveRecord::Base
 
   scope :base_tags, -> { where(target_tag_id: nil) }
   scope :visible, ->(guardian = nil) { merge(DiscourseTagging.visible_tags(guardian)) }
+
+  scope :without_pm_only_tags,
+        ->(guardian) do
+          next all if guardian.can_tag_pms?
+          where("NOT (tags.pm_topic_count > 0 AND tags.#{Tag.topic_count_column(guardian)} = 0)")
+        end
+
+  scope :browsable, ->(guardian) { base_tags.visible(guardian) }
 
   has_many :tag_users, dependent: :destroy # notification settings
 
@@ -144,14 +153,10 @@ class Tag < ActiveRecord::Base
 
     return [] if scope_category_ids.empty?
 
-    filter_sql =
-      (
-        if guardian.is_staff?
-          ""
-        else
-          " AND tags.id IN (#{DiscourseTagging.visible_tags(guardian).select(:id).to_sql})"
-        end
-      )
+    filter_sql = +" AND tags.target_tag_id IS NULL"
+    if !guardian.is_admin?
+      filter_sql << " AND tags.id IN (#{DiscourseTagging.visible_tags(guardian).select(:id).to_sql})"
+    end
 
     tag_data = DB.query <<~SQL
       SELECT tags.id as tag_id, tags.name as tag_name, tags.slug as tag_slug, SUM(stats.topic_count) AS sum_topic_count

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -13,7 +13,7 @@ class TagGroup < ActiveRecord::Base
 
   has_many :tag_group_memberships, dependent: :destroy
   has_many :tags, through: :tag_group_memberships
-  has_many :none_synonym_tags,
+  has_many :base_tags,
            -> { where(target_tag_id: nil) },
            through: :tag_group_memberships,
            source: "tag"
@@ -37,9 +37,10 @@ class TagGroup < ActiveRecord::Base
   end
 
   def tag_ids=(ids)
-    base_tags = Tag.where(id: ids)
-    synonyms = Tag.where(target_tag_id: base_tags.select(:id)).where.not(id: base_tags.select(:id))
-    self.tags = base_tags + synonyms
+    selected_tags = Tag.where(id: ids)
+    synonyms =
+      Tag.where(target_tag_id: selected_tags.select(:id)).where.not(id: selected_tags.select(:id))
+    self.tags = selected_tags + synonyms
   end
 
   def parent_tag_id=(id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -409,11 +409,8 @@ class User < ActiveRecord::Base
   def visible_sidebar_tags(user_guardian = nil)
     user_guardian ||= guardian
 
-    DiscourseTagging.filter_visible(
-      Tag.where(
-        id: SidebarSectionLink.where(user_id: id, linkable_type: "Tag").select(:linkable_id),
-      ),
-      user_guardian,
+    Tag.browsable(user_guardian).where(
+      id: sidebar_section_links.where(linkable_type: "Tag").select(:linkable_id),
     )
   end
 

--- a/app/serializers/concerns/user_sidebar_mixin.rb
+++ b/app/serializers/concerns/user_sidebar_mixin.rb
@@ -8,7 +8,7 @@ module UserSidebarMixin
   end
 
   def display_sidebar_tags
-    DiscourseTagging.filter_visible(Tag, scope).exists?
+    Tag.browsable(scope).exists?
   end
 
   def include_display_sidebar_tags?

--- a/app/serializers/tag_group_serializer.rb
+++ b/app/serializers/tag_group_serializer.rb
@@ -4,7 +4,7 @@ class TagGroupSerializer < ApplicationSerializer
   attributes :id, :name, :tags, :parent_tag, :one_per_topic, :permissions
 
   def tags
-    object.tags.base_tags.order(:name).map { |t| { id: t.id, name: t.name, slug: t.slug_for_url } }
+    object.base_tags.order(:name).map { |t| { id: t.id, name: t.name, slug: t.slug_for_url } }
   end
 
   def parent_tag

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -245,10 +245,7 @@ class UserUpdater
         SidebarSectionLinksUpdater.update_tag_section_links(
           user,
           tag_ids:
-            DiscourseTagging
-              .filter_visible(Tag, @user_guardian)
-              .where(name: attributes[:sidebar_tag_names])
-              .pluck(:id),
+            Tag.browsable(@user_guardian).where(name: attributes[:sidebar_tag_names]).pluck(:id),
         )
       end
 

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -750,6 +750,12 @@ module DiscourseTagging
     guardian&.is_admin? ? query : query.where(id: visible_tags(guardian).select(:id))
   end
 
+  def self.visible_tag_ids(tags, guardian = nil)
+    ids = tags.map(&:id).uniq
+    return ids.to_set if ids.empty? || guardian&.is_admin?
+    visible_tags(guardian).where(id: ids).pluck(:id).to_set
+  end
+
   def self.filter_visible_in_accessible_categories(query, guardian = nil)
     return query if guardian.nil? || guardian.is_admin?
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1199,15 +1199,15 @@ class Search
 
   def tags_search
     return unless SiteSetting.tagging_enabled
-    tags =
-      DiscourseTagging
-        .visible_tags(@guardian)
-        .includes(:tag_search_data)
-        .where("tag_search_data.search_data @@ #{ts_query}")
-        .references(:tag_search_data)
-        .order("name asc")
-        .limit(limit)
-        .each { |tag| @results.add(tag) }
+
+    Tag
+      .browsable(@guardian)
+      .includes(:tag_search_data)
+      .where("tag_search_data.search_data @@ #{ts_query}")
+      .references(:tag_search_data)
+      .order("name asc")
+      .limit(limit)
+      .each { |tag| @results.add(tag) }
   end
 
   def exclude_topics_search

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1874,6 +1874,12 @@ RSpec.describe Search do
         expect(search.tags.map(&:name)).to eq([tag.name, "#{tag.name}9"])
       end
 
+      it "does not return synonyms" do
+        Fabricate(:tag, name: "#{tag.name}9", target_tag: tag)
+
+        expect(search.tags).to eq([tag])
+      end
+
       it "filters category-restricted tags based on category access" do
         category_tag = Fabricate(:tag, name: "#{tag.name}9")
         tag_group.tags = [category_tag]

--- a/spec/models/form_template_spec.rb
+++ b/spec/models/form_template_spec.rb
@@ -96,8 +96,9 @@ RSpec.describe FormTemplate, type: :model do
     fab!(:tag5, :tag)
     fab!(:tag_group) { Fabricate(:tag_group, tags: [tag1, tag2, tag3]) }
     fab!(:tag_group2) { Fabricate(:tag_group, tags: [tag4, tag5]) }
+    fab!(:synonym) { Fabricate(:tag, target_tag: tag1) }
 
-    it "automatically adds tags choices to the template" do
+    it "automatically adds tags choices, but no synonyms, to the template" do
       template = <<~YAML
         - type: tag-chooser
           id: tag-chooser

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe Tag do
     end
 
     context "with hidden tags" do
+      fab!(:moderator)
       let(:hidden_tag) { Fabricate(:tag, name: "hidden") }
       let!(:staff_tag_group) do
         Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
@@ -197,6 +198,27 @@ RSpec.describe Tag do
           { id: hidden_tag.id, name: hidden_tag.name, slug: hidden_tag.slug },
         )
       end
+
+      it "doesn't return tags hidden from moderators to a moderator" do
+        admin_only_tag = Fabricate(:tag, name: "admin-only")
+        Fabricate(:tag_group, permissions: { "admins" => 1 }, tag_names: [admin_only_tag.name])
+        Fabricate(:topic, tags: [admin_only_tag])
+
+        expect(Tag.top_tags(guardian: Guardian.new(moderator))).to_not include(
+          { id: admin_only_tag.id, name: admin_only_tag.name, slug: admin_only_tag.slug },
+        )
+      end
+    end
+
+    it "doesn't return synonyms" do
+      target_tag = Fabricate(:tag)
+      Fabricate(:topic, tags: [target_tag, Fabricate(:tag, target_tag: target_tag)])
+      serialized_target_tag = { id: target_tag.id, name: target_tag.name, slug: target_tag.slug }
+
+      expect(Tag.top_tags).to contain_exactly(serialized_target_tag)
+      expect(Tag.top_tags(guardian: Guardian.new(Fabricate(:admin)))).to contain_exactly(
+        serialized_target_tag,
+      )
     end
 
     context "with numeric-only tag names" do
@@ -381,6 +403,41 @@ RSpec.describe Tag do
       expect(tag2.public_topic_count).to eq(0)
       expect(tag3.staff_topic_count).to eq(0)
       expect(tag3.public_topic_count).to eq(0)
+    end
+  end
+
+  describe ".browsable" do
+    fab!(:admin)
+    fab!(:browsable_tag, :tag)
+    fab!(:hidden_tag, :tag)
+    fab!(:synonym) { Fabricate(:tag, target_tag: browsable_tag) }
+    fab!(:admin_tag_group) do
+      Fabricate(:tag_group, permissions: { "admins" => 1 }, tag_names: [hidden_tag.name])
+    end
+
+    it "excludes synonyms, and tags the guardian is not allowed to see" do
+      expect(Tag.browsable(Guardian.new)).to contain_exactly(browsable_tag)
+      expect(Tag.browsable(Guardian.new(admin))).to contain_exactly(browsable_tag, hidden_tag)
+    end
+  end
+
+  describe ".without_pm_only_tags" do
+    fab!(:admin)
+    fab!(:used_tag) { Fabricate(:tag, public_topic_count: 1, staff_topic_count: 1) }
+    fab!(:pm_only_tag) { Fabricate(:tag, pm_topic_count: 1) }
+
+    it "excludes tags only used in personal messages" do
+      expect(Tag.without_pm_only_tags(Guardian.new)).to contain_exactly(used_tag)
+      expect(Tag.without_pm_only_tags(Guardian.new(user))).to contain_exactly(used_tag)
+    end
+
+    it "keeps them for a guardian allowed to tag personal messages" do
+      SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:admins]
+
+      expect(Tag.without_pm_only_tags(Guardian.new(admin))).to contain_exactly(
+        used_tag,
+        pm_only_tag,
+      )
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3891,8 +3891,12 @@ RSpec.describe User do
     fab!(:tag_sidebar_section_link_2) do
       Fabricate(:tag_sidebar_section_link, user: user, linkable: hidden_tag)
     end
+    fab!(:synonym) { Fabricate(:tag, target_tag: tag) }
+    fab!(:tag_sidebar_section_link_3) do
+      Fabricate(:tag_sidebar_section_link, user: user, linkable: synonym)
+    end
 
-    it "should only return tag sidebar section link records of tags that the user is allowed to see" do
+    it "should only return tag sidebar section link records of tags that the user is allowed to browse" do
       expect(user.visible_sidebar_tags).to contain_exactly(tag)
 
       user.update!(admin: true)

--- a/spec/requests/tag_groups_controller_spec.rb
+++ b/spec/requests/tag_groups_controller_spec.rb
@@ -91,6 +91,25 @@ RSpec.describe TagGroupsController do
 
         expect(results).to be_empty
       end
+
+      it "does not return the tags restricted to a category anons can't see" do
+        tag_group = tag_group_with_permission(everyone, readonly)
+        secret_tag = Fabricate(:tag)
+        tag_group.tags << secret_tag
+        CategoryTag.create!(
+          category: Fabricate(:private_category, group: Fabricate(:group)),
+          tag: secret_tag,
+        )
+
+        get "/tag_groups/filter/search.json"
+        expect(response.status).to eq(200)
+
+        results = JSON.parse(response.body, symbolize_names: true).fetch(:results)
+
+        expect(results).to contain_exactly(
+          { name: tag_group.name, tags: [{ id: tag.id, name: tag.name, slug: tag.slug }] },
+        )
+      end
     end
 
     context "for regular users" do

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TagsController do
   before { SiteSetting.tagging_enabled = true }
 
   describe "#index" do
+    fab!(:group)
     fab!(:test_tag) { Fabricate(:tag, name: "test", description: "some description") }
 
     fab!(:topic_tag) do
@@ -30,7 +31,7 @@ RSpec.describe TagsController do
     fab!(:synonym) { Fabricate(:tag, name: "synonym", target_tag: topic_tag) }
 
     shared_examples "retrieves the right tags" do
-      it "retrieves all tags as a staff user" do
+      it "retrieves all tags but the synonyms as a staff user" do
         sign_in(admin)
 
         get "/tags.json"
@@ -38,6 +39,12 @@ RSpec.describe TagsController do
         expect(response.status).to eq(200)
 
         tags = response.parsed_body["tags"]
+
+        expect(tags.map { |t| t["name"] }).to contain_exactly(
+          test_tag.name,
+          topic_tag.name,
+          pm_only_tag.name,
+        )
 
         serialized_tag = tags.find { |t| t["name"] == test_tag.name }
 
@@ -104,7 +111,23 @@ RSpec.describe TagsController do
         expect(serialized_tag["pm_only"]).to eq(true)
       end
 
+      it "does not list tags restricted to a category the user can't see" do
+        secret_tag = Fabricate(:tag, name: "secret", public_topic_count: 1, staff_topic_count: 1)
+        CategoryTag.create!(category: Fabricate(:private_category, group:), tag: secret_tag)
+
+        sign_in(moderator)
+
+        get "/tags.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["tags"].map { |tag| tag["name"] }).to_not include(
+          secret_tag.name,
+        )
+      end
+
       it "only retrieve tags that have been used in public topics for non-staff user" do
+        synonym.update_columns(public_topic_count: 2, staff_topic_count: 2)
+
         sign_in(user)
 
         get "/tags.json"
@@ -194,6 +217,18 @@ RSpec.describe TagsController do
     context "with tags_listed_by_group enabled" do
       before { SiteSetting.tags_listed_by_group = true }
       include_examples "retrieves the right tags"
+
+      it "does not list tags of a visible group when they are restricted to a category the user can't see" do
+        secret_tag = Fabricate(:tag, name: "secret")
+        CategoryTag.create!(category: Fabricate(:private_category, group:), tag: secret_tag)
+        Fabricate(:tag_group, tags: [topic_tag, secret_tag])
+
+        get "/tags.json"
+
+        expect(response.status).to eq(200)
+        group = response.parsed_body.dig("extras", "tag_groups").first
+        expect(group["tags"].map { |tag| tag["name"] }).to contain_exactly(topic_tag.name)
+      end
 
       it "hides tags only used in personal messages from grouped lists for regular users" do
         Fabricate(:tag_group, tags: [topic_tag, pm_only_tag])
@@ -2660,6 +2695,62 @@ RSpec.describe TagsController do
           "/tags/list.json?offset=2",
         )
       end
+    end
+
+    it "does not return synonyms unless they are requested by name" do
+      synonym = Fabricate(:tag, name: "tag5", target_tag: tag1)
+
+      sign_in(user)
+
+      get "/tags/list.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq(
+        [tag1.name, tag2.name, tag3.name],
+      )
+
+      get "/tags/list.json", params: { only_tags: synonym.name }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq([synonym.name])
+    end
+
+    it "only returns the tags each user is allowed to browse" do
+      pm_only_tag = Fabricate(:tag, name: "tag5", pm_topic_count: 1)
+      admin_only_tag = Fabricate(:tag, name: "tag6")
+      Fabricate(:tag_group, permissions: { "admins" => 1 }, tag_names: [admin_only_tag.name])
+
+      sign_in(user)
+
+      get "/tags/list.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq(
+        [tag1.name, tag2.name, tag3.name],
+      )
+
+      sign_in(moderator)
+
+      get "/tags/list.json"
+
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq(
+        [tag1.name, tag2.name, tag3.name, staff_only_tag.name],
+      )
+
+      sign_in(admin)
+
+      get "/tags/list.json"
+
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq(
+        [
+          tag1.name,
+          tag2.name,
+          tag3.name,
+          staff_only_tag.name,
+          pm_only_tag.name,
+          admin_only_tag.name,
+        ],
+      )
     end
 
     it "accepts a `filter` param and filters the tags by tag name" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3126,7 +3126,7 @@ RSpec.describe UsersController do
             expect(user.reload.sidebar_section_links.count).to eq(0)
           end
 
-          it "should allow user to add tag sidebar section links only for tags that are visible to the user" do
+          it "should allow user to add tag sidebar section links only for tags that the user can browse" do
             SiteSetting.tagging_enabled = true
 
             tag = Fabricate(:tag)
@@ -3135,10 +3135,11 @@ RSpec.describe UsersController do
             hidden_tag = Fabricate(:tag)
             Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
 
-            put "/u/#{user.username}.json",
-                params: {
-                  sidebar_tag_names: [tag.name, "somerandomtag", hidden_tag.name],
-                }
+            synonym = Fabricate(:tag, target_tag: tag)
+
+            sidebar_tag_names = [tag.name, "somerandomtag", hidden_tag.name, synonym.name]
+
+            put "/u/#{user.username}.json", params: { sidebar_tag_names: }
 
             expect(response.status).to eq(200)
             expect(user.sidebar_section_links.count).to eq(1)
@@ -3151,10 +3152,7 @@ RSpec.describe UsersController do
             user.update!(admin: true)
 
             expect do
-              put "/u/#{user.username}.json",
-                  params: {
-                    sidebar_tag_names: [tag.name, "somerandomtag", hidden_tag.name],
-                  }
+              put "/u/#{user.username}.json", params: { sidebar_tag_names: }
 
               expect(response.status).to eq(200)
             end.to change { user.sidebar_section_links.count }.from(1).to(2)


### PR DESCRIPTION
Every endpoint that lists tags for browsing hand-rolled its own filter chain, and they had drifted apart.

The tags page filtered synonyms out when tags were listed flat but not when they were listed by group, so a synonym of a tag belonging to no tag group was shown next to its target — a duplicate entry whose page only redirects back to the tag it duplicates. Synonyms of grouped tags were hidden by accident rather than by design: creating a synonym copies the target's tag group memberships onto it, which happens to satisfy the "belongs to no tag group" condition the ungrouped list is built from. Non-admins were shielded by a second accident, since a synonym normally ends up with a zero topic count — so any synonym that kept its topics, whether from an import, a plugin, or assigning `target_tag_id` directly, was listed to everyone.

Tag visibility has two independent mechanisms: tag group permissions, and the categories a tag is attached to. Only the second one can apply to a tag that belongs to no tag group, and neither the grouped tags page nor the tag group search endpoint applied it, so the names of tags restricted to a category the viewer cannot read were listed to them. `TagGroup.visible` gates which groups are returned, never the tags inside them.

The navigation menu tag picker filtered out neither synonyms nor tags only used in personal messages, and gated on staff where the tags page gates on admin, so moderators were served the entire tag table. A synonym picked there was saved as a sidebar link and rendered from then on. Top tags and tag search had the same gap.

Paths that resolve a tag by name keep matching synonyms on purpose: the composer offers them so that typing a retired name finds the tag that replaced it, and hashtags in posts cooked before a rename have to keep working. Serializers that echo configuration back are left alone, because filtering a value the client posts straight back would silently delete it.
