### PR TITLE
FIX: Don't rewrite the composer value when opening the rich editor

### DIFF
--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
@@ -271,6 +271,8 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
       dispatchTransaction: (tr) => {
         this.view.updateState(this.view.state.apply(tr));
 
+        // serializing rewrites the whole document, so only the user's own
+        // edits, the ones they can undo, may replace the value
         if (tr.docChanged && tr.getMeta("addToHistory") !== false) {
           // If this gets expensive, we can debounce it
           const value = this.convertToMarkdown(this.view.state.doc);

--- a/frontend/discourse/app/static/prosemirror/extensions/hashtag.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/hashtag.js
@@ -179,7 +179,7 @@ const extension = {
                   );
                 }
 
-                view.dispatch(change);
+                view.dispatch(change.setMeta("addToHistory", false));
 
                 const domNode = view.nodeDOM(pos);
                 if (!validHashtag || !domNode) {

--- a/frontend/discourse/app/static/prosemirror/extensions/mention.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/mention.js
@@ -154,7 +154,9 @@ const extension = {
                 // insert invalid mentions as text nodes
                 const textNode = view.state.schema.text(`@${name}`);
                 view.dispatch(
-                  view.state.tr.replaceWith(pos, pos + node.nodeSize, textNode)
+                  view.state.tr
+                    .replaceWith(pos, pos + node.nodeSize, textNode)
+                    .setMeta("addToHistory", false)
                 );
               }
             };

--- a/frontend/discourse/app/static/prosemirror/extensions/onebox.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/onebox.js
@@ -452,7 +452,7 @@ const extension = {
 
             if (removeDecorations.length || tr.docChanged) {
               tr.setMeta(plugin, { removeDecorations });
-              view.dispatch(tr);
+              view.dispatch(tr.setMeta("addToHistory", false));
             }
           },
         };

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/onebox-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/onebox-test.js
@@ -90,8 +90,8 @@ module(
         .doesNotExist("is no longer an inline onebox");
       assert.strictEqual(
         editor.value,
-        `${URL}\n\nb`,
-        "serializes the full onebox on its own line, matching the cooked output"
+        `${URL} \n\nb`,
+        "leaves the markdown the user typed alone"
       );
     });
 
@@ -159,8 +159,8 @@ module(
       );
       assert.strictEqual(
         editor.value,
-        `${URL}\n\nasd`,
-        "the trailing line becomes its own paragraph"
+        `${URL}\nasd`,
+        "leaves the markdown the user typed alone"
       );
       assert.false(
         view.state.selection instanceof NodeSelection,

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/open-document-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/open-document-test.gjs
@@ -1,0 +1,84 @@
+import { tracked } from "@glimmer/tracking";
+import { click, render, settled, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import DEditor from "discourse/ui-kit/d-editor";
+
+// Mocked by create-pretender for /onebox.
+const ONEBOX_URL = "http://www.example.com/has-title.html";
+
+async function openRichEditor(markdown) {
+  const state = new (class {
+    @tracked value = markdown;
+    changes = [];
+    onChange = (event) => this.changes.push(event.target.value);
+  })();
+
+  await render(
+    <template>
+      <DEditor
+        @value={{state.value}}
+        @change={{state.onChange}}
+        @processPreview={{false}}
+      />
+    </template>
+  );
+
+  await click(".composer-toggle-switch");
+  await waitFor(".ProseMirror");
+  await settled();
+
+  return state;
+}
+
+module(
+  "Integration | Component | prosemirror-editor - opening a document",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      pretender.get("/hashtags", () =>
+        response({
+          categories: [
+            { type: "category", ref: "product", style_type: "square", id: 2 },
+          ],
+        })
+      );
+
+      pretender.get("/composer/mentions", () =>
+        response({
+          users: [],
+          user_reasons: {},
+          groups: {},
+          group_reasons: {},
+          max_users_notified_per_group_mention: 100,
+        })
+      );
+    });
+
+    test("resolving a hashtag doesn't change the value", async function (assert) {
+      const state = await openRichEditor("#product");
+
+      assert
+        .dom("a.hashtag-cooked[data-processed='true']")
+        .exists("resolves the hashtag");
+      assert.deepEqual(state.changes, [], "doesn't report a value change");
+    });
+
+    test("invalidating a mention doesn't change the value", async function (assert) {
+      const state = await openRichEditor("Hello @invalid");
+
+      assert.dom("a.mention").doesNotExist("drops the invalid mention");
+      assert.deepEqual(state.changes, [], "doesn't report a value change");
+    });
+
+    test("loading a onebox doesn't change the value", async function (assert) {
+      // not last: the cursor lands there on open, holding back the preview
+      const state = await openRichEditor(`${ONEBOX_URL}\n\nHey`);
+
+      assert.dom(".onebox-wrapper").exists("renders the onebox");
+      assert.deepEqual(state.changes, [], "doesn't report a value change");
+    });
+  }
+);

--- a/spec/system/composer/prosemirror_onebox_spec.rb
+++ b/spec/system/composer/prosemirror_onebox_spec.rb
@@ -71,7 +71,7 @@ describe "Composer - ProseMirror - Oneboxing" do
 
     composer.toggle_rich_editor
 
-    expect(composer).to have_value("https://example.com\n\n")
+    expect(composer).to have_value("https://example.com")
   end
 
   it "creates an inline onebox for links that are part of a paragraph" do


### PR DESCRIPTION
Hashtags, mentions and oneboxes resolve asynchronously, and their transactions were dispatched as if the user had made an edit. Since serializing rewrites the whole document, opening a post with a valid hashtag, an invalid mention or a onebox committed round-trip differences from anywhere in it: the composer went dirty untouched, a draft was saved, and saving produced a revision of pure normalization.

None of these are edits the user made or can undo, so they now dispatch with `addToHistory: false`, which the editor already treats as "not the user's content" and skips the serialization for. A onebox preview no longer normalizes the whitespace around the URL it replaces, which cooks the same either way.