### PR TITLE
SECURITY: Partition anonymous cache keys by Referer for embed routes

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -2,6 +2,7 @@
 
 require "mobile_detection"
 require "crawler_detection"
+require "digest"
 require "guardian"
 require "http_language_parser"
 require "http_user_agent_encoder"
@@ -165,8 +166,13 @@ module Middleware
         @cache_key =
           +"ANON_CACHE_#{is_xhr}_#{@env["HTTP_ACCEPT"]}_#{@env[Rack::RACK_URL_SCHEME]}_#{@env["HTTP_HOST"]}#{@env["REQUEST_URI"]}"
 
+        @cache_key << key_embed_referer if @request.path.start_with?("/embed/")
         @cache_key << AnonymousCache.build_cache_key(self)
         @cache_key
+      end
+
+      def key_embed_referer
+        "|er=#{Digest::SHA256.hexdigest(@env["HTTP_REFERER"].to_s)}"
       end
 
       def key_cache_theme_ids

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -214,6 +214,39 @@ RSpec.describe EmbedController do
         expect(response.status).to eq(200)
       end
 
+      it "does not share an anonymous cached response between referers" do
+        global_setting :anon_cache_store_threshold, 1
+        Middleware::AnonymousCache.enable_anon_cache
+        Middleware::AnonymousCache.clear_all_cache!
+
+        attacker_referer = "https://origin-a.example/page"
+        victim_referer = "https://origin-b.example/page"
+
+        get "/embed/comments",
+            params: {
+              topic_id: topic.id,
+            },
+            headers: {
+              "REFERER" => attacker_referer,
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.headers["X-Discourse-Cached"]).to eq("store")
+        expect(response.body).to include("data-referer=\"#{attacker_referer}\"")
+
+        get "/embed/comments",
+            params: {
+              topic_id: topic.id,
+            },
+            headers: {
+              "REFERER" => victim_referer,
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.headers["X-Discourse-Cached"]).to eq("store")
+        expect(response.body).to include("data-referer=\"#{victim_referer}\"")
+      end
+
       fab!(:attacker, :trust_level_1)
       fab!(:existing_post) { Fabricate(:post, topic: topic) }
 


### PR DESCRIPTION
## Summary

Prevent anonymous cache poisoning on embed routes by incorporating a SHA-256 digest of the Referer header into the cache key for `/embed/` requests. This ensures cached responses, which reflect the request origin in the response body, are correctly partitioned by source domain.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1187

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>