### PR TITLE
FIX: Scope `PostMover` reviewable updates to moved posts

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -120,6 +120,8 @@ class PostMover
       end
     end
 
+    @moving_post_ids = posts.map(&:id)
+
     create_temp_table
     move_each_post
     handle_moved_references
@@ -748,10 +750,12 @@ class PostMover
   end
 
   def update_reviewables
-    Reviewable.where(target_type: "Post", target_id: @post_ids).update_all(
-      topic_id: @destination_topic.id,
-      category_id: @destination_topic.category_id,
-    )
+    Reviewable.where(
+      target_type: "Post",
+      target_id: @moving_post_ids,
+      topic_id: @original_topic.id,
+      category_id: @original_topic.category_id,
+    ).update_all(topic_id: @destination_topic.id, category_id: @destination_topic.category_id)
   end
 
   def watch_new_topic

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -342,6 +342,39 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
+      it "ignores unrelated post IDs without exposing their reviewables" do
+        restricted_category = Fabricate(:private_category, group: Fabricate(:group))
+        restricted_topic = Fabricate(:topic, category: restricted_category)
+        restricted_post = Fabricate(:post, topic: restricted_topic)
+        restricted_reviewable =
+          Fabricate(
+            :reviewable_flagged_post,
+            target: restricted_post,
+            target_created_by: restricted_post.user,
+            topic: restricted_topic,
+            category: restricted_category,
+          )
+
+        expect(Reviewable.list_for(user, preload: false)).not_to include(restricted_reviewable)
+
+        post "/t/#{topic.id}/move-posts.json",
+             params: {
+               title: "Logan is a good movie",
+               post_ids: [p2.id, restricted_post.id],
+               category_id: category.id,
+             }
+
+        aggregate_failures do
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["success"]).to eq(true)
+          expect(restricted_reviewable.reload).to have_attributes(
+            topic_id: restricted_topic.id,
+            category_id: restricted_category.id,
+          )
+          expect(Reviewable.list_for(user, preload: false)).not_to include(restricted_reviewable)
+        end
+      end
+
       it "does not allow posts outside of the category to be moved" do
         topic.update!(category: nil)
 


### PR DESCRIPTION
### Description

Previously, `PostMover` updated reviewables using the requested post IDs, so unrelated post IDs could affect reviewable topic and category metadata.

 This change updates reviewables only for resolved source-topic posts, preserving partial move behavior while  keeping unrelated reviewables unchanged.

Context: `patch-triage/1524`