### PR TITLE
FIX: Respect group member visibility in private-message read receipts

### DIFF
--- a/app/controllers/post_readers_controller.rb
+++ b/app/controllers/post_readers_controller.rb
@@ -39,17 +39,15 @@ class PostReadersController < ApplicationController
   private
 
   def ensure_can_see_readers!(post)
+    allowed_groups = post.topic.allowed_groups.to_a
+
     show_readers =
-      GroupUser
-        .where(user: current_user)
-        .joins(:group)
-        .where(
-          groups: {
-            id: post.topic.topic_allowed_groups.map(&:group_id),
-            publish_read_state: true,
-          },
-        )
-        .exists?
+      allowed_groups.all? { |group| guardian.can_see_group_members?(group) } &&
+        GroupUser
+          .where(user: current_user)
+          .joins(:group)
+          .where(groups: { id: allowed_groups.map(&:id), publish_read_state: true })
+          .exists?
 
     raise Discourse::InvalidAccess unless show_readers
   end

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -600,7 +600,7 @@ class TopicTrackingState
   def self.trigger_post_read_count_update(post, groups, last_read_post_number, user_id)
     return if !post
     return if groups.empty?
-    opts = { readers_count: post.readers_count, reader_id: user_id }
+    opts = { readers_count: post.readers_count }
     post.publish_change_to_clients!(:read, opts)
   end
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -297,7 +297,10 @@ class TopicView
   def show_read_indicator?
     return false if !@user || !topic.private_message?
 
-    topic.allowed_groups.any? { |group| group.publish_read_state? && group.users.include?(@user) }
+    allowed_groups = topic.allowed_groups
+
+    allowed_groups.all? { |group| @guardian.can_see_group_members?(group) } &&
+      allowed_groups.any? { |group| group.publish_read_state? && group.users.include?(@user) }
   end
 
   def canonical_path

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -1181,6 +1181,21 @@ RSpec.describe TopicView do
       expect(topic_view.show_read_indicator?).to be_truthy
     end
 
+    it "does not show read indicator if current_user cannot see members of the read state group" do
+      user = Fabricate(:user)
+      group =
+        Fabricate(
+          :group,
+          users: [user],
+          publish_read_state: true,
+          members_visibility_level: Group.visibility_levels[:staff],
+        )
+      pm_topic.topic_allowed_groups = [Fabricate.build(:topic_allowed_group, group: group)]
+
+      topic_view = TopicView.new(pm_topic.id, user)
+      expect(topic_view.show_read_indicator?).to be_falsey
+    end
+
     it "does not show read indicator if groups do not have read indicator enabled" do
       topic_view = TopicView.new(pm_topic.id, admin)
       expect(topic_view.show_read_indicator?).to be_falsey

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -522,7 +522,12 @@ RSpec.describe TopicTrackingState do
         expect(messages).to be_empty
       end
 
-      it "publish a read count update to every client" do
+      it "publishes the read count without identifying a reader in a group PM with hidden members" do
+        group.update!(
+          visibility_level: Group.visibility_levels[:members],
+          members_visibility_level: Group.visibility_levels[:staff],
+        )
+
         message =
           MessageBus
             .track_publish(read_post_key) do
@@ -534,7 +539,9 @@ RSpec.describe TopicTrackingState do
             end
             .first
 
-        expect(message.data[:type]).to eq :read
+        expect(message.data[:type]).to eq(:read)
+        expect(message.data[:readers_count]).to eq(post_2.readers_count)
+        expect(message.data).not_to have_key(:reader_id)
       end
     end
   end

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -522,12 +522,7 @@ RSpec.describe TopicTrackingState do
         expect(messages).to be_empty
       end
 
-      it "publishes the read count without identifying a reader in a group PM with hidden members" do
-        group.update!(
-          visibility_level: Group.visibility_levels[:members],
-          members_visibility_level: Group.visibility_levels[:staff],
-        )
-
+      it "publishes a read count update to every client" do
         message =
           MessageBus
             .track_publish(read_post_key) do
@@ -541,7 +536,6 @@ RSpec.describe TopicTrackingState do
 
         expect(message.data[:type]).to eq(:read)
         expect(message.data[:readers_count]).to eq(post_2.readers_count)
-        expect(message.data).not_to have_key(:reader_id)
       end
     end
   end

--- a/spec/requests/post_readers_controller_spec.rb
+++ b/spec/requests/post_readers_controller_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe PostReadersController do
 
       expect(response).to be_forbidden
       expect(response.parsed_body["error_type"]).to eq("invalid_access")
-      expect(response.body).not_to include(hidden_member.username)
     end
 
     it "returns forbidden if no group has publish_read_state enabled" do

--- a/spec/requests/post_readers_controller_spec.rb
+++ b/spec/requests/post_readers_controller_spec.rb
@@ -117,6 +117,31 @@ RSpec.describe PostReadersController do
       expect(reader_data["username_lower"]).to eq reader.username_lower
     end
 
+    it "returns forbidden if current_user cannot see members of the read state group" do
+      member = Fabricate(:user)
+      hidden_member = Fabricate(:user)
+
+      @group.update!(
+        visibility_level: Group.visibility_levels[:members],
+        members_visibility_level: Group.visibility_levels[:staff],
+        publish_read_state: true,
+      )
+      @group.add(member)
+      @group.add(hidden_member)
+      TopicUser.create!(
+        user: hidden_member,
+        topic: @group_message,
+        last_read_post_number: @post.post_number,
+      )
+
+      sign_in(member)
+      get "/post_readers.json", params: { id: @post.id }
+
+      expect(response).to be_forbidden
+      expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      expect(response.body).not_to include(hidden_member.username)
+    end
+
     it "returns forbidden if no group has publish_read_state enabled" do
       get "/post_readers.json", params: { id: @post.id }
 


### PR DESCRIPTION
## Summary

Align private-message read receipts with recipient-group visibility settings. `PostReadersController#ensure_can_see_readers!` (`app/controllers/post_readers_controller.rb:42`) now returns reader details only when the requester can view the membership of every recipient group and belongs to a group with read-state publishing enabled. `TopicView#show_read_indicator?` (`lib/topic_view.rb:297`) applies the same visibility rule to the UI.

Realtime `:read` events from `TopicTrackingState.trigger_post_read_count_update` (`app/models/topic_tracking_state.rb:600`) continue to publish `readers_count`, but no longer include `reader_id`. Reader identities remain available through the authorized `/post_readers.json` endpoint. Tests cover group private messages with restricted member visibility.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1151

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>