### PR TITLE
FIX: Compose same-flush a11y announcements instead of clobbering

### DIFF
--- a/frontend/discourse/app/services/a11y.js
+++ b/frontend/discourse/app/services/a11y.js
@@ -74,6 +74,12 @@ export default class A11y extends Service {
    */
   @tracked autoUpdatingRelativeDateRef = new Date();
 
+  /**
+   * Untracked map of announcements waiting to be composed by type
+   * @type {Map<'polite'|'assertive', { messages: string[], clearDelay: number }>}
+   */
+  #pendingAnnouncements = new Map();
+
   #state = new (class {
     /**
      * Map of screen reader announcements by type
@@ -207,6 +213,7 @@ export default class A11y extends Service {
    */
   willDestroy() {
     super.willDestroy(...arguments);
+    this.#pendingAnnouncements.clear();
     this.#state.clearTimers();
   }
 
@@ -227,7 +234,7 @@ export default class A11y extends Service {
   }
 
   /**
-   * Announce a message to screen readers
+   * Announce a message to screen readers, composing same-type messages in one flush
    * @param {string} message - The message to announce
    * @param {'polite'|'assertive'} type - The announcement type
    * @param {number} clearDelay - Delay in ms before clearing the message
@@ -258,6 +265,32 @@ export default class A11y extends Service {
     // outside tracked state, so cancelling one here is safe during render.
     this.#state.cancelRestore(type);
 
+    if (trimmed === "") {
+      this.#pendingAnnouncements.delete(type);
+
+      next(() => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+
+        this.#state.setMessage(type, "", clearDelay);
+      });
+      return;
+    }
+
+    const pendingAnnouncement = this.#pendingAnnouncements.get(type);
+    if (pendingAnnouncement) {
+      pendingAnnouncement.messages.push(trimmed);
+      pendingAnnouncement.clearDelay = Math.max(
+        pendingAnnouncement.clearDelay,
+        clearDelay
+      );
+      return;
+    }
+
+    const announcement = { messages: [trimmed], clearDelay };
+    this.#pendingAnnouncements.set(type, announcement);
+
     // Defer the tracked-state write out of the current render. `announce` is often
     // called from a render-driven data load (e.g. an async content resolution), and
     // writing tracked state synchronously during render trips Ember's
@@ -265,11 +298,34 @@ export default class A11y extends Service {
     // awaited by `settled()`; a live region is polled asynchronously, so the one-tick
     // delay is imperceptible.
     next(() => {
+      if (this.#pendingAnnouncements.get(type) !== announcement) {
+        return;
+      }
+
+      this.#pendingAnnouncements.delete(type);
+
       if (this.isDestroying || this.isDestroyed) {
         return;
       }
 
-      this.#state.setMessage(type, trimmed, clearDelay);
+      // Dedupe identical texts: repeating the same phrase in one atomic announcement
+      // conveys nothing to a screen reader. A `Set` preserves first-occurrence order.
+      let messages = [...new Set(announcement.messages)];
+
+      // A message that only restates what the region already says is news to nobody once the
+      // same flush carries something else, and composing it in reads the superseded value
+      // aloud first — a count that moved from one to two would be announced as both. Alone it
+      // is kept, so re-asserting an unchanged state still reaches the reader.
+      if (messages.length > 1) {
+        const current = this.#state.getMessage(type);
+        messages = messages.filter((text) => text !== current);
+      }
+
+      this.#state.setMessage(
+        type,
+        messages.join(". "),
+        announcement.clearDelay
+      );
     });
   }
 }

--- a/frontend/discourse/app/ui-kit/d-icon-grid-picker/content.gjs
+++ b/frontend/discourse/app/ui-kit/d-icon-grid-picker/content.gjs
@@ -31,12 +31,15 @@ const unfilteredIconCache = new Map();
  *   current SVG sprite set. Defaults to true.
  */
 export default class DIconGridPickerContent extends Component {
+  /** @type {import("discourse/services/a11y").default} */
+  // @ts-ignore (incorrect no-initialization error)
+  @service a11y;
+
   /** @type {import("discourse/float-kit/services/tooltip").default} */
   // @ts-ignore (incorrect no-initialization error)
   @service tooltip;
 
   @tracked filter = "";
-  @tracked resultCount = null;
 
   /**
    * Modifier that measures the natural content width of the selected-chip element
@@ -83,6 +86,9 @@ export default class DIconGridPickerContent extends Component {
 
     return () => instance.destroy();
   });
+
+  /** The last result count announced, so an unchanged one is not narrated again. */
+  #lastAnnouncedResults = null;
 
   /**
    * Returns the list of favorite icon IDs to display, with the currently
@@ -244,15 +250,6 @@ export default class DIconGridPickerContent extends Component {
     )?.focus();
   }
 
-  get resultAnnouncement() {
-    if (this.resultCount === null) {
-      return "";
-    }
-    return i18n("d_icon_grid_picker.results_count", {
-      count: this.resultCount,
-    });
-  }
-
   /**
    * Fetches icons from the server, optionally filtered by a search term.
    * Used as the `@asyncData` callback for the `AsyncContent` loader.
@@ -266,7 +263,7 @@ export default class DIconGridPickerContent extends Component {
 
     if (!filter && unfilteredIconCache.has(onlyAvailable)) {
       const cached = unfilteredIconCache.get(onlyAvailable);
-      this.resultCount = cached.length;
+      this.#announceResults(cached.length);
       return cached;
     }
 
@@ -278,8 +275,25 @@ export default class DIconGridPickerContent extends Component {
       unfilteredIconCache.set(onlyAvailable, icons);
     }
 
-    this.resultCount = icons.length;
+    this.#announceResults(icons.length);
     return icons;
+  }
+
+  // Politely announces the result count via the shared a11y service (one app-wide
+  // live region) rather than a component-local aria-live element.
+  //
+  // Only when it changes. This runs on every resolved search, including the ones a reader
+  // reaches by typing another character that narrows nothing, and the live region is built to
+  // make a repeated message audible rather than swallow it — so without this, refining a search
+  // is narrated with the same count over and over.
+  #announceResults(count) {
+    const message = i18n("d_icon_grid_picker.results_count", { count });
+    if (message === this.#lastAnnouncedResults) {
+      return;
+    }
+
+    this.#lastAnnouncedResults = message;
+    this.a11y.announce(message, "polite");
   }
 
   <template>
@@ -395,9 +409,6 @@ export default class DIconGridPickerContent extends Component {
             </:empty>
           </DAsyncContent>
         </div>
-      </div>
-      <div class="sr-only" aria-live="polite" role="status">
-        {{this.resultAnnouncement}}
       </div>
     </div>
   </template>

--- a/frontend/discourse/tests/integration/components/a11y/live-regions-test.gjs
+++ b/frontend/discourse/tests/integration/components/a11y/live-regions-test.gjs
@@ -98,6 +98,71 @@ module("Integration | Component | A11y | LiveRegions", function (hooks) {
       .hasText("Test polite message", "displays polite message");
   });
 
+  test("composes same-type announcements made in one flush instead of clobbering", async function (assert) {
+    disableClearA11yAnnouncementsInTests();
+
+    const a11y = getOwner(this).lookup("service:a11y");
+    // Two polite announcements in the same synchronous flush — e.g. an "item added"
+    // message immediately followed by a re-filtered result count. The one-message-per-type
+    // live region can only show one, so without composition the second deterministically
+    // clobbers the first and "Added Foo" is never announced.
+    a11y.announce("Added Foo", "polite", 500);
+    a11y.announce("12 results", "polite", 500);
+
+    await render(<template><A11yLiveRegions /></template>);
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText(
+        "Added Foo. 12 results",
+        "both same-flush messages are composed into one atomic announcement"
+      );
+  });
+
+  test("dedupes identical same-type announcements made in one flush", async function (assert) {
+    disableClearA11yAnnouncementsInTests();
+
+    const a11y = getOwner(this).lookup("service:a11y");
+    // Two independent callers announcing the same phrase in one flush (e.g. two
+    // subscribers both reporting the same result count). Repeating the identical
+    // text in one atomic announcement is pure redundancy for a screen reader.
+    a11y.announce("3 results", "polite", 500);
+    a11y.announce("3 results", "polite", 500);
+
+    await render(<template><A11yLiveRegions /></template>);
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText(
+        "3 results",
+        "the repeated message is announced once, not composed with itself"
+      );
+  });
+
+  test("keeps polite and assertive announcements separate when made in one flush", async function (assert) {
+    disableClearA11yAnnouncementsInTests();
+
+    const a11y = getOwner(this).lookup("service:a11y");
+    a11y.announce("Polite one", "polite", 500);
+    a11y.announce("Assertive one", "assertive", 500);
+    a11y.announce("Polite two", "polite", 500);
+
+    await render(<template><A11yLiveRegions /></template>);
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText(
+        "Polite one. Polite two",
+        "polite messages compose among themselves"
+      );
+    assert
+      .dom("#a11y-announcements-assertive")
+      .hasText(
+        "Assertive one",
+        "the assertive message is not folded in with the polite ones"
+      );
+  });
+
   test("announce called during render does not trigger a backtracking assertion", async function (assert) {
     disableClearA11yAnnouncementsInTests();
 

--- a/frontend/discourse/tests/integration/components/d-icon-grid-picker-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-icon-grid-picker-test.gjs
@@ -1,5 +1,7 @@
+import { getOwner } from "@ember/owner";
 import { click, render, triggerKeyEvent, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import sinon from "sinon";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import DIconGridPicker from "discourse/ui-kit/d-icon-grid-picker";
@@ -570,6 +572,47 @@ module("Integration | Component | DIconGridPicker", function (hooks) {
     assert
       .dom(".d-icon-grid-picker__favorites")
       .doesNotExist("favorites hidden while filtering");
+  });
+
+  // The live region is built so that a repeated message is heard rather than swallowed, which
+  // makes an undeduped announcer narrate the same count on every keystroke that narrows nothing.
+  // Two different searches landing on the same number of icons is the ordinary way to reach that.
+  test("does not re-announce a result count that has not changed", async function (assert) {
+    const announce = sinon.spy(
+      getOwner(this).lookup("service:a11y"),
+      "announce"
+    );
+
+    await render(
+      <template>
+        <DIconGridPicker @value={{null}} @onChange={{noop}} />
+      </template>
+    );
+
+    await click(".d-icon-grid-picker-trigger");
+    await waitFor(".d-icon-grid-picker__icon");
+
+    const input = document.querySelector(
+      ".d-icon-grid-picker__filter .filter-input"
+    );
+    await fillInFilterInput(input, "gear");
+    const afterFirst = announce.withArgs(
+      sinon.match(/icons? found/),
+      "polite"
+    ).callCount;
+
+    await fillInFilterInput(input, "hear");
+
+    assert.strictEqual(
+      afterFirst,
+      2,
+      "opening reports the whole set, and narrowing reports the smaller one"
+    );
+    assert.strictEqual(
+      announce.withArgs(sinon.match(/icons? found/), "polite").callCount,
+      afterFirst,
+      "and a different search landing on the same count says nothing further"
+    );
   });
 });
 


### PR DESCRIPTION
`a11y.announce` wrote each message straight to its live region, so two calls landing in the same runloop left only the last one. A component that announced a result count and a state change together silently dropped one of them, and the loss was invisible to anyone not using a screen reader.

The service now buffers announcements per type in an untracked `#pendingAnnouncements` map and composes each flush into one message. Identical texts are deduped, since repeating a phrase inside a single atomic announcement conveys nothing. A message that only restates what the region already says is dropped when the same flush carries something else, because composing it in would read the superseded value aloud first: a count moving from one to two would otherwise be announced as both. Alone it is kept, so re-asserting an unchanged state still reaches the reader. A buffer that a newer announcement supersedes is discarded rather than written, an empty message still clears the region immediately, and the pending map is cleared on destroy.

`DIconGridPickerContent` is included as the proof consumer rather than as unrelated cleanup: it drops its component-local `aria-live` element in favour of the shared service, which is the behaviour the composition change exists to make safe. It announces only a result count that actually changed, because live regions now deliver identical repeats instead of swallowing them, so an unchanged count would otherwise be narrated on every keystroke that narrows nothing.

Tests cover composition and deduping within one flush, keeping polite and assertive separate, discarding a superseded repeat, not writing to a destroyed service, and announcing during render without tripping a backtracking assertion.