### PR TITLE
FIX: Refresh page properly after bulk-archive

### DIFF
--- a/frontend/discourse/app/components/topic-list/header/sortable-column.gjs
+++ b/frontend/discourse/app/components/topic-list/header/sortable-column.gjs
@@ -5,12 +5,14 @@ import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TopicBulkSelectDropdown from "discourse/components/topic-list/topic-bulk-select-dropdown";
 import lazyHash from "discourse/helpers/lazy-hash";
+import { resetCachedTopicList } from "discourse/lib/cached-topic-list";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class SortableColumn extends Component {
   @service router;
+  @service session;
 
   get localizedName() {
     if (this.args.forceName) {
@@ -63,6 +65,7 @@ export default class SortableColumn extends Component {
 
   @action
   afterBulkActionComplete() {
+    resetCachedTopicList(this.session);
     return this.router.refresh();
   }
 

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -508,6 +508,43 @@ describe "Topic bulk select" do
       expect(page).to have_content(group_private_message.title)
     end
 
+    it "removes archived group messages from the current inbox after infinite-scroll pagination" do
+      # Regression test: when the paginated topic list is cached in the
+      # session, refreshing the route after a bulk archive reused the
+      # stale cached list and left archived messages visible until the
+      # user manually reloaded.
+      other_group_messages =
+        Array.new(2) do
+          Fabricate(:group_private_message_topic, user: admin, recipient_group: group)
+        end
+      all_group_messages = [group_private_message, *other_group_messages]
+
+      stub_const(TopicQuery, "DEFAULT_PER_PAGE_COUNT", 2) do
+        sign_in(admin)
+        visit("/u/#{admin.username}/messages/group/#{group.name}")
+
+        expect(topic_list).to have_topics(count: 2)
+        page.execute_script(
+          "document.querySelector('.paginated-topics-list .load-more-sentinel').scrollIntoView()",
+        )
+        expect(topic_list).to have_topics(count: all_group_messages.size)
+
+        topic_list_header.click_bulk_select_button
+        all_group_messages.each { |topic| topic_list.click_topic_checkbox(topic) }
+
+        topic_list_header.click_bulk_select_topics_dropdown
+        topic_list_header.click_bulk_button("archive-messages")
+        expect(topic_bulk_actions_modal).to be_open
+        topic_bulk_actions_modal.click_bulk_topics_confirm
+
+        expect(page).to have_content(I18n.t("js.topics.bulk.completed"))
+        all_group_messages.each do |topic|
+          expect(topic_list).to have_no_topic(topic)
+          expect(GroupArchivedMessage.exists?(group_id: group.id, topic_id: topic.id)).to eq(true)
+        end
+      end
+    end
+
     it "allows archiving group private messages from the group inbox page" do
       sign_in(admin)
       visit("/g/#{group.name}/messages/inbox")


### PR DESCRIPTION
Previously, when bulk-archiving messages and using infinite scroll, `TopicList.loadMore()` was caching the mutated lists and `router.refresh()` was leading to the PM route's `model()` hook, which was calling `findOrResetCachedTopicList` and returning the stale cached list instead of re-fetching.

`afterBulkActionComplete` now calls `resetCachedTopicList()` before `router.refresh()`, so the route model hook re-fetches the data from the server.