### PR TITLE
FIX: Import user IP addresses in generic bulk importer

### DIFF
--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -585,6 +585,7 @@ class BulkImport::Generic < BulkImport::Base
         row["username"] = "anon_#{anon_username_suffix}"
         row["email"] = "#{row["username"]}#{UserAnonymizer::EMAIL_SUFFIX}"
         row["name"] = nil
+        row["ip_address"] = nil
         row["registration_ip_address"] = nil
         row["date_of_birth"] = nil
         row["title"] = nil
@@ -613,6 +614,7 @@ class BulkImport::Generic < BulkImport::Base
         suspended_at: suspended_at,
         suspended_till: suspended_till,
         trust_level: row["trust_level"],
+        ip_address: row["ip_address"],
         registration_ip_address: row["registration_ip_address"],
         date_of_birth: to_date(row["date_of_birth"]),
         primary_group_id: group_id_from_imported_id(row["primary_group_id"]),


### PR DESCRIPTION
Previously, generic bulk imports ignored the `ip_address` field, so imported users lost that data.
This change preserves imported IP addresses while ensuring they are cleared for anonymized users