### PR TITLE
FIX: Zoom webinar livestream not joining on countdown end sometimes

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/zoom-component-view-dom.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/zoom-component-view-dom.js
@@ -10,12 +10,18 @@ const MIN_VIDEO_HEIGHT = 135;
 const MAX_VIDEO_HEIGHT = 810;
 
 export function computeZoomViewSize(root) {
+  // Zoom is configured with this size once, at init, and only ever corrects it
+  // if a later sync gets through. Falling back to the minimum because the root
+  // happened to measure zero locks the component view into a 240px video for
+  // the rest of the session, so measure the container it sits in instead.
+  const measuredWidth =
+    root?.getBoundingClientRect().width ||
+    root?.parentElement?.getBoundingClientRect().width ||
+    0;
+
   const width = Math.max(
     MIN_VIDEO_WIDTH,
-    Math.min(
-      MAX_VIDEO_WIDTH,
-      Math.floor(root?.getBoundingClientRect().width || 0)
-    )
+    Math.min(MAX_VIDEO_WIDTH, Math.floor(measuredWidth))
   );
 
   const height = Math.max(

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/zoom-meeting-session.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/zoom-meeting-session.js
@@ -1,6 +1,7 @@
 import { tracked } from "@glimmer/tracking";
 import { setOwner } from "@ember/owner";
 import { isEmpty } from "@ember/utils";
+import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 import fetchZoomJoinPayload from "./fetch-zoom-join-payload";
 import { loadZoomMeetingSdkEmbedded } from "./load-zoom-meeting-sdk";
@@ -41,6 +42,8 @@ export default class ZoomMeetingSession {
     this.canJoin = canJoin;
     this.onBeforeJoinAttempt = onBeforeJoinAttempt;
     this.onJoined = onJoined;
+
+    document.addEventListener("visibilitychange", this.onVisibilityChange);
   }
 
   teardown() {
@@ -48,6 +51,7 @@ export default class ZoomMeetingSession {
     clearInterval(this.retryTimer);
     cancelAnimationFrame(this.layoutFrame);
     cancelAnimationFrame(this.videoSyncFrame);
+    document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.zoomClient?.leaveMeeting?.();
   }
 
@@ -126,13 +130,37 @@ export default class ZoomMeetingSession {
     } finally {
       this.isJoining = false;
 
-      this.layoutFrame = window.requestAnimationFrame(() =>
-        syncZoomLayout(this.element)
-      );
-      this.videoSyncFrame = window.requestAnimationFrame(() =>
-        this.syncVideoSize()
-      );
+      this.scheduleViewSync();
     }
+  }
+
+  // Both the frame callbacks below and the resize observer the modifier
+  // attaches are suspended while the document is hidden, so a join that lands
+  // in a background tab leaves Zoom rendering at whatever size it was last
+  // told about. `onVisibilityChange` picks the work back up on return.
+  scheduleViewSync() {
+    if (document.hidden) {
+      return;
+    }
+
+    cancelAnimationFrame(this.layoutFrame);
+    cancelAnimationFrame(this.videoSyncFrame);
+
+    this.layoutFrame = window.requestAnimationFrame(() =>
+      syncZoomLayout(this.element)
+    );
+    this.videoSyncFrame = window.requestAnimationFrame(() =>
+      this.syncVideoSize()
+    );
+  }
+
+  @bind
+  onVisibilityChange() {
+    if (document.hidden || this.#tornDown || !this.zoomClient) {
+      return;
+    }
+
+    this.scheduleViewSync();
   }
 
   async performJoin() {

--- a/plugins/discourse-calendar/assets/stylesheets/common/livestream.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/livestream.scss
@@ -70,8 +70,14 @@ body.chat-enabled.livestream-topic.confirmed-event-assistance {
   }
 
   &__frame {
+    // The frame has to lay out as soon as a join starts, not once Zoom mounts:
+    // the component view is initialized with a video size measured from this
+    // element, and a collapsed element measures zero.
+    display: none;
+
     // Zoom sets `display` inline on this element when it mounts, which beats
-    // anything declared here. Only `justify-content` and `padding-top` apply.
+    // anything declared here. Only `justify-content` and `padding-top` apply
+    // from then on.
     //
     // Until the meeting is joined the widget is a small dialog (spinner,
     // "meeting has not started"), so it is centred. Once joined it fills the

--- a/plugins/discourse-calendar/assets/stylesheets/desktop/livestream.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/desktop/livestream.scss
@@ -84,7 +84,6 @@
       border-radius: 8px;
       overflow: hidden;
       background: var(--secondary);
-      display: none;
     }
   }
 }

--- a/plugins/discourse-calendar/test/javascripts/lib/zoom-component-view-dom-test.js
+++ b/plugins/discourse-calendar/test/javascripts/lib/zoom-component-view-dom-test.js
@@ -1,0 +1,48 @@
+import { module, test } from "qunit";
+import { computeZoomViewSize } from "discourse/plugins/discourse-calendar/discourse/lib/zoom-component-view-dom";
+
+function elementOfWidth(width) {
+  return { getBoundingClientRect: () => ({ width }) };
+}
+
+module("Unit | Lib | zoom-component-view-dom", function () {
+  test("computeZoomViewSize measures the root", function (assert) {
+    assert.deepEqual(computeZoomViewSize(elementOfWidth(754)), {
+      width: 754,
+      height: 424,
+    });
+  });
+
+  test("computeZoomViewSize falls back to the container when the root is collapsed", function (assert) {
+    const root = {
+      ...elementOfWidth(0),
+      parentElement: elementOfWidth(754),
+    };
+
+    assert.deepEqual(
+      computeZoomViewSize(root),
+      { width: 754, height: 424 },
+      "a root that has not been laid out yet does not pin Zoom to the minimum"
+    );
+  });
+
+  test("computeZoomViewSize clamps to the supported range", function (assert) {
+    assert.deepEqual(
+      computeZoomViewSize(elementOfWidth(120)),
+      { width: 240, height: 135 },
+      "below the minimum"
+    );
+
+    assert.deepEqual(
+      computeZoomViewSize(elementOfWidth(4000)),
+      { width: 1440, height: 810 },
+      "above the maximum"
+    );
+
+    assert.deepEqual(
+      computeZoomViewSize(null),
+      { width: 240, height: 135 },
+      "without an element to measure"
+    );
+  });
+});

--- a/plugins/discourse-calendar/test/javascripts/unit/lib/zoom-meeting-session-test.js
+++ b/plugins/discourse-calendar/test/javascripts/unit/lib/zoom-meeting-session-test.js
@@ -1,0 +1,97 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import ZoomMeetingSession from "../../discourse/lib/zoom-meeting-session";
+
+// `document.hidden` is an inherited accessor, so it can only be faked by
+// shadowing it on the document itself.
+function stubDocumentHidden(hidden) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+}
+
+function restoreDocumentHidden() {
+  delete document.hidden;
+}
+
+// The view sync runs in a frame callback, which `settled` knows nothing about.
+function nextFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+module("Unit | Lib | ZoomMeetingSession", function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    restoreDocumentHidden();
+  });
+
+  test("defers sizing Zoom's view while the document is hidden", async function (assert) {
+    const session = new ZoomMeetingSession(getOwner(this), {
+      topicId: 1,
+      canJoin: () => true,
+    });
+    sinon.stub(session, "performJoin").resolves();
+    const syncVideoSize = sinon.stub(session, "syncVideoSize");
+    session.zoomClient = { updateVideoOptions: () => {} };
+
+    stubDocumentHidden(true);
+
+    await session.join();
+    await nextFrame();
+
+    assert.false(
+      syncVideoSize.called,
+      "frame callbacks do not run in a background tab"
+    );
+
+    stubDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await nextFrame();
+
+    assert.true(
+      syncVideoSize.called,
+      "the view is sized once the tab is visible again"
+    );
+
+    session.teardown();
+  });
+
+  test("sizes Zoom's view straight away when the document is visible", async function (assert) {
+    const session = new ZoomMeetingSession(getOwner(this), {
+      topicId: 1,
+      canJoin: () => true,
+    });
+    sinon.stub(session, "performJoin").resolves();
+    const syncVideoSize = sinon.stub(session, "syncVideoSize");
+
+    stubDocumentHidden(false);
+
+    await session.join();
+    await nextFrame();
+
+    assert.true(syncVideoSize.called);
+
+    session.teardown();
+  });
+
+  test("stops listening for visibility changes once torn down", async function (assert) {
+    const session = new ZoomMeetingSession(getOwner(this), {
+      topicId: 1,
+      canJoin: () => true,
+    });
+    const syncVideoSize = sinon.stub(session, "syncVideoSize");
+    session.zoomClient = { updateVideoOptions: () => {} };
+
+    stubDocumentHidden(false);
+    session.teardown();
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    await nextFrame();
+
+    assert.false(syncVideoSize.called);
+  });
+});


### PR DESCRIPTION
**Disclaimer: Claude was the driver here mostly, but I tested before/after locally**

Attempts to fix some issues with the Zoom livestream integration
when a user clicks Join before the webinar has started by the host.
This shows a 30s countdown timer and then attempts to join the webinar
when the countdown ends.

However, when the tab wasn't focused/visible, Chrome (and assuming
other browsers) do some throttling of timers, requestAnimationFrame,
and ResizeObserver callbacks. When the user switches back to the tab,
the Zoom video frame appeared to not be rendered.

The Zoom frame was `display: none` when `init()` measured it, the
desktop rule setting that had a higher specificity than the `--visible`
class meant to reveal it, so the class never applied and the element
only became visible once Zoom wrote an inline `display` of its own.
`computeZoomViewSize` read a zero width and clamped to its 240px
minimum, meaning every session configured Zoom at the wrong size.

That went unnoticed because the post-join sync corrected it
immediately. But that sync runs in a frame callback, and both it and
the modifier's resize observer are suspended while the document is
hidden.

A retry that landed in a background tab never got the
correction, and the single queued frame callback fired on return
racing Zoom's remount, so the meeting rendered at 240px with none of
the layout heights applied, making it seem like the video didn't appear.

Moves the base `display: none` to where `--visible` outranks it, so
the frame is laid out before Zoom is initialized; falls back to the
container's width rather than the minimum when the root measures zero;
and skips the frame callbacks while hidden, re-running them on
`visibilitychange` instead.
