### PR TITLE
DEV: Render text field site settings with FormKit

### DIFF
--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -401,7 +401,7 @@ export default class SiteSettingComponent extends Component {
 
   get useFormKit() {
     return (
-      this.trackChanges && resolveSettingFieldType(this.setting).adminReady
+      this.trackChanges && resolveSettingFieldType(this.definition).adminReady
     );
   }
 
@@ -784,6 +784,7 @@ export default class SiteSettingComponent extends Component {
               <SettingDefinitionField
                 @definition={{this.definition}}
                 @form={{form}}
+                @format="full"
                 @showTitle={{false}}
                 @showControlTitle={{false}}
                 @showDescription={{false}}
@@ -871,7 +872,7 @@ export default class SiteSettingComponent extends Component {
           />
         </div>
       {{else if (and this.groupedOverridden this.canUpdate (not @inline))}}
-        {{#if this.setting.secret}}
+        {{#if (and this.setting.secret (not this.useFormKit))}}
           <DButton
             @action={{this.toggleSecret}}
             @icon={{if this.isSecret "far-eye" "far-eye-slash"}}

--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -376,7 +376,7 @@ export default class SiteSettingComponent extends Component {
 
   get useFormKit() {
     return (
-      this.trackChanges && resolveSettingFieldType(this.setting).adminReady
+      this.trackChanges && resolveSettingFieldType(this.definition).adminReady
     );
   }
 
@@ -759,6 +759,7 @@ export default class SiteSettingComponent extends Component {
               <SettingDefinitionField
                 @definition={{this.definition}}
                 @form={{form}}
+                @format="full"
                 @showTitle={{false}}
                 @showControlTitle={{false}}
                 @showDescription={{false}}
@@ -846,7 +847,7 @@ export default class SiteSettingComponent extends Component {
           />
         </div>
       {{else if (and this.groupedOverridden this.canUpdate (not @inline))}}
-        {{#if this.setting.secret}}
+        {{#if (and this.setting.secret (not this.useFormKit))}}
           <DButton
             @action={{this.toggleSecret}}
             @icon={{if this.isSecret "far-eye" "far-eye-slash"}}

--- a/frontend/discourse/admin/models/site-setting.js
+++ b/frontend/discourse/admin/models/site-setting.js
@@ -159,6 +159,20 @@ export default class SiteSetting extends EmberObject {
     };
   }
 
+  get settingSubtype() {
+    if (this.list_type) {
+      return;
+    }
+
+    if (this.textarea) {
+      return "textarea";
+    }
+
+    if (this.secret) {
+      return "password";
+    }
+  }
+
   get definition() {
     return {
       key: this.setting,
@@ -166,6 +180,7 @@ export default class SiteSetting extends EmberObject {
       description: trustHTML(this.description),
       type: this.type,
       list_type: this.list_type,
+      subtype: this.settingSubtype,
       min: this.min,
       max: this.max,
       choices: this.choices,

--- a/frontend/discourse/app/components/setting-definition-field.gjs
+++ b/frontend/discourse/app/components/setting-definition-field.gjs
@@ -27,7 +27,7 @@ export default class SettingDefinitionField extends Component {
   }
 
   get format() {
-    return this.args.definition.format ?? this.entry.format;
+    return this.args.format ?? this.args.definition.format ?? this.entry.format;
   }
 
   get validation() {

--- a/frontend/discourse/app/form-kit/components/fk/control/input.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/input.gjs
@@ -1,6 +1,8 @@
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import FKBaseControl from "discourse/form-kit/components/fk/control/base";
+import { siteDir } from "discourse/lib/text-direction";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 const SUPPORTED_TYPES = [
@@ -23,6 +25,8 @@ const SUPPORTED_TYPES = [
 
 export default class FKControlInput extends FKBaseControl {
   static controlType = "input";
+
+  @service siteSettings;
 
   constructor(owner, args) {
     super(owner, args);
@@ -50,6 +54,14 @@ export default class FKControlInput extends FKBaseControl {
 
   get type() {
     return this.args.type ?? "text";
+  }
+
+  get dir() {
+    if (!this.siteSettings.support_mixed_text_direction) {
+      return;
+    }
+
+    return this.args.field.value ? "auto" : siteDir();
   }
 
   get displayValue() {
@@ -104,6 +116,7 @@ export default class FKControlInput extends FKBaseControl {
 
       <input
         type={{this.type}}
+        dir={{this.dir}}
         value={{this.displayValue}}
         class={{dConcatClass
           "form-kit__control-input"

--- a/frontend/discourse/app/form-kit/components/fk/control/password.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/password.gjs
@@ -64,8 +64,10 @@ export default class FKControlPassword extends FKBaseControl {
         disabled={{@field.disabled}}
         id={{@field.id}}
         name={{@field.name}}
+        autocomplete="new-password"
         aria-invalid={{if @field.error "true"}}
         aria-describedby={{@field.describedBy}}
+        placeholder={{@field.placeholder}}
         ...attributes
         {{on "input" this.handleInput}}
         {{this.focusState}}

--- a/frontend/discourse/app/lib/setting-field-registry.js
+++ b/frontend/discourse/app/lib/setting-field-registry.js
@@ -51,11 +51,28 @@ function typeKeyFor({ type, subtype, list_type }) {
   return "default";
 }
 
+const TEXT_INPUT = { ...ROW, type: "input", adminReady: true };
+
 registerSettingFieldType("default", { ...ROW, type: "input" });
-registerSettingFieldType("textarea", { ...ROW, type: "textarea" });
-registerSettingFieldType("email", { ...ROW, type: "input-email" });
+registerSettingFieldType("string", TEXT_INPUT);
+registerSettingFieldType("float", TEXT_INPUT);
+registerSettingFieldType("username", TEXT_INPUT);
+registerSettingFieldType("textarea", {
+  ...ROW,
+  type: "textarea",
+  adminReady: true,
+});
+registerSettingFieldType("email", {
+  ...ROW,
+  type: "input-email",
+  adminReady: true,
+});
 registerSettingFieldType("date", { ...ROW, type: "input-date" });
-registerSettingFieldType("password", { ...ROW, type: "password" });
+registerSettingFieldType("password", {
+  ...ROW,
+  type: "password",
+  adminReady: true,
+});
 registerSettingFieldType("radio-group", {
   ...ROW,
   type: "radio-group",

--- a/frontend/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/frontend/discourse/tests/acceptance/admin-site-settings-test.js
@@ -68,13 +68,13 @@ acceptance("Admin - Site Settings", function (needs) {
       .dom(".row.setting.overridden")
       .doesNotExist("setting isn't overridden");
 
-    await fillIn(".input-setting-string", "Test");
+    await fillIn(".form-kit__control-input", "Test");
     await click("button.cancel");
     assert
       .dom(".row.setting.overridden")
       .doesNotExist("canceling doesn't mark setting as overridden");
 
-    await fillIn(".input-setting-string", "Test");
+    await fillIn(".form-kit__control-input", "Test");
     await click("button.ok");
     assert
       .dom(".row.setting.overridden")
@@ -95,12 +95,6 @@ acceptance("Admin - Site Settings", function (needs) {
     assert
       .dom(".row.setting.overridden")
       .doesNotExist("setting isn't marked as overridden after undo");
-
-    await fillIn(".input-setting-string", "Test");
-    await triggerKeyEvent(".input-setting-string", "keydown", "Enter");
-    assert
-      .dom(".row.setting.overridden")
-      .exists("saving via Enter key marks setting as overridden");
   });
 
   test("always shows filtered site settings if a filter is set", async function (assert) {
@@ -202,7 +196,7 @@ acceptance("Admin - Site Settings", function (needs) {
     await click('[data-setting="highlight_scope"] > .setting-controls__undo');
 
     assert
-      .dom('[data-setting="highlight_categories"] .input-setting-string')
+      .dom('[data-setting="highlight_categories"] .form-kit__control-input')
       .hasValue("default", "parent controls reset the dependent setting");
     assert
       .dom(".setting-depends-on-notice")
@@ -349,15 +343,15 @@ acceptance("Admin - Site Settings", function (needs) {
     await visit("/admin/site_settings");
 
     await fillIn(
-      '[data-setting="highlight_scope"] .input-setting-string',
+      '[data-setting="highlight_scope"] .form-kit__control-input',
       "include"
     );
     await fillIn(
-      '[data-setting="highlight_categories"] .input-setting-string',
+      '[data-setting="highlight_categories"] .form-kit__control-input',
       "selected categories"
     );
     await fillIn(
-      '[data-setting="unrelated_setting"] .input-setting-string',
+      '[data-setting="unrelated_setting"] .form-kit__control-input',
       "do not save me"
     );
 

--- a/frontend/discourse/tests/integration/components/site-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-setting-test.gjs
@@ -290,14 +290,46 @@ module("Integration | Component | SiteSetting", function (hooks) {
       secret: true,
       value: "foo",
     });
-    assert.dom(".input-setting-string").hasAttribute("type", "password");
-    assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye");
-    await click(".setting-toggle-secret");
-    assert.dom(".input-setting-string").hasAttribute("type", "text");
-    assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye-slash");
-    await click(".setting-toggle-secret");
-    assert.dom(".input-setting-string").hasAttribute("type", "password");
-    assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye");
+
+    assert.dom(".form-kit__control-password").hasAttribute("type", "password");
+    assert
+      .dom(".form-kit__control-password")
+      .hasAttribute(
+        "autocomplete",
+        "new-password",
+        "does not let password managers autofill credentials"
+      );
+    assert
+      .dom(".setting-toggle-secret")
+      .doesNotExist("the control owns the reveal toggle");
+
+    await click(".form-kit__control-password-toggle");
+    assert.dom(".form-kit__control-password").hasAttribute("type", "text");
+  });
+
+  test("a secret setting that is also a textarea stays readable", async function (assert) {
+    await renderSetting({
+      setting: "test_setting",
+      secret: true,
+      textarea: true,
+      value: "-----BEGIN PRIVATE KEY-----",
+    });
+
+    assert.dom(".form-kit__control-textarea").exists();
+    assert.dom(".form-kit__control-password").doesNotExist();
+  });
+
+  test("a secret list setting is not collapsed into a password input", async function (assert) {
+    await renderSetting({
+      setting: "test_setting",
+      type: "list",
+      list_type: "secret",
+      secret: true,
+      value: "key|secret",
+    });
+
+    assert.dom(".form-kit__control-password").doesNotExist();
+    assert.dom(".secret-value-list").exists();
   });
 
   test("shows link to the staff action logs for the setting on hover", async function (assert) {
@@ -522,7 +554,7 @@ module(
         themeable: true,
       });
 
-      assert.dom(".input-setting-string").hasAttribute("disabled", "");
+      assert.dom(".form-kit__control-input").hasAttribute("disabled", "");
       assert
         .dom(".setting-controls__ok")
         .doesNotExist("save button is not shown");

--- a/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
+++ b/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
@@ -75,6 +75,28 @@ module("Unit | Lib | setting-field-registry", function () {
         CategoryListControl
       );
     });
+
+    test("the text field family is admin-ready, the fallback never is", function (assert) {
+      for (const type of [
+        "string",
+        "float",
+        "username",
+        "email",
+        "textarea",
+        "password",
+      ]) {
+        assert.true(
+          resolveSettingFieldType({ type }).adminReady,
+          `${type} renders with FormKit on the admin page`
+        );
+      }
+
+      assert.strictEqual(
+        resolveSettingFieldType({ type: "not_a_real_type" }).adminReady,
+        undefined,
+        "types without an explicit entry keep their legacy control instead of degrading to a bare text input"
+      );
+    });
   });
 
   module("settingFieldValidation", function () {

--- a/frontend/discourse/tests/unit/models/site-setting-test.js
+++ b/frontend/discourse/tests/unit/models/site-setting-test.js
@@ -44,4 +44,24 @@ module("Unit | Model | site-setting", function (hooks) {
     assert.strictEqual(definition.valid_values[1].name, "Public categories");
     assert.strictEqual(definition.valid_values[1].value, "b");
   });
+
+  test("definition refines a text setting into a textarea or password subtype", function (assert) {
+    const subtypeOf = (props) =>
+      SiteSetting.create({ setting: "test_setting", type: "string", ...props })
+        .definition.subtype;
+
+    assert.strictEqual(subtypeOf({}), undefined);
+    assert.strictEqual(subtypeOf({ textarea: true }), "textarea");
+    assert.strictEqual(subtypeOf({ secret: true }), "password");
+    assert.strictEqual(
+      subtypeOf({ textarea: true, secret: true }),
+      "textarea",
+      "a multi-line credential stays readable instead of collapsing into a masked single-line input"
+    );
+    assert.strictEqual(
+      subtypeOf({ type: "list", list_type: "secret", secret: true }),
+      undefined,
+      "a delimited value keeps its own control, otherwise its key|secret pairs are rewritten as one masked string"
+    );
+  });
 });

--- a/spec/system/admin_site_setting_string_spec.rb
+++ b/spec/system/admin_site_setting_string_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe "Admin site setting string" do
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  fab!(:admin)
+
+  before { sign_in(admin) }
+
+  it "saves a string setting with the ok button and with the Enter key" do
+    settings_page.visit("site_description")
+    settings_page.fill_setting("site_description", "A place to talk")
+    settings_page.save_setting("site_description")
+
+    expect(settings_page).to have_overridden_setting("site_description", value: "A place to talk")
+
+    settings_page.visit("company_name")
+    settings_page.submit_setting_with_keyboard("company_name", "Acme")
+
+    expect(settings_page).to have_overridden_setting("company_name", value: "Acme")
+
+    page.refresh
+
+    expect(settings_page).to have_overridden_setting("company_name", value: "Acme")
+  end
+
+  it "masks a secret setting until the admin reveals it" do
+    settings_page.visit("github_client_secret")
+    settings_page.fill_setting("github_client_secret", "s3cr3t")
+
+    expect(settings_page.secret_setting_input("github_client_secret")[:type]).to eq("password")
+
+    settings_page.reveal_secret_setting("github_client_secret")
+
+    expect(settings_page.secret_setting_input("github_client_secret")[:type]).to eq("text")
+  end
+end

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -82,6 +82,16 @@ module PageObjects
         find_setting(setting_name).find(".setting-value input[type=checkbox]", visible: :all)
       end
 
+      def secret_setting_input(setting_name)
+        find_setting(setting_name).find(".form-kit__control-password")
+      end
+
+      def reveal_secret_setting(setting_name)
+        setting = find_setting(setting_name)
+        PageObjects::Components::FormKitField.new(setting.find(".form-kit__field")).toggle
+        self
+      end
+
       def submit_setting_with_keyboard(setting_name, value)
         input = find_setting(setting_name).find(".form-kit__field input")
         input.fill_in(with: value)


### PR DESCRIPTION
Previously, the admin site settings page rendered every text field
setting — `string`, `float`, `username`, `email`, and the `textarea` and
`secret` variants of those — with a bespoke control, separate from the
shared FormKit field infrastructure that `bool` and `integer` were
already converted to.

This change renders them through that shared infrastructure, continuing
the per-type `adminReady` rollout so that every type not yet converted
keeps its current control. Each converted type gets its own registry
entry rather than relying on the registry's `default` fallback: that
fallback is the catch-all for every unregistered type, including more
than twenty that still have bespoke controls, so marking it ready would
have silently degraded all of them to bare text inputs.

The `textarea` and `secret` variants resolve through a `subtype` derived
on the setting model, rather than by teaching the shared registry two
site-setting-only flags. This keeps the registry dispatching on a single
axis and puts the two ordering rules next to the data that produces
them: `textarea` wins over `secret`, so a multi-line credential such as
a PEM key stays readable instead of collapsing into a masked single-line
input, and any `list_type` vetoes both, so the delimited `key|secret`
pairs of a `secret_list` are never rewritten as a single value. Settings
embedded in plugin admin pages now mask their secrets as a result, where
before they were rendered in cleartext.

Two behaviours the legacy control provided move into the FormKit
controls themselves rather than into setting-specific wrappers, since
both apply to every consumer: `FKControlInput` sets `dir` when
`support_mixed_text_direction` is enabled, restoring the bidi handling
these inputs used to inherit from `DTextField`, and `FKControlPassword`
sets `autocomplete="new-password"` so that browser password managers
stop offering to autofill credentials into API key fields.

Finally, pressing Enter on a text field setting now submits through the
row's full save path, including the confirmation dialog and the backfill
prompt, instead of bypassing them — the same fix already made for
`integer`.
