### PR TITLE
DEV: Render enum site settings with FormKit

### DIFF
--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -791,6 +791,7 @@ export default class SiteSettingComponent extends Component {
                 @disabled={{this.isDisabled}}
               />
             </Form>
+            {{this.preview}}
           {{else}}
             <this.resolvedComponent
               {{on "keydown" this._handleKeydown}}

--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -766,6 +766,7 @@ export default class SiteSettingComponent extends Component {
                 @disabled={{this.isDisabled}}
               />
             </Form>
+            {{this.preview}}
           {{else}}
             <this.resolvedComponent
               {{on "keydown" this._handleKeydown}}

--- a/frontend/discourse/app/components/setting-field/enum.gjs
+++ b/frontend/discourse/app/components/setting-field/enum.gjs
@@ -30,6 +30,19 @@ export default class SettingFieldEnum extends Component {
       );
   }
 
+  get fallbackChoice() {
+    const selected = this.selectedValue;
+
+    if (
+      selected === "" ||
+      this.choices.some(({ value }) => value === selected)
+    ) {
+      return null;
+    }
+
+    return { value: selected, name: selected };
+  }
+
   get selectedValue() {
     return String(this.args.field.value ?? "");
   }
@@ -53,10 +66,15 @@ export default class SettingFieldEnum extends Component {
         </option>
       {{/if}}
       {{#each this.choices as |choice|}}
-        <select.Option @value={{choice.value}} @selected={{this.selectedValue}}>
+        <select.Option @value={{choice.value}}>
           {{choice.name}}
         </select.Option>
       {{/each}}
+      {{#if this.fallbackChoice}}
+        <select.Option @value={{this.fallbackChoice.value}}>
+          {{this.fallbackChoice.name}}
+        </select.Option>
+      {{/if}}
     </@field.Control>
   </template>
 }

--- a/frontend/discourse/app/components/setting-field/enum.gjs
+++ b/frontend/discourse/app/components/setting-field/enum.gjs
@@ -30,6 +30,19 @@ export default class SettingFieldEnum extends Component {
       );
   }
 
+  get fallbackChoice() {
+    const selected = this.selectedValue;
+
+    if (
+      selected === "" ||
+      this.choices.some(({ value }) => value === selected)
+    ) {
+      return null;
+    }
+
+    return { value: selected, name: selected };
+  }
+
   get selectedValue() {
     return String(this.args.field.value ?? "");
   }
@@ -41,10 +54,15 @@ export default class SettingFieldEnum extends Component {
       as |select|
     >
       {{#each this.choices as |choice|}}
-        <select.Option @value={{choice.value}} @selected={{this.selectedValue}}>
+        <select.Option @value={{choice.value}}>
           {{choice.name}}
         </select.Option>
       {{/each}}
+      {{#if this.fallbackChoice}}
+        <select.Option @value={{this.fallbackChoice.value}}>
+          {{this.fallbackChoice.name}}
+        </select.Option>
+      {{/if}}
     </@field.Control>
   </template>
 }

--- a/frontend/discourse/app/components/setting-field/locale-enum.gjs
+++ b/frontend/discourse/app/components/setting-field/locale-enum.gjs
@@ -1,0 +1,13 @@
+import { service } from "@ember/service";
+import EnumControl from "discourse/components/setting-field/enum";
+
+export default class SettingFieldLocaleEnum extends EnumControl {
+  @service languageNameLookup;
+
+  get rawChoices() {
+    return super.rawChoices.map(({ value }) => ({
+      value,
+      name: this.languageNameLookup.getLanguageName(value),
+    }));
+  }
+}

--- a/frontend/discourse/app/lib/setting-field-registry.js
+++ b/frontend/discourse/app/lib/setting-field-registry.js
@@ -5,6 +5,7 @@ import DurationControl from "discourse/components/setting-field/duration";
 import EnumControl from "discourse/components/setting-field/enum";
 import GroupListControl from "discourse/components/setting-field/group-list";
 import IntegerControl from "discourse/components/setting-field/integer";
+import LocaleEnumControl from "discourse/components/setting-field/locale-enum";
 import RadioGroupControl from "discourse/components/setting-field/radio-group";
 
 const REGISTRY = {};
@@ -81,7 +82,14 @@ registerSettingFieldType("radio-group", {
 registerSettingFieldType("enum", {
   ...ROW,
   type: "select",
+  adminReady: true,
   renderer: EnumControl,
+});
+registerSettingFieldType("locale_enum", {
+  ...ROW,
+  type: "select",
+  adminReady: true,
+  renderer: LocaleEnumControl,
 });
 registerSettingFieldType("group_list", {
   ...ROW,

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -748,4 +748,93 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
 
     assert.dom("[data-name='my_setting']").hasClass("--full");
   });
+
+  test("enum keeps a stored value that is no longer one of the choices", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum="retired"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_enum'] select option[value='retired']")
+      .exists("the stored value is offered as its own option");
+    assert
+      .dom("[data-name='my_enum'] select")
+      .hasValue(
+        "retired",
+        "a native select would otherwise silently fall back to the first option"
+      );
+  });
+
+  test("enum does not invent an option for a blank value", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              allows_none=true
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_enum'] select option")
+      .exists({ count: 3 }, "none plus the two real choices");
+  });
+
+  test("locale_enum labels each option with its language name", async function (assert) {
+    this.siteSettings.available_locales = [
+      { value: "en", name: "English (US)" },
+      { value: "fr", name: "French (Français)" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash default_locale="fr"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="default_locale"
+              type="locale_enum"
+              label="Default locale"
+              valid_values=(array
+                (hash value="en" name="languages.en.name")
+                (hash value="fr" name="languages.fr.name")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='default_locale'] select option[value='fr']")
+      .hasText(
+        "French (Français)",
+        "the localized name is composed with the native name"
+      );
+    assert.form().field("default_locale").hasValue("fr");
+  });
 });

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -712,4 +712,93 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
 
     assert.dom("[data-name='my_setting']").hasClass("--full");
   });
+
+  test("enum keeps a stored value that is no longer one of the choices", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum="retired"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_enum'] select option[value='retired']")
+      .exists("the stored value is offered as its own option");
+    assert
+      .dom("[data-name='my_enum'] select")
+      .hasValue(
+        "retired",
+        "a native select would otherwise silently fall back to the first option"
+      );
+  });
+
+  test("enum does not invent an option for a blank value", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              allows_none=true
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_enum'] select option")
+      .exists({ count: 3 }, "none plus the two real choices");
+  });
+
+  test("locale_enum labels each option with its language name", async function (assert) {
+    this.siteSettings.available_locales = [
+      { value: "en", name: "English (US)" },
+      { value: "fr", name: "French (Français)" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash default_locale="fr"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="default_locale"
+              type="locale_enum"
+              label="Default locale"
+              valid_values=(array
+                (hash value="en" name="languages.en.name")
+                (hash value="fr" name="languages.fr.name")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='default_locale'] select option[value='fr']")
+      .hasText(
+        "French (Français)",
+        "the localized name is composed with the native name"
+      );
+    assert.form().field("default_locale").hasValue("fr");
+  });
 });

--- a/frontend/discourse/tests/integration/components/site-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-setting-test.gjs
@@ -307,6 +307,25 @@ module("Integration | Component | SiteSetting", function (hooks) {
     assert.dom(".form-kit__control-password").hasAttribute("type", "text");
   });
 
+  test("an enum setting renders its preview and keeps it in sync", async function (assert) {
+    await renderSetting({
+      setting: "tag_style",
+      value: "simple",
+      type: "enum",
+      preview: '<span class="tag-preview">{{value}}</span>',
+      valid_values: [
+        { name: "Simple", value: "simple" },
+        { name: "Box", value: "box" },
+      ],
+    });
+
+    assert.dom(".preview .tag-preview").hasText("simple");
+
+    await fillIn(".form-kit__control-select", "box");
+
+    assert.dom(".preview .tag-preview").hasText("box");
+  });
+
   test("a secret setting that is also a textarea stays readable", async function (assert) {
     await renderSetting({
       setting: "test_setting",
@@ -508,10 +527,7 @@ module("Integration | Component | SiteSetting", function (hooks) {
       ],
     });
 
-    const selector = selectKit(".select-kit");
-
-    await selector.expand();
-    await selector.selectRowByValue("1");
+    await fillIn(".form-kit__control-select", "1");
 
     assert
       .dom(".setting-controls__ok")
@@ -520,8 +536,7 @@ module("Integration | Component | SiteSetting", function (hooks) {
       .dom(".setting-controls__cancel")
       .exists("the cancel button is shown after changing the value");
 
-    await selector.expand();
-    await selector.selectRowByValue("2");
+    await fillIn(".form-kit__control-select", "2");
 
     assert
       .dom(".setting-controls__ok")

--- a/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
+++ b/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
@@ -84,6 +84,8 @@ module("Unit | Lib | setting-field-registry", function () {
         "email",
         "textarea",
         "password",
+        "enum",
+        "locale_enum",
       ]) {
         assert.true(
           resolveSettingFieldType({ type }).adminReady,

--- a/spec/system/admin_site_setting_enum_spec.rb
+++ b/spec/system/admin_site_setting_enum_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe "Admin site setting enum" do
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  fab!(:admin)
+
+  before { sign_in(admin) }
+
+  it "saves a string-valued enum and keeps the preview in sync" do
+    settings_page.visit("tag_style")
+    settings_page.select_enum_value("tag_style", "box")
+
+    expect(settings_page.find_setting("tag_style")).to have_css(".preview .discourse-tag.box")
+
+    settings_page.save_setting("tag_style")
+    page.refresh
+
+    expect(settings_page.enum_setting("tag_style").value).to eq("box")
+  end
+
+  it "round-trips an integer-valued enum" do
+    settings_page.visit("hide_post_sensitivity")
+    settings_page.select_enum_value("hide_post_sensitivity", "0")
+    settings_page.save_setting("hide_post_sensitivity")
+    page.refresh
+
+    expect(settings_page.enum_setting("hide_post_sensitivity").value).to eq("0")
+  end
+end

--- a/spec/system/admin_site_setting_locale_spec.rb
+++ b/spec/system/admin_site_setting_locale_spec.rb
@@ -15,13 +15,17 @@ describe "Admin Site Setting Locales" do
       settings_page.visit
 
       settings_page.type_in_search("default locale")
-      expect(settings_page.find_setting("default_locale")).to have_content("Español")
+      expect(settings_page.enum_setting("default_locale").value).to eq("es")
 
       settings_page.select_enum_value("default_locale", "en")
       settings_page.save_setting("default_locale")
 
       settings_page.type_in_search("default locale")
-      expect(settings_page.find_setting("default_locale")).to have_content("Inglés (English)")
+      expect(settings_page.enum_setting("default_locale").value).to eq("en")
+      expect(settings_page.find_setting("default_locale")).to have_css(
+        "option[value='en']",
+        text: "Inglés (English)",
+      )
     end
   end
 

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -42,13 +42,14 @@ module PageObjects
       end
 
       def select_enum_value(setting_name, value)
-        setting =
-          PageObjects::Components::SelectKit.new(
-            ".row.setting[data-setting='#{setting_name}'] .single-select",
-          )
-        setting.expand
-        setting.select_row_by_value(value)
+        enum_setting(setting_name).select(value)
         self
+      end
+
+      def enum_setting(setting_name)
+        PageObjects::Components::FormKitField.new(
+          find_setting(setting_name).find("[data-name='#{setting_name}']"),
+        )
       end
 
       def has_setting?(setting_name)


### PR DESCRIPTION
Previously, `enum` and `locale_enum` settings were the last large family
on the admin site settings page still rendered by a bespoke select-kit
control, even though the shared FormKit registry already had an enum
renderer at parity that the category type, plugin feature and workflow
forms use.

This change marks both types admin-ready so they render through that
shared renderer, and fixes two things a native `<select>` does not get
for free. A stored value that is no longer one of the choices is now
offered as its own option: select-kit synthesized a fallback item for
this case, whereas a native select with no matching option silently
falls back to the first one, so a setting pointing at a deleted record
or at a locale removed with its plugin would have displayed — and, on
the next save, persisted — the wrong value. And `locale_enum` gets its
own renderer that labels each option through the language name lookup,
because the shared valid-values projection translates the locale name
and drops the native one, which would have turned "Inglés (English)"
into "Inglés" for every admin.

The setting preview also moves into the FormKit branch of the row. Only
one setting in core ships a `preview`, it is an enum, and nothing
asserted on it, so converting the type would have deleted the feature
unnoticed; a test now covers it.

Finally, the enum page object helper moves from select-kit to `DSelect`,
and the locale system spec now asserts on the select's value instead of
the row's text — with every locale rendered as an option, a text match
passed no matter which one was selected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>