### PR TITLE
FIX: supports optional data for workflow user node

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/node-output-schemas.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/node-output-schemas.js
@@ -1,0 +1,26 @@
+// Nodes whose output keys come from what the author typed cannot declare them as a contract, so
+// they compute them in Ruby and name an editor-side counterpart through `output_schema_resolver`.
+const RESOLVER_MODULE = /\/admin\/lib\/workflows\/output-schemas\/([\w-]+)$/;
+
+let cache;
+
+function resolverFor(name) {
+  cache ??= Object.keys(require.entries).reduce((resolvers, moduleName) => {
+    const match = moduleName.match(RESOLVER_MODULE);
+    if (match) {
+      resolvers[match[1]] = moduleName;
+    }
+    return resolvers;
+  }, {});
+
+  const moduleName = cache[name];
+  return moduleName ? require(moduleName).default : null;
+}
+
+export function outputSchemasFromResolver(resolver, configuration = {}) {
+  if (!resolver) {
+    return null;
+  }
+
+  return resolverFor(resolver)?.(configuration || {}) || null;
+}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/output-schemas/summarize.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/output-schemas/summarize.js
@@ -1,0 +1,52 @@
+import { fixedCollectionRows } from "../property-engine";
+import { summarizeOutputKey } from "../summarize-output-key";
+
+const DRAFT_URI = "https://json-schema.org/draft/2020-12/schema";
+const NUMBER_TYPE = { type: ["number", "null"] };
+const INTEGER_TYPE = { type: "integer" };
+const STRING_TYPE = { type: "string" };
+const ARRAY_TYPE = { type: "array" };
+const ANY_TYPE = {};
+
+function schemaTypeFor(row = {}) {
+  switch (String(row.aggregation ?? "")) {
+    case "count":
+    case "count_unique":
+      return INTEGER_TYPE;
+    case "sum":
+    case "average":
+      return NUMBER_TYPE;
+    case "concatenate":
+      return STRING_TYPE;
+    case "append":
+    case "collect":
+    case "unique":
+      return ARRAY_TYPE;
+    default:
+      return ANY_TYPE;
+  }
+}
+
+function splitFieldList(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((field) => field.trim())
+    .filter(Boolean);
+}
+
+function leafName(field) {
+  return field.includes(".") ? field.split(".").pop() : field;
+}
+
+export default function summarizeOutputSchemas(configuration = {}) {
+  const properties = {};
+
+  for (const field of splitFieldList(configuration.fields_to_split_by)) {
+    properties[leafName(field)] = ANY_TYPE;
+  }
+  for (const row of fixedCollectionRows(configuration.fields_to_summarize)) {
+    properties[summarizeOutputKey(row)] = schemaTypeFor(row);
+  }
+
+  return [{ $schema: DRAFT_URI, type: "object", properties }];
+}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
@@ -493,6 +493,9 @@ function matchesRule(expected, value) {
 function matchesCondition(condition, value) {
   const operator = condition?.condition;
   if (!operator) {
+    if (Array.isArray(value) && !Array.isArray(condition)) {
+      return value.includes(condition);
+    }
     return condition === value;
   }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/schema-graph.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/schema-graph.js
@@ -2,6 +2,7 @@ import {
   normalizeSourceOutputIndex,
   normalizeTargetInputIndex,
 } from "./graph-constants";
+import { outputSchemasFromResolver } from "./node-output-schemas";
 import { resolveNodeTypeVersion, typeVersionForNode } from "./node-types";
 import { fieldDisplayState, fieldVisible } from "./property-engine";
 
@@ -90,6 +91,60 @@ function overlaySchemas(inputSchema, declaredSchema) {
   return merged;
 }
 
+function mergeSchemaPair(left, right) {
+  const merged = { ...left, ...right };
+  if (!isObjectSchema(left) || !isObjectSchema(right)) {
+    return merged;
+  }
+
+  const properties = { ...(left.properties || {}) };
+  for (const [name, value] of Object.entries(right.properties || {})) {
+    const existing = properties[name];
+    properties[name] =
+      existing && isObjectSchema(existing) && isObjectSchema(value)
+        ? mergeSchemaPair(existing, value)
+        : value;
+  }
+  merged.properties = properties;
+
+  const required = [
+    ...new Set([...(left.required || []), ...(right.required || [])]),
+  ];
+  if (required.length) {
+    merged.required = required;
+  } else {
+    delete merged.required;
+  }
+
+  return merged;
+}
+
+function augmentSchema(schema, extensions) {
+  const usable = extensions.filter((extension) => !isUnknown(extension));
+  if (!usable.length) {
+    return schema;
+  }
+
+  if (isAnyOfWrapper(schema)) {
+    return unionSchemas(
+      schema.anyOf.map((branch) => augmentSchema(branch, usable))
+    );
+  }
+
+  return usable.reduce(mergeSchemaPair, schema);
+}
+
+function activeOutputExtensions(contract, configuration) {
+  return (contract.extensions || [])
+    .filter((extension) =>
+      fieldVisible(
+        { display_options: extension.display_options },
+        configuration
+      )
+    )
+    .map((extension) => extension.schema || {});
+}
+
 function resolvedOutputSchema(contract, inputSchema = {}) {
   switch (contract.mode) {
     case "passthrough":
@@ -161,24 +216,41 @@ function nodeTypeDefinitionForNode(node, graph) {
   return resolveNodeTypeVersion(definition, typeVersionForNode(node));
 }
 
-function ownOutputContracts(node, graph, configuration) {
+function ownOutputResolution(node, graph, configuration) {
   const definition = nodeTypeDefinitionForNode(node, graph);
   if (!definition) {
-    return [[{ mode: "replace", schema: {} }]];
+    return { contracts: [[{ mode: "replace", schema: {} }]], extensions: [[]] };
   }
 
   const currentConfiguration = configuration ?? node.configuration ?? {};
+  const resolved = outputSchemasFromResolver(
+    definition.output_schema_resolver,
+    currentConfiguration
+  );
+  if (resolved) {
+    return {
+      contracts: resolved.map((schema) => [{ mode: "replace", schema }]),
+      extensions: resolved.map(() => []),
+    };
+  }
+
   const serializedContracts = definition.output_contracts;
-  const contracts = Array.isArray(serializedContracts)
+  const declarations = Array.isArray(serializedContracts)
     ? serializedContracts
     : [];
   const outputCount =
-    contracts.length ||
+    declarations.length ||
     (definition.outputs || definition.ports || [null]).length;
 
-  return Array.from({ length: outputCount }, (_, index) =>
-    activeOutputContracts(contracts[index] || {}, currentConfiguration)
-  );
+  const contracts = [];
+  const extensions = [];
+  for (let index = 0; index < outputCount; index++) {
+    const declaration = declarations[index] || {};
+    contracts.push(activeOutputContracts(declaration, currentConfiguration));
+    extensions.push(activeOutputExtensions(declaration, currentConfiguration));
+  }
+
+  return { contracts, extensions };
 }
 
 function nodeKey(node) {
@@ -223,10 +295,10 @@ export function resolveDeclaredOutputSchemas(
     incoming.sort(connectionOrder);
   }
 
-  const contractsByKey = new Map(
+  const resolutionByKey = new Map(
     nodes.map((candidate) => [
       nodeKey(candidate),
-      ownOutputContracts(
+      ownOutputResolution(
         candidate,
         graph,
         configurationOverrides.get(nodeKey(candidate))
@@ -267,7 +339,7 @@ export function resolveDeclaredOutputSchemas(
       changed = false;
       for (const candidate of nodes) {
         const key = nodeKey(candidate);
-        const contracts = contractsByKey.get(key);
+        const { contracts, extensions } = resolutionByKey.get(key);
         let inputSchema = {};
 
         if (
@@ -279,9 +351,14 @@ export function resolveDeclaredOutputSchemas(
           }
         }
 
-        const resolved = contracts.map((port) =>
-          unionSchemas(
-            port.map((contract) => resolvedOutputSchema(contract, inputSchema))
+        const resolved = contracts.map((port, index) =>
+          augmentSchema(
+            unionSchemas(
+              port.map((contract) =>
+                resolvedOutputSchema(contract, inputSchema)
+              )
+            ),
+            extensions[index] || []
           )
         );
         if (
@@ -304,7 +381,7 @@ export function resolveDeclaredOutputSchemas(
       promoted = true;
       outputSchemas.set(
         key,
-        contractsByKey.get(key).map(() => ({}))
+        resolutionByKey.get(key).contracts.map(() => ({}))
       );
     }
   }

--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/user_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/user_serializer.rb
@@ -2,7 +2,18 @@
 
 module DiscourseWorkflows
   class UserSerializer < ApplicationSerializer
-    attributes :id, :username, :name, :trust_level, :trust_level_name, :admin, :moderator, :staff
+    attributes :id,
+               :username,
+               :name,
+               :trust_level,
+               :trust_level_name,
+               :admin,
+               :moderator,
+               :staff,
+               :created_at,
+               :approved,
+               :silenced,
+               :suspended
 
     def trust_level_name
       TrustLevel.name(object.trust_level)
@@ -10,6 +21,14 @@ module DiscourseWorkflows
 
     def staff
       object.staff?
+    end
+
+    def silenced
+      object.silenced?
+    end
+
+    def suspended
+      object.suspended?
     end
   end
 end

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -461,6 +461,11 @@ en:
         title: "Title"
         trust_level: "Trust level"
         trust_level_locked: "Lock trust level"
+        include_extensions: "Include user extensions"
+        include_extensions_stats: "Reading and posting stats"
+        include_extensions_external_ids: "External ids"
+        include_extensions_emails: "Emails"
+        include_extensions_ips: "IP addresses and locations"
         actor_username: "Performed by user"
       badge:
         operation: "Operation"

--- a/plugins/discourse-workflows/config/locales/server.en.yml
+++ b/plugins/discourse-workflows/config/locales/server.en.yml
@@ -96,6 +96,7 @@ en:
         flag_failed: "Failed to flag post: %{errors}"
       user:
         unknown_operation: "Unknown operation: %{operation}."
+        unknown_extensions: "Unknown user extensions: %{extensions}."
         invalid_updates: "User updates must be an object."
         invalid_trust_level: "Invalid trust level: %{level}."
         update_failed: "Failed to update user: %{errors}"
@@ -179,6 +180,8 @@ en:
         payload_too_large: "Workflow call payload exceeds the maximum size of %{max} bytes."
     flag_post:
       flagged_by_workflow: "Flagged by the '%{workflow_name}' workflow."
+    user:
+      check_email_context: "Workflow user node"
     pin_data:
       errors:
         unsupported_node: "Only nodes with a single output can have pinned data."

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -21,6 +21,7 @@ module DiscourseWorkflows
       capabilities: {
       },
       output_contracts: [],
+      output_schema_resolver: nil,
       palette_visible: true,
       available: true,
       previewable: false,
@@ -123,13 +124,20 @@ module DiscourseWorkflows
     def self.output_schemas(configuration = {}, input_schemas: [])
       input_schema = Schema.union(*input_schemas.compact)
 
-      active_output_contracts(configuration).map do |candidates|
-        Schema.union(
-          *candidates.map do |contract|
-            Schema.resolve(contract.fetch(:schema), mode: contract.fetch(:mode), input_schema:)
-          end,
-        )
+      active_output_contracts(configuration).map.with_index do |candidates, index|
+        resolved =
+          Schema.union(
+            *candidates.map do |contract|
+              Schema.resolve(contract.fetch(:schema), mode: contract.fetch(:mode), input_schema:)
+            end,
+          )
+
+        Schema.augment(resolved, active_output_extensions(index, configuration))
       end
+    end
+
+    def self.output_schema_resolver
+      description_value(:output_schema_resolver)
     end
 
     def self.output_contracts
@@ -151,6 +159,16 @@ module DiscourseWorkflows
 
     def self.active_output_contracts(configuration = {})
       output_contracts.map { |contract| contract_candidates(contract, configuration) }
+    end
+
+    def self.active_output_extensions(output_index, configuration = {})
+      contract = output_contracts[output_index]
+      return [] if contract.nil?
+
+      contract
+        .fetch(:extensions)
+        .select { |extension| Schema.visible?(extension.fetch(:display_options), configuration) }
+        .map { |extension| extension.fetch(:schema) }
     end
 
     def self.contract_candidates(contract, configuration)
@@ -220,6 +238,10 @@ module DiscourseWorkflows
         variants:
           Array(contract[:variants]).map do |variant|
             normalize_contract_fields(variant.deep_symbolize_keys)
+          end,
+        extensions:
+          Array(contract[:extensions]).map do |extension|
+            normalize_contract_fields(extension.deep_symbolize_keys)
           end,
       )
     end

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type_serializer.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type_serializer.rb
@@ -65,6 +65,7 @@ module DiscourseWorkflows
         ports: klass.ports,
         operations: klass.operations,
         output_contracts: serializable_output_contracts(klass),
+        output_schema_resolver: klass.output_schema_resolver,
         palette_visible: klass.palette_visible?,
         previewable: klass.previewable?,
         available: klass.available?,
@@ -80,7 +81,8 @@ module DiscourseWorkflows
     def serializable_output_contracts(klass)
       contracts = klass.output_contracts
       if contracts.all? { |contract|
-           contract[:schema].empty? && contract[:mode] == :replace && contract[:variants].empty?
+           contract[:schema].empty? && contract[:mode] == :replace && contract[:variants].empty? &&
+             contract[:extensions].empty?
          }
         return
       end
@@ -94,6 +96,10 @@ module DiscourseWorkflows
           contract
             .fetch(:variants)
             .map { |variant| variant.slice(:schema, :mode, :display_options) },
+        extensions:
+          contract
+            .fetch(:extensions)
+            .map { |extension| extension.slice(:schema, :display_options) },
       )
     end
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/summarize/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/summarize/v1.rb
@@ -58,6 +58,7 @@ module DiscourseWorkflows
           },
           group: "data",
           previewable: true,
+          output_schema_resolver: "summarize",
           capabilities: {
             run_scope: "all_items",
           },

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user/v1.rb
@@ -13,6 +13,24 @@ module DiscourseWorkflows
         ].freeze
         MISSING = DiscourseWorkflows::Executor::NodeExecutionContext::MISSING
 
+        EXTENSIONS = {
+          "stats" => :stats_extension,
+          "external_ids" => :external_ids_extension,
+          "emails" => :emails_extension,
+          "ips" => :ips_extension,
+        }.freeze
+        STAT_FIELDS = %i[
+          topics_entered
+          posts_read_count
+          time_read
+          days_visited
+          post_count
+          topic_count
+          likes_given
+          likes_received
+          first_post_created_at
+        ].freeze
+
         description(
           name: "action:user",
           version: "1.0",
@@ -24,7 +42,15 @@ module DiscourseWorkflows
           capabilities: {
             run_scope: "per_item",
           },
-          output_contracts: [{ schema: Schema::USER_ACTION_SCHEMA }],
+          output_contracts: [
+            {
+              schema: Schema::USER_ACTION_SCHEMA,
+              extensions:
+                Schema::USER_EXTENSION_SCHEMAS.map do |name, schema|
+                  { schema:, display_options: { show: { include_extensions: [name] } } }
+                end,
+            },
+          ],
           properties: {
             operation: {
               type: :options,
@@ -55,6 +81,12 @@ module DiscourseWorkflows
                 },
               },
             },
+            include_extensions: {
+              type: :multi_options,
+              required: false,
+              options: EXTENSIONS.keys,
+              default: [],
+            },
             actor_username: {
               type: :string,
               required: false,
@@ -83,11 +115,13 @@ module DiscourseWorkflows
         private
 
         def process(exec_ctx, user, actor, operation, item_index)
+          extensions = requested_extensions(exec_ctx, item_index)
+
           case operation
           when "get"
-            get_user(user, actor.guardian)
+            get_user(user, actor.guardian, extensions:)
           when "edit"
-            edit_user(exec_ctx, user, actor, item_index)
+            edit_user(exec_ctx, user, actor, item_index, extensions:)
           else
             raise_node_error!(
               I18n.t("discourse_workflows.errors.user.unknown_operation", operation: operation),
@@ -95,12 +129,30 @@ module DiscourseWorkflows
           end
         end
 
-        def get_user(user, guardian)
-          guardian.ensure_can_see_profile!(user)
-          { user: user_data(user, guardian) }
+        def requested_extensions(exec_ctx, item_index)
+          requested = exec_ctx.get_node_parameter("include_extensions", item_index, default: [])
+          requested = [requested] unless requested.is_a?(Array)
+          requested = requested.compact.map(&:to_s)
+          unknown = requested - EXTENSIONS.keys
+
+          if unknown.any?
+            raise_node_error!(
+              I18n.t(
+                "discourse_workflows.errors.user.unknown_extensions",
+                extensions: unknown.sort.join(", "),
+              ),
+            )
+          end
+
+          requested
         end
 
-        def edit_user(exec_ctx, user, actor, item_index)
+        def get_user(user, guardian, extensions:)
+          guardian.ensure_can_see_profile!(user)
+          { user: user_data(user, guardian, extensions:) }
+        end
+
+        def edit_user(exec_ctx, user, actor, item_index, extensions:)
           guardian = actor.guardian
           updates = update_parameters(exec_ctx, item_index)
           attributes = editable_attributes(updates)
@@ -113,7 +165,7 @@ module DiscourseWorkflows
             update_trust_level_lock(user, actor, guardian, trust_level_locked)
           end
 
-          { user: user_data(user.reload, guardian) }
+          { user: user_data(user.reload, guardian, extensions:) }
         end
 
         def update_parameters(exec_ctx, item_index)
@@ -194,7 +246,7 @@ module DiscourseWorkflows
           )
         end
 
-        def user_data(user, guardian)
+        def user_data(user, guardian, extensions:)
           include_profile_details = include_profile_details?(user, guardian)
 
           serialize_user(user, guardian: guardian).merge(
@@ -211,7 +263,84 @@ module DiscourseWorkflows
                 end
               ),
             groups: groups_data(user, guardian),
+          ).merge(extensions_data(user, guardian, extensions))
+        end
+
+        def extensions_data(user, guardian, extensions)
+          extensions.reduce({}) do |data, extension|
+            data.merge(send(EXTENSIONS.fetch(extension), user, guardian))
+          end
+        end
+
+        def external_ids_extension(user, guardian)
+          {
+            external_id: connect_external_id(user, guardian),
+            external_ids: associated_account_ids(user, guardian),
+          }
+        end
+
+        def stats_extension(user, _guardian)
+          stat = user.user_stat
+          return { stats: nil } if stat.blank?
+
+          { stats: STAT_FIELDS.index_with { |field| stat.public_send(field) } }
+        end
+
+        def emails_extension(user, guardian)
+          return { email: nil, secondary_emails: [] } unless guardian.can_check_emails?(user)
+
+          log_email_check(user, guardian)
+
+          { email: user.email, secondary_emails: user.secondary_emails }
+        end
+
+        def log_email_check(user, guardian)
+          return if guardian.user.blank? || guardian.user == user
+
+          StaffActionLogger.new(guardian.user).log_check_email(
+            user,
+            context: I18n.t("discourse_workflows.user.check_email_context"),
           )
+        end
+
+        def ips_extension(user, guardian)
+          return blank_ips unless guardian.can_see_ip?
+
+          {
+            registration_ip_address: user.registration_ip_address&.to_s,
+            registration_location: ip_location(user.registration_ip_address),
+            ip_address: user.ip_address&.to_s,
+            last_location: ip_location(user.ip_address),
+          }
+        end
+
+        def blank_ips
+          {
+            registration_ip_address: nil,
+            registration_location: nil,
+            ip_address: nil,
+            last_location: nil,
+          }
+        end
+
+        def ip_location(ip)
+          return nil if ip.blank?
+
+          DiscourseIpInfo.get(ip.to_s).presence
+        end
+
+        def connect_external_id(user, guardian)
+          return nil unless guardian.can_check_sso_details?(user)
+
+          user.single_sign_on_record&.external_id
+        end
+
+        def associated_account_ids(user, guardian)
+          return {} unless guardian.is_admin?
+
+          user.user_associated_accounts.to_h do |account|
+            [account.provider_name, account.provider_uid]
+          end
         end
 
         def include_profile_details?(user, guardian)

--- a/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
@@ -26,6 +26,19 @@ module DiscourseWorkflows
       { "$schema" => DRAFT_URI, "type" => "object", "properties" => properties }.freeze
     end
 
+    def self.entity_extension(name, properties)
+      {
+        "$schema" => DRAFT_URI,
+        "type" => "object",
+        "properties" => {
+          name => {
+            "type" => "object",
+            "properties" => properties,
+          },
+        },
+      }.freeze
+    end
+
     TOPIC_PROPERTIES = JSON.parse(<<~JSON).freeze
       {
         "id": { "type": "integer" },
@@ -104,7 +117,11 @@ module DiscourseWorkflows
         "trust_level_name": { "type": "string" },
         "admin": { "type": "boolean" },
         "moderator": { "type": "boolean" },
-        "staff": { "type": "boolean" }
+        "staff": { "type": "boolean" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "approved": { "type": "boolean" },
+        "silenced": { "type": "boolean" },
+        "suspended": { "type": "boolean" }
       }
     JSON
 
@@ -146,10 +163,25 @@ module DiscourseWorkflows
     POST_SCHEMA = entity("post", POST_PROPERTIES, "DiscourseWorkflows::PostSerializer payload")
     BASIC_USER_SCHEMA = entity("user", BASIC_USER_PROPERTIES, "BasicUserSerializer payload")
     USER_SCHEMA = entity("user", USER_PROPERTIES, "Basic safe user attributes")
-    USER_ACTION_SCHEMA =
-      entity(
-        "user",
-        USER_PROPERTIES.merge(JSON.parse(<<~JSON)),
+    IP_LOCATION_PROPERTIES = JSON.parse(<<~JSON).freeze
+      {
+        "type": ["object", "null"],
+        "description": "Derived on demand from the MaxMind databases, null when unavailable",
+        "properties": {
+          "country": { "type": "string" },
+          "country_code": { "type": "string" },
+          "region": { "type": ["string", "null"] },
+          "city": { "type": ["string", "null"] },
+          "location": { "type": "string" },
+          "latitude": { "type": ["number", "null"] },
+          "longitude": { "type": ["number", "null"] },
+          "asn": { "type": ["integer", "null"] },
+          "organization": { "type": ["string", "null"] }
+        }
+      }
+    JSON
+
+    USER_ACTION_PROPERTIES = JSON.parse(<<~JSON).freeze
           {
             "title": { "type": ["string", "null"] },
             "bio_raw": { "type": ["string", "null"] },
@@ -170,8 +202,59 @@ module DiscourseWorkflows
             }
           }
         JSON
+
+    USER_STATS_PROPERTIES = JSON.parse(<<~JSON).freeze
+          {
+            "stats": {
+              "type": ["object", "null"],
+              "properties": {
+                "topics_entered": { "type": "integer" },
+                "posts_read_count": { "type": "integer" },
+                "time_read": { "type": "integer" },
+                "days_visited": { "type": "integer" },
+                "post_count": { "type": "integer" },
+                "topic_count": { "type": "integer" },
+                "likes_given": { "type": "integer" },
+                "likes_received": { "type": "integer" },
+                "first_post_created_at": { "type": ["string", "null"], "format": "date-time" }
+              }
+            }
+          }
+        JSON
+
+    USER_EXTENSION_PROPERTIES = {
+      "stats" => USER_STATS_PROPERTIES,
+      "external_ids" =>
+        JSON.parse(
+          '{ "external_id": { "type": ["string", "null"] }, "external_ids": { "type": "object" } }',
+        ).freeze,
+      "emails" =>
+        JSON.parse(
+          '{ "email": { "type": ["string", "null"] }, "secondary_emails": { "type": "array", "items": { "type": "string" } } }',
+        ).freeze,
+      "ips" => {
+        "registration_ip_address" => {
+          "type" => %w[string null],
+        },
+        "registration_location" => IP_LOCATION_PROPERTIES,
+        "ip_address" => {
+          "type" => %w[string null],
+        },
+        "last_location" => IP_LOCATION_PROPERTIES,
+      }.freeze,
+    }.freeze
+
+    USER_ACTION_SCHEMA =
+      entity(
+        "user",
+        USER_PROPERTIES.merge(USER_ACTION_PROPERTIES),
         "Discourse user lookup/update payload",
       )
+
+    USER_EXTENSION_SCHEMAS =
+      USER_EXTENSION_PROPERTIES
+        .transform_values { |properties| entity_extension("user", properties) }
+        .freeze
     BASIC_GROUP_SCHEMA =
       entity("group", BASIC_GROUP_PROPERTIES, "Group involved in the membership event")
     GROUP_SCHEMA = entity("group", GROUP_PROPERTIES, "WebHookGroupSerializer payload")
@@ -332,6 +415,18 @@ module DiscourseWorkflows
         return branches.first if branches.one?
 
         { "$schema" => DRAFT_URI, "anyOf" => branches }
+      end
+
+      def augment(schema, *extensions)
+        extensions = extensions.flatten.map { |extension| stringify(extension) }.reject(&:empty?)
+        return schema if extensions.empty?
+
+        schema = stringify(schema)
+        if any_of_wrapper?(schema)
+          return union(*union_branches(schema).map { |branch| augment(branch, extensions) })
+        end
+
+        extensions.reduce(schema) { |merged, extension| merge_pair(merged, extension) }
       end
 
       def resolve(schema, mode:, input_schema: {})
@@ -524,7 +619,10 @@ module DiscourseWorkflows
 
       def matches_condition?(condition, value)
         operator = condition.is_a?(Hash) ? condition["condition"] : nil
-        return condition == value if operator.blank?
+        if operator.blank?
+          return value.include?(condition) if value.is_a?(Array) && !condition.is_a?(Array)
+          return condition == value
+        end
         return value != operator["not"] if operator.key?("not")
 
         if operator.key?("exists")

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_output_contracts_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_output_contracts_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe DiscourseWorkflows::NodeType do
     }
   end
 
+  it "requires nodes that override output_schemas to name an editor-side resolver" do
+    overriding =
+      DiscourseWorkflows::NodeType.registered_nodes.select do |node_class|
+        node_class.singleton_class.instance_methods(false).include?(:output_schemas)
+      end
+
+    expect(overriding).to be_present
+    expect(overriding.reject(&:output_schema_resolver)).to be_empty
+  end
+
   it "preserves declarations through nodes that only forward or reorder items" do
     node_classes = [
       DiscourseWorkflows::Nodes::Log::V1,

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_serializer_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_serializer_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe DiscourseWorkflows::NodeTypeSerializer do
         display_options: {
         },
         variants: [],
+        extensions: [],
       )
     end
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe DiscourseWorkflows::NodeType do
           },
         },
         variants: [],
+        extensions: [],
       )
     end
 
@@ -226,6 +227,7 @@ RSpec.describe DiscourseWorkflows::NodeType do
         display_options: {
         },
         variants: [],
+        extensions: [],
       )
     end
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/summarize_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/summarize_spec.rb
@@ -330,6 +330,10 @@ RSpec.describe DiscourseWorkflows::Nodes::Summarize::V1 do
   end
 
   describe ".output_schemas" do
+    it "names the editor-side resolver so both sides derive the same keys" do
+      expect(described_class.output_schema_resolver).to eq("summarize")
+    end
+
     it "derives properties from the configured aggregations and group keys" do
       schema =
         described_class.output_schemas(

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/user_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/user_spec.rb
@@ -40,6 +40,253 @@ RSpec.describe DiscourseWorkflows::Nodes::User::V1 do
       expect(result["user"]).not_to have_key("email")
     end
 
+    it "always returns account status signals", :aggregate_failures do
+      user.update!(silenced_till: 1.day.from_now, approved: true)
+
+      result = execute_node(configuration: { "operation" => "get", "username" => user.username })
+
+      expect(result["user"]).to include(
+        "silenced" => true,
+        "suspended" => false,
+        "approved" => true,
+      )
+      expect(result.dig("user", "created_at")).to be_present
+    end
+
+    it "returns reading and posting stats when requested", :aggregate_failures do
+      user.user_stat.update!(time_read: 42, posts_read_count: 7, topics_entered: 3, post_count: 2)
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["stats"],
+          },
+        )
+
+      expect(result.dig("user", "stats")).to include(
+        "time_read" => 42,
+        "posts_read_count" => 7,
+        "topics_entered" => 3,
+        "post_count" => 2,
+      )
+    end
+
+    it "returns emails when requested, and logs the check", :aggregate_failures do
+      expect do
+        result =
+          execute_node(
+            configuration: {
+              "operation" => "get",
+              "username" => user.username,
+              "include_extensions" => ["emails"],
+              "actor_username" => admin.username,
+            },
+          )
+
+        expect(result.dig("user", "email")).to eq(user.email)
+        expect(result.dig("user", "secondary_emails")).to eq([])
+      end.to change {
+        UserHistory.where(action: UserHistory.actions[:check_email], target_user_id: user.id).count
+      }.by(1)
+    end
+
+    it "hides emails from actors who cannot check them", :aggregate_failures do
+      SiteSetting.moderators_view_emails = false
+      moderator = Fabricate(:moderator)
+
+      expect do
+        result =
+          execute_node(
+            configuration: {
+              "operation" => "get",
+              "username" => user.username,
+              "include_extensions" => ["emails"],
+              "actor_username" => moderator.username,
+            },
+          )
+
+        expect(result.dig("user", "email")).to eq(nil)
+        expect(result.dig("user", "secondary_emails")).to eq([])
+      end.not_to change { UserHistory.where(action: UserHistory.actions[:check_email]).count }
+    end
+
+    it "returns ip addresses and their locations when requested", :aggregate_failures do
+      user.update!(registration_ip_address: "1.1.1.1", ip_address: "2.2.2.2")
+      DiscourseIpInfo
+        .stubs(:get)
+        .with("1.1.1.1")
+        .returns({ country: "France", country_code: "FR", location: "Paris, France" })
+      DiscourseIpInfo
+        .stubs(:get)
+        .with("2.2.2.2")
+        .returns({ country: "Japan", country_code: "JP", location: "Tokyo, Japan" })
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["ips"],
+          },
+        )
+
+      expect(result.dig("user", "registration_ip_address")).to eq("1.1.1.1")
+      expect(result.dig("user", "ip_address")).to eq("2.2.2.2")
+      expect(result.dig("user", "registration_location", "country")).to eq("France")
+      expect(result.dig("user", "last_location", "country")).to eq("Japan")
+    end
+
+    it "returns a null location when the maxmind databases are unavailable" do
+      user.update!(registration_ip_address: "1.1.1.1", ip_address: nil)
+      DiscourseIpInfo.stubs(:get).returns({})
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["ips"],
+          },
+        )
+
+      expect(result.dig("user", "registration_location")).to eq(nil)
+    end
+
+    it "hides ip addresses from actors who cannot see them", :aggregate_failures do
+      user.update!(registration_ip_address: "1.1.1.1", ip_address: "2.2.2.2")
+      SiteSetting.moderators_view_ips = false
+      moderator = Fabricate(:moderator)
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["ips"],
+            "actor_username" => moderator.username,
+          },
+        )
+
+      expect(result.dig("user", "registration_ip_address")).to eq(nil)
+      expect(result.dig("user", "ip_address")).to eq(nil)
+      expect(result.dig("user", "last_location")).to eq(nil)
+    end
+
+    it "combines several extensions in one payload", :aggregate_failures do
+      Fabricate(:single_sign_on_record, user: user, external_id: "ext-42")
+      user.user_stat.update!(time_read: 11)
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => %w[stats external_ids],
+          },
+        )
+
+      expect(result.dig("user", "external_id")).to eq("ext-42")
+      expect(result.dig("user", "stats", "time_read")).to eq(11)
+      expect(result["user"]).not_to have_key("email")
+    end
+
+    it "returns external identity provider ids when requested", :aggregate_failures do
+      Fabricate(:single_sign_on_record, user: user, external_id: "ext-42")
+      Fabricate(:user_associated_account, user: user, provider_name: "oidc", provider_uid: "uid-7")
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["external_ids"],
+          },
+        )
+
+      expect(result.dig("user", "external_id")).to eq("ext-42")
+      expect(result.dig("user", "external_ids")).to eq("oidc" => "uid-7")
+    end
+
+    it "omits extensions that were not requested", :aggregate_failures do
+      Fabricate(:single_sign_on_record, user: user, external_id: "ext-42")
+
+      result = execute_node(configuration: { "operation" => "get", "username" => user.username })
+
+      expect(result["user"]).not_to have_key("external_id")
+      expect(result["user"]).not_to have_key("external_ids")
+    end
+
+    it "raises when an unknown extension is requested" do
+      expect do
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => %w[external_ids nope],
+          },
+        )
+      end.to raise_error(DiscourseWorkflows::NodeError, "Unknown user extensions: nope.")
+    end
+
+    it "returns external ids from the edit operation", :aggregate_failures do
+      Fabricate(:single_sign_on_record, user: user, external_id: "ext-42")
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "edit",
+            "username" => user.username,
+            "updates" => {
+              "title" => "Updated title",
+            },
+            "include_extensions" => ["external_ids"],
+            "actor_username" => admin.username,
+          },
+        )
+
+      expect(result.dig("user", "external_id")).to eq("ext-42")
+    end
+
+    it "hides external ids from actors who cannot see them", :aggregate_failures do
+      Fabricate(:single_sign_on_record, user: user, external_id: "ext-42")
+      Fabricate(:user_associated_account, user: user, provider_name: "oidc", provider_uid: "uid-7")
+      SiteSetting.moderators_view_sso_details = false
+      moderator = Fabricate(:moderator)
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["external_ids"],
+            "actor_username" => moderator.username,
+          },
+        )
+
+      expect(result.dig("user", "external_id")).to eq(nil)
+      expect(result.dig("user", "external_ids")).to eq({})
+    end
+
+    it "returns the connect external id to moderators when the site setting allows it" do
+      SiteSetting.moderators_view_sso_details = true
+      Fabricate(:single_sign_on_record, user: user, external_id: "ext-42")
+      moderator = Fabricate(:moderator)
+
+      result =
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "username" => user.username,
+            "include_extensions" => ["external_ids"],
+            "actor_username" => moderator.username,
+          },
+        )
+
+      expect(result.dig("user", "external_id")).to eq("ext-42")
+    end
+
     it "updates the bio and title", :aggregate_failures do
       result =
         execute_node(
@@ -228,6 +475,46 @@ RSpec.describe DiscourseWorkflows::Nodes::User::V1 do
       expect do
         execute_node(configuration: { "operation" => "get", "username" => "missing_user" })
       end.to raise_error(DiscourseWorkflows::NodeError, "User 'missing_user' not found")
+    end
+  end
+
+  describe ".output_schemas" do
+    def user_properties(configuration)
+      described_class.output_schemas(configuration).first.dig("properties", "user", "properties")
+    end
+
+    it "only advertises the extensions the node was configured with", :aggregate_failures do
+      expect(user_properties({}).keys).to include("username", "created_at", "groups")
+      expect(user_properties({}).keys).not_to include(
+        "stats",
+        "external_id",
+        "email",
+        "ip_address",
+        "last_location",
+      )
+    end
+
+    it "advertises each selected extension", :aggregate_failures do
+      stats_only = user_properties("include_extensions" => ["stats"])
+      ips_and_emails = user_properties("include_extensions" => %w[ips emails])
+
+      expect(stats_only.keys).to include("stats")
+      expect(stats_only.keys).not_to include("email")
+      expect(ips_and_emails.keys).to include(
+        "email",
+        "secondary_emails",
+        "registration_ip_address",
+        "registration_location",
+        "ip_address",
+        "last_location",
+      )
+      expect(ips_and_emails.keys).not_to include("stats")
+    end
+
+    it "advertises every extension when the selection is an expression" do
+      properties = user_properties("include_extensions" => "={{ $json.extensions }}")
+
+      expect(properties.keys).to include("stats", "external_id", "email", "ip_address")
     end
   end
 end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_spec.rb
@@ -194,6 +194,37 @@ RSpec.describe DiscourseWorkflows::Schema do
     end
   end
 
+  describe ".augment" do
+    it "merges extension properties into the same shape", :aggregate_failures do
+      base = described_class.entity("user", { "id" => { "type" => "integer" } }, "User")
+      extension = described_class.entity_extension("user", "email" => { "type" => "string" })
+
+      augmented = described_class.augment(base, extension)
+
+      expect(augmented.dig("properties", "user", "properties").keys).to eq(%w[id email])
+      expect(augmented.dig("properties", "user", "description")).to eq("User")
+    end
+
+    it "returns the schema untouched without usable extensions" do
+      base = described_class.entity("user", { "id" => { "type" => "integer" } }, "User")
+
+      expect(described_class.augment(base)).to eq(base)
+      expect(described_class.augment(base, {})).to eq(base)
+    end
+
+    it "augments every branch of an anyOf" do
+      left = described_class.document("a" => { "type" => "string" })
+      right = described_class.document("b" => { "type" => "string" })
+      extension = described_class.document("c" => { "type" => "string" })
+
+      augmented = described_class.augment(described_class.union(left, right), extension)
+
+      expect(augmented["anyOf"].map { |branch| branch["properties"].keys }).to eq(
+        [%w[a c], %w[b c]],
+      )
+    end
+  end
+
   describe ".resolve" do
     it "replaces the input schema by default" do
       expect(
@@ -334,6 +365,15 @@ RSpec.describe DiscourseWorkflows::Schema do
       display_options = { show: { operation: %w[add remove] } }
 
       expect(described_class.visible?(display_options, operation: "={{ $json.op }}")).to eq(true)
+    end
+
+    it "tests membership against a multi-select value", :aggregate_failures do
+      display_options = { show: { extensions: ["stats"] } }
+
+      expect(described_class.visible?(display_options, extensions: %w[stats ips])).to eq(true)
+      expect(described_class.visible?(display_options, extensions: ["stats"])).to eq(true)
+      expect(described_class.visible?(display_options, extensions: ["ips"])).to eq(false)
+      expect(described_class.visible?(display_options, extensions: [])).to eq(false)
     end
   end
 

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
@@ -406,6 +406,20 @@ module("Unit | Utility | workflows property engine", function () {
     );
   });
 
+  test("tests membership when the anchor is a multi-select", function (assert) {
+    const shown = { display_options: { show: { extensions: ["stats"] } } };
+
+    assert.true(fieldVisible(shown, { extensions: ["stats", "ips"] }));
+    assert.true(fieldVisible(shown, { extensions: ["stats"] }));
+    assert.false(fieldVisible(shown, { extensions: ["ips"] }));
+    assert.false(fieldVisible(shown, { extensions: [] }));
+    assert.strictEqual(
+      fieldDisplayState(shown, { extensions: "={{ $json.extensions }}" }),
+      "indeterminate",
+      "an expression anchor stays indeterminate for multi-selects too"
+    );
+  });
+
   test("treats an expression anchor as indeterminate rather than a failed rule", function (assert) {
     const expression = "={{ $json.op }}";
     const state = fieldDisplayState;

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-schema-graph-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-schema-graph-test.js
@@ -323,6 +323,100 @@ module("Unit | lib | discourse-workflows | schema-graph", function () {
     );
   });
 
+  test("extensions compose onto the contract per selected value", function (assert) {
+    const base = objectSchema({
+      user: objectSchema({ id: { type: "integer" } }),
+    });
+    const extension = (name) => ({
+      type: "object",
+      properties: {
+        user: objectSchema({ [name]: { type: "string" } }),
+      },
+    });
+    const picker = node("picker", "action:picker");
+    const graph = {
+      nodes: [picker],
+      nodeTypes: [
+        nodeType("action:picker", [
+          {
+            schema: base,
+            extensions: [
+              {
+                schema: extension("email"),
+                display_options: { show: { include: ["emails"] } },
+              },
+              {
+                schema: extension("ip"),
+                display_options: { show: { include: ["ips"] } },
+              },
+            ],
+          },
+        ]),
+      ],
+      connections: [],
+    };
+    const keys = (configuration) =>
+      Object.keys(
+        outputSchemaForNode(picker, graph, { configuration }).properties.user
+          .properties
+      );
+
+    assert.deepEqual(keys({}), ["id"], "nothing is added without a selection");
+    assert.deepEqual(
+      keys({ include: ["emails"] }),
+      ["id", "email"],
+      "a selected extension merges into the base contract"
+    );
+    assert.deepEqual(
+      keys({ include: ["ips", "emails"] }),
+      ["id", "email", "ip"],
+      "every selected extension composes, unlike variants which are exclusive"
+    );
+    assert.deepEqual(
+      keys({ include: "={{ $json.include }}" }),
+      ["id", "email", "ip"],
+      "an expression leaves every extension in contention"
+    );
+  });
+
+  test("nodes with author-defined output keys resolve from their configuration", function (assert) {
+    const summarize = node("summarize", "action:summarize");
+    const graph = {
+      nodes: [node("source", "trigger:source"), summarize],
+      connections: [conn("source", "summarize")],
+      nodeTypes: [
+        triggerType("trigger:source", prop("source", "string")),
+        {
+          name: "action:summarize",
+          versions: { "1.0": { output_schema_resolver: "summarize" } },
+        },
+      ],
+    };
+    const keys = (configuration) =>
+      Object.keys(
+        outputSchemaForNode(summarize, graph, { configuration }).properties
+      );
+
+    assert.deepEqual(
+      keys({
+        fields_to_split_by: "topic_id",
+        fields_to_summarize: {
+          values: [
+            { aggregation: "sum", field: "likes" },
+            { aggregation: "count", output_field_name: "posts" },
+          ],
+        },
+      }),
+      ["topic_id", "sum_likes", "posts"],
+      "the node's declared resolver derives keys from the configuration"
+    );
+    assert.deepEqual(
+      keys({}),
+      [],
+      "an unconfigured node resolves to an empty shape rather than the input"
+    );
+  });
+
   test("joins, union contracts and cycles resolve across the graph", function (assert) {
     const str = prop("v", "string");
     const num = prop("v", "integer");

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-summarize-output-schemas-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-summarize-output-schemas-test.js
@@ -1,0 +1,45 @@
+import { module, test } from "qunit";
+import summarizeOutputSchemas from "discourse/plugins/discourse-workflows/admin/lib/workflows/output-schemas/summarize";
+
+module(
+  "Unit | lib | discourse-workflows | summarize output schemas",
+  function () {
+    test("derives properties from group keys and aggregations", function (assert) {
+      const [schema] = summarizeOutputSchemas({
+        fields_to_split_by: "topic_id",
+        fields_to_summarize: {
+          values: [
+            {
+              aggregation: "sum",
+              field: "likes",
+              output_field_name: "post_likes",
+            },
+            { aggregation: "count" },
+          ],
+        },
+      });
+
+      assert.deepEqual(Object.keys(schema.properties), [
+        "topic_id",
+        "post_likes",
+        "count",
+      ]);
+      assert.strictEqual(schema.properties.count.type, "integer");
+      assert.deepEqual(schema.properties.post_likes.type, ["number", "null"]);
+    });
+
+    test("takes the leaf of a dotted group key", function (assert) {
+      const [schema] = summarizeOutputSchemas({
+        fields_to_split_by: "post.topic_id, tags",
+      });
+
+      assert.deepEqual(Object.keys(schema.properties), ["topic_id", "tags"]);
+    });
+
+    test("resolves an empty shape without configuration", function (assert) {
+      const [schema] = summarizeOutputSchemas();
+
+      assert.deepEqual(schema.properties, {});
+    });
+  }
+);


### PR DESCRIPTION
This commits add the logic necessary to support optional extensions, especially for the output in the node configurator: show only specific keys when the extension is selected. This has been updated for summarize node which has a similar behavior too.

The list of extensions added:
- stats
- external_id(s)
- ip
- emails

On top of this few missing keys have been added to the user serializer:
- created_at
- approved
- silenced
- suspended