### PR TITLE
UX: admin db > update support tooltips

### DIFF
--- a/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support/topic-outcomes.gjs
+++ b/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support/topic-outcomes.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { trustHTML } from "@ember/template";
+import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { i18n } from "discourse-i18n";
 
 const ROWS = ["resolved", "in_progress", "unanswered"];
@@ -37,14 +38,17 @@ export default class SupportTopicOutcomes extends Component {
     <div class="db-support-outcomes__bars">
       {{#each this.rows as |row|}}
         <div class="db-support-outcomes__row">
-          <LinkTo
-            @route="discovery.filter"
-            @query={{row.query}}
-            class="db-support-outcomes__label"
-            title={{row.tooltip}}
-          >
-            {{row.label}}
-          </LinkTo>
+          <DTooltip @content={{row.tooltip}}>
+            <:trigger>
+              <LinkTo
+                @route="discovery.filter"
+                @query={{row.query}}
+                class="db-support-outcomes__label"
+              >
+                {{row.label}}
+              </LinkTo>
+            </:trigger>
+          </DTooltip>
           <span class="db-support-outcomes__track" aria-hidden="true">
             <span
               class={{concat "db-support-outcomes__fill " row.fillClass}}

--- a/plugins/discourse-solved/assets/stylesheets/admin/dashboard-support.scss
+++ b/plugins/discourse-solved/assets/stylesheets/admin/dashboard-support.scss
@@ -45,10 +45,10 @@ $db-bar-height: var(--space-2);
     align-items: center;
     gap: var(--space-1);
     min-width: 0;
-    color: var(--primary-medium);
+    color: var(--primary);
 
     &:visited {
-      color: var(--primary-medium);
+      color: var(--primary);
     }
 
     &:hover,

--- a/plugins/discourse-solved/test/javascripts/integration/support/topic-outcomes-test.gjs
+++ b/plugins/discourse-solved/test/javascripts/integration/support/topic-outcomes-test.gjs
@@ -1,4 +1,4 @@
-import { render } from "@ember/test-helpers";
+import { render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import SupportTopicOutcomes from "discourse/plugins/discourse-solved/admin/components/dashboard/support/topic-outcomes";
@@ -33,9 +33,15 @@ module(
           `/filter?q=${encodeURIComponent(queries.resolved.q)}`,
           "resolved links to its given query"
         )
-        .hasText("Resolved", "resolved shows its label")
-        .hasAttribute(
-          "title",
+        .hasText("Resolved", "resolved shows its label");
+
+      await triggerEvent(
+        ".db-support-outcomes__row:nth-child(1) .fk-d-tooltip__trigger",
+        "pointermove"
+      );
+      assert
+        .dom(".fk-d-tooltip__content")
+        .hasText(
           "The number of topics that were marked solved.",
           "resolved keeps its tooltip"
         );


### PR DESCRIPTION
| Then | Now |
|--------|--------|
| <img width="874" height="456" alt="CleanShot 2026-08-06 at 11 20 27@2x" src="https://github.com/user-attachments/assets/7ff503be-6b12-4307-b118-76d0c130d0c1" /> | <img width="1138" height="464" alt="CleanShot 2026-08-06 at 11 20 09@2x" src="https://github.com/user-attachments/assets/9c8971d4-19cb-44dc-befa-3cead37d9431" /> | 