### PR TITLE
FIX: Embeddings settings shows model selected when it is not

### DIFF
--- a/frontend/discourse/app/components/setting-field/enum.gjs
+++ b/frontend/discourse/app/components/setting-field/enum.gjs
@@ -34,12 +34,24 @@ export default class SettingFieldEnum extends Component {
     return String(this.args.field.value ?? "");
   }
 
+  get hasInvalidSelection() {
+    return (
+      this.selectedValue !== "" &&
+      !this.choices.some((choice) => choice.value === this.selectedValue)
+    );
+  }
+
   <template>
     <@field.Control
       @includeNone={{this.includeNone}}
       @nonePlaceholder={{if this.includeNone (i18n "admin.settings.none")}}
       as |select|
     >
+      {{#if this.hasInvalidSelection}}
+        <option value={{this.selectedValue}} selected disabled>
+          {{i18n "admin.settings.none"}}
+        </option>
+      {{/if}}
       {{#each this.choices as |choice|}}
         <select.Option @value={{choice.value}} @selected={{this.selectedValue}}>
           {{choice.name}}

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -6,6 +6,7 @@ import SettingDefinitionField from "discourse/components/setting-definition-fiel
 import Site from "discourse/models/site";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { i18n } from "discourse-i18n";
 
 module("Integration | Component | SettingDefinitionField", function (hooks) {
   setupRenderingTest(hooks);
@@ -376,6 +377,41 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
     assert.dom("[data-name='my_enum'] select option[value='a']").hasText("a");
     assert.dom("[data-name='my_enum'] select option[value='b']").hasText("b");
     assert.form().field("my_enum").hasValue("a");
+  });
+
+  test("enum does not select the first choice when the current value is invalid", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum="missing"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_enum'] select option[value='missing']")
+      .hasText(
+        i18n("admin.settings.none"),
+        "the invalid value is presented as no selection"
+      )
+      .hasAttribute("disabled", "", "the invalid option cannot be selected");
+    assert
+      .form()
+      .field("my_enum")
+      .hasValue(
+        "missing",
+        "the browser does not select the first valid choice"
+      );
   });
 
   test("enum only offers a none option when the setting allows a blank value", async function (assert) {


### PR DESCRIPTION
This fix is not specific to embeddings but was found then. 

When an enum site setting contains a value that is not valid, the native select falls back to the first available option. This made embeddings appear configured with a newly created model even though the stored setting still referenced a missing ID.

This PR renders the unmatched value as a disabled “none” option, preserving the stored value without visually selecting a different model.

### bug

[embedding-ai-stale-selection.webm](https://github.com/user-attachments/assets/608d5f7e-65d7-4815-8bf1-eb46ca4b5e0f)

### fix


https://github.com/user-attachments/assets/bb7fc3a9-4d3f-4bcc-8da0-3de384ec664f

