### PR TITLE
FIX: Avoid duplicate category updated events

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -315,8 +315,6 @@ class CategoriesController < ApplicationController
         end
       end
 
-      DiscourseEvent.trigger(:category_updated, cat) if result
-
       result
     end
   end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -495,21 +495,21 @@ RSpec.describe CategoriesController do
   describe "extensibility event" do
     before { sign_in(admin) }
 
-    it "triggers a extensibility event" do
-      event =
-        DiscourseEvent
-          .track_events do
-            put "/categories/#{category.id}.json",
-                params: {
-                  name: "hello",
-                  color: "ff0",
-                  text_color: "fff",
-                }
-          end
-          .last
+    it "triggers the category updated event once" do
+      events =
+        DiscourseEvent.track_events do
+          put "/categories/#{category.id}.json",
+              params: {
+                name: "hello",
+                color: "ff0",
+                text_color: "fff",
+              }
+        end
 
-      expect(event[:event_name]).to eq(:category_updated)
-      expect(event[:params].first).to eq(category)
+      category_updated_events = events.select { |event| event[:event_name] == :category_updated }
+
+      expect(category_updated_events.size).to eq(1)
+      expect(category_updated_events.pluck(:params).map(&:first)).to all(eq(category))
     end
   end
 


### PR DESCRIPTION
Category updates already trigger the event through the model's `after_commit` callback. This PR removes the additional controller trigger, which caused the event to fire twice.