### PR TITLE
UX: make the +Subcategories picker shortcut easier to find

### DIFF
--- a/app/assets/stylesheets/common/select-kit/category-selector.scss
+++ b/app/assets/stylesheets/common/select-kit/category-selector.scss
@@ -1,6 +1,7 @@
 .select-kit,
 .select-kit-box {
-  &.category-selector {
+  &.category-selector,
+  &.multiple-categories-selector {
     .category-row {
       max-width: 100%;
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3209,6 +3209,7 @@ en:
       subcategory_count:
         one: "+%{count} subcategory"
         other: "+%{count} subcategories"
+      subcategories: "+ Subcategories"
       topic_count:
         one: "%{count} topic in this category"
         other: "%{count} topics in this category"

--- a/frontend/discourse/app/ui-kit/helpers/d-category-link.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-category-link.js
@@ -218,10 +218,9 @@ export function defaultCategoryLinkRenderer(category, opts) {
     html += buildTopicCount(opts.topicCount);
   }
 
-  if (opts.subcategoryCount) {
+  if (opts.hasSubcategories) {
     html += `<span class="plus-subcategories">${i18n(
-      "category_row.subcategory_count",
-      { count: opts.subcategoryCount }
+      "category_row.subcategories"
     )}</span>`;
   }
 

--- a/frontend/discourse/select-kit/components/category-row.gjs
+++ b/frontend/discourse/select-kit/components/category-row.gjs
@@ -127,9 +127,9 @@ export default class CategoryRow extends Component {
         hideParent: !this.hasParentCategory,
         ancestors: this.hideParentCategory ? [] : this.category?.predecessors,
         topicCount: this.topicCount,
-        subcategoryCount: this.args.item?.category
-          ? this.category.subcategory_count
-          : 0,
+        hasSubcategories: this.args.item?.category
+          ? this.category.has_children
+          : false,
         readOnly: this.isReadOnly,
       })
     );

--- a/frontend/discourse/select-kit/components/category-selector.js
+++ b/frontend/discourse/select-kit/components/category-selector.js
@@ -80,7 +80,7 @@ export default class CategorySelector extends MultiSelectComponent {
       (categories.length === 1 ||
         (categories.length > 0 &&
           categories[0].name.localeCompare(filter) === 0)) &&
-      categories[0].subcategory_count > 0
+      categories[0].has_children
     ) {
       categories.splice(
         1,

--- a/frontend/discourse/select-kit/components/multiple-categories-selector.js
+++ b/frontend/discourse/select-kit/components/multiple-categories-selector.js
@@ -74,20 +74,20 @@ export default class MultipleCategoriesSelector extends MultiSelectComponent {
       categories = categories.slice(0, MAX_UNSELECTED_RESULTS);
     }
 
-    if (
-      (categories.length === 1 ||
-        (categories.length > 0 &&
-          categories[0].name.localeCompare(filter || "") === 0)) &&
-      categories[0]?.subcategory_count > 0
-    ) {
-      categories.splice(
-        1,
-        0,
-        EmberObject.create({
-          id: `${categories[0].id}+subcategories`,
-          category: categories[0],
-        })
-      );
+    if (filter && filter.length >= 2) {
+      categories = categories.flatMap((category) => {
+        if (!category.has_children) {
+          return [category];
+        }
+
+        return [
+          category,
+          EmberObject.create({
+            id: `${category.id}+subcategories`,
+            category,
+          }),
+        ];
+      });
     }
 
     if (uncappedTotal) {

--- a/frontend/discourse/tests/integration/components/select-kit/category-selector-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/category-selector-test.gjs
@@ -45,7 +45,7 @@ module(
         .hasText("Parent Category× 95");
       assert
         .dom(this.subject.rowByIndex(1).el())
-        .hasText("Parent Category× 95+2 subcategories");
+        .hasText("Parent Category× 95+ Subcategories");
     });
   }
 );

--- a/frontend/discourse/tests/integration/components/select-kit/multiple-categories-selector-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/multiple-categories-selector-test.gjs
@@ -59,7 +59,71 @@ module(
         .hasText("Parent Category× 95");
       assert
         .dom(this.subject.rowByIndex(1).el())
-        .hasText("Parent Category× 95+2 subcategories");
+        .hasText("Parent Category× 95+ Subcategories");
+    });
+
+    test("shows a +subcategories row for every matching category with children, without requiring an exact match", async function (assert) {
+      const value = [];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+      await this.subject.expand();
+      await this.subject.fillInFilter("Category");
+
+      assert.strictEqual(this.subject.rows().length, 5);
+      assert
+        .dom(this.subject.rowByIndex(0).el())
+        .hasText("Parent Category× 95");
+      assert
+        .dom(this.subject.rowByIndex(1).el())
+        .hasText("Parent Category× 95+ Subcategories");
+      assert
+        .dom(this.subject.rowByIndex(2).el())
+        .hasText("Parent CategorySub Category× 95");
+      assert
+        .dom(this.subject.rowByIndex(3).el())
+        .hasText(
+          "Parent Category+ SubcategoriesSub Category× 95+ Subcategories"
+        );
+      assert
+        .dom(this.subject.rowByIndex(4).el())
+        .hasText("Parent CategorySub CategorySub Sub Category× 95");
+    });
+
+    test("does not show a +subcategories row for a single-character search", async function (assert) {
+      const value = [];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+      await this.subject.expand();
+      await this.subject.fillInFilter("S");
+
+      assert.dom(this.subject.el()).doesNotIncludeText("+ Subcategories");
+    });
+
+    test("selecting +subcategories adds the full descendant tree", async function (assert) {
+      this.set("value", []);
+      this.set("onChange", (categories) => this.set("value", categories));
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector
+            @categories={{this.value}}
+            @onChange={{this.onChange}}
+          />
+        </template>
+      );
+      await this.subject.expand();
+      await this.subject.fillInFilter("Parent Category");
+      await this.subject.selectRowByIndex(1);
+
+      assert.strictEqual(this.subject.header().value(), "1001,1002,1003");
     });
 
     test("caps unselected results and shows a notice when there are more than the limit", async function (assert) {


### PR DESCRIPTION
Picking a category and all its subcategories at once was hit or miss: the shortcut only showed up for an exact category name match, and often didn't appear at all unless you'd visited the categories page earlier in your session. It now shows up reliably for any close-enough search, next to every matching category with subcategories.

Demo:

https://github.com/user-attachments/assets/140021b7-8bdf-4d5d-92b0-458e5d6f0166