### PR TITLE
MT: update schema config for daily pageview crawler rollups

### DIFF
--- a/migrations/tooling/config/schema/intermediate_db/ignored.rb
+++ b/migrations/tooling/config/schema/intermediate_db/ignored.rb
@@ -168,6 +168,7 @@ Migrations::Tooling::Schema.ignored do
          :backup_metadata,
          :badge_types,
          :bookmarks,
+         :browser_pageview_crawler_daily_rollups,
          :browser_pageview_event_scores,
          :browser_pageview_events,
          :browser_pageview_session_engagement_daily_rollups,


### PR DESCRIPTION
Fixes a `schema config is out of sync with the database` error that is triggered recent core updates.