### PR TITLE
UX: Open the composer at its final size

### DIFF
--- a/frontend/discourse/app/components/topic-navigation.gjs
+++ b/frontend/discourse/app/components/topic-navigation.gjs
@@ -144,7 +144,7 @@ export default class TopicNavigation extends Component {
     }
 
     // If composer is open, check we have enough vertical space.
-    if (this.composer.visible && this.composer.isPreviewVisible) {
+    if (this.composer.isPreviewActive) {
       return this.heightQuery?.matches ?? false;
     }
 
@@ -153,10 +153,9 @@ export default class TopicNavigation extends Component {
 
   @cached
   get heightQuery() {
-    const threshold =
-      this.composer.visible && this.composer.isPreviewVisible
-        ? MIN_HEIGHT_TIMELINE + this.composerHeight + headerOffset()
-        : null;
+    const threshold = this.composer.isPreviewActive
+      ? MIN_HEIGHT_TIMELINE + this.composerHeight + headerOffset()
+      : null;
 
     return this.#buildHeightQuery(threshold);
   }

--- a/frontend/discourse/app/components/topic-navigation.gjs
+++ b/frontend/discourse/app/components/topic-navigation.gjs
@@ -144,7 +144,7 @@ export default class TopicNavigation extends Component {
     }
 
     // If composer is open, check we have enough vertical space.
-    if (this.composer.isPreviewVisible) {
+    if (this.composer.visible && this.composer.isPreviewVisible) {
       return this.heightQuery?.matches ?? false;
     }
 
@@ -153,9 +153,10 @@ export default class TopicNavigation extends Component {
 
   @cached
   get heightQuery() {
-    const threshold = this.composer.isPreviewVisible
-      ? MIN_HEIGHT_TIMELINE + this.composerHeight + headerOffset()
-      : null;
+    const threshold =
+      this.composer.visible && this.composer.isPreviewVisible
+        ? MIN_HEIGHT_TIMELINE + this.composerHeight + headerOffset()
+        : null;
 
     return this.#buildHeightQuery(threshold);
   }

--- a/frontend/discourse/app/components/topic-timeline/container.gjs
+++ b/frontend/discourse/app/components/topic-timeline/container.gjs
@@ -223,10 +223,10 @@ export default class TopicTimelineScrollArea extends Component {
   }
 
   get scrollareaHeight() {
-    const composerHeight = this.composer.isPreviewVisible
-        ? document.getElementById("reply-control")?.offsetHeight || 0
-        : 0,
-      headerHeight = document.querySelector(".d-header")?.offsetHeight || 0;
+    const composerHeight = this.composer.isPreviewActive
+      ? document.getElementById("reply-control")?.offsetHeight || 0
+      : 0;
+    const headerHeight = document.querySelector(".d-header")?.offsetHeight || 0;
 
     // scrollarea takes up about half of the timeline's height
     const availableHeight =
@@ -234,12 +234,12 @@ export default class TopicTimelineScrollArea extends Component {
 
     const minHeight = this.site.mobileView
       ? DEFAULT_MIN_SCROLLAREA_HEIGHT
-      : this.composer.isPreviewVisible
+      : this.composer.isPreviewActive
         ? desktopMinScrollAreaHeight
         : DEFAULT_MIN_SCROLLAREA_HEIGHT;
     const maxHeight = this.site.mobileView
       ? DEFAULT_MAX_SCROLLAREA_HEIGHT
-      : this.composer.isPreviewVisible
+      : this.composer.isPreviewActive
         ? desktopMaxScrollAreaHeight
         : DEFAULT_MAX_SCROLLAREA_HEIGHT;
 

--- a/frontend/discourse/app/components/topic-timeline/container.gjs
+++ b/frontend/discourse/app/components/topic-timeline/container.gjs
@@ -224,7 +224,7 @@ export default class TopicTimelineScrollArea extends Component {
 
   get scrollareaHeight() {
     const composerHeight = this.composer.isPreviewVisible
-        ? document.getElementById("reply-control").offsetHeight || 0
+        ? document.getElementById("reply-control")?.offsetHeight || 0
         : 0,
       headerHeight = document.querySelector(".d-header")?.offsetHeight || 0;
 

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -301,6 +301,10 @@ export default class ComposerService extends Service {
     return this.showPreview && this.allowPreview;
   }
 
+  get isPreviewActive() {
+    return Boolean(this.visible && this.isPreviewVisible);
+  }
+
   @computed("model.action", "model.post.can_localize_post")
   get showTranslationSelector() {
     return (
@@ -2120,7 +2124,11 @@ export default class ComposerService extends Service {
 
     document.activeElement?.blur();
     document.documentElement.style.removeProperty("--composer-height");
-    this.setProperties({ model: null, lastValidatedAt: null });
+    this.setProperties({
+      model: null,
+      lastValidatedAt: null,
+      _allowPreview: null,
+    });
 
     // This is a temporary solution to reset the saved form template state while we don't store drafts
     this.set("formTemplateInitialValues", undefined);

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -19,6 +19,7 @@ import {
 } from "discourse/helpers/slow-mode";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { customPopupMenuOptions } from "discourse/lib/composer/custom-popup-menu-options";
+import { USER_OPTION_COMPOSITION_MODES } from "discourse/lib/constants";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
 import deprecated from "discourse/lib/deprecated";
@@ -120,7 +121,6 @@ export default class ComposerService extends Service {
   @service store;
   @service toasts;
 
-  @tracked allowPreview = false;
   @tracked selectedTranslationLocale = null;
   checkedMessages = false;
   messageCount = null;
@@ -137,6 +137,7 @@ export default class ComposerService extends Service {
   topic = null;
   linkLookup = null;
 
+  @tracked _allowPreview = null;
   @tracked _showPreview;
 
   @tracked _isStaffUserOverride;
@@ -249,6 +250,44 @@ export default class ComposerService extends Service {
 
   set showPreview(value) {
     this._showPreview = value;
+  }
+
+  // predicted from the editor mode that will load, so the composer is sized
+  // correctly before the editor mounts and sets the authoritative value
+  get allowPreview() {
+    if (this._allowPreview !== null) {
+      return this._allowPreview;
+    }
+
+    if (!this.currentUser) {
+      return false;
+    }
+
+    if (this.hasFormTemplate) {
+      return this.siteSettings.show_preview_for_form_templates;
+    }
+
+    const forcedMode = applyValueTransformer(
+      "composer-force-editor-mode",
+      null,
+      {
+        model: this.model,
+      }
+    );
+
+    return forcedMode !== null
+      ? forcedMode !== USER_OPTION_COMPOSITION_MODES.rich
+      : !this.currentUser.useRichEditor;
+  }
+
+  set allowPreview(value) {
+    // the editor confirms the prediction during render; skipping the no-op
+    // write avoids dirtying an already-consumed tag
+    if (this.allowPreview === value) {
+      return;
+    }
+
+    this._allowPreview = value;
   }
 
   /**

--- a/frontend/discourse/tests/acceptance/composer-preview-sizing-test.js
+++ b/frontend/discourse/tests/acceptance/composer-preview-sizing-test.js
@@ -1,0 +1,65 @@
+import { click, find, settled, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { USER_OPTION_COMPOSITION_MODES } from "discourse/lib/constants";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Composer preview sizing", function (needs) {
+  needs.user({
+    "user_option.composition_mode": USER_OPTION_COMPOSITION_MODES.markdown,
+  });
+  needs.settings({ allow_uncategorized_topics: true });
+
+  test("markdown has its final preview width before the first opening", async function (assert) {
+    await visit("/");
+    this.owner.lookup("service:composer").showPreview = true;
+    await settled();
+
+    assert
+      .dom("#reply-control")
+      .hasClass("closed", "the composer starts closed");
+    assert
+      .dom("#reply-control")
+      .hasClass("show-preview", "preview width is reserved before opening");
+    const initialMaxWidth = getComputedStyle(find("#reply-control")).maxWidth;
+
+    await click("#create-topic");
+
+    assert.dom("#reply-control").hasClass("open", "the composer opens");
+    assert
+      .dom("#reply-control")
+      .hasClass(
+        "show-preview",
+        "the mounted editor keeps the predicted preview"
+      );
+    assert.strictEqual(
+      getComputedStyle(find("#reply-control")).maxWidth,
+      initialMaxWidth,
+      "opening does not change the width target or trigger horizontal expansion"
+    );
+  });
+
+  test("a hidden markdown preview keeps the composer narrow before opening", async function (assert) {
+    await visit("/");
+    this.owner.lookup("service:composer").showPreview = false;
+    await settled();
+
+    assert
+      .dom("#reply-control")
+      .hasClass(
+        "hide-preview",
+        "the closed composer respects the preview preference"
+      );
+    const initialMaxWidth = getComputedStyle(find("#reply-control")).maxWidth;
+
+    await click("#create-topic");
+
+    assert
+      .dom("#reply-control")
+      .hasClass("hide-preview", "the preview stays hidden after opening");
+    assert.strictEqual(
+      getComputedStyle(find("#reply-control")).maxWidth,
+      initialMaxWidth,
+      "opening without preview does not change the width target"
+    );
+  });
+});

--- a/frontend/discourse/tests/acceptance/composer-preview-sizing-test.js
+++ b/frontend/discourse/tests/acceptance/composer-preview-sizing-test.js
@@ -37,29 +37,4 @@ acceptance("Composer preview sizing", function (needs) {
       "opening does not change the width target or trigger horizontal expansion"
     );
   });
-
-  test("a hidden markdown preview keeps the composer narrow before opening", async function (assert) {
-    await visit("/");
-    this.owner.lookup("service:composer").showPreview = false;
-    await settled();
-
-    assert
-      .dom("#reply-control")
-      .hasClass(
-        "hide-preview",
-        "the closed composer respects the preview preference"
-      );
-    const initialMaxWidth = getComputedStyle(find("#reply-control")).maxWidth;
-
-    await click("#create-topic");
-
-    assert
-      .dom("#reply-control")
-      .hasClass("hide-preview", "the preview stays hidden after opening");
-    assert.strictEqual(
-      getComputedStyle(find("#reply-control")).maxWidth,
-      initialMaxWidth,
-      "opening without preview does not change the width target"
-    );
-  });
 });

--- a/frontend/discourse/tests/acceptance/topic-timeline-test.js
+++ b/frontend/discourse/tests/acceptance/topic-timeline-test.js
@@ -1,6 +1,11 @@
 import { click, currentURL, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { setDesktopScrollAreaHeight } from "discourse/components/topic-timeline/container";
+import { USER_OPTION_COMPOSITION_MODES } from "discourse/lib/constants";
+import {
+  acceptance,
+  loggedInUser,
+} from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Glimmer Topic Timeline", function (needs) {
   needs.user({
@@ -331,6 +336,24 @@ acceptance("Glimmer Topic Timeline", function (needs) {
         },
       });
     });
+  });
+
+  needs.hooks.afterEach(function () {
+    setDesktopScrollAreaHeight();
+  });
+
+  test("predicted composer preview does not affect the closed timeline", async function (assert) {
+    loggedInUser().set(
+      "user_option.composition_mode",
+      USER_OPTION_COMPOSITION_MODES.markdown
+    );
+    setDesktopScrollAreaHeight({ min: 600, max: 600 });
+
+    await visit("/t/internationalization-localization/280/1");
+
+    assert
+      .dom(".timeline-scrollarea")
+      .hasStyle({ height: "300px" }, "the closed composer has no effect");
   });
 
   test("has a reply-to-post button", async function (assert) {

--- a/frontend/discourse/tests/integration/components/topic-navigation-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-navigation-test.gjs
@@ -1,8 +1,11 @@
-import { render } from "@ember/test-helpers";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import sinon from "sinon";
 import TopicNavigation from "discourse/components/topic-navigation";
+import { USER_OPTION_COMPOSITION_MODES } from "discourse/lib/constants";
 import { forceMobile } from "discourse/lib/mobile";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import Composer from "discourse/models/composer";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module("Integration | Component | TopicNavigation", function (hooks) {
@@ -50,5 +53,77 @@ module("Integration | Component | TopicNavigation", function (hooks) {
 
     assert.dom(".render-timeline").hasText("true");
     assert.dom(".with-timeline").exists();
+  });
+
+  module("short desktop viewport", function (viewportHooks) {
+    viewportHooks.beforeEach(function () {
+      this.matchMedia = sinon.stub(window, "matchMedia").callsFake((query) => {
+        const matcher = new EventTarget();
+        matcher.matches = query.startsWith("(min-width:");
+        return matcher;
+      });
+      this.currentUser.set(
+        "user_option.composition_mode",
+        USER_OPTION_COMPOSITION_MODES.markdown
+      );
+      this.composer = this.owner.lookup("service:composer");
+      this.composer.showPreview = true;
+    });
+
+    viewportHooks.afterEach(function () {
+      this.matchMedia.restore();
+    });
+
+    test("a predicted preview does not constrain the timeline while closed", async function (assert) {
+      const topic = this.topic;
+
+      await render(<template><TopicNavigation @topic={{topic}} /></template>);
+
+      assert.true(
+        this.composer.isPreviewVisible,
+        "the composer predicts its preview width before opening"
+      );
+      assert
+        .dom(".with-timeline")
+        .exists("a closed composer does not take space from the timeline");
+    });
+
+    test("the preview constrains the timeline only while the composer is visible", async function (assert) {
+      this.composer.set(
+        "model",
+        this.owner.lookup("service:store").createRecord("composer", {
+          action: Composer.CREATE_TOPIC,
+          composeState: Composer.OPEN,
+        })
+      );
+      const topic = this.topic;
+
+      await render(<template><TopicNavigation @topic={{topic}} /></template>);
+
+      assert
+        .dom(".with-topic-progress")
+        .exists("an open preview leaves insufficient room for the timeline");
+
+      this.composer.showPreview = false;
+      await settled();
+
+      assert
+        .dom(".with-timeline")
+        .exists("hiding the preview restores the timeline");
+
+      this.composer.showPreview = true;
+      await settled();
+
+      assert
+        .dom(".with-topic-progress")
+        .exists("showing the preview constrains the timeline again");
+
+      this.composer.close();
+      await settled();
+
+      assert
+        .dom(".with-timeline")
+        .exists("closing restores the timeline despite the predicted preview");
+    });
   });
 });

--- a/frontend/discourse/tests/integration/components/topic-navigation-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-navigation-test.gjs
@@ -74,7 +74,7 @@ module("Integration | Component | TopicNavigation", function (hooks) {
       this.matchMedia.restore();
     });
 
-    test("a predicted preview does not constrain the timeline while closed", async function (assert) {
+    test("the preview constrains the timeline only while the composer is visible", async function (assert) {
       const topic = this.topic;
 
       await render(<template><TopicNavigation @topic={{topic}} /></template>);
@@ -86,9 +86,7 @@ module("Integration | Component | TopicNavigation", function (hooks) {
       assert
         .dom(".with-timeline")
         .exists("a closed composer does not take space from the timeline");
-    });
 
-    test("the preview constrains the timeline only while the composer is visible", async function (assert) {
       this.composer.set(
         "model",
         this.owner.lookup("service:store").createRecord("composer", {
@@ -96,27 +94,11 @@ module("Integration | Component | TopicNavigation", function (hooks) {
           composeState: Composer.OPEN,
         })
       );
-      const topic = this.topic;
-
-      await render(<template><TopicNavigation @topic={{topic}} /></template>);
+      await settled();
 
       assert
         .dom(".with-topic-progress")
         .exists("an open preview leaves insufficient room for the timeline");
-
-      this.composer.showPreview = false;
-      await settled();
-
-      assert
-        .dom(".with-timeline")
-        .exists("hiding the preview restores the timeline");
-
-      this.composer.showPreview = true;
-      await settled();
-
-      assert
-        .dom(".with-topic-progress")
-        .exists("showing the preview constrains the timeline again");
 
       this.composer.close();
       await settled();

--- a/frontend/discourse/tests/unit/services/composer-test.js
+++ b/frontend/discourse/tests/unit/services/composer-test.js
@@ -38,23 +38,11 @@ module("Unit | Service | composer", function (hooks) {
     );
   });
 
-  test("predicts the markdown preview before the editor mounts", function (assert) {
-    setComposerModel(this);
-
-    assert.true(this.composer.allowPreview, "markdown allows a preview");
-    assert.true(
-      this.composer.isPreviewVisible,
-      "the composer can use its final width before the editor mounts"
-    );
-  });
-
   test("predicts no preview for the rich editor before it mounts", function (assert) {
     this.currentUser.set(
       "user_option.composition_mode",
       USER_OPTION_COMPOSITION_MODES.rich
     );
-    setComposerModel(this);
-
     assert.false(this.composer.allowPreview, "the rich editor has no preview");
     assert.false(
       this.composer.isPreviewVisible,
@@ -62,28 +50,19 @@ module("Unit | Service | composer", function (hooks) {
     );
   });
 
-  test("the mounted editor can override the predicted preview", function (assert) {
-    this.currentUser.set(
-      "user_option.composition_mode",
-      USER_OPTION_COMPOSITION_MODES.rich
-    );
+  test("closing clears the mounted editor override", function (assert) {
     setComposerModel(this);
-    this.composer.set("allowPreview", true);
+    this.composer.set("allowPreview", false);
 
-    assert.true(
-      this.composer.isPreviewVisible,
-      "the mounted editor can override the prediction"
+    assert.false(
+      this.composer.allowPreview,
+      "the mounted editor can override the prediction for this composer"
     );
-  });
-
-  test("closing preserves the predicted markdown preview width", function (assert) {
-    setComposerModel(this);
     this.composer.close();
 
-    assert.false(this.composer.isOpen, "the composer is closed");
     assert.true(
-      this.composer.isPreviewVisible,
-      "the next opening does not need to expand the composer width"
+      this.composer.allowPreview,
+      "the next composer uses the predicted markdown mode"
     );
   });
 });

--- a/frontend/discourse/tests/unit/services/composer-test.js
+++ b/frontend/discourse/tests/unit/services/composer-test.js
@@ -1,0 +1,89 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { USER_OPTION_COMPOSITION_MODES } from "discourse/lib/constants";
+import Composer from "discourse/models/composer";
+import { logIn } from "discourse/tests/helpers/qunit-helpers";
+
+module("Unit | Service | composer", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.currentUser = logIn(this.owner);
+    this.currentUser.set(
+      "user_option.composition_mode",
+      USER_OPTION_COMPOSITION_MODES.markdown
+    );
+    this.composer = this.owner.lookup("service:composer");
+    this.composer.showPreview = true;
+  });
+
+  function setComposerModel(context) {
+    context.composer.set(
+      "model",
+      context.owner.lookup("service:store").createRecord("composer", {
+        action: Composer.CREATE_TOPIC,
+        composeState: Composer.OPEN,
+      })
+    );
+  }
+
+  test("predicts the markdown preview before a composer model exists", function (assert) {
+    assert.true(
+      this.composer.allowPreview,
+      "markdown allows a preview even before opening"
+    );
+    assert.true(
+      this.composer.isPreviewVisible,
+      "the closed composer reserves its final preview width"
+    );
+  });
+
+  test("predicts the markdown preview before the editor mounts", function (assert) {
+    setComposerModel(this);
+
+    assert.true(this.composer.allowPreview, "markdown allows a preview");
+    assert.true(
+      this.composer.isPreviewVisible,
+      "the composer can use its final width before the editor mounts"
+    );
+  });
+
+  test("predicts no preview for the rich editor before it mounts", function (assert) {
+    this.currentUser.set(
+      "user_option.composition_mode",
+      USER_OPTION_COMPOSITION_MODES.rich
+    );
+    setComposerModel(this);
+
+    assert.false(this.composer.allowPreview, "the rich editor has no preview");
+    assert.false(
+      this.composer.isPreviewVisible,
+      "the rich editor does not reserve preview space before it mounts"
+    );
+  });
+
+  test("the mounted editor can override the predicted preview", function (assert) {
+    this.currentUser.set(
+      "user_option.composition_mode",
+      USER_OPTION_COMPOSITION_MODES.rich
+    );
+    setComposerModel(this);
+    this.composer.set("allowPreview", true);
+
+    assert.true(
+      this.composer.isPreviewVisible,
+      "the mounted editor can override the prediction"
+    );
+  });
+
+  test("closing preserves the predicted markdown preview width", function (assert) {
+    setComposerModel(this);
+    this.composer.close();
+
+    assert.false(this.composer.isOpen, "the composer is closed");
+    assert.true(
+      this.composer.isPreviewVisible,
+      "the next opening does not need to expand the composer width"
+    );
+  });
+});


### PR DESCRIPTION
`allowPreview` started as `false` and was only corrected once the async editor bundle loaded, so a markdown composer with the preview enabled opened narrow and expanded a moment later.

This change predicts the value from the editor mode that is about to load (the persisted preference or the `composer-force-editor-mode` transformer) with the editor still setting the authoritative value on mount, and guards a latent `#reply-control` null dereference in the topic timeline that the boot-time value exposed.