### PR TITLE
UX: Smoothly resize the composer when toggling the preview

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -3,13 +3,20 @@
 html.composer-open:not(.has-full-page-chat) {
   #main-outlet {
     padding-bottom: var(--composer-height);
-    transition: padding-bottom 250ms ease;
+    transition: padding-bottom var(--composer-transition-duration)
+      var(--composer-transition-easing);
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 }
 
 :root {
   --composer-max-width--hide-preview: 740px;
   --composer-popup-background: var(--secondary);
+  --composer-transition-duration: 250ms;
+  --composer-transition-easing: cubic-bezier(0.2, 0, 0, 1);
 }
 
 .grippie {
@@ -55,13 +62,14 @@ html.composer-open:not(.has-full-page-chat) {
   height: 0;
   min-height: 0;
   z-index: z("composer", "content");
-  transition:
-    height 0.2s,
-    max-width 0.2s,
-    padding-bottom 0.2s,
-    top 0.2s,
-    transform 0.2s,
-    min-height 0.2s;
+  transition-property:
+    height, max-width, margin, left, padding-bottom, top, transform, min-height;
+  transition-duration: var(--composer-transition-duration);
+  transition-timing-function: var(--composer-transition-easing);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   background-color: var(--secondary);
   box-shadow: var(--shadow-composer);
   border-top-left-radius: var(--d-border-radius-large);
@@ -764,7 +772,12 @@ html.composer-open:not(.has-full-page-chat) {
 
 .toggle-preview {
   margin-left: auto;
-  transition: all 0.33s ease-out;
+  transition: transform var(--composer-transition-duration)
+    var(--composer-transition-easing);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 
   &.active {
     transform: rotate(180deg);
@@ -1175,6 +1188,48 @@ html.composer-open:not(.has-full-page-chat) {
 
   kbd {
     background: none;
+  }
+}
+
+// interpolable auto-margin centering, so the position animates on toggle
+#reply-control:not(.fullscreen).show-preview {
+  margin-inline-start: max(0px, calc((100% - #{$reply-area-max-width}) / 2));
+}
+
+// visibility (not display) so the toggle animates but first render doesn't;
+// markdown-editor-scoped so the rich editor keeps its instant display: none,
+// desktop-only — a collapsing in-flow wrapper would squeeze the mobile textarea
+@include viewport.from(sm) {
+  #reply-control
+    .d-editor-container.--markdown-editor-enabled
+    .d-editor-preview-wrapper {
+    transition:
+      opacity var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      flex-grow var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      margin var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      padding var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      visibility var(--composer-transition-duration);
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  #reply-control.hide-preview
+    .d-editor-container.--markdown-editor-enabled
+    .d-editor-preview-wrapper {
+    display: flex;
+    visibility: hidden;
+    opacity: 0;
+    margin-left: 0;
+
+    // themes may pad the wrapper; a padded box can't flex below its padding
+    padding: 0;
+    border: 0;
   }
 }
 

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -203,16 +203,18 @@
   }
 
   #reply-control .d-editor-textarea-wrapper {
-    --composer-slide-easing: cubic-bezier(0.2, 0, 0, 1);
     border: 0;
 
     // padding and border-radius must animate in lockstep with margin,
     // otherwise the text counter-jumps when the focus state toggles
     transition:
-      margin 250ms var(--composer-slide-easing),
-      padding 250ms var(--composer-slide-easing),
-      border-radius 250ms var(--composer-slide-easing),
-      box-shadow 250ms ease;
+      margin var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      padding var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      border-radius var(--composer-transition-duration)
+        var(--composer-transition-easing),
+      box-shadow var(--composer-transition-duration) ease;
 
     @media (prefers-reduced-motion: reduce) {
       transition: none;
@@ -282,6 +284,26 @@
 
     .d-editor-preview-wrapper {
       grid-area: preview;
+    }
+  }
+
+  // keep both tracks on desktop so the preview column collapses to 0fr
+  // and the toggle can animate; removing the track would snap
+  @include viewport.from(sm) {
+    #reply-control .d-editor-container.--markdown-editor-enabled {
+      transition: grid-template-columns var(--composer-transition-duration)
+        var(--composer-transition-easing);
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
+    }
+
+    #reply-control.hide-preview .d-editor-container.--markdown-editor-enabled {
+      grid-template-columns: 1fr 0fr;
+      grid-template-areas:
+        "fields fields"
+        "editor preview";
     }
   }
 

--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -102,6 +102,7 @@ const DEBOUNCE_JIT_MS = 2000;
 @classNameBindings("composer.showToolbar:toolbar-visible", ":wmd-controls")
 export default class ComposerEditor extends Component {
   @service composer;
+  @service site;
   @service siteSettings;
   @service currentUser;
 
@@ -253,6 +254,7 @@ export default class ComposerEditor extends Component {
       ? elem
       : elem.querySelector(".d-editor-preview-wrapper");
     this._registerImageAltTextButtonClick(preview);
+    preview.addEventListener("transitionend", this._handlePreviewTransitionEnd);
     this._editorInitPreview = true;
   }
 
@@ -273,6 +275,10 @@ export default class ComposerEditor extends Component {
       preview.removeEventListener("click", this._handleImageGridButtonClick);
       preview.removeEventListener("click", this._handleImageScaleButtonClick);
       preview.removeEventListener("keypress", this._handleAltTextInputKeypress);
+      preview.removeEventListener(
+        "transitionend",
+        this._handlePreviewTransitionEnd
+      );
 
       apiImageWrapperBtnEvents.forEach((fn) =>
         preview.removeEventListener("click", fn)
@@ -393,8 +399,49 @@ export default class ComposerEditor extends Component {
 
   @bind
   _throttledSyncEditorAndPreviewScroll(event) {
+    if (!this.composer.isPreviewVisible) {
+      return;
+    }
+
     const preview = this.element.querySelector(".d-editor-preview-wrapper");
     throttle(this, this._syncEditorAndPreviewScroll, event.target, preview, 20);
+  }
+
+  // scroll sync is skipped while the preview is hidden, so catch up when it
+  // is shown again: right away when the toggle isn't animated (e.g. reduced
+  // motion), or at transitionend when it is, once the layout is final
+  @observes("composer.showPreview", "composer.allowPreview")
+  _syncScrollOnPreviewShown() {
+    if (!this.composer.isPreviewVisible || this.site.mobileView) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
+      const preview = this.element.querySelector(".d-editor-preview-wrapper");
+      if (!preview || preview.getAnimations().length > 0) {
+        return;
+      }
+
+      const input = this.element.querySelector(".d-editor-input");
+      this._syncEditorAndPreviewScroll(input, preview);
+    });
+  }
+
+  @bind
+  _handlePreviewTransitionEnd(event) {
+    if (
+      event.propertyName !== "visibility" ||
+      !this.composer.isPreviewVisible
+    ) {
+      return;
+    }
+
+    const input = this.element.querySelector(".d-editor-input");
+    this._syncEditorAndPreviewScroll(input, event.currentTarget);
   }
 
   _syncEditorAndPreviewScroll(input, preview) {

--- a/frontend/discourse/tests/acceptance/composer-test.js
+++ b/frontend/discourse/tests/acceptance/composer-test.js
@@ -9,6 +9,7 @@ import {
   triggerKeyEvent,
   visit,
   waitFor,
+  waitUntil,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
@@ -194,6 +195,36 @@ acceptance(`Composer`, function (needs) {
     assert.true(resizedTriggered, "composer:resized is triggered");
   });
 
+  test("preview scroll catches up when re-shown without animation", async function (assert) {
+    // mirrors the prefers-reduced-motion behavior, where no transitionend
+    // fires for the toggle
+    const style = document.createElement("style");
+    style.innerHTML =
+      "#reply-control .d-editor-preview-wrapper { transition: none !important; }";
+    document.head.appendChild(style);
+
+    try {
+      await visit("/");
+      await click("#create-topic");
+      await fillIn(".d-editor-input", "line\n\n".repeat(200));
+
+      const preview = find(".d-editor-preview-wrapper");
+      preview.scrollTop = 500;
+
+      await click(".toggle-preview");
+      await click(".toggle-preview");
+      await waitUntil(() => preview.scrollTop === 0);
+
+      assert.strictEqual(
+        preview.scrollTop,
+        0,
+        "the preview position syncs to the editor when shown again"
+      );
+    } finally {
+      style.remove();
+    }
+  });
+
   test("composer controls", async function (assert) {
     await visit("/");
     assert.dom("#create-topic").exists("the create button is visible");
@@ -209,11 +240,17 @@ acceptance(`Composer`, function (needs) {
       .exists("body errors are hidden by default");
 
     await click(".toggle-preview");
+    // the preview collapses with a transition; hidden state applies at the end
+    await waitUntil(() => {
+      const style = getComputedStyle(find(".d-editor-preview-wrapper"));
+      return style.visibility === "hidden" || style.display === "none";
+    });
     assert
       .dom(".d-editor-preview")
       .isNotVisible("clicking the toggle hides the preview");
 
     await click(".toggle-preview");
+    await waitUntil(() => find(".d-editor-preview").offsetWidth > 0);
     assert
       .dom(".d-editor-preview")
       .isVisible("clicking the toggle shows the preview again");


### PR DESCRIPTION
Toggling the markdown preview animated only the composer's width: its position snapped to the topic-aligned spot and the preview pane popped in and out via `display: none`.

This change makes the resize move as one piece — position, width, and preview pane animate together, under both the classic flex layout and the composer redesign's grid layout, scoped to the markdown editor on desktop viewports, and honoring `prefers-reduced-motion`.