### PR TITLE
FIX: Invalidate cached 404 topic suggestions when category access is revoked

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -149,6 +149,7 @@ class Category < ActiveRecord::Base
   after_update :revise_category_definition, if: :saved_change_to_description?
   after_update :run_plugin_category_update_param_callbacks
   after_update :enqueue_category_hashtag_remap, if: :saved_change_to_hashtag_ref?
+  after_update :clear_page_not_found_topics_cache, if: :saved_change_to_read_restricted?
   after_destroy :trash_category_definition
   after_destroy :clear_related_site_settings
 
@@ -1449,6 +1450,11 @@ class Category < ActiveRecord::Base
       SQL
 
     result.map { |row| [row.group_id, row.permission_type] }
+  end
+
+  def clear_page_not_found_topics_cache
+    Topic.clear_page_not_found_topics_cache!
+    DB.after_commit { Topic.clear_page_not_found_topics_cache! }
   end
 
   def clear_site_cache

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -306,6 +306,7 @@ class Topic < ActiveRecord::Base
   belongs_to :og_image_upload, class_name: "Upload"
   has_many :topic_thumbnails, through: :image_upload
 
+  after_update :clear_page_not_found_topics_cache, if: :moved_to_read_restricted_category?
   after_save :regenerate_og_image
 
   # When we want to temporarily attach some data to a forum topic (usually before serialization)
@@ -441,6 +442,15 @@ class Topic < ActiveRecord::Base
     elsif saved_changes[:category_id] && category&.read_restricted?
       UserProfile.remove_featured_topic_from_all_profiles(self)
     end
+  end
+
+  def self.clear_page_not_found_topics_cache!
+    Discourse.cache.keys("page_not_found_topics:*").each { |key| Discourse.cache.redis.del(key) }
+  end
+
+  def clear_page_not_found_topics_cache
+    self.class.clear_page_not_found_topics_cache!
+    DB.after_commit { self.class.clear_page_not_found_topics_cache! }
   end
 
   def regenerate_og_image
@@ -2252,6 +2262,10 @@ class Topic < ActiveRecord::Base
   end
 
   private
+
+  def moved_to_read_restricted_category?
+    saved_change_to_category_id? && category&.read_restricted?
+  end
 
   def invite_to_private_message(invited_by, target_user, guardian)
     if !guardian.can_send_private_message?(target_user)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -604,6 +604,59 @@ RSpec.describe ApplicationController do
         end
       end
 
+      it "does not retain topics moved to a restricted category" do
+        Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
+        topic = Fabricate(:topic_with_op, title: "restricted 404 cache topic")
+        private_category = Fabricate(:private_category, group: Group[:staff])
+
+        get "/missing-route"
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include(topic.title)
+
+        admin = sign_in(Fabricate(:admin))
+        put "/t/#{topic.id}.json", params: { category_id: private_category.id }
+
+        expect(response).to have_http_status(:ok)
+
+        delete "/session/#{admin.username}.json"
+        get "/missing-route"
+
+        aggregate_failures do
+          expect(response).to have_http_status(:not_found)
+          expect(response.body).not_to include(topic.title)
+        end
+      end
+
+      it "does not retain topics after a category becomes restricted" do
+        Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
+        category = Fabricate(:category)
+        topic = Fabricate(:topic_with_op, title: "restricted category 404 cache topic", category:)
+
+        get "/missing-route"
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include(topic.title)
+
+        admin = sign_in(Fabricate(:admin))
+        put "/categories/#{category.id}.json",
+            params: {
+              permissions: {
+                Group[:staff].name => CategoryGroup.permission_types[:full],
+              },
+            }
+
+        expect(response).to have_http_status(:ok)
+
+        delete "/session/#{admin.username}.json"
+        get "/missing-route"
+
+        aggregate_failures do
+          expect(response).to have_http_status(:not_found)
+          expect(response.body).not_to include(topic.title)
+        end
+      end
+
       it "should cache results" do
         Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
         Discourse.cache.delete("page_not_found_topics:fr")


### PR DESCRIPTION
## Summary

Correctly invalidate the locale-keyed 404 suggestions cache whenever a topic is moved into a read-restricted category or a category becomes read-restricted, preventing anonymous users from seeing stale topic titles after access has been revoked. The fix clears all locale variants of the dedicated fragment both immediately and after transaction commit to close the refill race.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1672

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>