### PR TITLE
UX: Swipe to clear notifications on chat channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
@@ -29,6 +29,7 @@ const FADEOUT_CLASS = "-fade-out";
 export default class ChatChannelRow extends Component {
   @service capabilities;
   @service chat;
+  @service chatApi;
   @service menu;
   @service site;
 
@@ -128,10 +129,32 @@ export default class ChatChannelRow extends Component {
   @bind
   onSwipeEnd() {
     if (this.isAtThreshold) {
-      this.rowStyle = trustHTML("margin-right: 0px;");
-      this.shouldRemoveChannel = true;
+      if (this.isSwipeToClearNotifications) {
+        this.#clearNotifications();
+        this.shouldReset = true;
+      } else {
+        this.rowStyle = trustHTML("margin-right: 0px;");
+        this.shouldRemoveChannel = true;
+      }
     } else {
       this.shouldReset = true;
+    }
+  }
+
+  #clearNotifications() {
+    const channel = this.args.channel;
+    if (!channel.currentUserMembership) {
+      return;
+    }
+
+    const lastMessageId = channel.lastMessage?.id;
+    channel.tracking.reset();
+    channel.updateLastViewedAt();
+
+    if (lastMessageId) {
+      this.chatApi
+        .markChannelAsRead(channel.id, lastMessageId)
+        .catch(popupAjaxError);
     }
   }
 
@@ -186,7 +209,15 @@ export default class ChatChannelRow extends Component {
   }
 
   get shouldHandleSwipe() {
-    return this.capabilities.touch && this.args.channel.isDirectMessageChannel;
+    if (!this.capabilities.touch) {
+      return false;
+    }
+
+    return this.args.channel.isDirectMessageChannel || this.channelHasUnread;
+  }
+
+  get isSwipeToClearNotifications() {
+    return !this.args.channel.isDirectMessageChannel;
   }
 
   get leaveDirectMessageLabel() {
@@ -297,10 +328,13 @@ export default class ChatChannelRow extends Component {
         <div
           class={{dConcatClass
             "chat-channel-row__action-btn"
+            (if this.isSwipeToClearNotifications "--clear" "--remove")
             (if this.isAtThreshold "-at-threshold" "-not-at-threshold")
           }}
         >
-          {{dIcon "circle-xmark"}}
+          {{dIcon
+            (if this.isSwipeToClearNotifications "circle-check" "circle-xmark")
+          }}
         </div>
       {{/if}}
     </LinkTo>

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -74,8 +74,16 @@
     bottom: 0;
     right: 0;
     left: 0;
-    background: var(--danger);
-    color: var(--primary-very-low);
+
+    &.--remove {
+      background: var(--danger);
+      color: var(--primary-very-low);
+    }
+
+    &.--clear {
+      background: var(--tertiary);
+      color: var(--secondary);
+    }
 
     .d-icon {
       transform-origin: 50% 50%;

--- a/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
@@ -1,12 +1,36 @@
 import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
-import { render } from "@ember/test-helpers";
+import { find, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import sinon from "sinon";
 import CoreFabricators from "discourse/lib/fabricators";
 import { forceMobile, resetMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatChannelRow from "discourse/plugins/chat/discourse/components/chat-channel-row";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+function forceTouch(owner) {
+  Object.defineProperty(owner.lookup("service:capabilities"), "touch", {
+    configurable: true,
+    get: () => true,
+  });
+}
+
+async function swipeRowToThreshold(screenX = 10000) {
+  const content = find(".chat-channel-row__content");
+
+  for (const [type, x] of [
+    ["touchstart", screenX],
+    ["touchmove", 0],
+    ["touchend", 0],
+  ]) {
+    const event = new Event(type, { bubbles: true });
+    event.changedTouches = [{ screenX: x }];
+    content.dispatchEvent(event);
+  }
+
+  await settled();
+}
 
 module("Component | ChatChannelRow", function (hooks) {
   setupRenderingTest(hooks);
@@ -273,5 +297,67 @@ module("Component | ChatChannelRow", function (hooks) {
     );
 
     assert.dom(".user-status-message").doesNotExist();
+  });
+
+  test("swiping a channel with notifications clears them", async function (assert) {
+    forceTouch(this.owner);
+    const markAsRead = sinon
+      .stub(this.owner.lookup("service:chat-api"), "markChannelAsRead")
+      .resolves();
+    this.categoryChatChannel.tracking.unreadCount = 1;
+
+    await render(
+      <template>
+        <ChatChannelRow @channel={{this.categoryChatChannel}} />
+      </template>
+    );
+
+    await swipeRowToThreshold();
+
+    assert.dom(".chat-channel-row__action-btn.--clear").exists();
+    assert.dom(".chat-channel-row__action-btn .d-icon-circle-check").exists();
+    assert.dom(".chat-channel-row").doesNotHaveClass("-fade-out");
+    assert.true(
+      markAsRead.calledWith(
+        this.categoryChatChannel.id,
+        this.categoryChatChannel.lastMessage.id
+      ),
+      "marks the channel as read up to the last message"
+    );
+    assert.strictEqual(this.categoryChatChannel.tracking.unreadCount, 0);
+  });
+
+  test("channels without notifications are not swipeable", async function (assert) {
+    forceTouch(this.owner);
+
+    await render(
+      <template>
+        <ChatChannelRow @channel={{this.categoryChatChannel}} />
+      </template>
+    );
+
+    await swipeRowToThreshold();
+
+    assert.dom(".chat-channel-row__action-btn").doesNotExist();
+  });
+
+  test("swiping a direct message reveals the remove action", async function (assert) {
+    forceTouch(this.owner);
+    const markAsRead = sinon.spy(
+      this.owner.lookup("service:chat-api"),
+      "markChannelAsRead"
+    );
+
+    await render(
+      <template>
+        <ChatChannelRow @channel={{this.directMessageChannel}} />
+      </template>
+    );
+
+    await swipeRowToThreshold();
+
+    assert.dom(".chat-channel-row__action-btn.--remove").exists();
+    assert.dom(".chat-channel-row__action-btn .d-icon-circle-xmark").exists();
+    assert.true(markAsRead.notCalled, "does not clear notifications for a DM");
   });
 });


### PR DESCRIPTION
Adding a swipe gesture on touch devices to clear the notifications from a channel (ie mark as read).

Same principle as swipe-to-close for DMs, but blue and with a checkmark (reminiscent of the dismiss topic btn)

<img width="366" height="899" alt="image" src="https://github.com/user-attachments/assets/d70e72b2-e821-4124-acc1-cd7f5d181547" />

Does not clear underlying channel threads.