### PR TITLE
UX: Let anyone dismiss the chat pinned bar

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-pinned-messages-list.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-pinned-messages-list.gjs
@@ -82,9 +82,8 @@ export default class ChatPinnedMessagesList extends Component {
   #lastViewedPinsAtSnapshot =
     this.args.channel.currentUserMembership?.lastViewedPinsAt;
 
-  // not managers — "Dismiss pinned messages" would read as unpinning for all
   get canToggleDismissal() {
-    return this.pinnedMessages.length > 0 && !this.args.channel.canManagePins;
+    return this.pinnedMessages.length > 0;
   }
 
   get barDismissed() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
@@ -37,10 +37,9 @@ export default class ChatNavbarPinnedMessagesButton extends Component {
         class="c-navbar__pinned-messages-btn btn no-text btn-transparent"
         {{on "click" this.handleClick}}
       >
+        {{! no unread dot: this button only exists once the bar was dismissed,
+        so it would flag pins the user chose to hide }}
         {{dIcon "thumbtack"}}
-        {{#if @channel.hasUnseenPins}}
-          <span class="c-navbar__pinned-messages-btn__unread-indicator"></span>
-        {{/if}}
       </LinkTo>
     {{/if}}
   </template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
@@ -37,8 +37,8 @@ export default class ChatNavbarPinnedMessagesButton extends Component {
         class="c-navbar__pinned-messages-btn btn no-text btn-transparent"
         {{on "click" this.handleClick}}
       >
-        {{! no unread dot: this button only exists once the bar was dismissed,
-        so it would flag pins the user chose to hide }}
+        {{! no unread dot: a pin newer than the dismissal brings the bar itself
+        back, so this button never needs to signal newness }}
         {{dIcon "thumbtack"}}
       </LinkTo>
     {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/pinned-messages-button.gjs
@@ -23,7 +23,6 @@ export default class ChatNavbarPinnedMessagesButton extends Component {
       this.siteSettings.chat_pinned_messages &&
       !this.chatStateManager.isDrawerCollapsed &&
       this.args.channel?.hasPinnedMessages &&
-      !this.args.channel.canManagePins &&
       hasPinsDismissal(this.args.channel) &&
       this.router.currentRoute?.name !== "chat.channel.pins"
     );

--- a/plugins/chat/assets/javascripts/discourse/components/chat/pinned-message-bar.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/pinned-message-bar.gjs
@@ -43,9 +43,6 @@ export default class ChatPinnedMessageBar extends Component {
   #loadSequence = 0;
 
   get dismissed() {
-    if (this.args.channel.canManagePins) {
-      return false;
-    }
     const dismissedAbove = pinsDismissedAboveId(this.args.channel);
     if (dismissedAbove == null || this.pins.length === 0) {
       return false;
@@ -133,10 +130,6 @@ export default class ChatPinnedMessageBar extends Component {
     );
   }
 
-  get showInlineDismiss() {
-    return !this.hasMultiplePins && !this.args.channel.canManagePins;
-  }
-
   get pinsPanelOpen() {
     return this.router.currentRoute?.name === "chat.channel.pins";
   }
@@ -148,7 +141,7 @@ export default class ChatPinnedMessageBar extends Component {
   get seeAllLabel() {
     return this.pinsPanelOpen
       ? i18n("chat.pinned_messages.close")
-      : i18n("chat.pinned_bar.see_all");
+      : i18n("chat.pinned_messages.title");
   }
 
   get currentExcerpt() {
@@ -225,6 +218,19 @@ export default class ChatPinnedMessageBar extends Component {
   @action
   dismiss() {
     dismissPinsUpTo(this.args.channel, newestPinId(this.pins));
+    this.#markPinsAsRead();
+  }
+
+  // without this the navbar button that replaces the bar would carry an unread
+  // dot for the very pin just dismissed
+  #markPinsAsRead() {
+    const membership = this.args.channel.currentUserMembership;
+    if (!membership) {
+      return;
+    }
+    membership.lastViewedPinsAt = new Date();
+    membership.hasUnseenPins = false;
+    this.chatApi.markPinsAsRead(this.args.channel.id).catch(() => {});
   }
 
   <template>
@@ -274,15 +280,8 @@ export default class ChatPinnedMessageBar extends Component {
           </button>
         {{/if}}
 
-        {{#if this.showInlineDismiss}}
-          <DButton
-            @action={{this.dismiss}}
-            @icon="xmark"
-            @title="chat.pinned_bar.dismiss"
-            @ariaLabel="chat.pinned_bar.dismiss"
-            class="chat-pinned-bar__dismiss btn-transparent no-text"
-          />
-        {{else}}
+        {{! a lone pin has no list to open, and the excerpt wants the width }}
+        {{#if this.hasMultiplePins}}
           <LinkTo
             @route={{this.seeAllRoute}}
             @models={{@channel.routeModels}}
@@ -300,6 +299,14 @@ export default class ChatPinnedMessageBar extends Component {
             {{/if}}
           </LinkTo>
         {{/if}}
+
+        <DButton
+          @action={{this.dismiss}}
+          @icon="xmark"
+          @title="chat.pinned_messages.dismiss"
+          @ariaLabel="chat.pinned_messages.dismiss"
+          class="chat-pinned-bar__dismiss btn-transparent no-text"
+        />
       </div>
     {{/if}}
   </template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/pinned-message-bar.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/pinned-message-bar.gjs
@@ -218,19 +218,6 @@ export default class ChatPinnedMessageBar extends Component {
   @action
   dismiss() {
     dismissPinsUpTo(this.args.channel, newestPinId(this.pins));
-    this.#markPinsAsRead();
-  }
-
-  // without this the navbar button that replaces the bar would carry an unread
-  // dot for the very pin just dismissed
-  #markPinsAsRead() {
-    const membership = this.args.channel.currentUserMembership;
-    if (!membership) {
-      return;
-    }
-    membership.lastViewedPinsAt = new Date();
-    membership.hasUnseenPins = false;
-    this.chatApi.markPinsAsRead(this.args.channel.id).catch(() => {});
   }
 
   <template>

--- a/plugins/chat/assets/stylesheets/common/chat-pinned-messages.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-pinned-messages.scss
@@ -4,18 +4,8 @@
 }
 
 .c-navbar__pinned-messages-btn {
-  position: relative;
-
   .d-icon {
     transform: rotate(45deg);
-  }
-
-  &__unread-indicator {
-    @include chat-unread-indicator;
-    position: absolute;
-    inset-block-start: 5px;
-    inset-inline-end: 5px;
-    border: 2px solid var(--secondary);
   }
 }
 

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -68,15 +68,13 @@ en:
       pinned_messages:
         title: "Pinned messages"
         close: "Close pinned messages"
-        dismiss: "Dismiss pinned messages"
+        dismiss: "Dismiss for me"
         show: "Show pinned messages"
         pinned_by_you: "Pinned by you"
         pinned_by_user: "Pinned by %{username}"
       pinned_bar:
         title: "Pinned"
-        see_all: "See all pinned messages"
         jump_to_pinned: "Jump to pinned message"
-        dismiss: "Dismiss pinned message"
       no_pinned_messages: "No pinned messages in this channel."
       pin_message: "Pin message"
       unpin_message: "Unpin message"

--- a/plugins/chat/spec/system/pinned_messages_spec.rb
+++ b/plugins/chat/spec/system/pinned_messages_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe "Chat pinned messages" do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
 
+  # the bar only offers the list icon (and with it the unread dot) at 2+ pins
+  def pin_another_message(user: admin)
+    second = Fabricate(:chat_message, chat_channel: channel, message: "Second message")
+    Chat::PinnedMessage.create!(chat_message: second, chat_channel: channel, user: user)
+    second
+  end
+
   before do
     chat_system_bootstrap
     SiteSetting.chat_pinned_messages = true
@@ -15,26 +22,40 @@ RSpec.describe "Chat pinned messages" do
     sign_in(admin)
   end
 
-  it "allows staff to pin and unpin messages" do
+  # dismissals live in local storage, which outlives a Capybara session reset,
+  # and `fab!` hands every example the same channel id to key them by
+  after do
+    page.execute_script("window.localStorage.clear()") if page.current_url.start_with?("http")
+  end
+
+  it "allows staff to pin a message" do
     chat_page.visit_channel(channel)
 
     channel_page.messages.find(id: message.id).secondary_action("pin")
 
     expect(page).to have_css(".chat-message-info__pinned")
-    expect(page).to have_css(".chat-pinned-bar__see-all")
+    expect(page).to have_css(".chat-pinned-bar__excerpt", text: "Important message")
+  end
 
-    find(".chat-pinned-bar__see-all").click
-    expect(page).to have_css(".c-routes.--channel-pins")
-    expect(page).to have_content("Important message")
+  # separate example: unpinning while the bar is still appearing shifts the
+  # scroller under the open message actions menu
+  it "allows staff to unpin a message" do
+    Chat::PinnedMessage.create!(chat_message: message, chat_channel: channel, user: admin)
 
-    find(".c-navbar__close-pins-button").click
+    chat_page.visit_channel(channel)
+    expect(page).to have_css(".chat-pinned-bar")
+
     channel_page.messages.find(id: message.id).secondary_action("unpin")
 
     expect(page).to have_no_css(".chat-message-info__pinned")
+    expect(page).to have_no_css(".chat-pinned-bar")
   end
 
   it "shows unread indicator for unseen pins" do
+    pin_another_message # a self-pin is never unseen, and it brings out the list icon
+
     chat_page.visit_channel(channel)
+    expect(page).to have_css(".chat-pinned-bar")
 
     # Another user pins the message while admin is viewing
     pin =
@@ -56,11 +77,9 @@ RSpec.describe "Chat pinned messages" do
   end
 
   it "marks pins as read when viewing the panel" do
-    Chat::PinnedMessage.create!(
-      chat_message: message,
-      chat_channel: channel,
-      user: Fabricate(:admin),
-    )
+    other_admin = Fabricate(:admin)
+    Chat::PinnedMessage.create!(chat_message: message, chat_channel: channel, user: other_admin)
+    pin_another_message(user: other_admin)
 
     chat_page.visit_channel(channel)
     expect(page).to have_css(".chat-pinned-bar__unread-indicator")
@@ -78,6 +97,7 @@ RSpec.describe "Chat pinned messages" do
   it "shows unseen pin icon in the panel for pins not yet viewed" do
     other_user = Fabricate(:admin)
     Chat::PinnedMessage.create!(chat_message: message, chat_channel: channel, user: other_user)
+    pin_another_message(user: other_user)
 
     chat_page.visit_channel(channel)
     find(".chat-pinned-bar__see-all").click
@@ -171,6 +191,7 @@ RSpec.describe "Chat pinned messages" do
 
   it "toggles the pinned messages panel from the bar's see-all button" do
     Chat::PinnedMessage.create!(chat_message: message, chat_channel: channel, user: admin)
+    pin_another_message
 
     chat_page.visit_channel(channel)
 
@@ -209,8 +230,6 @@ RSpec.describe "Chat pinned messages" do
     sign_in(user)
     chat_page.visit_channel(channel)
 
-    # a single pin offers an inline dismiss instead of the see-all button
-    expect(page).to have_no_css(".chat-pinned-bar__see-all")
     find(".chat-pinned-bar__dismiss").click
     expect(page).to have_no_css(".chat-pinned-bar")
 
@@ -223,19 +242,40 @@ RSpec.describe "Chat pinned messages" do
     expect(page).to have_no_css(".c-navbar__pinned-messages-btn")
   end
 
-  it "does not offer the dismiss button to users who can manage pins" do
+  it "lets a user who can manage pins hide the bar without unpinning" do
     Chat::PinnedMessage.create!(chat_message: message, chat_channel: channel, user: admin)
 
     chat_page.visit_channel(channel)
-    find(".chat-pinned-bar__see-all").click
+    find(".chat-pinned-bar__dismiss").click
 
-    expect(page).to have_css(".c-routes.--channel-pins")
-    expect(page).to have_content("Important message")
-    expect(page).to have_no_css(".chat-pinned-messages-list__dismiss")
+    expect(page).to have_no_css(".chat-pinned-bar")
+    # the message stays pinned for everyone else
+    expect(channel.pinned_messages.count).to eq(1)
+
+    find(".c-navbar__pinned-messages-btn").click
+    find(".chat-pinned-messages-list__show").click
+
+    expect(page).to have_css(".chat-pinned-bar")
+    expect(page).to have_no_css(".c-navbar__pinned-messages-btn")
+  end
+
+  it "hides the bar from the pins panel for a user who can manage pins" do
+    Chat::PinnedMessage.create!(chat_message: message, chat_channel: channel, user: admin)
+    pin_another_message
+
+    chat_page.visit_channel(channel)
+    find(".chat-pinned-bar__see-all").click
+    find(".chat-pinned-messages-list__dismiss").click
+
+    expect(page).to have_no_css(".c-routes.--channel-pins")
+    expect(page).to have_no_css(".chat-pinned-bar")
+    expect(channel.pinned_messages.count).to eq(2)
   end
 
   context "when viewing pinned messages attribution" do
     it "shows 'Pinned by you' when current user pinned the message" do
+      pin_another_message
+
       chat_page.visit_channel(channel)
       channel_page.messages.find(id: message.id).secondary_action("pin")
 
@@ -259,6 +299,7 @@ RSpec.describe "Chat pinned messages" do
           chat_channel: channel,
           pinned_by_id: other_user.id,
         )
+        pin_another_message(user: other_user)
       end
 
       it "shows 'Pinned by [username]'" do

--- a/plugins/chat/test/javascripts/components/chat-pinned-message-bar-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-pinned-message-bar-test.gjs
@@ -65,9 +65,6 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
     this.siteSettings.chat_pinned_messages = true;
     this.channel = new ChatFabricators(getOwner(this)).channel();
     this.noop = () => {};
-    pretender.put(`/chat/api/channels/${this.channel.id}/pins/read`, () =>
-      response({})
-    );
   });
 
   test("does not render when the channel has no pins", async function (assert) {
@@ -318,30 +315,6 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
     await click(".chat-pinned-bar__dismiss");
 
     assert.dom(".chat-pinned-bar").hasClass("--dismissed");
-  });
-
-  test("marks pins as read when dismissing", async function (assert) {
-    this.channel.pinnedMessagesCount = 1;
-    this.channel.currentUserMembership.hasUnseenPins = true;
-    pretender.get(`/chat/api/channels/${this.channel.id}/pins`, () =>
-      pinResponse(this.channel, 1)
-    );
-
-    await render(
-      <template>
-        <ChatPinnedMessageBar
-          @channel={{this.channel}}
-          @onJumpToMessage={{this.noop}}
-        />
-      </template>
-    );
-
-    await click(".chat-pinned-bar__dismiss");
-
-    assert.false(
-      this.channel.currentUserMembership.hasUnseenPins,
-      "the navbar button that replaces the bar can't show an unread dot for a dismissed pin"
-    );
   });
 
   test("offers the inline dismiss to pin managers too", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-pinned-message-bar-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-pinned-message-bar-test.gjs
@@ -65,6 +65,9 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
     this.siteSettings.chat_pinned_messages = true;
     this.channel = new ChatFabricators(getOwner(this)).channel();
     this.noop = () => {};
+    pretender.put(`/chat/api/channels/${this.channel.id}/pins/read`, () =>
+      response({})
+    );
   });
 
   test("does not render when the channel has no pins", async function (assert) {
@@ -295,7 +298,7 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
       .hasAttribute("href", new RegExp(`/${this.channel.id}/pins$`));
   });
 
-  test("shows an inline dismiss instead of the see-all icon for a single pin", async function (assert) {
+  test("hides the list icon for a single pin", async function (assert) {
     this.channel.pinnedMessagesCount = 1;
     pretender.get(`/chat/api/channels/${this.channel.id}/pins`, () =>
       pinResponse(this.channel, 1)
@@ -311,16 +314,15 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
     );
 
     assert.dom(".chat-pinned-bar__see-all").doesNotExist();
-    assert.dom(".chat-pinned-bar__dismiss").exists();
 
     await click(".chat-pinned-bar__dismiss");
 
     assert.dom(".chat-pinned-bar").hasClass("--dismissed");
   });
 
-  test("keeps the see-all icon for pin managers with a single pin", async function (assert) {
-    this.channel.meta.can_manage_pins = true;
+  test("marks pins as read when dismissing", async function (assert) {
     this.channel.pinnedMessagesCount = 1;
+    this.channel.currentUserMembership.hasUnseenPins = true;
     pretender.get(`/chat/api/channels/${this.channel.id}/pins`, () =>
       pinResponse(this.channel, 1)
     );
@@ -334,8 +336,33 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
       </template>
     );
 
-    assert.dom(".chat-pinned-bar__dismiss").doesNotExist();
-    assert.dom(".chat-pinned-bar__see-all").exists();
+    await click(".chat-pinned-bar__dismiss");
+
+    assert.false(
+      this.channel.currentUserMembership.hasUnseenPins,
+      "the navbar button that replaces the bar can't show an unread dot for a dismissed pin"
+    );
+  });
+
+  test("offers the inline dismiss to pin managers too", async function (assert) {
+    this.channel.meta.can_manage_pins = true;
+    this.channel.pinnedMessagesCount = 2;
+    pretender.get(`/chat/api/channels/${this.channel.id}/pins`, () =>
+      pinResponse(this.channel, 2)
+    );
+
+    await render(
+      <template>
+        <ChatPinnedMessageBar
+          @channel={{this.channel}}
+          @onJumpToMessage={{this.noop}}
+        />
+      </template>
+    );
+
+    await click(".chat-pinned-bar__dismiss");
+
+    assert.dom(".chat-pinned-bar").hasClass("--dismissed");
   });
 
   test("shows an unread indicator when there are unseen pins", async function (assert) {
@@ -567,8 +594,7 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
     assert.dom(".chat-pinned-bar").hasClass("--dismissed");
   });
 
-  test("pin managers bypass a stored dismissal", async function (assert) {
-    // a dismissal recorded before the user could manage pins
+  test("honors a stored dismissal for pin managers", async function (assert) {
     const store = new KeyValueStore(STORE_NAMESPACE);
     store.setObject({ key: String(this.channel.id), value: 100 });
     this.channel.meta.can_manage_pins = true;
@@ -589,7 +615,7 @@ module("Component | ChatPinnedMessageBar", function (hooks) {
 
     assert
       .dom(".chat-pinned-bar")
-      .doesNotHaveClass("--dismissed", "managers always see the bar");
+      .hasClass("--dismissed", "dismissal is not tied to pin permissions");
   });
 
   test("stays dismissed when the dismissed pin is unpinned", async function (assert) {


### PR DESCRIPTION
Dismissing the pinned bar hides it for the current user only, so gating it on pin permission punished the people with the most pinned channels. Being able to manage a pin and wanting it in front of you are different things: channel instructions you wrote yourself are the common case.

The dismiss control is now always in the bar, since the need to hide the bar grows with the number of pins rather than shrinking, and the list icon appears only when there is a list worth opening. The navbar button that replaces a dismissed bar no longer carries an unread dot, which would have flagged pins the user chose to hide.

Note that a dismissal recorded before a user could manage pins now takes effect for them.
