### PR TITLE
FIX: Clean up stranded PM notifications when access is revoked

### DIFF
--- a/app/jobs/regular/delete_inaccessible_notifications.rb
+++ b/app/jobs/regular/delete_inaccessible_notifications.rb
@@ -12,11 +12,30 @@ module Jobs
       user_ids ||= Notification.where(topic_id: topic.id).distinct.pluck(:user_id)
       return if user_ids.blank?
 
-      inaccessible_users = User.where(id: user_ids).reject { |user| user.guardian.can_see?(topic) }
-      return if inaccessible_users.empty?
+      inaccessible_ids = inaccessible_user_ids(topic, user_ids)
+      return if inaccessible_ids.empty?
 
-      Notification.where(user_id: inaccessible_users.map(&:id), topic_id: topic.id).delete_all
-      inaccessible_users.each(&:publish_notifications_state)
+      Notification.where(user_id: inaccessible_ids, topic_id: topic.id).delete_all
+      User.where(id: inaccessible_ids).find_each(&:publish_notifications_state)
+    end
+
+    private
+
+    # For PMs (the common case) resolve access with two set-based queries instead
+    # of one Guardian#can_see? call per user, so a job on a large group PM does
+    # not fan out into N SQL round-trips.
+    def inaccessible_user_ids(topic, user_ids)
+      return per_user_guardian_check(topic, user_ids) if !topic.private_message? || topic.deleted_at
+
+      accessible_ids = topic.all_allowed_users.where(id: user_ids).pluck(:id)
+      if !SiteSetting.suppress_secured_categories_from_admin
+        accessible_ids |= User.where(id: user_ids, admin: true).pluck(:id)
+      end
+      user_ids - accessible_ids
+    end
+
+    def per_user_guardian_check(topic, user_ids)
+      User.where(id: user_ids).reject { |u| u.guardian.can_see?(topic) }.map(&:id)
     end
   end
 end

--- a/app/jobs/regular/delete_inaccessible_notifications.rb
+++ b/app/jobs/regular/delete_inaccessible_notifications.rb
@@ -8,19 +8,15 @@ module Jobs
       topic = Topic.find_by(id: args[:topic_id])
       return if topic.blank?
 
-      scope = Notification.where(topic_id: topic.id)
-      scope = scope.where(user_id: args[:user_ids]) if args[:user_ids].present?
-      user_ids = scope.distinct.pluck(:user_id)
-      return if user_ids.empty?
+      user_ids = args[:user_ids].presence
+      user_ids ||= Notification.where(topic_id: topic.id).distinct.pluck(:user_id)
+      return if user_ids.blank?
 
-      User
-        .where(id: user_ids)
-        .find_each do |user|
-          next if user.guardian.can_see?(topic)
+      inaccessible_users = User.where(id: user_ids).reject { |user| user.guardian.can_see?(topic) }
+      return if inaccessible_users.empty?
 
-          removed_count = Notification.where(user_id: user.id, topic_id: topic.id).delete_all
-          user.publish_notifications_state if removed_count.positive?
-        end
+      Notification.where(user_id: inaccessible_users.map(&:id), topic_id: topic.id).delete_all
+      inaccessible_users.each(&:publish_notifications_state)
     end
   end
 end

--- a/app/jobs/regular/delete_inaccessible_notifications.rb
+++ b/app/jobs/regular/delete_inaccessible_notifications.rb
@@ -5,12 +5,21 @@ module Jobs
     def execute(args)
       raise Discourse::InvalidParameters.new(:topic_id) if args[:topic_id].blank?
 
-      Notification
-        .where(topic_id: args[:topic_id])
-        .find_each do |notification|
-          next unless notification.user && notification.topic
+      topic = Topic.find_by(id: args[:topic_id])
+      return if topic.blank?
 
-          notification.destroy if !Guardian.new(notification.user).can_see?(notification.topic)
+      scope = Notification.where(topic_id: topic.id)
+      scope = scope.where(user_id: args[:user_ids]) if args[:user_ids].present?
+      user_ids = scope.distinct.pluck(:user_id)
+      return if user_ids.empty?
+
+      User
+        .where(id: user_ids)
+        .find_each do |user|
+          next if user.guardian.can_see?(topic)
+
+          removed_count = Notification.where(user_id: user.id, topic_id: topic.id).delete_all
+          user.publish_notifications_state if removed_count.positive?
         end
     end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1275,7 +1275,6 @@ class Topic < ActiveRecord::Base
       end
     end
 
-    # test
     false
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1257,6 +1257,7 @@ class Topic < ActiveRecord::Base
         group_user.destroy
         allowed_groups.reload
         add_small_action(removed_by, "removed_group", group.name, skip_guardian: true)
+        Jobs.enqueue(:delete_inaccessible_notifications, topic_id: id)
         return true
       end
     end
@@ -1277,6 +1278,11 @@ class Topic < ActiveRecord::Base
           add_small_action(removed_by, "user_left", user.username, skip_guardian: true)
         else
           add_small_action(removed_by, "removed_user", user.username, skip_guardian: true)
+        end
+
+        unless Guardian.new(user).can_see?(self)
+          removed_count = Notification.remove_for(user.id, id)
+          user.publish_notifications_state if removed_count.positive?
         end
 
         MessageBus.publish("/topic/#{id}", { type: "remove_allowed_user" }, user_ids: [user.id])

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1281,8 +1281,7 @@ class Topic < ActiveRecord::Base
         end
 
         unless user.guardian.can_see?(self)
-          removed_count = Notification.remove_for(user.id, id)
-          user.publish_notifications_state if removed_count.positive?
+          user.publish_notifications_state if Notification.remove_for(user.id, id).positive?
         end
 
         MessageBus.publish("/topic/#{id}", { type: "remove_allowed_user" }, user_ids: [user.id])

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1289,6 +1289,7 @@ class Topic < ActiveRecord::Base
       end
     end
 
+    # test
     false
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1280,7 +1280,7 @@ class Topic < ActiveRecord::Base
           add_small_action(removed_by, "removed_user", user.username, skip_guardian: true)
         end
 
-        unless Guardian.new(user).can_see?(self)
+        unless user.guardian.can_see?(self)
           removed_count = Notification.remove_for(user.id, id)
           user.publish_notifications_state if removed_count.positive?
         end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1275,6 +1275,7 @@ class Topic < ActiveRecord::Base
       end
     end
 
+    # test
     false
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1289,7 +1289,6 @@ class Topic < ActiveRecord::Base
       end
     end
 
-    # test
     false
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1267,8 +1267,7 @@ class Topic < ActiveRecord::Base
         end
 
         unless user.guardian.can_see?(self)
-          removed_count = Notification.remove_for(user.id, id)
-          user.publish_notifications_state if removed_count.positive?
+          user.publish_notifications_state if Notification.remove_for(user.id, id).positive?
         end
 
         MessageBus.publish("/topic/#{id}", { type: "remove_allowed_user" }, user_ids: [user.id])

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1243,6 +1243,7 @@ class Topic < ActiveRecord::Base
         group_user.destroy
         allowed_groups.reload
         add_small_action(removed_by, "removed_group", group.name, skip_guardian: true)
+        Jobs.enqueue(:delete_inaccessible_notifications, topic_id: id)
         return true
       end
     end
@@ -1263,6 +1264,11 @@ class Topic < ActiveRecord::Base
           add_small_action(removed_by, "user_left", user.username, skip_guardian: true)
         else
           add_small_action(removed_by, "removed_user", user.username, skip_guardian: true)
+        end
+
+        unless Guardian.new(user).can_see?(self)
+          removed_count = Notification.remove_for(user.id, id)
+          user.publish_notifications_state if removed_count.positive?
         end
 
         MessageBus.publish("/topic/#{id}", { type: "remove_allowed_user" }, user_ids: [user.id])

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1266,7 +1266,7 @@ class Topic < ActiveRecord::Base
           add_small_action(removed_by, "removed_user", user.username, skip_guardian: true)
         end
 
-        unless Guardian.new(user).can_see?(self)
+        unless user.guardian.can_see?(self)
           removed_count = Notification.remove_for(user.id, id)
           user.publish_notifications_state if removed_count.positive?
         end

--- a/db/post_migrate/20260807182856_cleanup_stranded_pm_notifications.rb
+++ b/db/post_migrate/20260807182856_cleanup_stranded_pm_notifications.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CleanupStrandedPmNotifications < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 10_000
+
+  def up
+    loop do
+      count = DB.exec(<<~SQL, batch_size: BATCH_SIZE)
+        DELETE FROM notifications
+        WHERE id IN (
+          SELECT n.id
+          FROM notifications n
+          INNER JOIN topics t ON t.id = n.topic_id
+          WHERE t.archetype = 'private_message'
+            AND NOT EXISTS (
+              SELECT 1 FROM topic_allowed_users tau
+              WHERE tau.topic_id = n.topic_id AND tau.user_id = n.user_id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM topic_allowed_groups tag
+              INNER JOIN group_users gu ON gu.group_id = tag.group_id
+              WHERE tag.topic_id = n.topic_id AND gu.user_id = n.user_id
+            )
+          LIMIT :batch_size
+        )
+      SQL
+
+      break if count == 0
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23153,6 +23153,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260810154331'),
 ('20260810012238'),
+('20260807182856'),
 ('20260806074210'),
 ('20260806074204'),
 ('20260803015314'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23128,6 +23128,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260807182856'),
 ('20260803015314'),
 ('20260731055703'),
 ('20260730183114'),

--- a/lib/group_manager.rb
+++ b/lib/group_manager.rb
@@ -33,6 +33,7 @@ class GroupManager
 
     recalculate_trust_level(removed_user_ids)
     bulk_publish_category_updates(removed_user_ids)
+    enqueue_pm_notification_cleanup
 
     User.where(id: removed_user_ids).find_each { |user| @group.trigger_user_removed_event(user) }
     enqueue_user_removed_webhook_events(webhook_payloads)
@@ -147,6 +148,13 @@ class GroupManager
     else
       Discourse.request_refresh!(user_ids:)
     end
+  end
+
+  def enqueue_pm_notification_cleanup
+    TopicAllowedGroup
+      .where(group_id: @group.id)
+      .pluck(:topic_id)
+      .each { |topic_id| Jobs.enqueue(:delete_inaccessible_notifications, topic_id:) }
   end
 
   def build_user_removed_webhook_payloads(group_users_relation)

--- a/lib/group_manager.rb
+++ b/lib/group_manager.rb
@@ -33,7 +33,7 @@ class GroupManager
 
     recalculate_trust_level(removed_user_ids)
     bulk_publish_category_updates(removed_user_ids)
-    enqueue_pm_notification_cleanup
+    enqueue_pm_notification_cleanup(removed_user_ids)
 
     User.where(id: removed_user_ids).find_each { |user| @group.trigger_user_removed_event(user) }
     enqueue_user_removed_webhook_events(webhook_payloads)
@@ -150,9 +150,13 @@ class GroupManager
     end
   end
 
-  def enqueue_pm_notification_cleanup
-    TopicAllowedGroup
-      .where(group_id: @group.id)
+  def enqueue_pm_notification_cleanup(removed_user_ids)
+    Notification
+      .where(
+        user_id: removed_user_ids,
+        topic_id: TopicAllowedGroup.where(group_id: @group.id).select(:topic_id),
+      )
+      .distinct
       .pluck(:topic_id)
       .each { |topic_id| Jobs.enqueue(:delete_inaccessible_notifications, topic_id:) }
   end

--- a/lib/group_manager.rb
+++ b/lib/group_manager.rb
@@ -157,8 +157,15 @@ class GroupManager
         topic_id: TopicAllowedGroup.where(group_id: @group.id).select(:topic_id),
       )
       .distinct
-      .pluck(:topic_id)
-      .each { |topic_id| Jobs.enqueue(:delete_inaccessible_notifications, topic_id:) }
+      .pluck(:topic_id, :user_id)
+      .group_by(&:first)
+      .each do |topic_id, pairs|
+        Jobs.enqueue(
+          :delete_inaccessible_notifications,
+          topic_id: topic_id,
+          user_ids: pairs.map(&:last),
+        )
+      end
   end
 
   def build_user_removed_webhook_payloads(group_users_relation)

--- a/spec/db/post_migrate/20260807182856_cleanup_stranded_pm_notifications_spec.rb
+++ b/spec/db/post_migrate/20260807182856_cleanup_stranded_pm_notifications_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require Rails.root.join("db/post_migrate/20260807182856_cleanup_stranded_pm_notifications.rb")
+
+RSpec.describe CleanupStrandedPmNotifications do
+  before do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after { ActiveRecord::Migration.verbose = @original_verbose }
+
+  fab!(:user1, :user)
+  fab!(:user2, :user)
+  fab!(:admin)
+  fab!(:group)
+
+  fab!(:pm_topic) do
+    Fabricate(
+      :private_message_topic,
+      user: admin,
+      topic_allowed_users: [
+        Fabricate.build(:topic_allowed_user, user: admin),
+        Fabricate.build(:topic_allowed_user, user: user1),
+      ],
+    )
+  end
+
+  fab!(:group_pm_topic) do
+    topic =
+      Fabricate(
+        :private_message_topic,
+        user: admin,
+        topic_allowed_users: [Fabricate.build(:topic_allowed_user, user: admin)],
+      )
+    Fabricate(:topic_allowed_group, topic: topic, group: group)
+    topic
+  end
+
+  it "deletes notifications for users removed from a PM" do
+    orphaned = Fabricate(:notification, user: user2, topic: pm_topic)
+
+    described_class.new.up
+
+    expect(Notification.exists?(orphaned.id)).to eq(false)
+  end
+
+  it "preserves notifications for users still allowed on the PM" do
+    kept = Fabricate(:notification, user: user1, topic: pm_topic)
+
+    described_class.new.up
+
+    expect(Notification.exists?(kept.id)).to eq(true)
+  end
+
+  it "preserves notifications for users with access via a group" do
+    group.add(user2)
+    kept = Fabricate(:notification, user: user2, topic: group_pm_topic)
+
+    described_class.new.up
+
+    expect(Notification.exists?(kept.id)).to eq(true)
+  end
+
+  it "deletes all notification types from an inaccessible PM" do
+    types = %i[private_message invited_to_private_message mentioned quoted replied]
+    orphaned =
+      types.map do |type|
+        Fabricate(
+          :notification,
+          user: user2,
+          topic: pm_topic,
+          notification_type: Notification.types[type],
+        )
+      end
+
+    described_class.new.up
+
+    orphaned.each { |n| expect(Notification.exists?(n.id)).to eq(false) }
+  end
+
+  it "leaves non-PM notifications alone" do
+    regular_topic = Fabricate(:topic)
+    kept = Fabricate(:notification, user: user2, topic: regular_topic)
+
+    described_class.new.up
+
+    expect(Notification.exists?(kept.id)).to eq(true)
+  end
+end

--- a/spec/jobs/delete_inaccessible_notifications_spec.rb
+++ b/spec/jobs/delete_inaccessible_notifications_spec.rb
@@ -51,4 +51,32 @@ RSpec.describe Jobs::DeleteInaccessibleNotifications do
       expect(Notification.exists?(third_notification.id)).to eq(true)
     end
   end
+
+  it "resolves PM access without an SQL query per user" do
+    group = Fabricate(:group)
+    group_pm =
+      Fabricate(
+        :private_message_topic,
+        user: admin,
+        topic_allowed_groups: [Fabricate.build(:topic_allowed_group, group: group)],
+      )
+    users = 5.times.map { Fabricate(:user) }
+    users.each { |u| Fabricate(:notification, user: u, topic: group_pm) }
+
+    access_queries = 0
+    subscriber =
+      ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        # Guardian's per-PM access check hits topic_allowed_users/topic_allowed_groups.
+        access_queries += 1 if event.payload[:sql] =~ /topic_allowed_(users|groups)/
+      end
+
+    begin
+      described_class.new.execute(topic_id: group_pm.id)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    expect(access_queries).to be <= 2
+  end
 end

--- a/spec/jobs/delete_inaccessible_notifications_spec.rb
+++ b/spec/jobs/delete_inaccessible_notifications_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::DeleteInaccessibleNotifications do
+  fab!(:admin)
+  fab!(:user)
+  fab!(:other_user, :user)
+  fab!(:pm) { Fabricate(:private_message_topic, user: admin, recipient: user) }
+
+  it "raises if topic_id is missing" do
+    expect { described_class.new.execute({}) }.to raise_error(Discourse::InvalidParameters)
+  end
+
+  it "does nothing when the topic is gone" do
+    expect { described_class.new.execute(topic_id: -1) }.not_to raise_error
+  end
+
+  it "deletes notifications for users who can no longer see the topic" do
+    other_notification = Fabricate(:notification, user: other_user, topic: pm, read: false) # not an allowed user
+
+    expect { described_class.new.execute(topic_id: pm.id) }.to change {
+      Notification.exists?(other_notification.id)
+    }.from(true).to(false)
+  end
+
+  it "preserves notifications for users who can still see the topic" do
+    notification = Fabricate(:notification, user: user, topic: pm, read: false)
+
+    expect { described_class.new.execute(topic_id: pm.id) }.not_to change {
+      Notification.exists?(notification.id)
+    }
+  end
+
+  it "publishes notification state once per affected user, not per notification" do
+    Fabricate(:notification, user: other_user, topic: pm)
+    Fabricate(:notification, user: other_user, topic: pm)
+    Fabricate(:notification, user: other_user, topic: pm)
+
+    User.any_instance.expects(:publish_notifications_state).once
+
+    described_class.new.execute(topic_id: pm.id)
+  end
+
+  context "with user_ids arg" do
+    it "only considers the given users" do
+      Fabricate(:notification, user: other_user, topic: pm)
+      third_user = Fabricate(:user)
+      third_notification = Fabricate(:notification, user: third_user, topic: pm)
+
+      described_class.new.execute(topic_id: pm.id, user_ids: [other_user.id])
+
+      expect(Notification.exists?(third_notification.id)).to eq(true)
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1301,6 +1301,18 @@ RSpec.describe Group do
       expect(events).to include(:user_removed_from_group)
     end
 
+    it "enqueues an inaccessible-notifications cleanup for each PM the group is on" do
+      pm_topic = Fabricate(:private_message_topic)
+      Fabricate(:topic_allowed_group, topic: pm_topic, group: group)
+
+      expect_enqueued_with(
+        job: :delete_inaccessible_notifications,
+        args: {
+          topic_id: pm_topic.id,
+        },
+      ) { group.remove(user) }
+    end
+
     describe "with webhook" do
       fab!(:group_user_web_hook)
 
@@ -1652,6 +1664,18 @@ RSpec.describe Group do
       result = group.bulk_remove([user.id, admin.id, admin.id + 1000])
 
       expect(result).to contain_exactly(user.id, admin.id)
+    end
+
+    it "enqueues an inaccessible-notifications cleanup for each PM the group is on" do
+      pm_topic = Fabricate(:private_message_topic)
+      Fabricate(:topic_allowed_group, topic: pm_topic, group: group)
+
+      expect_enqueued_with(
+        job: :delete_inaccessible_notifications,
+        args: {
+          topic_id: pm_topic.id,
+        },
+      ) { group.bulk_remove([user.id, admin.id]) }
     end
 
     it "clears primary_group_id" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1301,16 +1301,18 @@ RSpec.describe Group do
       expect(events).to include(:user_removed_from_group)
     end
 
-    it "enqueues an inaccessible-notifications cleanup for each PM the group is on" do
-      pm_topic = Fabricate(:private_message_topic)
-      Fabricate(:topic_allowed_group, topic: pm_topic, group: group)
+    it "enqueues an inaccessible-notifications cleanup for each PM the removed user has notifications on" do
+      pm_topic1 = Fabricate(:private_message_topic)
+      pm_topic2 = Fabricate(:private_message_topic)
+      Fabricate(:topic_allowed_group, topic: pm_topic1, group: group)
+      Fabricate(:topic_allowed_group, topic: pm_topic2, group: group)
+      Fabricate(:notification, user: user, topic: pm_topic1)
+      Fabricate(:notification, user: user, topic: pm_topic2)
 
-      expect_enqueued_with(
-        job: :delete_inaccessible_notifications,
-        args: {
-          topic_id: pm_topic.id,
-        },
-      ) { group.remove(user) }
+      group.remove(user)
+
+      expect_job_enqueued(job: :delete_inaccessible_notifications, args: { topic_id: pm_topic1.id })
+      expect_job_enqueued(job: :delete_inaccessible_notifications, args: { topic_id: pm_topic2.id })
     end
 
     describe "with webhook" do
@@ -1666,16 +1668,18 @@ RSpec.describe Group do
       expect(result).to contain_exactly(user.id, admin.id)
     end
 
-    it "enqueues an inaccessible-notifications cleanup for each PM the group is on" do
-      pm_topic = Fabricate(:private_message_topic)
-      Fabricate(:topic_allowed_group, topic: pm_topic, group: group)
+    it "enqueues an inaccessible-notifications cleanup for each PM a removed user has notifications on" do
+      pm_topic1 = Fabricate(:private_message_topic)
+      pm_topic2 = Fabricate(:private_message_topic)
+      Fabricate(:topic_allowed_group, topic: pm_topic1, group: group)
+      Fabricate(:topic_allowed_group, topic: pm_topic2, group: group)
+      Fabricate(:notification, user: user, topic: pm_topic1)
+      Fabricate(:notification, user: admin, topic: pm_topic2)
 
-      expect_enqueued_with(
-        job: :delete_inaccessible_notifications,
-        args: {
-          topic_id: pm_topic.id,
-        },
-      ) { group.bulk_remove([user.id, admin.id]) }
+      group.bulk_remove([user.id, admin.id])
+
+      expect_job_enqueued(job: :delete_inaccessible_notifications, args: { topic_id: pm_topic1.id })
+      expect_job_enqueued(job: :delete_inaccessible_notifications, args: { topic_id: pm_topic2.id })
     end
 
     it "clears primary_group_id" do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3689,8 +3689,6 @@ RSpec.describe Topic do
     end
 
     it "enqueues an inaccessible-notifications cleanup for the topic" do
-      pm_group.add(moderator)
-
       private_topic =
         Fabricate(
           :private_message_topic,

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3614,6 +3614,47 @@ RSpec.describe Topic do
         }.by(1)
       end
     end
+
+    it "removes notifications when the removed user loses access" do
+      notification =
+        Fabricate(
+          :notification,
+          user: user1,
+          topic: private_topic,
+          notification_type: Notification.types[:private_message],
+          read: false,
+        )
+
+      user1.expects(:publish_notifications_state).once
+
+      expect { private_topic.remove_allowed_user(admin, user1) }.to change {
+        Notification.exists?(notification.id)
+      }.from(true).to(false)
+
+      expect(Guardian.new(user1).can_see?(private_topic)).to eq(false)
+    end
+
+    it "preserves notifications when the removed user still has group access" do
+      group.add(user1)
+      Fabricate(:topic_allowed_group, topic: private_topic, group: group)
+
+      notification =
+        Fabricate(
+          :notification,
+          user: user1,
+          topic: private_topic,
+          notification_type: Notification.types[:private_message],
+          read: false,
+        )
+
+      user1.expects(:publish_notifications_state).never
+
+      expect { private_topic.remove_allowed_user(admin, user1) }.not_to change {
+        Notification.exists?(notification.id)
+      }
+
+      expect(Guardian.new(user1).can_see?(private_topic)).to eq(true)
+    end
   end
 
   describe "#remove_allowed_group" do
@@ -3645,6 +3686,25 @@ RSpec.describe Topic do
       small_action = private_topic.posts.where(action_code: "removed_group").last
       expect(small_action).to be_present
       expect(small_action.user).to eq(moderator)
+    end
+
+    it "enqueues an inaccessible-notifications cleanup for the topic" do
+      pm_group.add(moderator)
+
+      private_topic =
+        Fabricate(
+          :private_message_topic,
+          user: admin,
+          topic_allowed_users: [Fabricate.build(:topic_allowed_user, user: admin)],
+          topic_allowed_groups: [Fabricate.build(:topic_allowed_group, group: pm_group)],
+        )
+
+      expect_enqueued_with(
+        job: :delete_inaccessible_notifications,
+        args: {
+          topic_id: private_topic.id,
+        },
+      ) { private_topic.remove_allowed_group(admin, pm_group.name) }
     end
   end
 


### PR DESCRIPTION
The notification list Guardian-filters inaccessible topics, but the unread-badge counter (raw SQL COUNT) does not. When a user lost PM access, stale notification rows kept inflating the badge — the menu showed nothing new, but the count wouldn't clear.

Discourse already has `Jobs::DeleteInaccessibleNotifications` (used by `TopicConverter` and `PostMover`). This PR:

- Wires it into `Topic#remove_allowed_user` (inline, Guardian-guarded so users with group-based access are preserved), `Topic#remove_allowed_group`, and `GroupManager#remove/bulk_remove`.
- Narrows the `GroupManager` enqueue to topics where removed users actually have notifications, and passes `user_ids` so the job scopes its work — prevents fan-out when a large group sits on many PMs.
- Rewrites the job: Guardian-check once per user (not per notification), single batched `delete_all`, one publish_notifications_state` per user.
- Adds a post-deploy backfill migration to clean up existing orphaned PM notifications.

Category-permission, trust-level, and direct `GroupUser#destroy` paths (SSO, auto-groups) are left as follow-ups.

[`/t/311995`](https://meta.discourse.org/t/cant-clear-unread-notification-after-being-removed-from-a-pm/311995)
[`/t/384961`](https://meta.discourse.org/t/sticky-unread-reply-notification/384961)