### PR TITLE
A11Y: shorten long redundant input labels

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3288,6 +3288,7 @@ en:
 
     d_icon_grid_picker:
       select_icon: "Select icon"
+      search_label: "Search icons"
       search_placeholder: "Search icons..."
       no_results: "No icons found"
       results_count:
@@ -5768,6 +5769,7 @@ en:
     invalid_video_url: This video cannot be played because the URL is invalid or unavailable.
 
     keyboard_shortcuts_help:
+      search_label: "Search shortcuts"
       search_placeholder: "Search for a shortcut by description or key combination"
       shortcut_key_delimiter_comma: ", "
       shortcut_key_delimiter_plus: "+"

--- a/frontend/discourse/app/components/modal/keyboard-shortcuts-help.gjs
+++ b/frontend/discourse/app/components/modal/keyboard-shortcuts-help.gjs
@@ -518,7 +518,7 @@ export default class KeyboardShortcutsHelp extends Component {
             @filterAction={{this.filterShortcuts}}
             @value={{this.searchTerm}}
             placeholder={{i18n "keyboard_shortcuts_help.search_placeholder"}}
-            aria-label={{i18n "keyboard_shortcuts_help.search_placeholder"}}
+            aria-label={{i18n "keyboard_shortcuts_help.search_label"}}
           />
 
           <div class="keyboard-shortcuts-help__container">

--- a/frontend/discourse/app/ui-kit/d-icon-grid-picker/content.gjs
+++ b/frontend/discourse/app/ui-kit/d-icon-grid-picker/content.gjs
@@ -291,7 +291,7 @@ export default class DIconGridPickerContent extends Component {
     >
       <div class="d-icon-grid-picker__filter-container">
         <DFilterInput
-          aria-label={{i18n "d_icon_grid_picker.search_placeholder"}}
+          aria-label={{i18n "d_icon_grid_picker.search_label"}}
           aria-controls="d-icon-grid-picker-listbox"
           placeholder={{i18n "d_icon_grid_picker.search_placeholder"}}
           @value={{this.filter}}


### PR DESCRIPTION
This just shortens a couple aria-labels that were reusing placeholder content. Some screenreaders will read both the aria-label and placeholder, so the aria-label being shorter avoids some really long duplicate reading. 