### PR TITLE
UX: improve margin of horizon new topic button

### DIFF
--- a/themes/horizon/scss/sidebar-new-topic-button.scss
+++ b/themes/horizon/scss/sidebar-new-topic-button.scss
@@ -10,8 +10,7 @@
   &__wrapper {
     box-sizing: border-box;
     display: flex;
-    border-radius: 6.25em;
-    margin-top: 4px; // hover & focus effect visibility
+    margin: var(--space-2) var(--space-6) 0 var(--space-2);
 
     &:focus-visible,
     &:hover {

--- a/themes/horizon/scss/sidebar.scss
+++ b/themes/horizon/scss/sidebar.scss
@@ -86,10 +86,6 @@ body.has-full-page-chat .sidebar-wrapper,
   }
 }
 
-.sidebar-new-topic-button__wrapper {
-  margin: 0 var(--space-2) var(--space-4) var(--space-4);
-}
-
 // put the draft menu above the slide-out hamburger on small desktop screens
 @include viewport.until(md) {
   html:not(.mobile-view) {


### PR DESCRIPTION
Consolidates some styles and improves spacing consistency

before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/42af9b46-ddd3-4889-b096-6c1623d0b969" />


after
<img width="350" alt="image" src="https://github.com/user-attachments/assets/331cca12-3333-4af0-978c-b52821cf68c2" />
