### PR TITLE
UX: apply border radius to tag choosers

### DIFF
--- a/app/assets/stylesheets/common/select-kit/tag-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/tag-chooser.scss
@@ -2,7 +2,7 @@
   &.tag-chooser,
   &.mini-tag-chooser,
   &.tag-drop {
-    border-radius: var(--d-border-radius);
+    border-radius: var(--d-input-border-radius);
 
     .select-kit-row {
       display: flex;

--- a/app/assets/stylesheets/common/select-kit/tag-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/tag-chooser.scss
@@ -2,6 +2,8 @@
   &.tag-chooser,
   &.mini-tag-chooser,
   &.tag-drop {
+    border-radius: var(--d-border-radius);
+
     .select-kit-row {
       display: flex;
       align-items: baseline;


### PR DESCRIPTION
Some unrounded background can leak through sometimes, so this rounds it 

before (the little white corners)
<img width="618" height="128" alt="image" src="https://github.com/user-attachments/assets/778bb07f-bf9b-44cf-8acc-3184332f8934" />


after
<img width="644" height="182" alt="image" src="https://github.com/user-attachments/assets/12045e2d-55f9-4137-a3b1-ad0d96a951e7" />
