### PR TITLE
DEV: Use constant-time signature comparison for DiscourseConnect HMAC validation

### DIFF
--- a/lib/discourse_connect_base.rb
+++ b/lib/discourse_connect_base.rb
@@ -103,15 +103,19 @@ class DiscourseConnectBase
     decoded = Base64.decode64(parsed["sso"])
     decoded_hash = Rack::Utils.parse_query(decoded)
 
-    raise SignatureError, <<~MSG if sso.sign(parsed["sso"]) != parsed["sig"]
+    expected_sig = sso.sign(parsed["sso"])
+
+    if !ActiveSupport::SecurityUtils.secure_compare(expected_sig, parsed["sig"].to_s)
+      raise SignatureError, <<~MSG
         Bad signature for payload
 
         sso: #{parsed["sso"]}
         
         sig: #{parsed["sig"]}
         
-        expected sig: #{sso.sign(parsed["sso"])}
+        expected sig: #{expected_sig}
         MSG
+    end
 
     ACCESSORS.each do |k|
       val = decoded_hash[k.to_s]

--- a/lib/discourse_connect_provider.rb
+++ b/lib/discourse_connect_provider.rb
@@ -76,7 +76,10 @@ class DiscourseConnectProvider < DiscourseConnectBase
       provider_secrets.find do |domain, configured_secret|
         if WildcardDomainChecker.check_domain(domain, return_url_host)
           first_domain_match ||= configured_secret
-          sign(parsed_payload["sso"], configured_secret) == parsed_payload["sig"]
+          ActiveSupport::SecurityUtils.secure_compare(
+            sign(parsed_payload["sso"], configured_secret),
+            parsed_payload["sig"].to_s,
+          )
         end
       end
 


### PR DESCRIPTION
## Summary

Replace byte-by-byte string equality comparisons with constant-time `ActiveSupport::SecurityUtils.secure_compare` when validating HMAC signatures at both DiscourseConnect boundaries — the consumer-facing base parser and the provider-secret lookup. The provided signature is coerced to a string before comparison so missing or malformed values fail validation cleanly rather than raising, and no behavioral or flow changes are made to the authentication endpoints.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1395

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>