### PR TITLE
FIX: Hide browser pageview cards in legacy mode

### DIFF
--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -40,7 +40,7 @@ class AdminDashboardSiteTraffic
       pageview_series: pageview_series(current_rows, include_embedded: include_embedded),
     }
 
-    if SiteSetting.persist_browser_pageview_events
+    if SiteSetting.persist_browser_pageview_events && !SiteSetting.use_legacy_pageviews
       top_countries = fetch_card("top_countries_by_browser_pageviews")
       response[:top_countries] = top_countries if top_countries
 

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -644,8 +644,7 @@ RSpec.describe AdminDashboardSiteTraffic do
         SiteSetting.use_legacy_pageviews = true
 
         result = build_traffic(start_date: nil, end_date: nil)
-        expect(result).not_to have_key(:top_countries)
-        expect(result).not_to have_key(:top_referrers)
+        expect(result.keys).to contain_exactly(:kpis, :pageview_series)
       end
 
       it "returns top_countries and top_referrers with rows and no error when matching events exist" do

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -640,6 +640,14 @@ RSpec.describe AdminDashboardSiteTraffic do
         expect(result).not_to have_key(:top_referrers)
       end
 
+      it "omits top_countries and top_referrers when legacy pageviews are enabled" do
+        SiteSetting.use_legacy_pageviews = true
+
+        result = build_traffic(start_date: nil, end_date: nil)
+        expect(result).not_to have_key(:top_countries)
+        expect(result).not_to have_key(:top_referrers)
+      end
+
       it "returns top_countries and top_referrers with rows and no error when matching events exist" do
         6.times do
           Fabricate(:browser_pageview_event, country_code: "US", normalized_referrer: "google.com")


### PR DESCRIPTION
Top countries and Top referrers rely on browser pageview events, so showing them while legacy pageviews are enabled can produce dashboard data that does not match the selected pageview source.

Skip browser-pageview-dependent Site Traffic cards in legacy mode while leaving the remaining traffic payload unchanged.