### PR TITLE
DEV: Rearranging settings for content localization

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2950,7 +2950,7 @@ en:
     content_localization_language_switcher: "Show a language switcher in the header, allowing visitors to switch between translated versions of Discourse and user-contributed content. Uses languages defined in {{setting:content_localization_supported_locales}}"
     content_localization_crawler_param: "Serve localized content to web crawlers when {{setting:content_localization_enabled}} and {{setting:set_locale_from_param}} is enabled. The list of supported locales is defined in {{setting:content_localization_supported_locales}}."
     content_localization_use_default_locale_when_unsupported: "Serve localized content in the site's default locale to users whose preferred language is not listed in 'content localization supported locales'."
-    content_localization_allow_author_localization: "Allow authors update localizations of their own topics and posts via the post menu."
+    content_localization_allow_author_localization: "Allow authors to update localizations of their own topics and posts via the post menu."
     nested_replies_enabled: "Enable the nested replies view for topics."
     nested_replies_default: "Use nested replies as the default view for all topics."
     nested_replies_hot_sort_enabled: "Allow people to sort nested replies by a demand-driven hot score. Hot scores are calculated in the background only for topics where hot sorting is requested."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -222,31 +222,6 @@ basic:
     client: true
     default: false
     area: "localization"
-  allow_user_locale:
-    client: true
-    default: true
-    area: "localization"
-  set_locale_from_accept_language_header:
-    default: false
-    client: true
-    validator: "AllowUserLocaleEnabledValidator"
-    area: "localization"
-    depends_on:
-      - "allow_user_locale"
-  set_locale_from_cookie:
-    default: false
-    client: true
-    validator: "AllowUserLocaleEnabledValidator"
-    area: "localization"
-    depends_on:
-      - "allow_user_locale"
-  set_locale_from_param:
-    default: false
-    client: true
-    validator: "AllowUserLocaleEnabledValidator"
-    area: "localization"
-    depends_on:
-      - "allow_user_locale"
   support_mixed_text_direction:
     client: true
     default: false
@@ -1932,10 +1907,33 @@ posting:
     hidden: true
 
 content_localization:
+  allow_user_locale:
+    client: true
+    default: true
+    area: "localization"
   content_localization_enabled:
     client: true
     default: false
     area: "localization"
+  content_localization_supported_locales:
+    default: ""
+    type: list
+    client: true
+    list_type: locale
+    allow_any: false
+    enum: "LocaleSiteSetting"
+    area: "localization"
+    validator: "ContentLocalizationLocalesValidator"
+  content_localization_language_switcher:
+    type: enum
+    choices:
+      - none
+      - anonymous
+      - all
+    default: none
+    client: true
+    area: "localization"
+    validator: "LanguageSwitcherSettingValidator"
   content_localization_allowed_groups:
     type: group_list
     list_type: compact
@@ -1948,29 +1946,10 @@ content_localization:
     default: true
     client: true
     area: "localization"
-  content_localization_supported_locales:
-    default: ""
-    type: list
-    client: true
-    list_type: locale
-    allow_any: false
-    enum: "LocaleSiteSetting"
-    area: "localization"
-    validator: "ContentLocalizationLocalesValidator"
   content_localization_max_locales:
     default: 10
     type: integer
     hidden: true
-  content_localization_language_switcher:
-    type: enum
-    choices:
-      - none
-      - anonymous
-      - all
-    default: none
-    client: true
-    area: "localization"
-    validator: "LanguageSwitcherSettingValidator"
   content_localization_crawler_param:
     default: false
     area: "localization"
@@ -1978,6 +1957,27 @@ content_localization:
   content_localization_use_default_locale_when_unsupported:
     default: true
     area: "localization"
+  set_locale_from_accept_language_header:
+    default: false
+    client: true
+    validator: "AllowUserLocaleEnabledValidator"
+    area: "localization"
+    depends_on:
+      - "allow_user_locale"
+  set_locale_from_cookie:
+    default: false
+    client: true
+    validator: "AllowUserLocaleEnabledValidator"
+    area: "localization"
+    depends_on:
+      - "allow_user_locale"
+  set_locale_from_param:
+    default: false
+    client: true
+    validator: "AllowUserLocaleEnabledValidator"
+    area: "localization"
+    depends_on:
+      - "allow_user_locale"
 
 nested_replies:
   nested_replies_enabled:

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -509,7 +509,8 @@ export default class AiTranslations extends Component {
           />
           <actions.Default
             @label="discourse_ai.translations.admin_actions.localization_settings"
-            @route="adminConfig.localization.settings"
+            @route="adminSiteSettingsCategory"
+            @routeModels="content_localization"
             class="ai-localization-settings-button"
           />
         </:actions>

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -112,10 +112,10 @@ describe "Admin AI translations" do
       )
     end
 
-    it "navigates to app language settings when clicking the app language button" do
+    it "takes the user to content localization settings when clicking the localization settings button" do
       find(".ai-localization-settings-button").click
 
-      expect(page).to have_current_path("/admin/config/localization")
+      expect(page).to have_current_path("/admin/site_settings/category/content_localization")
     end
 
     it "toggles the selected target for the upcoming details panel" do


### PR DESCRIPTION
Routes the "App language settings" button here

<img width="1127" height="523" alt="Screenshot 2026-08-07 at 3 32 06 PM" src="https://github.com/user-attachments/assets/0506543f-7c37-4916-866b-e59fdbf6fedc" />

to here

<img width="1127" height="672" alt="Screenshot 2026-08-07 at 3 32 36 PM" src="https://github.com/user-attachments/assets/62427680-166f-45e9-83d6-8542079198ec" />

and rearrange the order of some settings.