### PR TITLE
DEV: prevent backfill of uncategorized category definition

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,6 +16,12 @@ class Category < ActiveRecord::Base
   SLUG_REF_SEPARATOR = ":"
   DEFAULT_TEXT_COLORS = %w[FFFFFF 000000]
 
+  # Set on a category that intentionally has no definition topic, so
+  # `ensure_consistency!` does not backfill one for it.
+  SKIP_DEFINITION_CUSTOM_FIELD = "skip_category_definition"
+
+  register_custom_field_type(SKIP_DEFINITION_CUSTOM_FIELD, :boolean)
+
   belongs_to :topic
   belongs_to :topic_only_relative_url,
              -> { select "id, title, slug" },
@@ -605,7 +611,7 @@ class Category < ActiveRecord::Base
   end
 
   def create_category_definition
-    return if skip_category_definition
+    return if skip_category_definition || custom_fields[SKIP_DEFINITION_CUSTOM_FIELD]
 
     Topic.transaction do
       t =

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -12,7 +12,8 @@
 # Uncategorized category), the now-normal category is pinned as the
 # `default_composer_category` so the composer keeps pre-selecting it. An
 # explicit default already pointing at that category needs no change — the id
-# simply becomes a normal category.
+# simply becomes a normal category. The exemption from definition topics moves
+# from the setting onto the category itself.
 #
 # The site's prior state is snapshotted onto the change's UpcomingChangeEvent
 # so that opt-out can either restore the special category or do nothing.
@@ -53,6 +54,13 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
 
       SiteSetting.set_and_log(:uncategorized_category_id, -1)
       SiteSetting.set_and_log(:allow_uncategorized_topics, false)
+
+      # Definition topics were skipped for the special category only by virtue
+      # of `uncategorized_category_id` pointing at it, so move the exemption
+      # onto the category before it stops matching.
+      Category.find_by(id: former_uncategorized_id)&.upsert_custom_fields(
+        Category::SKIP_DEFINITION_CUSTOM_FIELD => true,
+      )
     end
 
     Site.clear_cache
@@ -73,6 +81,10 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
       if SiteSetting.default_composer_category != snapshot["default_composer_category"]
         SiteSetting.set_and_log(:default_composer_category, snapshot["default_composer_category"])
       end
+
+      Category.find_by(id: snapshot["uncategorized_category_id"])&.upsert_custom_fields(
+        Category::SKIP_DEFINITION_CUSTOM_FIELD => false,
+      )
     end
 
     Site.clear_cache

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -82,9 +82,12 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
         SiteSetting.set_and_log(:default_composer_category, snapshot["default_composer_category"])
       end
 
-      Category.find_by(id: snapshot["uncategorized_category_id"])&.upsert_custom_fields(
-        Category::SKIP_DEFINITION_CUSTOM_FIELD => false,
-      )
+      # The category is special again, so the setting covers it once more and
+      # the exemption returns to being absent rather than explicitly false.
+      CategoryCustomField.where(
+        category_id: snapshot["uncategorized_category_id"],
+        name: Category::SKIP_DEFINITION_CUSTOM_FIELD,
+      ).delete_all
     end
 
     Site.clear_cache

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1427,6 +1427,16 @@ RSpec.describe Category do
       expect(category_destroyed.reload.topic).to_not eq(nil)
       expect(category_trashed.reload.topic).to_not eq(nil)
     end
+
+    it "does not create a category topic for a category exempted from definition topics" do
+      category = Fabricate(:category_with_definition)
+      category.topic.destroy!
+      category.upsert_custom_fields(Category::SKIP_DEFINITION_CUSTOM_FIELD => true)
+
+      Category.ensure_consistency!
+
+      expect(category.reload.topic_id).to eq(nil)
+    end
   end
 
   describe "#find_by_slug_path" do

--- a/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
+++ b/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       expect(uncategorized.reload.uncategorized?).to eq(false)
     end
 
+    it "exempts the demoted category from being backfilled a definition topic" do
+      described_class.call(enabled: true)
+      Category.ensure_consistency!
+
+      expect(uncategorized.reload.topic_id).to eq(nil)
+    end
+
     it "leaves default_composer_category pointing at the now-normal category" do
       SiteSetting.default_composer_category = uncategorized.id.to_s
 
@@ -129,6 +136,7 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       SiteSetting.uncategorized_category_id = -1
       SiteSetting.allow_uncategorized_topics = false
       SiteSetting.default_composer_category = ""
+      uncategorized.upsert_custom_fields(Category::SKIP_DEFINITION_CUSTOM_FIELD => true)
 
       described_class.call(enabled: false)
 
@@ -136,6 +144,7 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       expect(SiteSetting.allow_uncategorized_topics).to eq(true)
       expect(SiteSetting.default_composer_category).to eq(uncategorized.id.to_s)
       expect(uncategorized.reload.uncategorized?).to eq(true)
+      expect(uncategorized.custom_fields[Category::SKIP_DEFINITION_CUSTOM_FIELD]).to eq(false)
     end
 
     it "does nothing when the site was not using uncategorized topics at opt-in" do

--- a/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
+++ b/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       expect(SiteSetting.allow_uncategorized_topics).to eq(true)
       expect(SiteSetting.default_composer_category).to eq(uncategorized.id.to_s)
       expect(uncategorized.reload.uncategorized?).to eq(true)
-      expect(uncategorized.custom_fields[Category::SKIP_DEFINITION_CUSTOM_FIELD]).to eq(false)
+      expect(uncategorized.custom_fields).not_to include(Category::SKIP_DEFINITION_CUSTOM_FIELD)
     end
 
     it "does nothing when the site was not using uncategorized topics at opt-in" do


### PR DESCRIPTION
In #41169 we demoted the uncategorized category, a knock on effect is that `Jobs::EnsureDbConsistency` backfills the definition topic as `SiteSetting.uncategorized_category_id` (now set to `-1`) no longer matches the original uncategorized category id.

Previously it would be skipped due to the check in the [Category.ensure_consistency!](https://github.com/discourse/discourse/blob/main/app/models/category.rb#L1253) against the site setting value.

The solution here is to upsert a custom field to the original uncategorized topic so that the backfill job that runs every 12 hours does not attempt to create the definition topic.