### PR TITLE
FIX: preserve scroll position when returning to user activity streams

### DIFF
--- a/frontend/discourse/app/routes/user-activity-stream.js
+++ b/frontend/discourse/app/routes/user-activity-stream.js
@@ -1,28 +1,36 @@
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
+const STREAM_KEY = Symbol("user-activity-stream");
+
 export default class UserActivityStream extends DiscourseRoute {
+  @service historyStore;
+
   templateName = "user/stream";
 
   queryParams = {
     acting_username: { refreshModel: true },
   };
 
-  model() {
-    const user = this.modelFor("user");
-    const stream = user.get("stream");
+  async model(params) {
+    // Reuse the stream we left behind, including the items infinite scroll
+    // appended. Reloading it would leave the page shorter than it was, and the
+    // scroll position restored by route-scroll-manager would be clamped.
+    let stream = this.historyStore.isPoppedState
+      ? this.historyStore.get(STREAM_KEY)
+      : null;
 
-    return {
-      stream,
-      emptyState: this.emptyState(),
-    };
-  }
+    if (!stream) {
+      stream = this.modelFor("user").stream;
+      await stream.filterBy({
+        filter: this.userActionType,
+        actingUsername: params.acting_username,
+      });
+      this.historyStore.set(STREAM_KEY, stream);
+    }
 
-  afterModel(model, transition) {
-    return model.stream.filterBy({
-      filter: this.userActionType,
-      actingUsername: transition.to.queryParams.acting_username,
-    });
+    return { stream, emptyState: this.emptyState() };
   }
 
   setupController() {

--- a/spec/system/page_objects/pages/user_activity_stream.rb
+++ b/spec/system/page_objects/pages/user_activity_stream.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class UserActivityStream < PageObjects::Pages::Base
+      def visit_replies(user)
+        page.visit("/u/#{user.username_lower}/activity/replies")
+        self
+      end
+
+      def has_items?(count:)
+        page.has_css?(".user-stream-item", count:)
+      end
+
+      def scroll_to_bottom
+        page.scroll_to(:bottom)
+        self
+      end
+
+      def scroll_to_item(index)
+        page.execute_script(
+          "document.querySelectorAll('.user-stream-item')[#{index}].scrollIntoView(true)",
+        )
+        self
+      end
+
+      def open_item(index)
+        page.all(".user-stream-item .title a")[index].click
+        self
+      end
+
+      def scroll_position
+        page.evaluate_script("window.scrollY")
+      end
+    end
+  end
+end

--- a/spec/system/user_activity_scroll_restoration_spec.rb
+++ b/spec/system/user_activity_scroll_restoration_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe "User activity scroll restoration" do
+  before_all { UserActionManager.enable }
+
+  fab!(:user)
+
+  # 40 replies: the stream serves 30 per page, so the rest arrive via infinite scroll
+  fab!(:topics) do
+    Fabricate
+      .times(5, :topic)
+      .each do |topic|
+        Fabricate
+          .times(9, :post, topic:, user:)
+          .each { |post| UserActionManager.post_created(post) }
+      end
+  end
+
+  let(:activity_stream) { PageObjects::Pages::UserActivityStream.new }
+
+  it "takes the user back to where they were reading after they open a post and go back" do
+    activity_stream.visit_replies(user)
+    expect(activity_stream).to have_items(count: 30)
+
+    activity_stream.scroll_to_bottom
+    expect(activity_stream).to have_items(count: 40)
+
+    activity_stream.scroll_to_item(35)
+    position = activity_stream.scroll_position
+
+    activity_stream.open_item(36)
+    expect(page).to have_css("#topic-title")
+
+    page.go_back
+    expect(activity_stream).to have_items(count: 40)
+
+    try_until_success(reason: "scroll position is restored") do
+      expect(activity_stream.scroll_position).to be_within(20).of(position)
+    end
+  end
+end


### PR DESCRIPTION
Scrolling a user activity stream far enough to trigger infinite scroll, opening a topic, then pressing back would land the user higher up the page than where they left off.

The scroll position was being restored correctly, but the stream was refetched from scratch, so the page only held its first page of items and was too short to scroll back to the saved offset — the browser clamped it.

On a back/forward navigation we now reuse the stream we left behind, including everything infinite scroll appended, so the page is the same height it was and the restored position lands where the user was reading. The stream is stored per history entry via the historyStore service, so ordinary forward navigation still loads a fresh stream.

Meta bug report: https://meta.discourse.org/t/regression-u-username-activity-loses-scroll-position-after-browser-back/406292