### PR TITLE
DEV: Do not show email invite option if it is disabled in site settings

### DIFF
--- a/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
+++ b/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
@@ -80,6 +80,10 @@ export default class CreateInviteWithRoles extends Component {
     this.initialStaffRole = this.staffRole;
   }
 
+  get allowEmailInvites() {
+    return this.siteSettings.allow_email_invites;
+  }
+
   get canInviteAdmins() {
     return !!this.currentUser?.can_create_admin_invite;
   }
@@ -677,9 +681,11 @@ export default class CreateInviteWithRoles extends Component {
                       <Condition @name="link">{{i18n
                           "user.invited.invite_roles.invite_by_link"
                         }}</Condition>
-                      <Condition @name="email">{{i18n
-                          "user.invited.invite_roles.invite_by_email"
-                        }}</Condition>
+                      {{#if this.allowEmailInvites}}
+                        <Condition @name="email">{{i18n
+                            "user.invited.invite_roles.invite_by_email"
+                          }}</Condition>
+                      {{/if}}
                     </conditional.Conditions>
                   </fieldset>
                 {{/unless}}


### PR DESCRIPTION
We should not show the email invite option if it is disabled in site settings.

<img width="1104" height="788" alt="CleanShot 2026-08-07 at 08 01 55@2x" src="https://github.com/user-attachments/assets/2f275a22-f8ef-4d40-92ca-b8d62f35d194" />
