### PR TITLE
UX: more consistent horizon new topic button alignment, plus a fade!

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -29,7 +29,7 @@
   --nav-space: var(--space-3);
   --nav-horizontal-padding: 0em;
   --d-main-content-gap: var(--space-8);
-  --main-outlet-padding-top: var(--space-6);
+  --main-outlet-padding-top: var(--space-4);
   --main-outlet-padding-x: 0em;
   --main-outlet-padding-bottom: 0em;
   --table-border-width: 1px;

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -9,8 +9,8 @@
   }
 
   --d-sidebar-vertical-gap: var(--space-half);
-  --sidebar-section-wrapper-padding: var(--space-6) var(--space-2)
-    var(--space-4);
+  --sidebar-section-wrapper-padding: var(--main-outlet-padding-top)
+    var(--space-2) var(--space-4);
 
   // ems so height is variable along with font size
   --d-sidebar-row-height: 2.2em;

--- a/app/assets/stylesheets/common/upcoming-changes/uc-modernize-foundation-theme/sidebar.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-modernize-foundation-theme/sidebar.scss
@@ -1,6 +1,4 @@
 :where(.uc-modernize-foundation-theme) {
-  --sidebar-section-wrapper-padding: var(--main-outlet-padding-top)
-    var(--space-2) var(--space-4);
   --d-sidebar-active-background: var(--token-color-surface-hovered);
   --d-sidebar-active-color: var(--token-color-text-default);
   --d-sidebar-link-color: var(--token-color-text-subtle);

--- a/app/assets/stylesheets/common/upcoming-changes/uc-modernize-foundation-theme/variables.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-modernize-foundation-theme/variables.scss
@@ -6,7 +6,6 @@
   -webkit-font-smoothing: var(--webkit-font-smoothing);
 
   // Misc
-  --main-outlet-padding-top: var(--space-4);
   --d-nav-underline-height: var(--space-half);
   --d-input-border: 1px solid var(--primary-300);
   --input-border-color: var(--primary-300);

--- a/themes/horizon/scss/sidebar-new-topic-button.scss
+++ b/themes/horizon/scss/sidebar-new-topic-button.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .has-ai-conversations-sidebar {
   .sidebar-new-topic-button__wrapper {
     display: none;
@@ -11,6 +13,25 @@
     box-sizing: border-box;
     display: flex;
     margin: var(--space-2) var(--space-6) 0 var(--space-2);
+    position: relative;
+
+    @include viewport.from(lg) {
+      &:not(:hover, :focus-visible) {
+        &::after {
+          content: "";
+          width: 100%;
+          height: var(--space-4);
+          position: absolute;
+          bottom: calc(var(--space-4) * -1);
+          background: linear-gradient(
+            to top,
+            transparent 0,
+            var(--background-color) 100%
+          );
+          z-index: 1;
+        }
+      }
+    }
 
     &:focus-visible,
     &:hover {

--- a/themes/horizon/scss/sidebar.scss
+++ b/themes/horizon/scss/sidebar.scss
@@ -1,8 +1,6 @@
 @use "lib/viewport";
 
 :root {
-  --sidebar-section-wrapper-padding: 0 var(--space-2) var(--space-4)
-    var(--space-4);
   --d-sidebar-active-background: var(--d-selected);
 }
 


### PR DESCRIPTION
The change in https://github.com/discourse/discourse/commit/8774757849723e0f8b3d8e2f67ce2eee192c64a9 adjusted the new topic button margin in Horizon, but didn't take into account sites with the "Modernized Foundation" upcoming change turned off... which resulted in no margin at all in some cases. 

This shuffles some styles around, pulls a few out of Modernized Foundation in to core, so we get more consistency here. 

I also added a fade on scroll below the new topic button in Horizon to improve the appearance on scroll: 

<img width="281" alt="image" src="https://github.com/user-attachments/assets/be36c62e-7a76-476b-a2e7-7f69b4dd3e44" />

Previously this was harsher: 

<img width="281" alt="image" src="https://github.com/user-attachments/assets/88e79dda-4c36-411f-9ea5-85e18344aedd" />
