### PR TITLE
FEATURE: Add a `livestream_allowed_hosts` site setting for livestreams [backport 2026.7]

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -61,11 +61,11 @@ module DiscoursePostEvent
     def reset_invalid_livestream
       return unless livestream?
 
-      self.livestream = false unless livestream_location? && post&.is_first_post?
+      self.livestream = false unless allowed_livestream_url? && post&.is_first_post?
     end
 
-    def livestream_location?
-      location.to_s.match?(%r{\Ahttps?://}i)
+    def allowed_livestream_url?
+      DiscourseCalendar::Livestream::AllowedHosts.allows_url?(livestream_url)
     end
 
     def create_livestream_chat_channel

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -205,7 +205,9 @@ export default class CompactEventEditor extends Component {
   }
 
   get isLivestreamUrl() {
-    return this.hasLocation && isLivestreamUrl(this.location);
+    return (
+      this.hasLocation && isLivestreamUrl(this.location, this.siteSettings)
+    );
   }
 
   get locationIcon() {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -151,7 +151,7 @@ export default class PostEventBuilder extends Component {
     set("location", value);
     this.event.location = value;
 
-    if (!isLivestreamUrl(value)) {
+    if (!isLivestreamUrl(value, this.siteSettings)) {
       set("livestream", false);
       this.event.livestream = false;
     }
@@ -325,7 +325,8 @@ export default class PostEventBuilder extends Component {
 
   get showLivestream() {
     return (
-      isLivestreamUrl(this.event.location) && this.siteSettings.chat_enabled
+      isLivestreamUrl(this.event.location, this.siteSettings) &&
+      this.siteSettings.chat_enabled
     );
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -1,12 +1,65 @@
-// `([\w-]+\.)*` allows any subdomain, since livestream hosts routinely use them
-// (us06web.zoom.us, www.youtube.com). It cannot match a host that merely ends in
-// one of these names, because each captured label must be followed by a dot:
-// "notzoom.us" and "zoom.us.evil.com" are both rejected.
-const LIVESTREAM_URL =
-  /^(https?:\/\/)?([\w-]+\.)*(youtube\.com|youtu\.be|twitch\.tv|zoom\.us|kick\.com|tiktok\.com|instagram\.com|facebook\.com)\//i;
+let lastSetting;
+let lastHosts;
 
-export function isLivestreamUrl(url) {
-  return LIVESTREAM_URL.test(url ?? "");
+// A bare host, mirroring `AllowedHosts::HOST_FORMAT` on the server, which is
+// what the setting validator holds list entries to.
+const HOST_FORMAT =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+
+// Resolves the host the browser would actually connect to, so that percent
+// escapes, Unicode and separators are compared after the browser has had its
+// say rather than as written. `AllowedHosts.canonical_host` does the same on
+// the server.
+function canonicalHost(url) {
+  let parsed;
+  try {
+    parsed = new URL(url ?? "");
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:") {
+    return null;
+  }
+
+  return parsed.hostname.replace(/\.$/, "") || null;
+}
+
+// Parsed once per setting value because this runs on every location keystroke.
+function allowedHosts(setting) {
+  if (setting !== lastSetting) {
+    lastSetting = setting;
+    lastHosts = (setting ?? "")
+      .split("|")
+      .map((entry) => entry.trim())
+      .filter((entry) => HOST_FORMAT.test(entry))
+      .map((entry) => canonicalHost(`https://${entry}`))
+      .filter(Boolean);
+  }
+
+  return lastHosts;
+}
+
+// Mirrors DiscourseCalendar::Livestream::AllowedHosts on the server, down to
+// canonicalizing the URL rather than pattern-matching it: a location the editor
+// presents as a livestream must be one the save path still recognizes, or the
+// livestream flag is silently dropped. Subdomains are allowed because livestream
+// hosts routinely use them (us06web.zoom.us, www.youtube.com); a host that merely
+// ends in an allowed name is not, since the match is anchored to a label boundary.
+export function isLivestreamUrl(url, siteSettings) {
+  const hosts = allowedHosts(siteSettings?.livestream_allowed_hosts);
+  if (!hosts.length) {
+    return false;
+  }
+
+  const host = canonicalHost(url);
+  if (!host) {
+    return false;
+  }
+
+  return hosts.some(
+    (allowed) => host === allowed || host.endsWith(`.${allowed}`)
+  );
 }
 
 export function defaultReminderFor({ startsAt, endsAt, allDay } = {}) {

--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -73,6 +73,8 @@ en:
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
     calendar_first_day_of_week: "Set the first day of the week for calendar display. Options are Saturday, Sunday, or Monday."
     enable_events_category_type_setup: "Enables the Events category type option during category creation setup."
+    livestream_allowed_hosts: "Hosts that can be used as an event livestream."
+    livestream_allowed_hosts_invalid: "These entries are not hosts: %{hosts}. Enter the host on its own (for example zoom.us), which allows every URL on it and its subdomains."
     livestream_zoom_enabled: "Enable Zoom video embedding for livestream topics."
     livestream_zoom_sdk_key: "Zoom Meeting SDK client ID."
     livestream_zoom_sdk_secret: "Zoom Meeting SDK client secret."

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -141,6 +141,12 @@ discourse_calendar:
       impact: "feature,staff"
       learn_more_url: "https://meta.discourse.org/t/-/401309"
       requires_plugin_enabled: false
+  livestream_allowed_hosts:
+    type: host_list
+    default: "youtube.com|youtu.be|twitch.tv|zoom.us|kick.com|tiktok.com|instagram.com|facebook.com"
+    client: true
+    hidden: true
+    validator: "DiscourseCalendar::Livestream::AllowedHostsValidator"
   livestream_zoom_enabled:
     default: false
     client: true

--- a/plugins/discourse-calendar/lib/discourse_calendar/livestream/allowed_hosts.rb
+++ b/plugins/discourse-calendar/lib/discourse_calendar/livestream/allowed_hosts.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module DiscourseCalendar
+  module Livestream
+    # Server-side counterpart of `isLivestreamUrl` in raw-event-helper.js: both
+    # accept a host listed in `livestream_allowed_hosts` and any of its
+    # subdomains. Keep the two in sync.
+    module AllowedHosts
+      # Browsers drop these outright before parsing a URL, so a comparison that
+      # keeps them resolves a different host than the one that gets loaded.
+      IGNORED_CHARACTERS = /[\t\n\r]/
+
+      # A list entry is a bare host, never a URL: a scheme, port or path would
+      # suggest a single address can be allowed when everything on the host and
+      # its subdomains is. `AllowedHostsValidator` rejects the rest on save.
+      # ASCII only, so that the editor's copy of this cannot disagree with it
+      # over which characters make up a host. An international host is listed in
+      # punycode, which is the form it gets compared as either way.
+      HOST_FORMAT = /\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*\z/i
+
+      def self.list
+        SiteSetting.livestream_allowed_hosts.to_s.split("|").filter_map { |entry| normalize(entry) }
+      end
+
+      def self.allows_url?(url)
+        host = canonical_host(url)
+        return false if host.blank?
+
+        list.any? { |allowed| host == allowed || host.end_with?(".#{allowed}") }
+      end
+
+      # Canonicalized like the URLs it is compared against, so an entry written
+      # in another case or script still matches the host the browser resolves.
+      def self.normalize(entry)
+        entry = entry.to_s.strip
+        return if !entry.match?(HOST_FORMAT)
+
+        canonical_host("https://#{entry}")
+      end
+
+      # Resolves the host the browser would actually connect to. Matching the
+      # raw string instead lets an authority that only looks like an allowed
+      # host through: browsers treat a backslash as a separator, strip control
+      # characters, decode percent-escapes and map Unicode to punycode, so
+      # `https://allowed.example\@evil.example/` loads `allowed.example` while
+      # `https://%65vil.example/` loads `evil.example`.
+      def self.canonical_host(url)
+        cleaned = url.to_s.gsub(IGNORED_CHARACTERS, "").strip.tr("\\", "/")
+        uri = Addressable::URI.parse(cleaned)&.normalize
+        return if uri.nil? || uri.host.blank?
+        return if uri.scheme != "https"
+
+        uri.host
+      rescue Addressable::URI::InvalidURIError
+        nil
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/lib/discourse_calendar/livestream/allowed_hosts_validator.rb
+++ b/plugins/discourse-calendar/lib/discourse_calendar/livestream/allowed_hosts_validator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DiscourseCalendar
+  module Livestream
+    # Replaces the default `host_list` validator, which only rejects wildcards.
+    class AllowedHostsValidator
+      def initialize(opts = {})
+        @opts = opts
+      end
+
+      def valid_value?(val)
+        @invalid =
+          val
+            .to_s
+            .split("|")
+            .map(&:strip)
+            .reject(&:blank?)
+            .reject { |entry| entry.match?(AllowedHosts::HOST_FORMAT) }
+
+        @invalid.empty?
+      end
+
+      def error_message
+        I18n.t("site_settings.livestream_allowed_hosts_invalid", hosts: @invalid.join(", "))
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -211,6 +211,8 @@ module ::DiscoursePostEvent
 end
 
 require_relative "lib/discourse_calendar/engine"
+require_relative "lib/discourse_calendar/livestream/allowed_hosts"
+require_relative "lib/discourse_calendar/livestream/allowed_hosts_validator"
 require_relative "lib/discourse_calendar/livestream/topic_extension"
 require_relative "lib/discourse_calendar/livestream/chat_channel_extension"
 require_relative "lib/discourse_calendar/livestream/zoom_url_parser"

--- a/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/warm_livestream_onebox_spec.rb
+++ b/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/warm_livestream_onebox_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Jobs::WarmLivestreamOnebox do
-  let(:livestream_url) { "https://example.com/live" }
+  let(:livestream_url) { "https://www.youtube.com/live/abc123" }
 
   fab!(:topic)
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/plugins/discourse-calendar/spec/lib/discourse_calendar/livestream/allowed_hosts_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_calendar/livestream/allowed_hosts_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseCalendar::Livestream::AllowedHosts do
+  describe ".allows_url?" do
+    it "accepts a host on the default list and its subdomains" do
+      expect(described_class.allows_url?("https://www.youtube.com/watch?v=abc")).to eq(true)
+      expect(described_class.allows_url?("https://youtu.be/abc")).to eq(true)
+      expect(described_class.allows_url?("https://us06web.zoom.us/j/123456789")).to eq(true)
+      expect(described_class.allows_url?("https://twitch.tv/username")).to eq(true)
+    end
+
+    it "is case-insensitive" do
+      expect(described_class.allows_url?("HTTPS://US06WEB.ZOOM.US/j/123456789")).to eq(true)
+    end
+
+    it "rejects a host that is not listed" do
+      expect(described_class.allows_url?("https://example.com/live")).to eq(false)
+    end
+
+    it "rejects hosts that merely resemble a listed host" do
+      expect(described_class.allows_url?("https://notzoom.us/j/123456789")).to eq(false)
+      expect(described_class.allows_url?("https://zoom.us.evil.com/j/123456789")).to eq(false)
+      expect(described_class.allows_url?("https://myyoutube.com/watch?v=abc")).to eq(false)
+    end
+
+    it "rejects a listed host smuggled into the userinfo" do
+      expect(described_class.allows_url?("https://youtube.com@evil.com/live")).to eq(false)
+      expect(described_class.allows_url?("https://youtube.com%5C@evil.com/live")).to eq(false)
+      expect(described_class.allows_url?("https://youtube.com\t@evil.com/live")).to eq(false)
+      expect(described_class.allows_url?("https://youtube.com\n@evil.com/live")).to eq(false)
+    end
+
+    # The browser resolves these to a host the admin did allow, so the editor
+    # offers the livestream toggle for them and the save path has to agree.
+    it "matches the host the browser would connect to" do
+      expect(described_class.allows_url?("https://youtube.com\\@evil.com/live")).to eq(true)
+      expect(described_class.allows_url?("https://%79outube.com/live")).to eq(true)
+      expect(described_class.allows_url?("https://ｙoutube.com/live")).to eq(true)
+      expect(described_class.allows_url?("https://youtube.com./live")).to eq(true)
+    end
+
+    it "rejects a separator that only looks like a label boundary" do
+      expect(described_class.allows_url?("https://youtube.com。evil.com/live")).to eq(false)
+      expect(described_class.allows_url?("https://youtube.com%2eevil.com/live")).to eq(false)
+    end
+
+    it "rejects anything that is not an https URL" do
+      expect(described_class.allows_url?("youtube.com/watch?v=abc")).to eq(false)
+      expect(described_class.allows_url?("http://youtube.com/watch")).to eq(false)
+      expect(described_class.allows_url?("ftp://youtube.com/watch")).to eq(false)
+      expect(described_class.allows_url?("//youtube.com/watch")).to eq(false)
+      expect(described_class.allows_url?("Room 5")).to eq(false)
+      expect(described_class.allows_url?("https://")).to eq(false)
+      expect(described_class.allows_url?(nil)).to eq(false)
+    end
+
+    it "follows the site setting" do
+      SiteSetting.livestream_allowed_hosts = "stream.example.com"
+
+      expect(described_class.allows_url?("https://stream.example.com/live")).to eq(true)
+      expect(described_class.allows_url?("https://cdn.stream.example.com/live")).to eq(true)
+      expect(described_class.allows_url?("https://www.youtube.com/watch?v=abc")).to eq(false)
+    end
+
+    it "allows nothing when the setting is empty" do
+      SiteSetting.livestream_allowed_hosts = ""
+
+      expect(described_class.allows_url?("https://www.youtube.com/watch?v=abc")).to eq(false)
+    end
+  end
+
+  describe ".list" do
+    it "returns the configured hosts" do
+      SiteSetting.livestream_allowed_hosts = "youtube.com|zoom.us"
+
+      expect(described_class.list).to eq(%w[youtube.com zoom.us])
+    end
+  end
+
+  describe ".normalize" do
+    it "canonicalizes an entry to the host a browser resolves" do
+      expect(described_class.normalize("YOUTUBE.com")).to eq("youtube.com")
+      expect(described_class.normalize(" zoom.us ")).to eq("zoom.us")
+    end
+
+    it "takes an international host in the punycode it is compared as" do
+      expect(described_class.normalize("xn--80ak6aa92e.com")).to eq("xn--80ak6aa92e.com")
+      expect(described_class.normalize("ｙoutube.com")).to be_nil
+    end
+
+    it "rejects an entry that is not a bare host" do
+      expect(described_class.normalize("https://vimeo.com/videos")).to be_nil
+      expect(described_class.normalize("vimeo.com/videos")).to be_nil
+      expect(described_class.normalize("vimeo.com:443")).to be_nil
+      expect(described_class.normalize("youtube.com@evil.com")).to be_nil
+      expect(described_class.normalize("youtube.com。evil.com")).to be_nil
+      expect(described_class.normalize("")).to be_nil
+      expect(described_class.normalize(nil)).to be_nil
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/lib/discourse_calendar/livestream/allowed_hosts_validator_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_calendar/livestream/allowed_hosts_validator_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseCalendar::Livestream::AllowedHostsValidator do
+  subject(:validator) { described_class.new }
+
+  it "accepts bare hosts" do
+    expect(validator.valid_value?("youtube.com|us06web.zoom.us|youtu.be")).to eq(true)
+  end
+
+  it "accepts an empty list" do
+    expect(validator.valid_value?("")).to eq(true)
+    expect(validator.valid_value?(nil)).to eq(true)
+  end
+
+  it "rejects an entry carrying a scheme, path or port" do
+    expect(validator.valid_value?("https://vimeo.com")).to eq(false)
+    expect(validator.valid_value?("vimeo.com/videos")).to eq(false)
+    expect(validator.valid_value?("vimeo.com:443")).to eq(false)
+  end
+
+  it "rejects a non-ASCII host, which is listed in punycode instead" do
+    expect(validator.valid_value?("ｙoutube.com")).to eq(false)
+    expect(validator.valid_value?("xn--80ak6aa92e.com")).to eq(true)
+  end
+
+  it "rejects wildcards, which the default host_list validator would have caught" do
+    expect(validator.valid_value?("*.zoom.us")).to eq(false)
+    expect(validator.valid_value?("zoom.?s")).to eq(false)
+  end
+
+  it "names every offending entry, leaving the valid ones out of the message" do
+    expect(validator.valid_value?("youtube.com|https://vimeo.com|zoom.us/j")).to eq(false)
+
+    expect(validator.error_message).to include("https://vimeo.com", "zoom.us/j")
+    expect(validator.error_message).not_to include("youtube.com")
+  end
+
+  it "is wired up to the site setting" do
+    expect { SiteSetting.livestream_allowed_hosts = "https://vimeo.com/videos" }.to raise_error(
+      Discourse::InvalidParameters,
+    )
+
+    expect { SiteSetting.livestream_allowed_hosts = "vimeo.com" }.not_to raise_error
+  end
+end

--- a/plugins/discourse-calendar/spec/lib/discourse_calendar/livestream/handle_topic_chat_channel_creation_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_calendar/livestream/handle_topic_chat_channel_creation_spec.rb
@@ -36,7 +36,12 @@ RSpec.describe DiscourseCalendar::Livestream do
           SiteSetting.calendar_enabled = true
           SiteSetting.chat_pinned_messages = true
           post = Fabricate(:post, topic: topic)
-          Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+          Fabricate(
+            :event,
+            post: post,
+            livestream: true,
+            location: "https://www.youtube.com/live/abc123",
+          )
         end
 
         it "creates a chat channel" do
@@ -128,7 +133,7 @@ RSpec.describe DiscourseCalendar::Livestream do
             :event,
             post: malicious_post,
             livestream: true,
-            location: "https://example.com/live",
+            location: "https://www.youtube.com/live/abc123",
           )
 
           channel = malicious.reload.topic_chat_channel.chat_channel
@@ -155,7 +160,12 @@ RSpec.describe DiscourseCalendar::Livestream do
           SiteSetting.calendar_enabled = true
           SiteSetting.chat_pinned_messages = false
           post = Fabricate(:post, topic: topic)
-          Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+          Fabricate(
+            :event,
+            post: post,
+            livestream: true,
+            location: "https://www.youtube.com/live/abc123",
+          )
         end
 
         it "posts the topic reference message without pinning it" do

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -21,7 +21,7 @@ describe DiscoursePostEvent::Event do
   end
 
   describe "#warm_livestream_onebox" do
-    let(:livestream_url) { "https://example.com/live" }
+    let(:livestream_url) { "https://www.youtube.com/live/abc123" }
 
     fab!(:topic) { Fabricate(:topic, category: nil) }
     fab!(:post) { Fabricate(:post, topic: topic) }
@@ -68,9 +68,9 @@ describe DiscoursePostEvent::Event do
         job: :warm_livestream_onebox,
         args: {
           event_id: event.id,
-          url: "https://example.com/other-live",
+          url: "https://www.youtube.com/live/def456",
         },
-      ) { event.update!(location: "https://example.com/other-live") }
+      ) { event.update!(location: "https://www.youtube.com/live/def456") }
     end
 
     it "does not warm the onebox when an unrelated attribute changes" do
@@ -145,7 +145,7 @@ describe DiscoursePostEvent::Event do
     end
 
     it "rejects a non-Zoom livestream URL" do
-      expect(event_for("https://example.com/live")).not_to be_is_zoom_livestream
+      expect(event_for("https://www.youtube.com/live/abc123")).not_to be_is_zoom_livestream
     end
 
     it "is false when the event is not a livestream" do
@@ -173,7 +173,12 @@ describe DiscoursePostEvent::Event do
 
     it "creates the chat channel after the livestream event is committed" do
       expect {
-        Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+        Fabricate(
+          :event,
+          post: post,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
       }.to change(DiscourseCalendar::Livestream::TopicChatChannel, :count).by(1)
 
       expect(post.topic.topic_chat_channel.chat_channel.chatable).to eq(category)
@@ -183,7 +188,12 @@ describe DiscoursePostEvent::Event do
       SiteSetting.chat_enabled = false
 
       expect {
-        Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+        Fabricate(
+          :event,
+          post: post,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
       }.not_to change(DiscourseCalendar::Livestream::TopicChatChannel, :count)
     end
 
@@ -191,7 +201,12 @@ describe DiscoursePostEvent::Event do
       reply = Fabricate(:post, topic: topic)
 
       expect {
-        Fabricate(:event, post: reply, livestream: true, location: "https://example.com/live")
+        Fabricate(
+          :event,
+          post: reply,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
       }.not_to change(DiscourseCalendar::Livestream::TopicChatChannel, :count)
     end
   end
@@ -202,14 +217,78 @@ describe DiscoursePostEvent::Event do
     # enqueue (don't run) the onebox-warming job so it doesn't make a real request
     before { Jobs.run_later! }
 
-    it "keeps livestream enabled for an http(s) location" do
-      event = Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+    it "keeps livestream enabled for an allowed host" do
+      event =
+        Fabricate(
+          :event,
+          post: post,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
 
       expect(event.reload.livestream).to eq(true)
     end
 
-    it "resets livestream when the location is not an http(s) URL" do
+    it "keeps livestream enabled for a host an admin added" do
+      SiteSetting.livestream_allowed_hosts = "stream.example.com"
+
+      event =
+        Fabricate(:event, post: post, livestream: true, location: "https://stream.example.com/live")
+
+      expect(event.reload.livestream).to eq(true)
+    end
+
+    it "resets livestream when the location is not an https URL" do
       event = Fabricate(:event, post: post, livestream: true, location: "Room 5")
+
+      expect(event.reload.livestream).to eq(false)
+
+      event.update!(location: "http://www.youtube.com/live/abc123")
+
+      expect(event.reload.livestream).to eq(false)
+    end
+
+    it "falls back to the url, which is what the onebox and serializers use" do
+      event =
+        Fabricate(
+          :event,
+          post: post,
+          livestream: true,
+          location: nil,
+          url: "https://www.youtube.com/live/abc123",
+        )
+
+      expect(event.reload.livestream).to eq(true)
+
+      event.update!(url: "https://example.com/live")
+
+      expect(event.reload.livestream).to eq(false)
+    end
+
+    it "resets livestream when the location host is not allowed" do
+      event = Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+
+      expect(event.reload.livestream).to eq(false)
+    end
+
+    it "resets livestream when the location only resembles an allowed host" do
+      event =
+        Fabricate(:event, post: post, livestream: true, location: "https://youtube.com.evil.com/x")
+
+      expect(event.reload.livestream).to eq(false)
+    end
+
+    it "resets livestream when an admin removes the host from the allowlist" do
+      event =
+        Fabricate(
+          :event,
+          post: post,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
+      SiteSetting.livestream_allowed_hosts = "zoom.us"
+
+      event.update!(name: "Renamed")
 
       expect(event.reload.livestream).to eq(false)
     end
@@ -221,7 +300,13 @@ describe DiscoursePostEvent::Event do
     end
 
     it "resets livestream when the location is edited away from a URL" do
-      event = Fabricate(:event, post: post, livestream: true, location: "https://example.com/live")
+      event =
+        Fabricate(
+          :event,
+          post: post,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
       event.update!(location: "Room 5")
 
       expect(event.reload.livestream).to eq(false)
@@ -231,7 +316,13 @@ describe DiscoursePostEvent::Event do
       reply = Fabricate(:post, topic: post.topic)
       expect(reply.is_first_post?).to be(false)
 
-      event = Fabricate(:event, post: reply, livestream: true, location: "https://example.com/live")
+      event =
+        Fabricate(
+          :event,
+          post: reply,
+          livestream: true,
+          location: "https://www.youtube.com/live/abc123",
+        )
 
       expect(event.reload.livestream).to eq(false)
     end
@@ -1175,7 +1266,7 @@ describe DiscoursePostEvent::Event do
 
       post.update!(
         raw:
-          "[event start=\"2020-04-24 14:15\" livestream=\"true\" location=\"https://example.com/live\"]\n[/event]",
+          "[event start=\"2020-04-24 14:15\" livestream=\"true\" location=\"https://www.youtube.com/live/abc123\"]\n[/event]",
       )
       post.rebake!
       DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })

--- a/plugins/discourse-calendar/spec/requests/chat/livestream_channels_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/chat/livestream_channels_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Livestream channel list serialization" do
       id: post.id,
       original_starts_at: 1.hour.from_now,
       original_ends_at: 2.hours.from_now,
-      location: "https://example.com/live",
+      location: "https://www.youtube.com/live/abc123",
       status: DiscoursePostEvent::Event.statuses[:private],
       raw_invitees: [group.name],
       livestream: true,

--- a/plugins/discourse-calendar/spec/requests/livestream_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/livestream_controller_spec.rb
@@ -136,7 +136,7 @@ module DiscourseCalendar
         end
 
         it "returns not found when the livestream URL is not a supported Zoom URL" do
-          event.update!(location: "https://example.com/stream")
+          event.update!(location: "https://www.youtube.com/live/abc123")
 
           get "/discourse-calendar/livestream/zoom/signature.json", params: { topic_id: topic.id }
 

--- a/plugins/discourse-calendar/spec/serializers/chat_channel_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/chat_channel_serializer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Chat::ChannelSerializer do
       id: first_post.id,
       original_starts_at: 1.hour.from_now,
       original_ends_at: 2.hours.from_now,
-      location: "https://example.com/live",
+      location: "https://www.youtube.com/live/abc123",
       status: DiscoursePostEvent::Event.statuses[status],
       raw_invitees:,
       livestream:,

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -102,7 +102,7 @@ describe DiscoursePostEvent::EventSerializer do
     end
 
     context "when event is a livestream" do
-      let(:livestream_url) { "https://example.com/live" }
+      let(:livestream_url) { "https://www.youtube.com/live/abc123" }
       # The event must live on the topic's first post: `Event#before_save` clears
       # the `livestream` flag on any other post.
       let(:livestream_topic) { Fabricate(:topic, category: category) }

--- a/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe TopicViewSerializer do
         id: first_post.id,
         original_starts_at: 1.hour.from_now,
         original_ends_at: 2.hours.from_now,
-        location: "https://example.com/live",
+        location: "https://www.youtube.com/live/abc123",
         status: DiscoursePostEvent::Event.statuses[status],
         raw_invitees:,
         livestream:,

--- a/plugins/discourse-calendar/spec/services/discourse_calendar/livestream/prepare_zoom_join_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_calendar/livestream/prepare_zoom_join_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe DiscourseCalendar::Livestream::PrepareZoomJoin do
     end
 
     context "when the livestream URL is not a supported Zoom URL" do
-      before { event.update!(location: "https://example.com/stream") }
+      before { event.update!(location: "https://www.youtube.com/live/abc123") }
 
       it { is_expected.to fail_to_find_a_model(:zoom_join_data) }
     end

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/livestream/topic_livestream.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/livestream/topic_livestream.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Pages
     class TopicLivestream < PageObjects::Pages::Base
-      LIVESTREAM_URL = "https://example.com/live"
+      LIVESTREAM_URL = "https://www.youtube.com/live/abc123"
 
       def cache_livestream_onebox
         Discourse.cache.write(

--- a/plugins/discourse-calendar/test/javascripts/lib/raw-event-helper-test.js
+++ b/plugins/discourse-calendar/test/javascripts/lib/raw-event-helper-test.js
@@ -1,3 +1,5 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import {
   attendanceTransition,
@@ -38,7 +40,9 @@ const LONG_DEFAULT = {
   period: "before",
 };
 
-module("Unit | Lib | raw-event-helper", function () {
+module("Unit | Lib | raw-event-helper", function (hooks) {
+  setupTest(hooks);
+
   test("removeEvent", function (assert) {
     assert.strictEqual(
       removeEvent('[event start="2024-01-01"]\nDescription\n[/event]'),
@@ -483,79 +487,207 @@ module("Unit | Lib | raw-event-helper", function () {
     );
   });
 
-  test("isLivestreamUrl only accepts http(s) URLs for major livestreaming platforms", function (assert) {
+  test("isLivestreamUrl only accepts https URLs for major livestreaming platforms", function (assert) {
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
     assert.false(
-      isLivestreamUrl("https://example.com/live"),
+      isLivestreamUrl("https://example.com/live", siteSettings),
       "does not accept arbitrary URLs"
     );
     assert.false(
-      isLivestreamUrl("http://example.com/live"),
+      isLivestreamUrl("http://example.com/live", siteSettings),
       "does not accept arbitrary URLs"
     );
     assert.false(
-      isLivestreamUrl("HTTPS://EXAMPLE.COM"),
+      isLivestreamUrl("http://www.youtube.com/watch?v=1", siteSettings),
+      "rejects http on an allowed host"
+    );
+    assert.false(
+      isLivestreamUrl("HTTPS://EXAMPLE.COM", siteSettings),
       "does not accept arbitrary URLs"
     );
-    assert.false(isLivestreamUrl("www.example.com"), "rejects schemeless www");
-    assert.false(isLivestreamUrl("mailto:host@example.com"), "rejects mailto");
-    assert.false(isLivestreamUrl("Room 5"), "rejects plain text");
-    assert.false(isLivestreamUrl(null), "handles null");
-    assert.false(isLivestreamUrl(undefined), "handles undefined");
+    assert.false(
+      isLivestreamUrl("www.example.com", siteSettings),
+      "rejects schemeless www"
+    );
+    assert.false(
+      isLivestreamUrl("youtube.com/watch?v=dQw4w9WgXcQ", siteSettings),
+      "rejects a schemeless allowed host, which the save path would not retain"
+    );
+    assert.false(
+      isLivestreamUrl("mailto:host@example.com", siteSettings),
+      "rejects mailto"
+    );
+    assert.false(
+      isLivestreamUrl("ftp://youtube.com/watch", siteSettings),
+      "rejects a non-https scheme on an allowed host"
+    );
+    assert.false(
+      isLivestreamUrl("https://", siteSettings),
+      "rejects a bare scheme"
+    );
+    assert.false(isLivestreamUrl("Room 5", siteSettings), "rejects plain text");
+    assert.false(isLivestreamUrl(null, siteSettings), "handles null");
+    assert.false(isLivestreamUrl(undefined, siteSettings), "handles undefined");
 
     assert.true(
-      isLivestreamUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+      isLivestreamUrl(
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        siteSettings
+      ),
       "accepts YouTube"
     );
     assert.true(
-      isLivestreamUrl("https://youtu.be/dQw4w9WgXcQ"),
+      isLivestreamUrl("https://youtu.be/dQw4w9WgXcQ", siteSettings),
       "accepts YouTube short link"
     );
     assert.true(
-      isLivestreamUrl("https://www.twitch.tv/username"),
+      isLivestreamUrl("https://www.twitch.tv/username", siteSettings),
       "accepts Twitch"
     );
     assert.true(
-      isLivestreamUrl("https://www.facebook.com/username/videos/123456789"),
+      isLivestreamUrl(
+        "https://www.facebook.com/username/videos/123456789",
+        siteSettings
+      ),
       "accepts Facebook"
     );
     assert.true(
-      isLivestreamUrl("https://www.tiktok.com/@username/video/123456789"),
+      isLivestreamUrl(
+        "https://www.tiktok.com/@username/video/123456789",
+        siteSettings
+      ),
       "accepts TikTok"
     );
     assert.true(
-      isLivestreamUrl("https://www.instagram.com/tv/123456789"),
+      isLivestreamUrl("https://www.instagram.com/tv/123456789", siteSettings),
       "accepts Instagram"
     );
-    assert.true(isLivestreamUrl("https://zoom.us/j/123456789"), "accepts Zoom");
+    assert.true(
+      isLivestreamUrl("https://zoom.us/j/123456789", siteSettings),
+      "accepts Zoom"
+    );
   });
 
   test("isLivestreamUrl accepts subdomains of livestreaming platforms", function (assert) {
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
     assert.true(
-      isLivestreamUrl("https://us06web.zoom.us/j/123456789?pwd=secret"),
+      isLivestreamUrl(
+        "https://us06web.zoom.us/j/123456789?pwd=secret",
+        siteSettings
+      ),
       "accepts the vanity subdomain Zoom actually hands out"
     );
     assert.true(
-      isLivestreamUrl("https://gaming.youtube.com/watch?v=dQw4w9WgXcQ"),
+      isLivestreamUrl(
+        "https://gaming.youtube.com/watch?v=dQw4w9WgXcQ",
+        siteSettings
+      ),
       "accepts a YouTube subdomain"
     );
     assert.true(
-      isLivestreamUrl("HTTPS://US06WEB.ZOOM.US/j/123456789"),
+      isLivestreamUrl("HTTPS://US06WEB.ZOOM.US/j/123456789", siteSettings),
       "is case-insensitive"
     );
   });
 
   test("isLivestreamUrl rejects hosts that merely resemble a platform", function (assert) {
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
     assert.false(
-      isLivestreamUrl("https://notzoom.us/j/123456789"),
+      isLivestreamUrl("https://notzoom.us/j/123456789", siteSettings),
       "rejects a host ending in the platform name"
     );
     assert.false(
-      isLivestreamUrl("https://zoom.us.evil.com/j/123456789"),
+      isLivestreamUrl("https://zoom.us.evil.com/j/123456789", siteSettings),
       "rejects a host starting with the platform name"
     );
     assert.false(
-      isLivestreamUrl("https://myyoutube.com/watch?v=1"),
+      isLivestreamUrl("https://myyoutube.com/watch?v=1", siteSettings),
       "rejects a host prefixed with the platform name"
+    );
+    assert.false(
+      isLivestreamUrl("https://youtube.com@evil.com/live", siteSettings),
+      "rejects a platform name smuggled into the userinfo"
+    );
+    assert.false(
+      isLivestreamUrl("https://youtube.com\t@evil.com/live", siteSettings),
+      "rejects userinfo hidden behind a stripped control character"
+    );
+    assert.false(
+      isLivestreamUrl("https://youtube.com。evil.com/live", siteSettings),
+      "rejects a separator that only looks like a label boundary"
+    );
+  });
+
+  // The browser resolves these to a host the admin did allow, so the save path
+  // keeps the livestream flag and the editor has to agree.
+  test("isLivestreamUrl matches the host the browser would connect to", function (assert) {
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
+    assert.true(
+      isLivestreamUrl("https://youtube.com\\@evil.com/live", siteSettings),
+      "resolves a backslash as a path separator"
+    );
+    assert.true(
+      isLivestreamUrl("https://%79outube.com/live", siteSettings),
+      "decodes percent escapes in the host"
+    );
+    assert.true(
+      isLivestreamUrl("https://ｙoutube.com/live", siteSettings),
+      "maps Unicode to the host it resolves to"
+    );
+    assert.true(
+      isLivestreamUrl("https://youtube.com./live", siteSettings),
+      "ignores a fully qualified trailing dot"
+    );
+  });
+
+  test("isLivestreamUrl follows the livestream_allowed_hosts setting", function (assert) {
+    const custom = { livestream_allowed_hosts: "stream.example.com|vimeo.com" };
+
+    assert.true(
+      isLivestreamUrl("https://stream.example.com/live/1", custom),
+      "accepts an admin-added host"
+    );
+    assert.true(
+      isLivestreamUrl("https://player.vimeo.com/video/123", custom),
+      "accepts subdomains of an admin-added host"
+    );
+    assert.false(
+      isLivestreamUrl("https://www.youtube.com/watch?v=1", custom),
+      "rejects a default host the admin removed"
+    );
+
+    assert.true(
+      isLivestreamUrl("https://vimeo.com/123", {
+        livestream_allowed_hosts: "VIMEO.com",
+      }),
+      "canonicalizes a list entry before comparing"
+    );
+    assert.false(
+      isLivestreamUrl("https://vimeo.com/123", {
+        livestream_allowed_hosts: "https://vimeo.com/videos",
+      }),
+      "ignores a list entry that is not a bare host, as the validator rejects it on save"
+    );
+    assert.false(
+      isLivestreamUrl("https://youtube.com/live", {
+        livestream_allowed_hosts: "ｙoutube.com",
+      }),
+      "ignores a non-ASCII list entry, which the validator requires in punycode"
+    );
+
+    assert.false(
+      isLivestreamUrl("https://www.youtube.com/watch?v=1", {
+        livestream_allowed_hosts: "",
+      }),
+      "an empty list allows nothing"
+    );
+    assert.false(
+      isLivestreamUrl("https://www.youtube.com/watch?v=1", {}),
+      "a missing setting allows nothing"
     );
   });
 });


### PR DESCRIPTION
Backport of #42374 to release/2026.7.

---

Currently the hosts that can be used for a livestream event are hardcoded in the composer's JavaScript, and the server accepts any https location, so the list isn't really enforced... and there's no way to use hosts that would otherwise work, including custom or self-hosted sources.

This adds a `livestream_allowed_hosts` site setting (defaulting to the existing hardcoded list) and validates against it both in the composer and on the server. Whether a livestream embeds a player still depends on the site's onebox settings. 
