### PR TITLE
FIX: Serialize preloaded custom fields when finding categories for lazy_load_categories_groups

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -451,6 +451,10 @@ class CategoriesController < ApplicationController
 
     Category.preload_user_fields!(guardian, categories)
 
+    if serializer == SiteCategorySerializer && Site.preloaded_category_custom_fields.present?
+      Category.preload_custom_fields(categories, Site.preloaded_category_custom_fields)
+    end
+
     render_serialized(categories, serializer, root: :categories, scope: guardian)
   end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1946,6 +1946,35 @@ RSpec.describe CategoriesController do
       expect(category["subcategory_count"]).to eq(1)
     end
 
+    it "returns preloaded custom fields" do
+      Site.preloaded_category_custom_fields << "bob"
+      category.upsert_custom_fields("bob" => "marley")
+
+      get "/categories/find.json", params: { slug_path_with_id: "#{category.slug}/#{category.id}" }
+
+      expect(response.parsed_body["categories"].first["custom_fields"]).to eq("bob" => "marley")
+    ensure
+      Site.reset_preloaded_category_custom_fields
+    end
+
+    it "returns all custom fields when permissions are included" do
+      Site.preloaded_category_custom_fields << "bob"
+      category.upsert_custom_fields("bob" => "marley", "tosh" => "peter")
+
+      get "/categories/find.json",
+          params: {
+            slug_path_with_id: "#{category.slug}/#{category.id}",
+            include_permissions: true,
+          }
+
+      expect(response.parsed_body["categories"].first["custom_fields"]).to eq(
+        "bob" => "marley",
+        "tosh" => "peter",
+      )
+    ensure
+      Site.reset_preloaded_category_custom_fields
+    end
+
     context "with a read restricted child category" do
       before_all { subcategory.update!(read_restricted: true) }
 


### PR DESCRIPTION
When `lazy_load_categories_groups` is used site categories may be loaded using the `find` action in the categories controller. Currently that action leaves out preloaded custom fields normally serialized for site categories. See https://meta.discourse.org/t/custom-wizard-plugin/73345/967?u=angus and subsequent posts for an example of an issue this can cause.