### PR TITLE
DEV: Remove hard-coded temperatures from built-in agents

### DIFF
--- a/plugins/discourse-ai/evals/lib/judge.rb
+++ b/plugins/discourse-ai/evals/lib/judge.rb
@@ -86,7 +86,6 @@ module DiscourseAi
           judge_llm.to_llm.generate(
             prompt,
             user: Discourse.system_user,
-            temperature: 0,
             response_format: RESPONSE_FORMAT,
             execution_context:,
           )
@@ -113,7 +112,6 @@ module DiscourseAi
           judge_llm.to_llm.generate(
             prompt,
             user: Discourse.system_user,
-            temperature: 0,
             response_format: COMPARISON_RESPONSE_FORMAT,
             execution_context:,
           )

--- a/plugins/discourse-ai/lib/agents/admin_dashboard_highlights.rb
+++ b/plugins/discourse-ai/lib/agents/admin_dashboard_highlights.rb
@@ -11,10 +11,6 @@ module DiscourseAi
         []
       end
 
-      def temperature
-        0
-      end
-
       def system_prompt
         <<~PROMPT.strip
           You write the brief highlight shown at the top of a Discourse community admin dashboard, for the community owner.

--- a/plugins/discourse-ai/lib/agents/locale_detector.rb
+++ b/plugins/discourse-ai/lib/agents/locale_detector.rb
@@ -52,10 +52,6 @@ module DiscourseAi
         ]
       end
 
-      def temperature
-        0
-      end
-
       private
 
       def configured_locale_lines

--- a/plugins/discourse-ai/lib/agents/markdown_table_generator.rb
+++ b/plugins/discourse-ai/lib/agents/markdown_table_generator.rb
@@ -25,10 +25,6 @@ module DiscourseAi
         [{ "key" => "output", "type" => "string" }]
       end
 
-      def temperature
-        0.5
-      end
-
       def examples
         [
           ["<input>sam,joe,jane\nage: 22|  10|11</input>", { output: <<~TEXT }.to_json],

--- a/plugins/discourse-ai/lib/agents/spam_detector.rb
+++ b/plugins/discourse-ai/lib/agents/spam_detector.rb
@@ -7,10 +7,6 @@ module DiscourseAi
         false
       end
 
-      def temperature
-        0.1
-      end
-
       def system_prompt
         <<~PROMPT
           You are a spam detection system. Analyze the following post content and context.

--- a/plugins/discourse-ai/lib/agents/sql_helper.rb
+++ b/plugins/discourse-ai/lib/agents/sql_helper.rb
@@ -43,10 +43,6 @@ module DiscourseAi
         [Tools::DbSchema]
       end
 
-      def temperature
-        0.2
-      end
-
       def system_prompt
         <<~PROMPT
             You are a PostgreSQL expert.

--- a/plugins/discourse-ai/lib/agents/tools/summarize.rb
+++ b/plugins/discourse-ai/lib/agents/tools/summarize.rb
@@ -132,13 +132,7 @@ module DiscourseAi
             prompt = section_prompt(topic, section, guidance)
 
             summary =
-              llm.generate(
-                prompt,
-                temperature: 0.6,
-                max_tokens: 400,
-                user: bot_user,
-                feature_name: "summarize_tool",
-              )
+              llm.generate(prompt, max_tokens: 400, user: bot_user, feature_name: "summarize_tool")
 
             summaries << summary
           end
@@ -155,7 +149,6 @@ module DiscourseAi
 
             llm.generate(
               concatenation_prompt,
-              temperature: 0.6,
               max_tokens: 500,
               user: bot_user,
               feature_name: "summarize_tool",

--- a/plugins/discourse-ai/lib/agents/translator.rb
+++ b/plugins/discourse-ai/lib/agents/translator.rb
@@ -33,10 +33,6 @@ module DiscourseAi
       def response_format
         [{ "key" => "output", "type" => "string" }]
       end
-
-      def temperature
-        0.2
-      end
     end
   end
 end

--- a/plugins/discourse-ai/lib/automation/report_runner.rb
+++ b/plugins/discourse-ai/lib/automation/report_runner.rb
@@ -53,7 +53,7 @@ module DiscourseAi
         exclude_category_ids: nil,
         exclude_tags: nil,
         top_p: 0.1,
-        temperature: 0.2,
+        temperature: nil,
         suppress_notifications: false,
         automation: nil
       )

--- a/plugins/discourse-ai/lib/completions/endpoints/hugging_face.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/hugging_face.rb
@@ -20,7 +20,7 @@ module DiscourseAi
         end
 
         def default_options
-          { model: llm_model.name, temperature: 0.7 }
+          { model: llm_model.name }
         end
 
         def provider_id

--- a/plugins/discourse-ai/lib/configuration/llm_validator.rb
+++ b/plugins/discourse-ai/lib/configuration/llm_validator.rb
@@ -88,7 +88,6 @@ module DiscourseAi
           TEST_PROMPT,
           user: @opts[:user] || Discourse.system_user,
           feature_name: "llm_validator",
-          temperature: 0.7,
           top_p: 0.9,
           &blk
         )

--- a/plugins/discourse-ai/spec/evals/judge_spec.rb
+++ b/plugins/discourse-ai/spec/evals/judge_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe DiscourseAi::Evals::Judge do
     expect(llm_proxy).to have_received(:generate).with(
       satisfy { |prompt| prompt.messages.any? { |msg| msg[:content].include?("hash-output") } },
       user: Discourse.system_user,
-      temperature: 0,
       response_format: DiscourseAi::Evals::Judge::RESPONSE_FORMAT,
       execution_context: nil,
     )
@@ -73,7 +72,6 @@ RSpec.describe DiscourseAi::Evals::Judge do
           prompt.messages.any? { |msg| msg[:content].include?("Candidate 2 (custom):") }
         end,
         user: Discourse.system_user,
-        temperature: 0,
         response_format: DiscourseAi::Evals::Judge::COMPARISON_RESPONSE_FORMAT,
         execution_context: nil,
       )

--- a/plugins/discourse-ai/spec/lib/agents/admin_dashboard_highlights_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/admin_dashboard_highlights_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe DiscourseAi::Agents::AdminDashboardHighlights do
     instance = described_class.new
 
     expect(instance.tools).to eq([])
-    expect(instance.temperature).to eq(0)
     expect(instance.response_format).to eq([{ "key" => "highlight", "type" => "string" }])
   end
 

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_generator.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_generator.rb
@@ -19,10 +19,6 @@ module DiscourseDataExplorer
       100_000
     end
 
-    def temperature
-      0.2
-    end
-
     def system_prompt
       <<~PROMPT
         You are a PostgreSQL expert that generates queries for Discourse Data Explorer.


### PR DESCRIPTION
Previously, most built-in agents overrode `temperature` with a fixed value, along with a handful of other call sites (the LLM connectivity probe, the Hugging Face default options, the LLM report automation default, and the evals judge). This was a historical artifact from when temperature was a meaningful toggle across models.

This change drops those overrides so everything runs at the model's native temperature, which is what modern models expect and what several providers enforce regardless.