### PR TITLE
UX: Better UX for disabled state

### DIFF
--- a/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
+++ b/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
@@ -80,6 +80,10 @@ export default class CreateInviteWithRoles extends Component {
     this.initialStaffRole = this.staffRole;
   }
 
+  get allowEmailInvites() {
+    return this.siteSettings.allow_email_invites;
+  }
+
   get canInviteAdmins() {
     return !!this.currentUser?.can_create_admin_invite;
   }
@@ -677,9 +681,11 @@ export default class CreateInviteWithRoles extends Component {
                       <Condition @name="link">{{i18n
                           "user.invited.invite_roles.invite_by_link"
                         }}</Condition>
-                      <Condition @name="email">{{i18n
-                          "user.invited.invite_roles.invite_by_email"
-                        }}</Condition>
+                      {{#if this.allowEmailInvites}}
+                        <Condition @name="email">{{i18n
+                            "user.invited.invite_roles.invite_by_email"
+                          }}</Condition>
+                      {{/if}}
                     </conditional.Conditions>
                   </fieldset>
                 {{/unless}}

--- a/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
+++ b/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
@@ -29,6 +29,7 @@ import DButton from "discourse/ui-kit/d-button";
 import DCopyButton from "discourse/ui-kit/d-copy-button";
 import DFutureDateInput from "discourse/ui-kit/d-future-date-input";
 import DModal from "discourse/ui-kit/d-modal";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 const FORM = "form";
@@ -568,7 +569,10 @@ export default class CreateInviteWithRoles extends Component {
               @data={{this.adminFormData}}
               @onSubmit={{this.onAdminFormSubmit}}
               @onRegisterApi={{this.registerApi}}
-              class="create-invite-with-roles-modal__admin-form"
+              class={{dConcatClass
+                "create-invite-with-roles-modal__admin-form"
+                (if this.submitDisabled "--disabled" "")
+              }}
               as |form|
             >
               {{#unless this.inviteCreated}}
@@ -584,6 +588,7 @@ export default class CreateInviteWithRoles extends Component {
                   <field.Control
                     @title={{this.staffRoleLabel}}
                     class="--inline"
+                    disabled={{this.submitDisabled}}
                     as |radioGroup|
                   >
                     {{#each this.staffRoleItems as |item|}}
@@ -615,6 +620,7 @@ export default class CreateInviteWithRoles extends Component {
                   autocomplete="off"
                   data-1p-ignore
                   data-lpignore="true"
+                  disabled={{this.submitDisabled}}
                   placeholder={{i18n
                     "user.invited.invite_roles.email_placeholder"
                   }}
@@ -907,11 +913,13 @@ export default class CreateInviteWithRoles extends Component {
           <DButton
             @label="user.invited.invite.cancel"
             @action={{this.cancel}}
+            disabled={{this.submitDisabled}}
             class="btn-transparent cancel-button"
           />
           <AdvancedModeToggle
             @active={{this.showAdvanced}}
             @onToggle={{this.toggleAdvanced}}
+            disabled={{this.submitDisabled}}
           />
         {{else if (eq this.screen "summary")}}
           <DButton


### PR DESCRIPTION
When a user cannot invite using the current settings, make it more clear that the inputs are disabled.

| Before | After |
| -- | -- |
|<img width="1140" height="812" alt="CleanShot 2026-08-07 at 12 45 52@2x" src="https://github.com/user-attachments/assets/0f277a0d-183c-491a-8ef9-3e508ba44655" />|<img width="1052" height="772" alt="CleanShot 2026-08-07 at 12 47 51@2x" src="https://github.com/user-attachments/assets/5597fdec-ba15-4bb2-b52d-b31f7ac06d3b" />|