### PR TITLE
UX: don't show "me too" button on category description topics

### DIFF
--- a/plugins/discourse-solved/lib/discourse_solved/guardian_extensions.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/guardian_extensions.rb
@@ -57,6 +57,7 @@ module DiscourseSolved
       return false if topic.blank? || !authenticated?
       return false if topic.user_id == current_user.id
       return false if topic.private_message?
+      return false if topic.is_category_topic?
       return false if topic.trashed? || topic.closed? || topic.archived?
       return false if topic.solved.present? && !SiteSetting.solved_allow_multiple_solutions
       return false unless topic_in_support_category?(topic)
@@ -68,6 +69,7 @@ module DiscourseSolved
     def shared_issue_visible?(topic)
       return false if topic.blank?
       return false if topic.private_message?
+      return false if topic.is_category_topic?
       return false if topic.trashed?
       return false unless topic_in_support_category?(topic)
       return false unless shared_issues_enabled_for_category?(topic)

--- a/plugins/discourse-solved/spec/lib/guardian_extensions_spec.rb
+++ b/plugins/discourse-solved/spec/lib/guardian_extensions_spec.rb
@@ -146,4 +146,38 @@ describe DiscourseSolved::GuardianExtensions do
       expect(guardian.can_unaccept_answer?(restricted_topic, restricted_post)).to eq(false)
     end
   end
+
+  describe "shared issues" do
+    fab!(:support_category) do
+      Fabricate(:category_with_definition).tap do |c|
+        c.upsert_custom_fields(DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD => "true")
+      end
+    end
+    fab!(:support_topic) { Fabricate(:topic_with_op, category: support_category, user: other_user) }
+
+    before do
+      SiteSetting.enable_solved_shared_issues = true
+      DiscourseSolved::AcceptedAnswerCache.reset_accepted_answer_cache
+    end
+
+    describe ".can_create_shared_issue?" do
+      it "returns true for a regular topic in a support category" do
+        expect(guardian.can_create_shared_issue?(support_topic)).to eq(true)
+      end
+
+      it "returns false for the category definition topic" do
+        expect(guardian.can_create_shared_issue?(support_category.topic)).to eq(false)
+      end
+    end
+
+    describe ".shared_issue_visible?" do
+      it "returns true for a regular topic in a support category" do
+        expect(guardian.shared_issue_visible?(support_topic)).to eq(true)
+      end
+
+      it "returns false for the category definition topic" do
+        expect(guardian.shared_issue_visible?(support_category.topic)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
It doesn't make sense to show the button in topics meant to be category descriptions 

Before
<img width="1592"  alt="image" src="https://github.com/user-attachments/assets/ab3eb17e-6873-4af5-8595-a5ea4152a0e3" />


After
<img width="1612"  alt="image" src="https://github.com/user-attachments/assets/fd49bfb5-d914-4906-b285-1c99000a4668" />
