### PR TITLE
FEATURE: when vote limits are disabled, adjust the closed notification to suit it

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3799,7 +3799,6 @@ en:
         other: "%{count} open membership requests for '%{group_name}'"
       reaction: "<span>%{username}</span> %{description}"
       reaction_2: "<span>%{username}, %{username2}</span> %{description}"
-      votes_released: "%{description} - completed"
       new_features: "New features available!"
       admin_problems: "New advice on your site dashboard"
       upcoming_changes:

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/initializers/discourse-topic-voting.js
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/initializers/discourse-topic-voting.js
@@ -7,12 +7,26 @@ export default {
 
   initialize() {
     withPluginApi((api) => {
+      api.replaceIcon("topic_voting.voting_closed", "lock");
+
       api.registerNotificationTypeRenderer(
         "votes_released",
         (NotificationTypeBase) => {
           return class extends NotificationTypeBase {
             get label() {
-              return i18n("topic_voting.notification_label.vote_released");
+              return this.siteSettings.topic_voting_enable_vote_limits
+                ? i18n("topic_voting.notification_label.vote_released")
+                : i18n("topic_voting.notification_label.voting_closed");
+            }
+
+            get linkTitle() {
+              return this.label;
+            }
+
+            get icon() {
+              return this.siteSettings.topic_voting_enable_vote_limits
+                ? super.icon
+                : "topic_voting.voting_closed";
             }
           };
         }

--- a/plugins/discourse-topic-voting/config/locales/client.en.yml
+++ b/plugins/discourse-topic-voting/config/locales/client.en.yml
@@ -11,6 +11,7 @@ en:
     topic_voting:
       notification_label:
         vote_released: "Vote returned"
+        voting_closed: "Voting closed"
       hot_nav_help: "top recent topics, including those with recent votes"
       voted: "You voted on this topic"
       vote_title: "Vote"

--- a/plugins/discourse-topic-voting/test/javascripts/integration/votes-released-notification-test.gjs
+++ b/plugins/discourse-topic-voting/test/javascripts/integration/votes-released-notification-test.gjs
@@ -1,0 +1,51 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import MenuItem from "discourse/components/user-menu/menu-item";
+import UserMenuNotificationItem from "discourse/lib/user-menu/notification-item";
+import Notification from "discourse/models/notification";
+import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Notification | votes released", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const notification = Notification.create({
+      id: 11,
+      user_id: 1,
+      notification_type: NOTIFICATION_TYPES.votes_released,
+      read: false,
+      topic_id: 449,
+      fancy_title: "Add dark mode",
+      slug: "add-dark-mode",
+      data: { message: "votes_released", title: "votes_released" },
+    });
+
+    this.item = new UserMenuNotificationItem({
+      notification,
+      currentUser: this.currentUser,
+      siteSettings: this.siteSettings,
+      site: this.site,
+    });
+  });
+
+  test("says the vote was returned when vote limits are enabled", async function (assert) {
+    this.siteSettings.topic_voting_enable_vote_limits = true;
+
+    await render(<template><MenuItem @item={{this.item}} /></template>);
+
+    assert.dom("li .item-label").hasText("Vote returned");
+    assert.dom("li a").hasAttribute("title", "Vote returned");
+    assert.dom("li a .d-icon-plus").exists();
+  });
+
+  test("says voting closed when vote limits are disabled", async function (assert) {
+    this.siteSettings.topic_voting_enable_vote_limits = false;
+
+    await render(<template><MenuItem @item={{this.item}} /></template>);
+
+    assert.dom("li .item-label").hasText("Voting closed");
+    assert.dom("li a").hasAttribute("title", "Voting closed");
+    assert.dom("li a .d-icon-lock").exists();
+  });
+});


### PR DESCRIPTION
Previously topic voting always had limits, so when a topic was closed a vote was returned to the voter and we notified them

<img width="320" height="69" alt="image" src="https://github.com/user-attachments/assets/09674ac6-cb78-49d2-952b-0602d730fe19" />

Recently we added the ability to disable vote limits, and this notification no longer makes much sense. In this case, it would be better to simply notify the voter that voting has closed — which is the feature I'm adding here: 

<img width="392"  alt="image" src="https://github.com/user-attachments/assets/a889a809-280c-4531-9c1c-1355269380dc" />

The icon is given the alias `topic_voting.voting_closed` so it can be replaced independently of the lock icon used elsewhere. 

I also removed a translation that no longer seems to be used anywhere. 



