### PR TITLE
A11Y: use aria-description for unread post badge instead of aria-label

### DIFF
--- a/frontend/discourse/app/components/topic-post-badges.gjs
+++ b/frontend/discourse/app/components/topic-post-badges.gjs
@@ -19,10 +19,14 @@ export default class TopicPostBadges extends Component {
     {{~! no whitespace ~}}
     <span class="topic-post-badges">
       {{~#if this.displayUnreadPosts~}}
+        {{! eslint-disable-next-line ember/template-no-unsupported-role-attributes }}
         &nbsp;<a
           href={{@url}}
           title={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
-          aria-label={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
+          aria-description={{i18n
+            "topic.unread_posts"
+            count=this.displayUnreadPosts
+          }}
           class="badge badge-notification unread-posts"
         >{{this.displayUnreadPosts}}</a>
       {{~/if~}}

--- a/frontend/discourse/tests/integration/components/topic-post-badges-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-post-badges-test.gjs
@@ -1,0 +1,41 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import TopicPostBadges from "discourse/components/topic-post-badges";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+module("Integration | Component | TopicPostBadges", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("keeps the unread count as the accessible name", async function (assert) {
+    await render(
+      <template><TopicPostBadges @unreadPosts={{5}} @url="/t/1/2" /></template>
+    );
+
+    const link = ".badge-notification.unread-posts";
+    assert.dom(link).hasText("5", "the visible count is rendered");
+    assert
+      .dom(link)
+      .hasNoAttribute(
+        "aria-label",
+        "the verbose sentence does not override the accessible name"
+      );
+    assert
+      .dom(link)
+      .hasAttribute("title", i18n("topic.unread_posts", { count: 5 }));
+  });
+
+  test("exposes the full sentence as a description for consistent announcements", async function (assert) {
+    await render(
+      <template><TopicPostBadges @unreadPosts={{5}} @url="/t/1/2" /></template>
+    );
+
+    assert
+      .dom(".badge-notification.unread-posts")
+      .hasAttribute(
+        "aria-description",
+        i18n("topic.unread_posts", { count: 5 }),
+        "the description matches the tooltip sentence"
+      );
+  });
+});


### PR DESCRIPTION
We received some feedback that the aria-label here was a bit too verbose and aria-description is both more consistent with the title, and doesn't have the verbosity issue because it's optional (have to intentionally linger to hear it, and controllable via user prefs) 
