### PR TITLE
FIX: Return a validation error for invalid pluralized email templates

### DIFF
--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -163,12 +163,8 @@ class Admin::EmailTemplatesController < Admin::AdminController
         rest_serializer: true,
       )
     else
-      TranslationOverride.upsert!(
-        I18n.locale,
-        "#{key}.subject_template",
-        subject_result[:old_value],
-      )
-      TranslationOverride.upsert!(I18n.locale, "#{key}.text_body_template", body_result[:old_value])
+      restore_key(subject_result)
+      restore_key(body_result)
 
       render_json_error(error_messages)
     end
@@ -201,12 +197,23 @@ class Admin::EmailTemplatesController < Admin::AdminController
 
   def update_key(key, value)
     old_value = I18n.t(key)
+    has_override = TranslationOverride.exists?(locale: I18n.locale, translation_key: key)
 
     unless old_value.is_a?(Hash)
       translation_override = TranslationOverride.upsert!(I18n.locale, key, value)
     end
 
-    { key:, old_value:, error_messages: translation_override&.errors&.full_messages }
+    { key:, old_value:, has_override:, error_messages: translation_override&.errors&.full_messages }
+  end
+
+  def restore_key(update_result)
+    return if update_result[:old_value].is_a?(Hash)
+
+    if update_result[:has_override]
+      TranslationOverride.upsert!(I18n.locale, update_result[:key], update_result[:old_value])
+    else
+      TranslationOverride.revert!(I18n.locale, update_result[:key])
+    end
   end
 
   def revert_and_log(*keys)

--- a/spec/requests/admin/email_templates_controller_spec.rb
+++ b/spec/requests/admin/email_templates_controller_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Admin::EmailTemplatesController do
         end
       end
 
-      context "when subject has plural keys" do
+      context "when subject or body has plural keys" do
         it "doesn't update the subject" do
           old_subject = I18n.t("system_messages.pending_users_reminder.subject_template")
           expect(old_subject).to be_a(Hash)
@@ -379,6 +379,54 @@ RSpec.describe Admin::EmailTemplatesController do
           expect(I18n.t("system_messages.pending_users_reminder.text_body_template")).to eq(
             "Lorem ipsum",
           )
+        end
+
+        it "returns validation errors without creating overrides for pluralized templates" do
+          templates = [
+            {
+              key: "system_messages.pending_users_reminder",
+              subject: "",
+              body: "Body with %{invalid} interpolation key",
+              invalid_attribute: "Body",
+            },
+            {
+              key: "system_messages.reviewables_reminder",
+              subject: "Subject with %{invalid} interpolation key",
+              body: "",
+              invalid_attribute: "Subject",
+            },
+          ]
+
+          templates.each do |template|
+            subject_key = "#{template[:key]}.subject_template"
+            body_key = "#{template[:key]}.text_body_template"
+            expect([I18n.t(subject_key), I18n.t(body_key)]).to include(be_a(Hash))
+
+            put "/admin/email/templates/#{template[:key]}",
+                params: {
+                  email_template: template.slice(:subject, :body),
+                },
+                headers: headers
+
+            expect(response.status).to eq(422)
+            expect(response.parsed_body["errors"]).to eq(
+              [
+                "<b>#{template[:invalid_attribute]}</b>: #{
+                  I18n.t(
+                    "activerecord.errors.models.translation_overrides.attributes.value.invalid_interpolation_keys",
+                    keys: "invalid",
+                    count: 1,
+                  )
+                }",
+              ],
+            )
+            expect(
+              TranslationOverride.where(
+                locale: I18n.locale,
+                translation_key: [subject_key, body_key],
+              ),
+            ).to be_empty
+          end
         end
       end
     end


### PR DESCRIPTION
Pluralized email-template subject and body values are hashes. When an invalid edit triggered the rollback path, it attempted to store that hash as a translation override and raised a TypeError.

Track the original override state for scalar values, restore it after a failed update, and leave pluralized roots untouched. Invalid edits now return the expected 422 response without creating override records.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>