### PR TITLE
FIX: Report effective welcome banner state for themes without overrides

### DIFF
--- a/app/controllers/admin/config/welcome_banner_controller.rb
+++ b/app/controllers/admin/config/welcome_banner_controller.rb
@@ -13,7 +13,7 @@ class Admin::Config::WelcomeBannerController < Admin::AdminController
     themes_data =
       themes.map do |theme|
         setting = theme.theme_site_settings.find { |s| s.name == "enable_welcome_banner" }
-        value = setting&.setting_rb_value || false
+        value = setting&.setting_rb_value || SiteSetting.defaults[:enable_welcome_banner]
 
         { id: theme.id, name: theme.name, enable_welcome_banner: value }
       end

--- a/app/controllers/admin/config/welcome_banner_controller.rb
+++ b/app/controllers/admin/config/welcome_banner_controller.rb
@@ -13,7 +13,7 @@ class Admin::Config::WelcomeBannerController < Admin::AdminController
     themes_data =
       themes.map do |theme|
         setting = theme.theme_site_settings.find { |s| s.name == "enable_welcome_banner" }
-        value = setting&.setting_rb_value || SiteSetting.defaults[:enable_welcome_banner]
+        value = setting ? setting.setting_rb_value : SiteSetting.defaults[:enable_welcome_banner]
 
         { id: theme.id, name: theme.name, enable_welcome_banner: value }
       end

--- a/spec/requests/admin/config/welcome_banner_controller_spec.rb
+++ b/spec/requests/admin/config/welcome_banner_controller_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Admin::Config::WelcomeBannerController do
         expect(theme_data["enable_welcome_banner"]).to eq(true)
       end
 
+      it "returns false when the theme explicitly disables the welcome banner" do
+        Fabricate(
+          :theme_site_setting,
+          theme: user_selectable_theme,
+          name: "enable_welcome_banner",
+          value: false,
+        )
+
+        get "/admin/config/welcome-banner/themes-with-setting.json"
+
+        expect(response.status).to eq(200)
+
+        theme_data = response.parsed_body["themes"].find { |t| t["id"] == user_selectable_theme.id }
+        expect(theme_data["enable_welcome_banner"]).to eq(false)
+      end
+
       it "returns the effective default for enable_welcome_banner when setting is not present" do
         get "/admin/config/welcome-banner/themes-with-setting.json"
 

--- a/spec/requests/admin/config/welcome_banner_controller_spec.rb
+++ b/spec/requests/admin/config/welcome_banner_controller_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe Admin::Config::WelcomeBannerController do
         expect(theme_data["enable_welcome_banner"]).to eq(true)
       end
 
-      it "returns false for enable_welcome_banner when setting is not present" do
+      it "returns the effective default for enable_welcome_banner when setting is not present" do
         get "/admin/config/welcome-banner/themes-with-setting.json"
 
         expect(response.status).to eq(200)
 
         theme_data = response.parsed_body["themes"].find { |t| t["id"] == user_selectable_theme.id }
-        expect(theme_data["enable_welcome_banner"]).to eq(false)
+        expect(theme_data["enable_welcome_banner"]).to eq(true)
       end
     end
 


### PR DESCRIPTION
Previously, the `themes-with-setting` endpoint reported themes with no `ThemeSiteSetting` override as disabled, even though a missing override means the theme inherits the `enable_welcome_banner` default (true), so saving unrelated fields on the admin welcome-banner form silently persisted `false` and hid the banner for those themes.

This change falls back to `SiteSetting.defaults[:enable_welcome_banner]` only when no override row exists — while still reporting explicit `false` overrides correctly — matching how `ThemeSiteSetting.generate_theme_map` and `ThemeSiteSettingResolver` resolve effective values.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1666

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
