### PR TITLE
FIX: Prevent deletion of system badges via the admin API

### DIFF
--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -170,6 +170,8 @@ class Admin::BadgesController < Admin::AdminController
   def destroy
     Badge.transaction do
       badge = find_badge
+      raise Discourse::InvalidAccess if badge.system?
+
       StaffActionLogger.new(current_user).log_badge_deletion(badge)
       badge.clear_user_titles!
       badge.destroy!

--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -168,10 +168,11 @@ class Admin::BadgesController < Admin::AdminController
   end
 
   def destroy
-    Badge.transaction do
-      badge = find_badge
-      raise Discourse::InvalidAccess if badge.system?
+    badge = find_badge
 
+    return render_json_error(I18n.t("badges.errors.cant_delete_system_badge")) if badge.system?
+
+    Badge.transaction do
       StaffActionLogger.new(current_user).log_badge_deletion(badge)
       badge.clear_user_titles!
       badge.destroy!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5634,6 +5634,8 @@ en:
       This document is CC-BY-SA. It was last updated [INSERT LAST UPDATE DATE HERE].
 
   badges:
+    errors:
+      cant_delete_system_badge: System badges cannot be deleted.
     mass_award:
       errors:
         invalid_csv: We encountered an error on line %{line_number}. Please confirm the CSV has one email per line.

--- a/spec/requests/admin/badges_controller_spec.rb
+++ b/spec/requests/admin/badges_controller_spec.rb
@@ -273,6 +273,22 @@ RSpec.describe Admin::BadgesController do
     context "when logged in as an admin" do
       before { sign_in(admin) }
 
+      it "prevents deletion of system badges" do
+        system_badge = Badge.find(Badge::Editor)
+        user_badge = BadgeGranter.grant(system_badge, user)
+        user.update!(title: system_badge.name)
+        user.user_profile.update!(granted_title_badge_id: system_badge.id)
+
+        delete "/admin/badges/#{system_badge.id}.json"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        expect(Badge.where(id: system_badge.id)).to exist
+        expect(UserBadge.where(id: user_badge.id)).to exist
+        expect(user.reload.title).to eq(system_badge.name)
+        expect(user.user_profile.reload.granted_title_badge_id).to eq(system_badge.id)
+      end
+
       it "deletes the badge" do
         delete "/admin/badges/#{badge.id}.json"
         expect(response.status).to eq(200)

--- a/spec/requests/admin/badges_controller_spec.rb
+++ b/spec/requests/admin/badges_controller_spec.rb
@@ -274,19 +274,29 @@ RSpec.describe Admin::BadgesController do
       before { sign_in(admin) }
 
       it "prevents deletion of system badges" do
-        system_badge = Badge.find(Badge::Editor)
+        system_badge = Badge.find(Badge::Regular)
+        expect(system_badge.system?).to eq(true)
+
         user_badge = BadgeGranter.grant(system_badge, user)
         user.update!(title: system_badge.name)
         user.user_profile.update!(granted_title_badge_id: system_badge.id)
 
         delete "/admin/badges/#{system_badge.id}.json"
 
-        expect(response.status).to eq(403)
-        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          I18n.t("badges.errors.cant_delete_system_badge"),
+        )
         expect(Badge.where(id: system_badge.id)).to exist
         expect(UserBadge.where(id: user_badge.id)).to exist
         expect(user.reload.title).to eq(system_badge.name)
         expect(user.user_profile.reload.granted_title_badge_id).to eq(system_badge.id)
+        expect(
+          UserHistory.where(
+            acting_user_id: admin.id,
+            action: UserHistory.actions[:delete_badge],
+          ).exists?,
+        ).to eq(false)
       end
 
       it "deletes the badge" do


### PR DESCRIPTION
Previously, the admin UI hid the delete button for seeded system badges, but `DELETE /admin/badges/:id` accepted direct requests and destroyed the badge, its `UserBadge` grants, and any user titles granted from it.

This change rejects the request with a translated 422 error before anything is logged or destroyed — matching how system flags and automatic groups are protected — while leaving custom badge deletion unchanged.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>