### PR TITLE
FIX: Handle concurrent About localization creation

### DIFF
--- a/app/services/site_setting_localizations/about_config/update.rb
+++ b/app/services/site_setting_localizations/about_config/update.rb
@@ -49,32 +49,24 @@ class SiteSettingLocalizations::AboutConfig::Update
         locale: params.locale,
       ).destroy_all
     else
-      localization =
-        SiteSettingLocalization.find_by(
-          setting_name: submitted_setting[:setting_name],
-          locale: params.locale,
-        )
+      attributes = { value: submitted_setting[:value], localizer_user_id: guardian.user.id }
 
-      if localization
-        localization.update!(value: submitted_setting[:value], localizer_user_id: guardian.user.id)
-      else
-        localization =
-          SiteSettingLocalization.create_or_find_by!(
+      localization =
+        begin
+          SiteSettingLocalization.find_or_create_by!(
             setting_name: submitted_setting[:setting_name],
             locale: params.locale,
-          ) do |record|
-            record.value = submitted_setting[:value]
-            record.localizer_user_id = guardian.user.id
-          end
+          ) { |record| record.assign_attributes(attributes) }
+        rescue ActiveRecord::RecordInvalid => error
+          raise unless error.record.errors.of_kind?(:setting_name, :taken)
 
-        if localization.value != submitted_setting[:value] ||
-             localization.localizer_user_id != guardian.user.id
-          localization.update!(
-            value: submitted_setting[:value],
-            localizer_user_id: guardian.user.id,
+          SiteSettingLocalization.lock.find_by!(
+            setting_name: submitted_setting[:setting_name],
+            locale: params.locale,
           )
         end
-      end
+
+      localization.update!(attributes) unless localization.previously_new_record?
     end
   end
 

--- a/app/services/site_setting_localizations/about_config/update.rb
+++ b/app/services/site_setting_localizations/about_config/update.rb
@@ -50,13 +50,31 @@ class SiteSettingLocalizations::AboutConfig::Update
       ).destroy_all
     else
       localization =
-        SiteSettingLocalization.find_or_initialize_by(
+        SiteSettingLocalization.find_by(
           setting_name: submitted_setting[:setting_name],
           locale: params.locale,
         )
-      localization.value = submitted_setting[:value]
-      localization.localizer_user_id = guardian.user.id
-      localization.save!
+
+      if localization
+        localization.update!(value: submitted_setting[:value], localizer_user_id: guardian.user.id)
+      else
+        localization =
+          SiteSettingLocalization.create_or_find_by!(
+            setting_name: submitted_setting[:setting_name],
+            locale: params.locale,
+          ) do |record|
+            record.value = submitted_setting[:value]
+            record.localizer_user_id = guardian.user.id
+          end
+
+        if localization.value != submitted_setting[:value] ||
+             localization.localizer_user_id != guardian.user.id
+          localization.update!(
+            value: submitted_setting[:value],
+            localizer_user_id: guardian.user.id,
+          )
+        end
+      end
     end
   end
 

--- a/spec/requests/admin/config/about_localizations_concurrency_spec.rb
+++ b/spec/requests/admin/config/about_localizations_concurrency_spec.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::Config::AboutController do
-  self.use_transactional_tests = false
-
   fab!(:admin)
+  fab!(:another_admin, :admin)
 
   before do
     sign_in(admin)
     SiteSetting.content_localization_enabled = true
     SiteSetting.content_localization_supported_locales = "ja|pt_BR"
-  end
-
-  after do
-    UserHistory.where(acting_user_id: admin.id).delete_all
-    admin.destroy!
   end
 
   it "returns a successful response when a concurrent first create leaves a stale lookup" do
@@ -27,13 +21,8 @@ RSpec.describe Admin::Config::AboutController do
 
     expect(response.status).to eq(200)
 
-    stale_localization = SiteSettingLocalization.new(setting_name: "title", locale: "ja")
     SiteSettingLocalization.stubs(:find_by).with(setting_name: "title", locale: "ja").returns(nil)
-    SiteSettingLocalization
-      .stubs(:find_or_initialize_by)
-      .with(setting_name: "title", locale: "ja")
-      .returns(stale_localization)
-    SiteSettingLocalization.any_instance.stubs(:valid?).returns(true)
+    sign_in(another_admin)
 
     put "/admin/config/about/localizations.json",
         params: {
@@ -45,6 +34,11 @@ RSpec.describe Admin::Config::AboutController do
 
     expect(response.status).to eq(200)
     expect(response.parsed_body.dig("localizations", "title", "value")).to eq("Updated title")
-    expect(SiteSettingLocalization.where(setting_name: "title", locale: "ja").count).to eq(1)
+
+    localization = SiteSettingLocalization.where(setting_name: "title", locale: "ja").sole
+    expect(localization).to have_attributes(
+      value: "Updated title",
+      localizer_user_id: another_admin.id,
+    )
   end
 end

--- a/spec/requests/admin/config/about_localizations_concurrency_spec.rb
+++ b/spec/requests/admin/config/about_localizations_concurrency_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::Config::AboutController do
+  self.use_transactional_tests = false
+
+  fab!(:admin)
+
+  before do
+    sign_in(admin)
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_supported_locales = "ja|pt_BR"
+  end
+
+  after do
+    UserHistory.where(acting_user_id: admin.id).delete_all
+    admin.destroy!
+  end
+
+  it "returns a successful response when a concurrent first create leaves a stale lookup" do
+    put "/admin/config/about/localizations.json",
+        params: {
+          locale: "ja",
+          general_settings: {
+            name: "Original title",
+          },
+        }
+
+    expect(response.status).to eq(200)
+
+    stale_localization = SiteSettingLocalization.new(setting_name: "title", locale: "ja")
+    SiteSettingLocalization.stubs(:find_by).with(setting_name: "title", locale: "ja").returns(nil)
+    SiteSettingLocalization
+      .stubs(:find_or_initialize_by)
+      .with(setting_name: "title", locale: "ja")
+      .returns(stale_localization)
+    SiteSettingLocalization.any_instance.stubs(:valid?).returns(true)
+
+    put "/admin/config/about/localizations.json",
+        params: {
+          locale: "ja",
+          general_settings: {
+            name: "Updated title",
+          },
+        }
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body.dig("localizations", "title", "value")).to eq("Updated title")
+    expect(SiteSettingLocalization.where(setting_name: "title", locale: "ja").count).to eq(1)
+  end
+end


### PR DESCRIPTION
Fixes a race when two admins create the same localized About setting at once.

This also adds regression coverage for the committed-row stale-lookup case, ensuring the latest value and localizer are saved while exactly one localization row remains.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>