### PR TITLE
FIX: Export Theme - PWA fix

### DIFF
--- a/frontend/discourse/admin/components/admin-config-areas/components.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/components.gjs
@@ -15,6 +15,7 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { extractErrorInfo } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
+import downloadBlob from "discourse/lib/download-blob";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import getURL from "discourse/lib/get-url";
 import { descriptionForRemoteUrl } from "discourse/lib/popular-themes";
@@ -455,6 +456,17 @@ class ComponentRow extends Component {
   }
 
   @action
+  async export() {
+    try {
+      await downloadBlob(
+        getURL(`/admin/customize/themes/${this.args.component.id}/export`)
+      );
+    } catch {
+      this.dialog.alert(i18n("generic_error"));
+    }
+  }
+
+  @action
   delete() {
     return this.dialog.deleteConfirm({
       title: i18n(
@@ -636,15 +648,9 @@ class ComponentRow extends Component {
                 <dropdown.item>
                   <DButton
                     class="btn-transparent admin-config-components__export"
-                    target="_blank"
-                    rel="noopener noreferrer"
                     @label="admin.config_areas.themes_and_components.components.export"
                     @icon="download"
-                    @href={{getURL
-                      (concat
-                        "/admin/customize/themes/" @component.id "/export"
-                      )
-                    }}
+                    @action={{this.export}}
                   />
                 </dropdown.item>
                 <dropdown.item>

--- a/frontend/discourse/admin/components/admin-config-areas/components.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/components.gjs
@@ -16,6 +16,7 @@ import { ajax } from "discourse/lib/ajax";
 import { extractErrorInfo } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
 import downloadBlob from "discourse/lib/download-blob";
+import { attachmentDownloadStrategy } from "discourse/lib/download-strategy";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import getURL from "discourse/lib/get-url";
 import { descriptionForRemoteUrl } from "discourse/lib/popular-themes";
@@ -455,6 +456,10 @@ class ComponentRow extends Component {
     }
   }
 
+  get exportAction() {
+    return attachmentDownloadStrategy() === "native" ? undefined : this.export;
+  }
+
   @action
   async export() {
     try {
@@ -650,7 +655,12 @@ class ComponentRow extends Component {
                     class="btn-transparent admin-config-components__export"
                     @label="admin.config_areas.themes_and_components.components.export"
                     @icon="download"
-                    @action={{this.export}}
+                    @href={{getURL
+                      (concat
+                        "/admin/customize/themes/" @component.id "/export"
+                      )
+                    }}
+                    @action={{this.exportAction}}
                   />
                 </dropdown.item>
                 <dropdown.item>

--- a/frontend/discourse/admin/controllers/admin-customize-themes/show/index.js
+++ b/frontend/discourse/admin/controllers/admin-customize-themes/show/index.js
@@ -10,6 +10,7 @@ import ThemeSettings from "discourse/admin/models/theme-settings";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { removeValueFromArray } from "discourse/lib/array-tools";
+import downloadBlob from "discourse/lib/download-blob";
 import getURL from "discourse/lib/get-url";
 import { makeArray } from "discourse/lib/helpers";
 import { i18n } from "discourse-i18n";
@@ -356,6 +357,15 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
   @computed("model.user.id", "model.default")
   get showConvert() {
     return this.model?.user?.id > 0 && !this.model?.default;
+  }
+
+  @action
+  async exportTheme() {
+    try {
+      await downloadBlob(this.downloadUrl);
+    } catch {
+      this.dialog.alert(i18n("generic_error"));
+    }
   }
 
   @action

--- a/frontend/discourse/admin/controllers/admin-customize-themes/show/index.js
+++ b/frontend/discourse/admin/controllers/admin-customize-themes/show/index.js
@@ -11,6 +11,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { removeValueFromArray } from "discourse/lib/array-tools";
 import downloadBlob from "discourse/lib/download-blob";
+import { attachmentDownloadStrategy } from "discourse/lib/download-strategy";
 import getURL from "discourse/lib/get-url";
 import { makeArray } from "discourse/lib/helpers";
 import { i18n } from "discourse-i18n";
@@ -357,6 +358,12 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
   @computed("model.user.id", "model.default")
   get showConvert() {
     return this.model?.user?.id > 0 && !this.model?.default;
+  }
+
+  get exportAction() {
+    return attachmentDownloadStrategy() === "native"
+      ? undefined
+      : this.exportTheme;
   }
 
   @action

--- a/frontend/discourse/admin/controllers/admin-watched-words/action.js
+++ b/frontend/discourse/admin/controllers/admin-watched-words/action.js
@@ -6,6 +6,7 @@ import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import WatchedWordTestingModal from "discourse/admin/components/modal/watched-word-testing";
 import { ajax } from "discourse/lib/ajax";
+import downloadBlob from "discourse/lib/download-blob";
 import { i18n } from "discourse-i18n";
 
 export default class AdminWatchedWordsActionController extends Controller {
@@ -117,6 +118,15 @@ export default class AdminWatchedWordsActionController extends Controller {
   @action
   async uploadComplete() {
     return this.adminWatchedWords.updateAllWords();
+  }
+
+  @action
+  async download() {
+    try {
+      await downloadBlob(this.downloadLink);
+    } catch {
+      this.dialog.alert(i18n("generic_error"));
+    }
   }
 
   @action

--- a/frontend/discourse/admin/controllers/admin-watched-words/action.js
+++ b/frontend/discourse/admin/controllers/admin-watched-words/action.js
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import WatchedWordTestingModal from "discourse/admin/components/modal/watched-word-testing";
 import { ajax } from "discourse/lib/ajax";
 import downloadBlob from "discourse/lib/download-blob";
+import { attachmentDownloadStrategy } from "discourse/lib/download-strategy";
 import { i18n } from "discourse-i18n";
 
 export default class AdminWatchedWordsActionController extends Controller {
@@ -118,6 +119,12 @@ export default class AdminWatchedWordsActionController extends Controller {
   @action
   async uploadComplete() {
     return this.adminWatchedWords.updateAllWords();
+  }
+
+  get downloadAction() {
+    return attachmentDownloadStrategy() === "native"
+      ? undefined
+      : this.download;
   }
 
   @action

--- a/frontend/discourse/admin/services/admin-emojis.js
+++ b/frontend/discourse/admin/services/admin-emojis.js
@@ -7,6 +7,7 @@ import {
   removeValueFromArray,
   uniqueItemsFromArray,
 } from "discourse/lib/array-tools";
+import { triggerBlobDownload } from "discourse/lib/download-blob";
 import getURL from "discourse/lib/get-url";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
 import Session from "discourse/models/session";
@@ -72,15 +73,10 @@ export default class AdminEmojis extends Service {
         return;
       }
 
-      const blob = await response.blob();
-      const objectUrl = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = objectUrl;
-      a.download = "emojis.zip";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      setTimeout(() => URL.revokeObjectURL(objectUrl), 20_000);
+      triggerBlobDownload(await response.blob(), {
+        fallbackFilename: "emojis.zip",
+        contentDisposition: response.headers.get("Content-Disposition"),
+      });
     } catch {
       this.dialog.alert(i18n("admin.emoji.export_failed"));
     } finally {

--- a/frontend/discourse/admin/templates/admin-customize-themes/show/index.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-themes/show/index.gjs
@@ -483,12 +483,12 @@ export default <template>
       class="btn btn-default"
     >{{dIcon "desktop"}}{{i18n "admin.customize.theme.preview"}}</a>
     {{#unless @controller.model.system}}
-      <a
-        class="btn btn-default export"
-        rel="noopener noreferrer"
-        target="_blank"
-        href={{@controller.downloadUrl}}
-      >{{dIcon "download"}} {{i18n "admin.export_json.button_text"}}</a>
+      <DButton
+        class="btn-default export"
+        @action={{@controller.exportTheme}}
+        @icon="download"
+        @label="admin.export_json.button_text"
+      />
     {{/unless}}
 
     {{#if @controller.showConvert}}

--- a/frontend/discourse/admin/templates/admin-customize-themes/show/index.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-themes/show/index.gjs
@@ -485,7 +485,8 @@ export default <template>
     {{#unless @controller.model.system}}
       <DButton
         class="btn-default export"
-        @action={{@controller.exportTheme}}
+        @href={{@controller.downloadUrl}}
+        @action={{@controller.exportAction}}
         @icon="download"
         @label="admin.export_json.button_text"
       />

--- a/frontend/discourse/admin/templates/admin-watched-words/action.gjs
+++ b/frontend/discourse/admin/templates/admin-watched-words/action.gjs
@@ -24,7 +24,7 @@ export default <template>
 
   <div class="watched-word-controls">
     <DButton
-      @href={{@controller.downloadLink}}
+      @action={{@controller.download}}
       @icon="download"
       @label="admin.watched_words.download"
       class="btn-default download-link"

--- a/frontend/discourse/admin/templates/admin-watched-words/action.gjs
+++ b/frontend/discourse/admin/templates/admin-watched-words/action.gjs
@@ -24,7 +24,8 @@ export default <template>
 
   <div class="watched-word-controls">
     <DButton
-      @action={{@controller.download}}
+      @href={{@controller.downloadLink}}
+      @action={{@controller.downloadAction}}
       @icon="download"
       @label="admin.watched_words.download"
       class="btn-default download-link"

--- a/frontend/discourse/app/lib/download-blob.js
+++ b/frontend/discourse/app/lib/download-blob.js
@@ -1,0 +1,60 @@
+const REVOKE_AFTER = 20_000;
+
+function parseFilename(contentDisposition) {
+  if (!contentDisposition) {
+    return null;
+  }
+  const utf8Match = contentDisposition.match(
+    /filename\*\s*=\s*UTF-8''([^;]+)/i
+  );
+  if (utf8Match) {
+    try {
+      return decodeURIComponent(utf8Match[1].trim().replace(/^"|"$/g, ""));
+    } catch {
+      // fall through to ascii match
+    }
+  }
+  const asciiMatch = contentDisposition.match(/filename\s*=\s*"?([^";]+)"?/i);
+  return asciiMatch ? asciiMatch[1].trim() : null;
+}
+
+// Triggers a browser download of the given Blob via a hidden `<a download>`.
+// Preferable to a plain `<a href target=_blank>` navigation for large binaries
+// in iOS PWA and embedded WebView contexts, where the new-tab navigation
+// either strands the user in a standalone window or renders the binary as
+// text.
+export function triggerBlobDownload(
+  blob,
+  { fallbackFilename, contentDisposition } = {}
+) {
+  const objectUrl = URL.createObjectURL(blob);
+  const filename = parseFilename(contentDisposition) ?? fallbackFilename;
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  if (filename) {
+    a.download = filename;
+  }
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(objectUrl), REVOKE_AFTER);
+}
+
+// Fetches `url` and triggers a browser download of the response body.
+export default async function downloadBlob(
+  url,
+  { fallbackFilename, fetchOptions } = {}
+) {
+  const response = await fetch(url, {
+    credentials: "same-origin",
+    ...fetchOptions,
+  });
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.status}`);
+  }
+  triggerBlobDownload(await response.blob(), {
+    fallbackFilename,
+    contentDisposition: response.headers.get("Content-Disposition"),
+  });
+}

--- a/frontend/discourse/app/lib/download-strategy.js
+++ b/frontend/discourse/app/lib/download-strategy.js
@@ -1,0 +1,18 @@
+import { capabilities } from "discourse/services/capabilities";
+
+// Reports how the current runtime handles server-generated attachment
+// downloads (responses with `Content-Disposition: attachment`).
+//
+//   "native" — a plain <a href> triggers a proper download: the browser
+//              streams to disk, uses its own header parser to pick the
+//              filename, and shows its native progress UI. This is the case
+//              for desktop and mobile browsers.
+//   "blob"   — a new-tab navigation to an attachment strands the user in a
+//              standalone window (iOS PWA). Callers must fetch the response
+//              and trigger a client-side blob download instead.
+export function attachmentDownloadStrategy() {
+  if (capabilities.isPwa) {
+    return "blob";
+  }
+  return "native";
+}

--- a/frontend/discourse/app/lib/url.js
+++ b/frontend/discourse/app/lib/url.js
@@ -33,6 +33,7 @@ const SERVER_SIDE_ONLY = [
   /\.json$/,
   /^\/logs($|\/)/,
   /^\/admin\/customize\/watched_words\/action\/[^\/]+\/download$/,
+  /^\/admin\/customize\/themes\/\d+\/export$/,
   /^\/pub\//,
   /^\/invites\//,
   /^\/styleguide/,

--- a/frontend/discourse/tests/unit/lib/download-blob-test.js
+++ b/frontend/discourse/tests/unit/lib/download-blob-test.js
@@ -1,0 +1,110 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import downloadBlob, { triggerBlobDownload } from "discourse/lib/download-blob";
+
+function captureAnchor() {
+  const original = document.createElement.bind(document);
+  const created = [];
+  const stub = sinon
+    .stub(document, "createElement")
+    .callsFake(function (tagName) {
+      const el = original(tagName);
+      if (tagName === "a") {
+        created.push(el);
+        sinon.stub(el, "click");
+      }
+      return el;
+    });
+  return { created, stub };
+}
+
+module("Unit | Utility | download-blob", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    sinon.stub(URL, "createObjectURL").returns("blob:mock");
+    sinon.stub(URL, "revokeObjectURL");
+  });
+
+  test("triggerBlobDownload uses fallbackFilename when no Content-Disposition", function (assert) {
+    const { created } = captureAnchor();
+
+    triggerBlobDownload(new Blob(["x"]), { fallbackFilename: "fallback.zip" });
+
+    assert.strictEqual(created.length, 1);
+    assert.strictEqual(created[0].getAttribute("download"), "fallback.zip");
+    assert.strictEqual(created[0].getAttribute("href"), "blob:mock");
+    assert.true(created[0].click.calledOnce);
+  });
+
+  test("triggerBlobDownload prefers the filename from Content-Disposition", function (assert) {
+    const { created } = captureAnchor();
+
+    triggerBlobDownload(new Blob(["x"]), {
+      fallbackFilename: "fallback.zip",
+      contentDisposition: 'attachment; filename="server-name.zip"',
+    });
+
+    assert.strictEqual(created[0].getAttribute("download"), "server-name.zip");
+  });
+
+  test("triggerBlobDownload parses RFC 5987 UTF-8 filename*", function (assert) {
+    const { created } = captureAnchor();
+
+    triggerBlobDownload(new Blob(["x"]), {
+      contentDisposition:
+        "attachment; filename=\"ascii-fallback.zip\"; filename*=UTF-8''caf%C3%A9.zip",
+    });
+
+    assert.strictEqual(created[0].getAttribute("download"), "café.zip");
+  });
+
+  test("triggerBlobDownload falls back to ASCII match when UTF-8 form is malformed", function (assert) {
+    const { created } = captureAnchor();
+
+    triggerBlobDownload(new Blob(["x"]), {
+      contentDisposition:
+        "attachment; filename=\"ascii-only.zip\"; filename*=UTF-8''%E0%A4%A",
+    });
+
+    assert.strictEqual(created[0].getAttribute("download"), "ascii-only.zip");
+  });
+
+  test("triggerBlobDownload omits the download attribute when no filename is available", function (assert) {
+    const { created } = captureAnchor();
+
+    triggerBlobDownload(new Blob(["x"]));
+
+    assert.false(created[0].hasAttribute("download"));
+  });
+
+  test("downloadBlob fetches the URL and triggers a download", async function (assert) {
+    const { created } = captureAnchor();
+    const blob = new Blob(["zip-bytes"]);
+    const fetchStub = sinon.stub(window, "fetch").resolves(
+      new Response(blob, {
+        status: 200,
+        headers: { "Content-Disposition": 'attachment; filename="theme.zip"' },
+      })
+    );
+
+    await downloadBlob("/some/export");
+
+    assert.true(
+      fetchStub.calledWith(
+        "/some/export",
+        sinon.match({ credentials: "same-origin" })
+      )
+    );
+    assert.strictEqual(created[0].getAttribute("download"), "theme.zip");
+  });
+
+  test("downloadBlob throws on non-2xx responses without triggering a download", async function (assert) {
+    const { created } = captureAnchor();
+    sinon.stub(window, "fetch").resolves(new Response("nope", { status: 500 }));
+
+    await assert.rejects(downloadBlob("/some/export"), /Download failed: 500/);
+    assert.strictEqual(created.length, 0);
+  });
+});

--- a/frontend/discourse/tests/unit/lib/download-strategy-test.js
+++ b/frontend/discourse/tests/unit/lib/download-strategy-test.js
@@ -1,0 +1,21 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { attachmentDownloadStrategy } from "discourse/lib/download-strategy";
+import { capabilities } from "discourse/services/capabilities";
+
+module("Unit | Utility | download-strategy", function (hooks) {
+  setupTest(hooks);
+
+  test("returns 'native' by default", function (assert) {
+    sinon.stub(capabilities, "isPwa").value(false);
+
+    assert.strictEqual(attachmentDownloadStrategy(), "native");
+  });
+
+  test("returns 'blob' in a PWA", function (assert) {
+    sinon.stub(capabilities, "isPwa").value(true);
+
+    assert.strictEqual(attachmentDownloadStrategy(), "blob");
+  });
+});


### PR DESCRIPTION
Previously, the download for exporting themes was broken in the PWA app (it is also broken in Discourse Hub but that needs its own change).

This commit uses the blob pattern used for emoji exports, as that allows the PWA to show a download page that has controls to get out of it. This fixes the white screen that previously displayed and would get stuck in the PWA.

It also applies the blob pattern to watched words exports, which also failed in the PWA.