### PR TITLE
FIX: Avoid traversing Redis keys when clearing 404 topic cache

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -445,7 +445,11 @@ class Topic < ActiveRecord::Base
   end
 
   def self.clear_page_not_found_topics_cache!
-    Discourse.cache.keys("page_not_found_topics:*").each { |key| Discourse.cache.redis.del(key) }
+    keys =
+      I18n.available_locales.map do |locale|
+        Discourse.cache.normalize_key("page_not_found_topics:#{locale}")
+      end
+    Discourse.cache.redis.del(*keys)
   end
 
   def clear_page_not_found_topics_cache

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3819,6 +3819,28 @@ RSpec.describe Topic do
     end
   end
 
+  describe ".clear_page_not_found_topics_cache!" do
+    it "clears every locale without traversing a large Redis keyspace" do
+      cache_keys =
+        I18n.available_locales.map do |locale|
+          Discourse.cache.normalize_key("page_not_found_topics:#{locale}")
+        end
+      post_keys = 10_000.times.map { |index| Discourse.cache.normalize_key("post:#{index}") }
+
+      Discourse.cache.redis.pipelined do |pipeline|
+        cache_keys.each { |key| pipeline.set(key, "cached topic suggestions") }
+        post_keys.each { |key| pipeline.set(key, "post") }
+      end
+      allow(Discourse.cache.redis).to receive(:scan_each).and_raise(Timeout::Error)
+
+      expect { described_class.clear_page_not_found_topics_cache! }.not_to raise_error
+      expect(Discourse.cache.redis.mget(*cache_keys)).to all be_nil
+      expect(Discourse.cache.redis.mget(*post_keys)).to all eq("post")
+    ensure
+      Discourse.cache.redis.del(*post_keys) if post_keys
+    end
+  end
+
   describe "#auto_close_threshold_reached?" do
     fab!(:post)
     fab!(:reviewable) { Fabricate(:reviewable_flagged_post, target: post, topic: post.topic) }


### PR DESCRIPTION
In #42413 , cache invalidation logic of topic is redesigned.

However, `Discourse.cache.keys("page_not_found_topics:*").each { |key| Discourse.cache.redis.del(key) }` will traverse all of the redis keys, causing performance issues, and may timeout if there are large amount of keys.

For a site with a large Redis DB, users may encounter 500 error when they move a topic to a restricted category.

<img width="240" height="211" alt="image" src="https://github.com/user-attachments/assets/e16e87d0-2c1e-437e-99bf-521c5e4774a1" />

This commit restrict the traverse scope to `Discourse.cache.normalize_key("page_not_found_topics:#{locale}")`, which is far smaller than the whole redis, also add a test to avoid the execution of `scan_each`.