### PR TITLE
FIX: Restore custom emoji endpoint

### DIFF
--- a/lib/application_layout_preloader.rb
+++ b/lib/application_layout_preloader.rb
@@ -70,6 +70,11 @@ class ApplicationLayoutPreloader
     MultiJson.dump(data)
   end
 
+  def custom_emoji
+    serializer = ActiveModel::ArraySerializer.new(Emoji.custom, each_serializer: EmojiSerializer)
+    MultiJson.dump(serializer)
+  end
+
   private
 
   def preload_current_user_data
@@ -158,10 +163,5 @@ class ApplicationLayoutPreloader
           }
         end
       end
-  end
-
-  def custom_emoji
-    serializer = ActiveModel::ArraySerializer.new(Emoji.custom, each_serializer: EmojiSerializer)
-    MultiJson.dump(serializer)
   end
 end

--- a/spec/requests/site_controller_spec.rb
+++ b/spec/requests/site_controller_spec.rb
@@ -153,6 +153,19 @@ RSpec.describe SiteController do
     end
   end
 
+  describe "#emoji" do
+    fab!(:custom_emoji)
+
+    it "returns the custom emoji" do
+      get "/site/emoji.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to contain_exactly(
+        a_hash_including("name" => custom_emoji.name, "url" => custom_emoji.upload.url),
+      )
+    end
+  end
+
   describe "#statistics" do
     after { DiscoursePluginRegistry.reset! }
 


### PR DESCRIPTION
Make the layout preloader's custom emoji serializer publicly accessible so the site emoji endpoint can return custom emoji data. Add request coverage for the response.
