### PR TITLE
FIX: Handle connection resets when fetching titles

### DIFF
--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -3,6 +3,7 @@
 module RetrieveTitle
   CRAWL_TIMEOUT = 1
   UNRECOVERABLE_ERRORS = [
+    Errno::ECONNRESET,
     Net::ReadTimeout,
     FinalDestination::SSRFError,
     FinalDestination::UrlEncodingError,
@@ -16,7 +17,7 @@ module RetrieveTitle
       headers: headers,
     )
   rescue *UNRECOVERABLE_ERRORS
-    # ¯\_(ツ)_/¯
+    nil
   end
 
   def self.extract_title(html, encoding = nil)

--- a/spec/lib/retrieve_title_spec.rb
+++ b/spec/lib/retrieve_title_spec.rb
@@ -202,6 +202,12 @@ RSpec.describe RetrieveTitle do
       expect(RetrieveTitle.crawl("https://example.com")).to eq(nil)
     end
 
+    it "ignores connection reset errors" do
+      described_class.stubs(:fetch_title).raises(Errno::ECONNRESET)
+
+      expect(RetrieveTitle.crawl("https://example.com")).to eq(nil)
+    end
+
     it "ignores SSRF lookup errors" do
       described_class.stubs(:fetch_title).raises(FinalDestination::SSRFDetector::LookupFailedError)
 


### PR DESCRIPTION
Treat ECONNRESET as an unrecoverable crawl error so remote servers closing
the connection do not interrupt title retrieval.
