### PR TITLE
FIX: Load reviewables whose type is no longer defined

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -70,6 +70,12 @@ class Reviewable < ActiveRecord::Base
     where("score >= ?", min_score_for_priority)
   end
 
+  def self.sti_class_for(type_name)
+    super
+  rescue ActiveRecord::SubclassNotFound
+    Reviewable::UnknownType
+  end
+
   def self.valid_type?(type)
     type.to_s.safe_constantize.in?(types)
   end

--- a/app/models/reviewable/unknown_type.rb
+++ b/app/models/reviewable/unknown_type.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Reviewables outlive the code that defines their type whenever a plugin is disabled or
+# removed. Their rows are loaded through this class so the generic behaviour they share
+# with every other reviewable keeps working, instead of raising `SubclassNotFound`.
+#
+# They are excluded from the review queue by `Reviewable.list_for`, so no action can be
+# performed on them until their type is defined again.
+class Reviewable::UnknownType < Reviewable
+  self.inheritance_column = nil
+
+  def build_actions(actions, guardian, args)
+  end
+
+  # Preserves the source recorded while the type was still defined, so administrators
+  # can tell which plugin these belong to.
+  def set_type_source
+  end
+end
+
+# == Schema Information
+#
+# Table name: reviewables
+#
+#  id                      :bigint           not null, primary key
+#  force_review            :boolean          default(FALSE), not null
+#  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
+#  type                    :string           not null
+#  type_source             :string           default("unknown"), not null
+#  version                 :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
+#
+# Indexes
+#
+#  idx_reviewables_score_desc_created_at_desc                  (score,created_at)
+#  index_reviewables_on_reviewable_by_group_id                 (reviewable_by_group_id)
+#  index_reviewables_on_status_and_created_at                  (status,created_at)
+#  index_reviewables_on_status_and_score                       (status,score)
+#  index_reviewables_on_status_and_type                        (status,type)
+#  index_reviewables_on_target_id_where_post_type_eq_post      (target_id) WHERE ((target_type)::text = 'Post'::text)
+#  index_reviewables_on_topic_id_and_status_and_created_by_id  (topic_id,status,created_by_id)
+#  index_reviewables_on_type_and_target_id                     (type,target_id) UNIQUE
+#

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -738,7 +738,11 @@ class PostSerializer < BasicPostSerializer
   end
 
   def reviewable
-    @reviewable ||= Reviewable.where(target: object).includes(:reviewable_scores).first
+    @reviewable ||=
+      Reviewable
+        .where(target: object, type: Reviewable.sti_names)
+        .includes(:reviewable_scores)
+        .first
   end
 
   def reviewable_scores

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -747,6 +747,7 @@ class TopicView
         WHERE
           r.target_id IN (:post_ids) AND
           r.target_type = 'Post' AND
+          r.type IN (:known_types) AND
           COALESCE(s.reason, '') != 'category'
         GROUP BY
           target_id
@@ -755,7 +756,12 @@ class TopicView
         counts = {}
 
         DB
-          .query(sql, pending: ReviewableScore.statuses[:pending], post_ids: @posts.map(&:id))
+          .query(
+            sql,
+            pending: ReviewableScore.statuses[:pending],
+            post_ids: @posts.map(&:id),
+            known_types: Reviewable.sti_names,
+          )
           .each do |row|
             counts[row.target_id] = {
               total: row.total,

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -525,6 +525,23 @@ RSpec.describe PostDestroyer do
       expect(history.created_by).to eq(Discourse.system_user)
     end
 
+    it "resolves reviewables whose type is no longer defined when the author deletes their post" do
+      reply = create_post(topic: post.topic)
+      reviewable = PostActionCreator.spam(coding_horror, reply).reviewable
+      reviewable.update_columns(type: "ReviewableDoesntExist", type_source: "some-plugin")
+
+      PostDestroyer.new(reply.user, reply).destroy
+
+      expect(reply.reload.user_deleted).to eq(true)
+
+      reviewable = Reviewable.find(reviewable.id)
+      expect(reviewable).to be_a(Reviewable::UnknownType)
+      expect(reviewable).to be_ignored
+      expect(reviewable.type_source).to eq("some-plugin")
+      expect(reviewable.reviewable_scores.first.reviewed_by_id).to eq(Discourse.system_user.id)
+      expect(reviewable.reviewable_histories.last.reviewable_history_type).to eq("transitioned")
+    end
+
     it "does not restore reviewable when manually ignored by moderator" do
       reply = create_post(topic: post.topic)
       result = PostActionCreator.spam(coding_horror, reply)

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -407,6 +407,35 @@ RSpec.describe Reviewable, type: :model do
     end
   end
 
+  describe "loading a reviewable whose type is no longer defined" do
+    fab!(:admin)
+    fab!(:reviewable, :reviewable_flagged_post)
+
+    before { reviewable.update_columns(type: "ReviewableDoesntExist", type_source: "some-plugin") }
+
+    it "loads it as an unknown type instead of raising" do
+      unknown = Reviewable.find(reviewable.id)
+
+      expect(unknown).to be_a(Reviewable::UnknownType)
+      expect(unknown.type).to eq("ReviewableDoesntExist")
+      expect(unknown.actions_for(admin.guardian).to_a).to be_empty
+    end
+
+    it "keeps the type and source when transitioned" do
+      unknown = Reviewable.find(reviewable.id)
+
+      expect(unknown.transition_to(:ignored, admin)).to eq(true)
+
+      expect(Reviewable.where(id: reviewable.id).pick(:type, :type_source)).to eq(
+        %w[ReviewableDoesntExist some-plugin],
+      )
+    end
+
+    it "is excluded from the review queue" do
+      expect(Reviewable.list_for(admin)).to be_empty
+    end
+  end
+
   describe ".unknown_types_and_sources" do
     it "returns an empty array when no unknown types are present" do
       expect(Reviewable.unknown_types_and_sources).to eq([])

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -141,6 +141,21 @@ RSpec.describe PostSerializer do
       expect(json[:reviewable_score_count]).to eq(1)
       expect(json[:reviewable_score_pending_count]).to eq(1)
     end
+
+    it "omits the reviewable data when the reviewable type is no longer defined" do
+      reviewable.update_columns(type: "ReviewableDoesntExist", type_source: "some-plugin")
+      moderator = Fabricate(:moderator)
+
+      json = PostSerializer.new(post, scope: Guardian.new(moderator), root: false).as_json
+      expect(json[:reviewable_id]).to eq(nil)
+      expect(json[:reviewable_score_count]).to eq(0)
+
+      serializer = PostSerializer.new(post, scope: Guardian.new(moderator), root: false)
+      serializer.topic_view = TopicView.new(post.topic, moderator)
+      json = serializer.as_json
+      expect(json[:reviewable_id]).to eq(0)
+      expect(json[:reviewable_score_count]).to eq(0)
+    end
   end
 
   context "with a post by a nuked user" do


### PR DESCRIPTION
Previously, reviewables created by a plugin raised `ActiveRecord::SubclassNotFound` once that plugin was disabled, breaking unrelated operations such as serializing or deleting the flagged post.

This change loads those records as `Reviewable::UnknownType` so the behaviour they share with every other reviewable keeps working, while the review queue and post serialization leave them out until their type is defined again.