### PR TITLE
DEV: Remove `/etc` from default `SafeExec` paths

### DIFF
--- a/lib/discourse/safe_exec.rb
+++ b/lib/discourse/safe_exec.rb
@@ -4,7 +4,7 @@ require "landlock"
 
 module Discourse
   class SafeExec
-    DEFAULT_READ_PATHS = %w[/bin /etc /lib /lib64 /usr].freeze
+    DEFAULT_READ_PATHS = %w[/bin /lib /lib64 /usr].freeze
     DEFAULT_EXECUTE_PATHS = %w[/bin /lib /lib64 /usr].freeze
 
     def self.capture(

--- a/lib/image_magick.rb
+++ b/lib/image_magick.rb
@@ -19,8 +19,13 @@ module ImageMagick
 
   DEFAULT_TIMEOUT = 30
 
+  FONTCONFIG_READ_PATHS = %w[/etc/fonts].freeze
+
   def self.asset_read_paths
-    @asset_read_paths ||= [Rails.root.join("vendor").to_s, ENV["MAGICK_CONFIGURE_PATH"]].compact
+    @asset_read_paths ||=
+      Discourse::SafeExec.existing_paths(
+        [Rails.root.join("vendor").to_s, ENV["MAGICK_CONFIGURE_PATH"], *FONTCONFIG_READ_PATHS],
+      )
   end
 
   def self.magick(*args, read: [], write: [], timeout: nil, nice: nil, failure_message: "")

--- a/plugins/discourse-ai/lib/completions/xls_to_text.rb
+++ b/plugins/discourse-ai/lib/completions/xls_to_text.rb
@@ -47,8 +47,11 @@ module DiscourseAi
           end
       end
 
+      CATDOC_CONFIG_PATH = "/etc/catdocrc"
+
       def self.sandbox_read_paths(path)
-        Discourse::SafeExec.default_read_paths + [File.realpath(path)]
+        Discourse::SafeExec.default_read_paths +
+          Discourse::SafeExec.existing_paths([CATDOC_CONFIG_PATH]) + [File.realpath(path)]
       end
     end
   end


### PR DESCRIPTION
`/etc` can sometimes include sensitive information. Better to list specific files/directories for each use-case.