### PR TITLE
UX: Show which attendance is selected on events

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -13,6 +13,9 @@ import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
+const statusButtonClass = (selected) =>
+  selected ? "btn-primary" : "btn-default";
+
 const GoingDropdown = <template>
   <DDropdownMenu as |dropdown|>
     <dropdown.item
@@ -90,6 +93,14 @@ export default class DiscoursePostEventStatus extends Component {
 
   get isGoing() {
     return this.watchingInviteeStatus === "going";
+  }
+
+  get isInterested() {
+    return this.watchingInviteeStatus === "interested";
+  }
+
+  get isNotGoing() {
+    return this.watchingInviteeStatus === "not_going";
   }
 
   get isGoingThisEvent() {
@@ -228,7 +239,10 @@ export default class DiscoursePostEventStatus extends Component {
               {{#if @event.recurrence}}
                 {{#if this.site.mobileView}}
                   <DMenu
-                    class="btn btn-default going-button"
+                    class={{dConcatClass
+                      "going-button"
+                      (statusButtonClass this.isGoing)
+                    }}
                     @identifier="discourse-post-event-going-menu"
                     @icon={{this.goingTriggerIcon}}
                     @label={{this.goingTriggerLabel}}
@@ -243,7 +257,8 @@ export default class DiscoursePostEventStatus extends Component {
                 {{else}}
                   <DComboButton class="going-button --has-menu" as |combo|>
                     <combo.Button
-                      class="btn-default"
+                      class={{statusButtonClass this.isGoing}}
+                      @ariaPressed={{this.isGoing}}
                       @disabled={{this.goingButtonDisabled}}
                       @icon={{this.goingTriggerIcon}}
                       @label={{if
@@ -255,7 +270,7 @@ export default class DiscoursePostEventStatus extends Component {
                     />
                     <combo.Menu
                       @identifier="discourse-post-event-going-menu"
-                      @triggerClass="btn-default"
+                      @triggerClass={{statusButtonClass this.isGoing}}
                       @disabled={{this.goingButtonDisabled}}
                       @onRegisterApi={{this.registerGoingMenu}}
                     >
@@ -265,7 +280,11 @@ export default class DiscoursePostEventStatus extends Component {
                 {{/if}}
               {{else}}
                 <DButton
-                  class="btn-default going-button"
+                  class={{dConcatClass
+                    "going-button"
+                    (statusButtonClass this.isGoing)
+                  }}
+                  @ariaPressed={{this.isGoing}}
                   @disabled={{this.goingButtonDisabled}}
                   @icon="check"
                   @label={{if
@@ -291,7 +310,11 @@ export default class DiscoursePostEventStatus extends Component {
             }}
           >
             <DButton
-              class="btn-default interested-button"
+              class={{dConcatClass
+                "interested-button"
+                (statusButtonClass this.isInterested)
+              }}
+              @ariaPressed={{this.isInterested}}
               @icon="star"
               @label="discourse_post_event.models.invitee.status.interested"
               @action={{fn this.changeWatchingInviteeStatus "interested"}}
@@ -309,7 +332,11 @@ export default class DiscoursePostEventStatus extends Component {
               }}
             >
               <DButton
-                class="btn-default not-going-button"
+                class={{dConcatClass
+                  "not-going-button"
+                  (statusButtonClass this.isNotGoing)
+                }}
+                @ariaPressed={{this.isNotGoing}}
                 @icon="xmark"
                 @label="discourse_post_event.models.invitee.status.not_going"
                 @action={{fn this.changeWatchingInviteeStatus "not_going"}}

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -273,19 +273,6 @@ $show-interested: inherit;
         display: $show-interested;
       }
 
-      &.status-going .going-button > .d-icon,
-      &.status-going .going-button .d-combo-button-button .d-icon {
-        color: var(--success);
-      }
-
-      &.status-interested .interested-button .d-icon {
-        color: $interested;
-      }
-
-      &.status-not_going .not-going-button .d-icon {
-        color: var(--danger);
-      }
-
       .not-going-button span {
         white-space: nowrap;
       }

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
@@ -6,6 +6,12 @@ module PageObjects
       class PostEvent < PageObjects::Pages::Base
         TRIGGER_MENU_SELECTOR = ".discourse-post-event-more-menu-trigger"
 
+        STATUS_BUTTONS = {
+          going: ".going-button",
+          interested: ".interested-button",
+          not_going: ".not-going-button",
+        }.freeze
+
         def open_more_menu
           try_until_success do
             locator("#{TRIGGER_MENU_SELECTOR}:not(.--saving)").click
@@ -16,6 +22,11 @@ module PageObjects
 
         def going
           locator(".going-button").click
+          self
+        end
+
+        def not_going
+          locator(".not-going-button").click
           self
         end
 
@@ -33,6 +44,18 @@ module PageObjects
 
         def has_going_status?
           has_css?(".event-status.status-going")
+        end
+
+        def has_selected_status?(status)
+          has_css?(status_button_selector(status, ".btn-primary"))
+        end
+
+        def has_no_selected_status?(status)
+          has_no_css?(status_button_selector(status, ".btn-primary"))
+        end
+
+        def has_pressed_status?(status, pressed: true)
+          has_css?(status_button_selector(status, "[aria-pressed='#{pressed}']"))
         end
 
         def has_going_count?(count)
@@ -143,6 +166,13 @@ module PageObjects
 
         def edit
           open_more_menu { locator(".edit-event").click }
+        end
+
+        private
+
+        def status_button_selector(status, state)
+          button = ".event-status #{STATUS_BUTTONS.fetch(status)}"
+          "#{button}#{state}, #{button} #{state}"
         end
       end
     end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -290,6 +290,7 @@ describe "Post event" do
       post_event_page.going_all_following
 
       expect(post_event_page).to have_going_status
+      expect(post_event_page).to have_selected_status(:going)
       invitee = DiscoursePostEvent::Invitee.find_by(user_id: rsvp_user.id, post_id: post.id)
       expect(invitee.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
       expect(invitee.recurring).to eq(true)
@@ -303,9 +304,33 @@ describe "Post event" do
       post_event_page.going_this_event
 
       expect(post_event_page).to have_going_status
+      expect(post_event_page).to have_selected_status(:going)
       invitee = DiscoursePostEvent::Invitee.find_by(user_id: rsvp_user.id, post_id: post.id)
       expect(invitee.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
       expect(invitee.recurring).to eq(false)
+    end
+
+    it "marks only the chosen attendance as selected" do
+      raw = "[event status='public' start='2222-02-22 14:22']\n[/event]"
+      post = PostCreator.create!(admin, title: "My test meetup event", raw:)
+
+      visit(post.topic.url)
+
+      expect(post_event_page).to have_no_selected_status(:going)
+      expect(post_event_page).to have_pressed_status(:going, pressed: false)
+
+      post_event_page.going
+
+      expect(post_event_page).to have_selected_status(:going)
+      expect(post_event_page).to have_pressed_status(:going)
+      expect(post_event_page).to have_no_selected_status(:interested)
+      expect(post_event_page).to have_no_selected_status(:not_going)
+
+      post_event_page.not_going
+
+      expect(post_event_page).to have_selected_status(:not_going)
+      expect(post_event_page).to have_no_selected_status(:going)
+      expect(post_event_page).to have_pressed_status(:going, pressed: false)
     end
 
     it "renders without a dropdown on non-recurring events" do


### PR DESCRIPTION
The Going / Interested / Not going buttons signalled your own attendance by recolouring the button's icon and nothing else. The three buttons were otherwise identical — same background, border, text colour and weight — so at a glance the only reliable way to tell whether you had already RSVP'd was to scan the attendee avatars for your own.

Nothing was exposed to assistive technology either: a screen reader announced "Going, button" whether or not you were going.

### What changed

The selected choice now takes the primary button treatment, and the three buttons carry `aria-pressed`.

`aria-pressed` rather than a radio group, because clicking the active choice clears your RSVP — a radio group forbids unchecking the checked option.

### Why swap the class instead of restyling `btn-default`

Doing this purely in CSS by pointing `--d-button-default-*` at `--d-button-primary-*` looks tidier and it is how the composer toolbar does it, but it is wrong here. Both shipped themes restyle `.btn-primary` with direct declarations rather than going through those tokens, and one of them also restyles `.btn-default` at a higher specificity than the rule that consumes the token. The result is that the text colour flips but the background does not, leaving white text on a light grey button.

Going through the class keeps the selected button identical to every other primary button in both themes and both colour modes. The class is threaded through the combo button and the menu trigger too, so recurring events match.

The three icon-colour rules are dropped rather than kept: they out-specify `.btn-primary` and would otherwise leave a green check on a filled background.

### Tests

The four existing `has_going_status?` assertions passed identically before and after this change, so they were not covering the visible state. Added a page-object predicate that handles both the plain button and the recurring combo wrapper, one new spec, and an assertion to each of the two recurring specs. Reverting the component makes three of them fail.

Verified in the browser across all three statuses, plain / combo / mobile menu shapes, both core themes, and light and dark.

### Follow-ups, not included here

- The Going dropdown's selected item (`This event` / `This and all following`) still uses a colour-only cue. Fixing it properly needs `aria-checked`, which needs `role="menu"` on the shared dropdown component.
- On a full event you have RSVP'd to, the now-filled button still reads "Full" rather than "Going". Pre-existing, and changing the label is a separate decision.