### PR TITLE
DEV: Refactor client_settings_json caching

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -305,18 +305,19 @@ module SiteSettingExtension
   end
 
   def client_settings_json
-    key = SiteSettingExtension.client_settings_cache_key
-    json = Discourse.cache.fetch(key, expires_in: 30.minutes) { client_settings_json_uncached }
-    Rails.logger.error("Nil client_settings_json from the cache for '#{key}'") if json.nil?
-    json || ""
+    client_settings_jsons[provider.current_site] ||= client_settings_json_uncached
   rescue => e
     Rails.logger.error("Error while retrieving client_settings_json: #{e.message}")
     ""
   end
 
-  def client_settings_json_uncached(return_defaults: false)
-    uncached_json =
-      @client_settings.filter_map do |name|
+  def client_settings_hash
+    client_settings_hashes[provider.current_site] ||= client_settings_hash_uncached
+  end
+
+  def client_settings_hash_uncached(return_defaults: false)
+    client_settings
+      .filter_map do |name|
         # Themeable site settings require a theme ID, which we do not always
         # have when loading client site settings. They are excluded here,
         # to get them use theme_site_settings_json(:theme_id)
@@ -345,7 +346,11 @@ module SiteSettingExtension
 
         [name, value]
       end
-    MultiJson.dump(Hash[uncached_json])
+      .to_h
+  end
+
+  def client_settings_json_uncached(return_defaults: false)
+    MultiJson.dump(client_settings_hash_uncached(return_defaults:))
   rescue => err
     # If something goes wrong here we really need to be aware of it in tests.
     raise err if Rails.env.test?
@@ -575,13 +580,6 @@ module SiteSettingExtension
       .compact
   end
 
-  def self.client_settings_cache_key
-    # NOTE: we use the git version in the key to ensure
-    # that we don't end up caching the incorrect version
-    # in cases where we are cycling unicorns
-    "client_settings_json_#{Discourse.git_version}"
-  end
-
   def self.theme_site_settings_cache_key(theme_id)
     theme_id = "notheme" if theme_id.blank?
 
@@ -654,6 +652,8 @@ module SiteSettingExtension
         modified.clear
         modified.merge!(new_modified)
         uploads.clear
+        client_settings_hashes.delete(provider.current_site)
+        client_settings_jsons.delete(provider.current_site)
 
         upcoming_change_default_overrides.each do |setting_name, override|
           if UpcomingChanges.enabled?(override[:upcoming_change])
@@ -1041,7 +1041,8 @@ module SiteSettingExtension
   protected
 
   def clear_cache!(expire_theme_site_setting_cache: false)
-    Discourse.cache.delete(SiteSettingExtension.client_settings_cache_key)
+    client_settings_hashes.delete(provider.current_site)
+    client_settings_jsons.delete(provider.current_site)
     Theme.expire_site_setting_cache! if expire_theme_site_setting_cache
     Site.clear_anon_cache!
   end
@@ -1455,6 +1456,14 @@ module SiteSettingExtension
   def uploads
     @uploads ||= {}
     @uploads[provider.current_site] ||= {}
+  end
+
+  def client_settings_hashes
+    @client_settings_hashes ||= {}
+  end
+
+  def client_settings_jsons
+    @client_settings_jsons ||= {}
   end
 
   def clear_uploads_cache(name)

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -184,6 +184,21 @@ RSpec.describe SiteSettingExtension do
     end
   end
 
+  describe "#client_settings_hash" do
+    it "memoizes the hash until a setting changes" do
+      settings.setting(:string_type, "haha", client: true)
+      settings.refresh!
+
+      hash = settings.client_settings_hash
+      expect(hash[:string_type]).to eq("haha")
+      expect(settings.client_settings_hash).to be(hash)
+
+      settings.string_type = "changed"
+
+      expect(settings.client_settings_hash[:string_type]).to eq("changed")
+    end
+  end
+
   describe ".after_fork" do
     it "refreshes the site settings" do
       settings.setting(:hello, 1)
@@ -1084,9 +1099,15 @@ RSpec.describe SiteSettingExtension do
       settings.default_locale = "zh_CN"
     end
 
-    it "expires the cache" do
+    it "expires the client settings caches" do
+      settings.refresh!
+      expect(JSON.parse(settings.client_settings_json)["default_locale"]).to eq("en")
+      expect(settings.client_settings_hash[:default_locale]).to eq("en")
+
       settings.default_locale = "zh_CN"
-      expect(Discourse.cache.exist?(SiteSettingExtension.client_settings_cache_key)).to be_falsey
+
+      expect(JSON.parse(settings.client_settings_json)["default_locale"]).to eq("zh_CN")
+      expect(settings.client_settings_hash[:default_locale]).to eq("zh_CN")
     end
 
     it "refreshes the client" do
@@ -1394,8 +1415,6 @@ RSpec.describe SiteSettingExtension do
         settings.setting(:test_setting, "value", client: true)
         settings.refresh!
 
-        cache_key = SiteSettingExtension.client_settings_cache_key
-
         call_count = 0
         allow(settings).to receive(:client_settings_json_uncached) do
           call_count += 1
@@ -1409,19 +1428,15 @@ RSpec.describe SiteSettingExtension do
         # First call fails
         result1 = settings.client_settings_json
         expect(result1).to eq("")
-        # Verify error was NOT cached in Redis
-        expect(Discourse.cache.exist?(cache_key)).to be_falsey
 
         # Second call should retry (not use cached error) and succeed
         result2 = settings.client_settings_json
         expect(result2).to eq('{"default_locale":"en","test_setting":"value"}')
         expect(call_count).to eq(2) # Both calls executed, error was not cached
 
-        # Verify success was cached in Redis
-        expect(Discourse.cache.exist?(cache_key)).to be_truthy
-        expect(Discourse.cache.read(cache_key)).to eq(
-          '{"default_locale":"en","test_setting":"value"}',
-        )
+        # Success is memoized; further calls do not regenerate
+        expect(settings.client_settings_json).to eq(result2)
+        expect(call_count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Most site-setting-related data is cached in-process. The exception was client_settings_json, which was cached in Redis. This could create some surprising behaviors, especially during deploys while multiple versions of the app are running against the same redis instance. It was somewhat mitigated by keying on git_version, but this was not perfect (e.g. if plugins change, or a patch is applied without committing).

This commit refactors things so that the client_settings and the JSON-serialized copy are cached in-process along with the rest of the site-settings data. This should be more robust, and also faster. It also provides direct access to the client settings hash, before it's serialized to JSON.