### PR TITLE
DEV: Tighten image_optim sandbox

### DIFF
--- a/lib/freedom_patches/image_optim_sandbox.rb
+++ b/lib/freedom_patches/image_optim_sandbox.rb
@@ -1,11 +1,27 @@
 # frozen_string_literal: true
 
 require "image_optim/cmd"
+require "image_optim/path"
+require "tmpdir"
 
 # Route image_optim's optimizer binaries through the Landlock sandbox, confining
 # them to the file being optimized with no network. Cmd.capture (version/CPU
 # probes, no untrusted input) is intentionally not patched.
 class ImageOptim
+  # Per-thread tmp directory, so that we don't have to grant access to the global tmpdir
+  def self.discourse_tmp_root
+    Thread.current[:discourse_image_optim_tmp_root] ||= Dir.mktmpdir("discourse-image-optim-")
+  end
+
+  module DiscourseScratchDestination
+    def temp_path(*args, &block)
+      return super if args.any?
+
+      super(ImageOptim.discourse_tmp_root, &block)
+    end
+  end
+  ImageOptim::Path.prepend(DiscourseScratchDestination)
+
   module Cmd
     class << self
       def run(*args)
@@ -13,7 +29,6 @@ class ImageOptim
         env = args.first.is_a?(Hash) ? args.shift : {}
 
         files = args.select { |arg| arg.is_a?(String) && File.file?(arg) }
-        dirs = files.map { |file| File.dirname(file) }.uniq
 
         Discourse::SafeExec.capture(
           *args,
@@ -23,7 +38,7 @@ class ImageOptim
           },
           unsetenv_others: true,
           read: [*Discourse::SafeExec.default_read_paths, *files],
-          write: [*files, *dirs],
+          write: [ImageOptim.discourse_tmp_root],
           execute: Discourse::SafeExec.default_execute_paths,
           timeout: options[:timeout]&.to_f || ImageMagick::DEFAULT_TIMEOUT,
           rlimits: ImageMagick::RLIMITS,


### PR DESCRIPTION
Create a dedicated tmp directory so that we don't have to grant read/write access to the system-level tmp directory.