### PR TITLE
SECURITY: Scope thread-read reset to originating channel and restrict bulk trigger to c... [backport 2026.1]

### DIFF
--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -237,12 +237,21 @@ module Chat
     def mark_all_threads_as_read(user: nil)
       return if !self.threading_enabled
 
-      DB.exec(<<~SQL, channel_id: self.id)
+      params = { channel_id: id }
+      user_condition = ""
+
+      if user
+        params[:user_id] = user.id
+        user_condition = "AND user_chat_thread_memberships.user_id = :user_id"
+      end
+
+      DB.exec(<<~SQL, params)
         UPDATE user_chat_thread_memberships
         SET last_read_message_id = chat_threads.last_message_id
         FROM chat_threads
         WHERE user_chat_thread_memberships.thread_id = chat_threads.id
-        #{user ? "AND user_chat_thread_memberships.user_id = #{user.id}" : ""}
+        AND chat_threads.channel_id = :channel_id
+        #{user_condition}
         AND (
           user_chat_thread_memberships.last_read_message_id < chat_threads.last_message_id OR
           user_chat_thread_memberships.last_read_message_id IS NULL

--- a/plugins/chat/app/services/chat/update_channel.rb
+++ b/plugins/chat/app/services/chat/update_channel.rb
@@ -77,6 +77,7 @@ module Chat
     end
 
     def mark_all_threads_as_read_if_needed(channel:)
+      return if !channel.category_channel?
       return unless channel.threading_enabled_previously_changed?(to: true)
       Jobs.enqueue(Jobs::Chat::MarkAllChannelThreadsRead, channel_id: channel.id)
     end

--- a/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
+++ b/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:thread_1) { Fabricate(:chat_thread, channel: channel) }
   fab!(:thread_2) { Fabricate(:chat_thread, channel: channel) }
+  fab!(:other_channel) { Fabricate(:chat_channel, threading_enabled: true) }
+  fab!(:other_thread) { Fabricate(:chat_thread, channel: other_channel) }
   fab!(:user_1, :user)
   fab!(:user_2, :user)
   fab!(:thread_1_message_1) { Fabricate(:chat_message, thread: thread_1, chat_channel: channel) }
@@ -11,6 +13,9 @@ RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
   fab!(:thread_1_message_3) { Fabricate(:chat_message, thread: thread_1, chat_channel: channel) }
   fab!(:thread_2_message_1) { Fabricate(:chat_message, thread: thread_2, chat_channel: channel) }
   fab!(:thread_2_message_2) { Fabricate(:chat_message, thread: thread_2, chat_channel: channel) }
+  fab!(:other_thread_message) do
+    Fabricate(:chat_message, thread: other_thread, chat_channel: other_channel)
+  end
 
   before do
     channel.add(user_1)
@@ -19,10 +24,16 @@ RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
     thread_1.update!(last_message: thread_1_message_3)
     thread_2.add(user_2)
     thread_2.update!(last_message: thread_2_message_2)
+    other_channel.add(user_1)
+    other_thread.add(user_1)
+    other_thread.update!(last_message: other_thread_message)
   end
 
-  def unread_count(user)
-    Chat::ThreadUnreadsQuery.call(channel_ids: [channel.id], user_id: user.id).first.unread_count
+  def unread_count(user, target_channel = channel)
+    Chat::ThreadUnreadsQuery
+      .call(channel_ids: [target_channel.id], user_id: user.id)
+      .first
+      .unread_count
   end
 
   it "marks all threads as read across all users in the channel" do
@@ -31,5 +42,11 @@ RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
     described_class.new.execute(channel_id: channel.id)
     expect(unread_count(user_1)).to eq(0)
     expect(unread_count(user_2)).to eq(0)
+  end
+
+  it "does not mark threads in other channels as read" do
+    expect(unread_count(user_1, other_channel)).to eq(1)
+    described_class.new.execute(channel_id: channel.id)
+    expect(unread_count(user_1, other_channel)).to eq(1)
   end
 end

--- a/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
@@ -454,6 +454,66 @@ RSpec.describe Chat::Api::ChannelsController do
       end
     end
 
+    context "when user is a direct message channel participant" do
+      fab!(:attacker, :user)
+      fab!(:attacker_recipient, :user)
+      fab!(:channel) do
+        Fabricate(
+          :direct_message_channel,
+          users: [attacker, attacker_recipient],
+          threading_enabled: false,
+        )
+      end
+      fab!(:victim, :user)
+      fab!(:victim_recipient, :user)
+      fab!(:victim_channel) do
+        Fabricate(
+          :direct_message_channel,
+          users: [victim, victim_recipient],
+          threading_enabled: true,
+        )
+      end
+      fab!(:victim_thread) do
+        Fabricate(:chat_thread, channel: victim_channel, original_message_user: victim_recipient)
+      end
+      fab!(:victim_reply) do
+        Fabricate(
+          :chat_message,
+          thread: victim_thread,
+          chat_channel: victim_channel,
+          user: victim_recipient,
+        )
+      end
+
+      before do
+        Jobs.run_immediately!
+        victim_thread.add(victim)
+        victim_thread.update!(last_message: victim_reply)
+        sign_in(attacker)
+      end
+
+      it "preserves unread threads in inaccessible direct messages" do
+        expect(victim_channel.chatable.user_can_access?(attacker)).to be(false)
+        expect(
+          Chat::ThreadUnreadsQuery
+            .call(channel_ids: [victim_channel.id], user_id: victim.id)
+            .first
+            .unread_count,
+        ).to eq(1)
+
+        put "/chat/api/channels/#{channel.id}", params: { channel: { threading_enabled: true } }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("channel", "threading_enabled")).to be(true)
+        expect(
+          Chat::ThreadUnreadsQuery
+            .call(channel_ids: [victim_channel.id], user_id: victim.id)
+            .first
+            .unread_count,
+        ).to eq(1)
+      end
+    end
+
     context "when channel is a direct message channel" do
       fab!(:user, :admin)
       fab!(:channel, :direct_message_channel)


### PR DESCRIPTION
Backport of #42417 to release/2026.1.

---

## Summary

A chat participant could enable threading in their own DM and trigger a thread-read reset job that marked thread memberships as read across all channels, including private DMs the attacker could not access. The patch scopes the SQL update to the target channel and only enqueues the bulk reset when threading is enabled on a category channel.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1531

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
