### PR TITLE
DEV: Bump web_hook_events_id_seq to bigint

### DIFF
--- a/db/migrate/20260728150000_alter_web_hook_events_id_sequence_to_bigint.rb
+++ b/db/migrate/20260728150000_alter_web_hook_events_id_sequence_to_bigint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AlterWebHookEventsIdSequenceToBigint < ActiveRecord::Migration[8.0]
+  def up
+    execute "ALTER SEQUENCE web_hook_events_id_seq AS bigint"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -12471,7 +12471,6 @@ ALTER SEQUENCE public.web_hook_events_daily_aggregates_id_seq OWNED BY public.we
 --
 
 CREATE SEQUENCE public.web_hook_events_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -23134,6 +23133,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260729153343'),
 ('20260728162521'),
 ('20260728162516'),
+('20260728150000'),
 ('20260728134532'),
 ('20260728071552'),
 ('20260728050038'),


### PR DESCRIPTION
The column is already bigint, but the sequence was still integer, so would break if any site exceeded max_int.

Migration is intentionally timestamped slightly in the past, so that it can be cleanly backported to `release/2026.7`. This migration is completely standalone, so ordering is not a concern.