### PR TITLE
DEV: Bump mini_racer and update AssetProcessor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
-    mini_racer (0.21.4)
+    mini_racer (0.22.0)
       libv8-node (~> 24.12.0.1)
     mini_scheduler (0.20.0)
       sidekiq (>= 6.5, < 9.0)
@@ -1139,7 +1139,7 @@ CHECKSUMS
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  mini_racer (0.21.4) sha256=ccf5e37288097f079d84449e111cd4e2170b37f3b80b30900766ffa6df4632db
+  mini_racer (0.22.0) sha256=52e4c1797bcb01be550d8317764ac5ca8aa96b37f8f72dec6e090db99847ae30
   mini_scheduler (0.20.0) sha256=bd8948228bf4a48a603a8e20de850d16b68295413d8651c8c05288f4c6997b05
   mini_sql (1.6.0) sha256=5296637f6a4af5bb43e06788037e9a2968ff9c8eb65928befcba8cb41f42d6ee
   mini_suffix (0.3.3) sha256=8d1d33f92f69a2247c9b7d27173235da90479d955cdb863b63a7f53843b722e7

--- a/frontend/asset-processor/asset-processor-rollup.js
+++ b/frontend/asset-processor/asset-processor-rollup.js
@@ -25,9 +25,6 @@ import buildEmberTemplateManipulatorPlugin from "./theme-hbs-ast-transforms";
 import transformActionSyntax from "./transform-action-syntax";
 import createVirtualFs from "./virtual-fs";
 
-let lastRollupResult;
-let lastRollupError;
-
 let caches = new Map();
 
 async function performRollup(modules, opts) {
@@ -170,22 +167,4 @@ async function performRollup(modules, opts) {
   return chunks;
 }
 
-globalThis.rollup = async function (modules, opts) {
-  try {
-    lastRollupResult = await performRollup(modules, opts);
-  } catch (error) {
-    lastRollupError = error;
-  }
-};
-
-globalThis.getRollupResult = function () {
-  const error = lastRollupError;
-  const result = lastRollupResult;
-
-  lastRollupError = lastRollupResult = null;
-
-  if (error) {
-    throw error;
-  }
-  return result;
-};
+globalThis.rollup = performRollup;

--- a/frontend/asset-processor/postcss.js
+++ b/frontend/asset-processor/postcss.js
@@ -14,34 +14,16 @@ const postCssProcessor = postcss([
   postcssNesting, // Un-nests the native css nesting from postcssLightDark
   postcssVariablePrefixer(),
 ]);
-let lastPostcssError, lastPostcssResult;
-
 globalThis.postCss = async function (css, map, sourcemapFile) {
-  try {
-    const rawResult = await postCssProcessor.process(css, {
-      from: "input.css",
-      to: "output.css",
-      map: {
-        prev: map,
-        inline: false,
-        absolute: false,
-        annotation: sourcemapFile,
-      },
-    });
-    lastPostcssResult = [rawResult.css, rawResult.map?.toString()];
-  } catch (e) {
-    lastPostcssError = e;
-  }
-};
-
-globalThis.getPostCssResult = function () {
-  const error = lastPostcssError;
-  const result = lastPostcssResult;
-
-  lastPostcssError = lastPostcssResult = null;
-
-  if (error) {
-    throw error;
-  }
-  return result;
+  const rawResult = await postCssProcessor.process(css, {
+    from: "input.css",
+    to: "output.css",
+    map: {
+      prev: map,
+      inline: false,
+      absolute: false,
+      annotation: sourcemapFile,
+    },
+  });
+  return [rawResult.css, rawResult.map?.toString()];
 };

--- a/frontend/asset-processor/shims.js
+++ b/frontend/asset-processor/shims.js
@@ -35,17 +35,6 @@ path.win32 = {
 
 globalThis.crypto = { getRandomValues };
 
-const oldInstantiate = WebAssembly.instantiate;
-WebAssembly.instantiate = async function (bytes, bindings) {
-  if (bytes === BindingsWasm) {
-    const mod = new WebAssembly.Module(bytes);
-    const instance = new WebAssembly.Instance(mod, bindings);
-    return instance;
-  } else {
-    return oldInstantiate(...arguments);
-  }
-};
-
 globalThis.fetch = function (url) {
   if (url.toString() === "http://example.com/bindings_wasm_bg.wasm") {
     return new Promise((resolve) => resolve(BindingsWasm));

--- a/frontend/asset-processor/transpiler.js
+++ b/frontend/asset-processor/transpiler.js
@@ -56,28 +56,4 @@ globalThis.transpile = function (source, options = {}) {
   }
 };
 
-// mini_racer doesn't have native support for getting the result of an async operation.
-// To work around that, we provide a getMinifyResult which can be used to fetch the result
-// in a followup method call.
-let lastMinifyError, lastMinifyResult;
-
-globalThis.minify = async function (sources, options) {
-  lastMinifyError = lastMinifyResult = null;
-  try {
-    lastMinifyResult = await terserMinify(sources, options);
-  } catch (e) {
-    lastMinifyError = e;
-  }
-};
-
-globalThis.getMinifyResult = function () {
-  const error = lastMinifyError;
-  const result = lastMinifyResult;
-
-  lastMinifyError = lastMinifyResult = null;
-
-  if (error) {
-    throw error.toString();
-  }
-  return result;
-};
+globalThis.minify = terserMinify;

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -124,15 +124,11 @@ class AssetProcessor
     @ctx
   end
 
-  # Call a method in the global scope of the v8 context.
-  # The `fetch_result_call` kwarg provides a workaround for the lack of mini_racer async
-  # result support. The first call can perform some async operation, and then `fetch_result_call`
-  # will be called to fetch the result.
-  def self.v8_call(*args, **kwargs)
-    fetch_result_call = kwargs.delete(:fetch_result_call)
+  # Call a method in the global scope of the v8 context. Promise results are
+  # awaited and returned as values.
+  def self.v8_call(*args)
     mutex.synchronize do
-      result = v8.call(*args, **kwargs)
-      result = v8.call(fetch_result_call) if fetch_result_call
+      result = v8.call_await(*args)
       v8.low_memory_notification if GlobalSetting.mini_racer_single_threaded
       result
     end
@@ -206,14 +202,14 @@ class AssetProcessor
   end
 
   def terser(tree, opts)
-    self.class.v8_call("minify", tree, opts, fetch_result_call: "getMinifyResult")
+    self.class.v8_call("minify", tree, opts)
   end
 
   def rollup(tree, opts)
-    self.class.v8_call("rollup", tree, opts, fetch_result_call: "getRollupResult")
+    self.class.v8_call("rollup", tree, opts)
   end
 
   def post_css(css:, map:, source_map_file:)
-    self.class.v8_call("postCss", css, map, source_map_file, fetch_result_call: "getPostCssResult")
+    self.class.v8_call("postCss", css, map, source_map_file)
   end
 end


### PR DESCRIPTION
mini_racer 0.22.0 adds `call_await`, which means we can remove a number of async-related workarounds in asset-processor.