### PR TITLE
DEV: Backport qunit stability improvements

### DIFF
--- a/frontend/discourse/testem.js
+++ b/frontend/discourse/testem.js
@@ -227,6 +227,7 @@ module.exports = {
     maxHttpBufferSize: 1e8, // 100MB
   },
   browser_start_timeout: 120,
+  browser_disconnect_timeout: 30,
   browser_args: {
     Chromium: [
       // --no-sandbox is needed when running Chromium inside a container or when explicitly requested

--- a/frontend/discourse/tests/setup-tests.js
+++ b/frontend/discourse/tests/setup-tests.js
@@ -5,6 +5,7 @@ import "discourse/static/markdown-it";
 /* eslint-enable simple-import-sort/imports */
 
 import { getOwner } from "@ember/owner";
+import { run } from "@ember/runloop";
 import {
   getSettledState,
   isSettled,
@@ -344,6 +345,14 @@ export default function setupTests(config) {
     testCleanup(getOwner(app), app);
 
     sinon.restore();
+
+    // Destroy the previous Application so its entire dependency graph
+    // (ApplicationInstance, container, registry, services, etc.) can be GC'd.
+    // Without this, every test leaks an Application which is never torn down.
+    run(() => {
+      app.destroy();
+    });
+
     resetPretender();
     clearPresenceState();
 
@@ -364,6 +373,10 @@ export default function setupTests(config) {
     MessageBus.unsubscribe("*");
     localStorage.clear();
     enableLoadMoreObserver();
+
+    // Release the app reference so the destroyed app isn't retained
+    // by this closure until the next test creates a new one.
+    app = null;
   });
 
   if (getUrlParameter("qunit_disable_auto_start") === "1") {

--- a/patches/ember-source@6.6.0.patch
+++ b/patches/ember-source@6.6.0.patch
@@ -37,6 +37,18 @@ index cd68afe479229ed77b4e4c93759aa90913cdc49c..6e7d71bbeb28f18259fa8afb48ef7827
    registerHandler = function registerHandler(type, callback) {
      let nextHandler = HANDLERS[type] || (() => {});
      HANDLERS[type] = (message, options) => {
+diff --git a/dist/packages/@glimmer/destroyable/index.js b/dist/packages/@glimmer/destroyable/index.js
+--- a/dist/packages/@glimmer/destroyable/index.js
++++ b/dist/packages/@glimmer/destroyable/index.js
+@@ -95,7 +95,7 @@ function destroy(destroyable) {
+         let parentMeta = getDestroyableMeta(parent);
+         0 === parentMeta.state && (parentMeta.children = remove(parentMeta.children, child, isDevelopingApp() && "attempted to remove child from parent, but the parent's children did not contain the child. This is likely a bug with destructors."));
+       }(destroyable, parent);
+-    }), meta.state = 2;
++    }), meta.state = 2, meta.parents = null, meta.children = null, meta.eagerDestructors = null, meta.destructors = null;
+   });
+ }
+ function destroyChildren(destroyable) {
 diff --git a/dist/packages/shared-chunks/array-BGH9y76r.js b/dist/packages/shared-chunks/array-BGH9y76r.js
 index 47fa056e935d4ddeae71a9a2d9ad801c4df21195..a8140f87cd68ab678a69a32921bcf70e93839b3f 100644
 --- a/dist/packages/shared-chunks/array-BGH9y76r.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ patchedDependencies:
     hash: 387f93bad78f3a98b20dc742f4f0b7a165c7e6ebc65cc60356748346c0725c7f
     path: patches/babel-plugin-debug-macros@0.3.4.patch
   ember-source@6.6.0:
-    hash: fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed
+    hash: 2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4
     path: patches/ember-source@6.6.0.patch
   ember-this-fallback@0.4.0:
     hash: 31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45
@@ -156,13 +156,13 @@ importers:
         version: link:../discourse-plugins
       ember-cli-htmlbars:
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-this-fallback:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.4.0(patch_hash=31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       fastestsmallesttextencoderdecoder:
         specifier: ^1.0.22
         version: 1.0.22
@@ -300,7 +300,7 @@ importers:
         version: 1.0.3
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-tracked-storage-polyfill:
         specifier: ^1.0.0
         version: 1.0.0
@@ -400,7 +400,7 @@ importers:
         version: 2.3.0
       '@ember/render-modifiers':
         specifier: ^3.0.0
-        version: 3.0.0(@glint/template@1.7.3)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.0(@glint/template@1.7.3)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
@@ -508,7 +508,7 @@ importers:
         version: 6.9.1(@types/node@25.0.3)(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-app-version:
         specifier: ^7.0.0
-        version: 7.0.0(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.0(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.6)
@@ -517,7 +517,7 @@ importers:
         version: 4.0.0(@babel/core@7.28.6)
       ember-cli-htmlbars:
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
@@ -535,10 +535,10 @@ importers:
         version: 6.1.1
       ember-exam:
         specifier: ^10.0.1
-        version: 10.0.1(@glint/template@1.7.3)(ember-qunit@9.0.4(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3))(@glint/template@1.7.3)(qunit@2.25.0))(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.99.9(@swc/core@1.15.7)(esbuild@0.25.12))
+        version: 10.0.1(@glint/template@1.7.3)(ember-qunit@9.0.4(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3))(@glint/template@1.7.3)(qunit@2.25.0))(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.99.9(@swc/core@1.15.7)(esbuild@0.25.12))
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^4.2.2
         version: 4.2.2(@babel/core@7.28.6)
@@ -661,13 +661,13 @@ importers:
         version: 8.2.0(@babel/core@7.28.6)
       ember-cli-htmlbars:
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-template-imports:
         specifier: ^4.4.0
         version: 4.4.0
       ember-this-fallback:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.4.0(patch_hash=31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
     devDependencies:
       ember-cli:
         specifier: ~6.9.1
@@ -689,7 +689,7 @@ importers:
         version: '@glint/template@1.7.3'
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
 
   frontend/ember-cli-progress-ci: {}
 
@@ -709,7 +709,7 @@ importers:
         version: 8.2.0(@babel/core@7.28.6)
       ember-cli-htmlbars:
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       xss:
         specifier: ^1.0.15
         version: 1.0.15
@@ -752,13 +752,13 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -10394,13 +10394,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@3.0.0(@glint/template@1.7.3)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/render-modifiers@3.0.0(@glint/template@1.7.3)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@babel/core': 7.28.6(supports-color@8.1.1)
       '@embroider/macros': 1.19.4(@glint/template@1.7.3)
       ember-cli-babel: 8.2.0(@babel/core@7.28.6)
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.6)
-      ember-source: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
       '@glint/template': 1.7.3
     transitivePeerDependencies:
@@ -13691,10 +13691,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cli-app-version@7.0.0(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cli-app-version@7.0.0(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -13800,7 +13800,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/core': 7.28.6(supports-color@8.1.1)
       '@ember/edition-utils': 1.2.0
@@ -13808,7 +13808,7 @@ snapshots:
       broccoli-debug: 0.6.5
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
-      ember-source: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       fs-tree-diff: 2.0.1
       heimdalljs-logger: 0.1.10
       js-string-escape: 1.0.1
@@ -14092,7 +14092,7 @@ snapshots:
       - eslint
       - typescript
 
-  ember-exam@10.0.1(@glint/template@1.7.3)(ember-qunit@9.0.4(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3))(@glint/template@1.7.3)(qunit@2.25.0))(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.99.9(@swc/core@1.15.7)(esbuild@0.25.12)):
+  ember-exam@10.0.1(@glint/template@1.7.3)(ember-qunit@9.0.4(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3))(@glint/template@1.7.3)(qunit@2.25.0))(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.99.9(@swc/core@1.15.7)(esbuild@0.25.12)):
     dependencies:
       '@babel/core': 7.28.6(supports-color@8.1.1)
       chalk: 5.6.2
@@ -14101,7 +14101,7 @@ snapshots:
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.99.9(@swc/core@1.15.7)(esbuild@0.25.12))
       ember-cli-babel: 8.2.0(@babel/core@7.28.6)
       ember-qunit: 9.0.4(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3))(@glint/template@1.7.3)(qunit@2.25.0)
-      ember-source: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       execa: 8.0.1
       fs-extra: 11.3.2
       js-yaml: 4.1.1
@@ -14115,9 +14115,9 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-load-initializers@3.0.1(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-load-initializers@3.0.1(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      ember-source: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
 
   ember-modifier-manager-polyfill@1.2.0(@babel/core@7.28.6):
     dependencies:
@@ -14177,7 +14177,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5):
+  ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.28.6(supports-color@8.1.1)
       '@ember/edition-utils': 1.2.0
@@ -14246,15 +14246,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-this-fallback@0.4.0(patch_hash=31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-this-fallback@0.4.0(patch_hash=31c150a292037db2b05d9030a75069bb0a9518a4a7e0969b9b4e14d957134e45)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@glimmer/syntax': 0.84.3
       babel-plugin-ember-template-compilation: 2.4.1
       debug: 4.4.3(supports-color@8.1.1)
       ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-cli-htmlbars: 7.0.0(@babel/core@7.28.6)(ember-source@6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-typescript: 5.3.0
-      ember-source: 6.6.0(patch_hash=fce06f88d4efb23d95b8bcd197505f279346ed295e4daea129961c9f263cdeed)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=2617af4b51110d03d5dbe92a6039fabac03d0e279dd40aa5927b8a98b23d1cb4)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       lodash: 4.17.21
       winston: 3.14.2
       zod: 3.25.76


### PR DESCRIPTION
The `core frontend` CI job on this branch fails intermittently with `Error: Browser timeout exceeded: 10s`, on a different test each time.

This backports the three QUnit stability changes from #38220, which landed on `main` after this branch was cut and are present on every other maintained release branch:

- destroy the `Application` in `QUnit.testDone` and release the reference, so its dependency graph can be GC'd instead of leaking one `Application` per test
- patch `@glimmer/destroyable` to clear metadata after destruction, breaking the ephemeron reference cycles that kept those graphs alive
- set `browser_disconnect_timeout: 30` in `testem.js`, replacing testem's 10s default so a transient stall on a loaded runner doesn't fail the run

The upgrade's `topic-tracking-state-test` sinon change is not included — it was needed for Ember 6.10's native `router` getter, and the test passes on 6.6.0 with this teardown in place.