### PR TITLE
UX: Refresh clients when content localization settings change

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1932,6 +1932,7 @@ content_localization:
       - all
     default: none
     client: true
+    refresh: true
     area: "localization"
     validator: "LanguageSwitcherSettingValidator"
     depends_on:

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -515,6 +515,7 @@ discourse_ai:
   ai_translation_enabled:
     default: false
     client: true
+    refresh: true
     validator: "DiscourseAi::Configuration::LlmDependencyValidator"
     area: "ai-features/translation"
   ai_translation_locale_detector_agent:


### PR DESCRIPTION
Previously, toggling `content_localization_language_switcher` or `ai_translation_enabled` did not prompt connected clients to reload, so users kept a stale UI (e.g. no language switcher) until they manually refreshed.

This change marks both settings with `refresh: true`, so clients perform a full page load on their next navigation after the setting changes.