### PR TITLE
UX: Align `DComboButton` menus with the trigger's trailing edge

### DIFF
--- a/frontend/discourse/app/ui-kit/d-combo-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-combo-button.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import curryComponent from "ember-curry-component";
 import DMenu from "discourse/float-kit/components/d-menu";
+import { or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 
 // eslint-disable-next-line ember/no-empty-glimmer-component-classes
@@ -19,8 +20,13 @@ class Button extends Component {
 class Menu extends Component {
   <template>
     {{#let (curryComponent DMenu this.args) as |CurriedComponent|}}
+      {{! The trigger sits at the group's trailing edge, so the float aligns
+          there. Both defaults are written as fallbacks because invocation-site
+          arguments beat curried ones, which would otherwise make them
+          overrides. }}
       <CurriedComponent
-        @icon="chevron-down"
+        @icon={{or @icon "chevron-down"}}
+        @placement={{or @placement "bottom-end"}}
         class="d-combo-button-menu"
         ...attributes
       >

--- a/frontend/discourse/tests/integration/ui-kit/d-combo-button-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-combo-button-test.gjs
@@ -1,0 +1,75 @@
+import { render, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DComboButton from "discourse/ui-kit/d-combo-button";
+
+module("Integration | ui-kit | DComboButton", function (hooks) {
+  setupRenderingTest(hooks);
+
+  async function open() {
+    await triggerEvent(".fk-d-menu__trigger", "click");
+  }
+
+  test("the menu aligns with the trailing edge of its trigger by default", async function (assert) {
+    await render(
+      <template>
+        <DComboButton class="--has-menu" as |combo|>
+          <combo.Button @translatedLabel="Action" />
+          <combo.Menu @inline={{true}} @visibilityOptimizer="none">
+            content
+          </combo.Menu>
+        </DComboButton>
+      </template>
+    );
+    await open();
+
+    assert.dom(".fk-d-menu").hasAttribute("data-placement", "bottom-end");
+  });
+
+  test("@placement overrides the default alignment", async function (assert) {
+    await render(
+      <template>
+        <DComboButton class="--has-menu" as |combo|>
+          <combo.Button @translatedLabel="Action" />
+          <combo.Menu
+            @inline={{true}}
+            @visibilityOptimizer="none"
+            @placement="bottom-start"
+          >
+            content
+          </combo.Menu>
+        </DComboButton>
+      </template>
+    );
+    await open();
+
+    assert.dom(".fk-d-menu").hasAttribute("data-placement", "bottom-start");
+  });
+
+  test("the menu trigger uses a chevron icon by default", async function (assert) {
+    await render(
+      <template>
+        <DComboButton class="--has-menu" as |combo|>
+          <combo.Button @translatedLabel="Action" />
+          <combo.Menu @inline={{true}}>content</combo.Menu>
+        </DComboButton>
+      </template>
+    );
+
+    assert.dom(".fk-d-menu__trigger .d-icon-chevron-down").exists();
+  });
+
+  test("@icon overrides the default trigger icon", async function (assert) {
+    await render(
+      <template>
+        <DComboButton class="--has-menu" as |combo|>
+          <combo.Button @translatedLabel="Action" />
+          <combo.Menu @inline={{true}} @icon="gear">content</combo.Menu>
+        </DComboButton>
+      </template>
+    );
+
+    assert.dom(".fk-d-menu__trigger .d-icon-gear").exists();
+    assert.dom(".fk-d-menu__trigger .d-icon-chevron-down").doesNotExist();
+  });
+});


### PR DESCRIPTION
`DComboButton` never passed a placement to `DMenu`, so FloatKit's `bottom-start` default applied. For an ordinary full-width trigger that is right, but a combo button's trigger is the narrow chevron welded to the group's trailing edge, so the dropdown opened left-aligned to the chevron and a wide menu ran past the right edge of the group. The menu now prefers `bottom-end`, aligning its trailing edge with the trigger's.

### Before

<img width="435" height="115" alt="image" src="https://github.com/user-attachments/assets/f47c1053-1c01-4c9b-93e1-5a67c815671f" />

### After

<img width="309" height="123" alt="image" src="https://github.com/user-attachments/assets/9e317c96-ed84-4978-a19f-72cabd926d28" />

Two of the four call sites had already worked around this by hand-writing `@placement="bottom-end"`, which is what suggested the default was wrong rather than those call sites being special. Those overrides still apply and are unchanged; the drafts dropdown on the topic list and discourse-calendar's event RSVP button pick up the new default.

The default is written as a fallback rather than a bare value because of how Glimmer merges curried arguments: `Menu` forwards consumer arguments through `curryComponent`, and the curry path only adds keys the invocation site has not already set, so arguments written on the curried invocation win. A bare value would therefore be a hard override that silently discarded any consumer's placement. The same applies to the `chevron-down` icon, which was previously hardcoded and did silently discard a consumer's `@icon`; it is now a real default.