### PR TITLE
FIX: Canonicalize cakeday timezones for PostgreSQL

### DIFF
--- a/plugins/discourse-cakeday/app/controllers/discourse_cakeday/cakeday_controller.rb
+++ b/plugins/discourse-cakeday/app/controllers/discourse_cakeday/cakeday_controller.rb
@@ -37,7 +37,7 @@ module DiscourseCakeday
         end.to_date
 
       if apply_timezone && @timezone.present? && @timezone != "UTC"
-        if (iana_timezone = ActiveSupport::TimeZone[@timezone]&.tzinfo&.identifier)
+        if (iana_timezone = ActiveSupport::TimeZone[@timezone]&.tzinfo&.canonical_identifier)
           quoted_timezone = ActiveRecord::Base.connection.quote(iana_timezone)
           column_sql = "#{column_sql} AT TIME ZONE 'UTC' AT TIME ZONE #{quoted_timezone}"
         end

--- a/plugins/discourse-cakeday/spec/integration/cakeday_spec.rb
+++ b/plugins/discourse-cakeday/spec/integration/cakeday_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe "Anniversaries and Birthdays" do
       end
 
       it "accounts for the current user's timezone" do
+        # Asia/Kolkata is +5.5 hours from UTC
         current_user.user_option.update!(timezone: "Asia/Kolkata")
 
         freeze_time(time) do

--- a/plugins/discourse-cakeday/spec/integration/cakeday_spec.rb
+++ b/plugins/discourse-cakeday/spec/integration/cakeday_spec.rb
@@ -96,12 +96,6 @@ RSpec.describe "Anniversaries and Birthdays" do
         end
       end
 
-      it "handles legacy timezone aliases without SQL errors" do
-        current_user.user_option.update!(timezone: "Asia/Calcutta")
-        get "/cakeday/anniversaries.json", params: { filter: "today" }
-        expect(response.status).to eq(200)
-      end
-
       it "handles Nuku'alofa timezone without SQL errors" do
         # Nuku'alofa contains an apostrophe and must be converted to Pacific/Tongatapu
         current_user.user_option.update!(timezone: "Nuku'alofa")

--- a/plugins/discourse-cakeday/spec/integration/cakeday_spec.rb
+++ b/plugins/discourse-cakeday/spec/integration/cakeday_spec.rb
@@ -71,8 +71,7 @@ RSpec.describe "Anniversaries and Birthdays" do
       end
 
       it "accounts for the current user's timezone" do
-        # Asia/Calcutta is +5.5 hours from UTC
-        current_user.user_option.update!(timezone: "Asia/Calcutta")
+        current_user.user_option.update!(timezone: "Asia/Kolkata")
 
         freeze_time(time) do
           created_at = time - 1.year
@@ -95,6 +94,12 @@ RSpec.describe "Anniversaries and Birthdays" do
           body = response.parsed_body
           expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly(user3.id, user4.id)
         end
+      end
+
+      it "handles legacy timezone aliases without SQL errors" do
+        current_user.user_option.update!(timezone: "Asia/Calcutta")
+        get "/cakeday/anniversaries.json", params: { filter: "today" }
+        expect(response.status).to eq(200)
       end
 
       it "handles Nuku'alofa timezone without SQL errors" do


### PR DESCRIPTION
Cakeday anniversary requests could pass legacy timezone aliases such as `Asia/Calcutta` to PostgreSQL. PostgreSQL 18 no longer recognizes that alias, so affected requests failed instead of returning anniversaries.

The [`plugins backend` CI job](https://github.com/discourse/discourse/actions/runs/31455659737/job/93668764690) failed in `plugins/discourse-cakeday/spec/integration/cakeday_spec.rb:73` with `PG::InvalidParameterValue: ERROR: time zone "Asia/Calcutta" not recognized`.

This commit uses TZInfo's canonical identifier for the SQL timezone while preserving the user's configured timezone for date calculations. The failing cakeday integration spec now passes on PostgreSQL 18.
