### PR TITLE
FEATURE: Add scoped AI tool read APIs

### DIFF
--- a/plugins/discourse-ai/lib/agents/tool_runner.rb
+++ b/plugins/discourse-ai/lib/agents/tool_runner.rb
@@ -238,10 +238,17 @@ module DiscourseAi
           },
         };
 
+        function unwrapDiscourseReadResult(result) {
+          if (result && result.__discourse_read_error) {
+            throw new Error(result.__discourse_read_error);
+          }
+          return result;
+        }
+
         const discourse = {
           baseUrl: #{::Discourse.base_url.to_json},
           search: function(params) {
-            return _discourse_search(params);
+            return unwrapDiscourseReadResult(_discourse_search(params));
           },
           updateAgent: function(agent_id_or_name, updates) {
             const result = _discourse_update_agent(agent_id_or_name, updates);
@@ -250,14 +257,34 @@ module DiscourseAi
             }
             return result;
           },
-          getPost: _discourse_get_post,
-          getTopic: _discourse_get_topic,
+          getPost: function(postId, options) {
+            return unwrapDiscourseReadResult(
+              _discourse_get_post(postId, options == null ? {} : options)
+            );
+          },
+          getTopicPost: function(topicId, postNumber, options) {
+            return unwrapDiscourseReadResult(
+              _discourse_get_topic_post(
+                topicId,
+                postNumber,
+                options == null ? {} : options
+              )
+            );
+          },
+          getTopicPosts: function(topicId, options) {
+            return unwrapDiscourseReadResult(
+              _discourse_get_topic_posts(topicId, options == null ? {} : options)
+            );
+          },
+          getTopic: function(topicId, options) {
+            return unwrapDiscourseReadResult(
+              _discourse_get_topic(topicId, options == null ? {} : options)
+            );
+          },
           filterTopics: function(params) {
-            const result = _discourse_filter_topics(params || {});
-            if (result.error) {
-              throw new Error(result.error);
-            }
-            return result;
+            return unwrapDiscourseReadResult(
+              _discourse_filter_topics(params == null ? {} : params)
+            );
           },
           getUser: _discourse_get_user,
           getAgent: function(name) {

--- a/plugins/discourse-ai/lib/agents/tool_runner/discourse.rb
+++ b/plugins/discourse-ai/lib/agents/tool_runner/discourse.rb
@@ -12,12 +12,15 @@ module DiscourseAi
       # to the script. Three non-obvious behaviors to preserve or explicitly
       # revisit if you change them:
       #
-      # 1. Read bindings (`getPost`, `getTopic`, `getUser`, `getAgent`) serialize
-      #    with `system_guardian` and can return staff-visible data including PMs
-      #    and staff-only fields (emails, IPs). `search` and `filterTopics`
-      #    default to public visibility and only elevate when `with_private: true`
-      #    is passed. Existing tools rely on these contracts — don't tighten or
-      #    widen without a corresponding preamble doc change and migration plan.
+      # 1. Source read bindings (`getPost`, `getTopicPost`, `getTopicPosts`,
+      #    `getTopic`) default to `system_guardian` for compatibility, but accept
+      #    `as_user_id` or `as_username` to scope visibility through that user's
+      #    Guardian. `search` and `filterTopics` default to public visibility;
+      #    their user scopes expand access and must only use trusted, admin-authored
+      #    identities. `with_private: true` uses SystemUser. Scope options are
+      #    mutually exclusive and unknown options fail closed with a catchable
+      #    JavaScript error. Other privileged reads (`getUser`, `getAgent`) retain
+      #    their existing SystemUser behavior.
       #
       # 2. `resolve_guardian` elevates staged users to `system_guardian`. This
       #    supports a seeding pattern exercised by the "can seed a category
@@ -36,34 +39,149 @@ module DiscourseAi
       #    If you add a new sub-operation, add its own inner permission check.
       #    Do not assume the outer `can_see?` is sufficient.
       module Discourse
+        MAX_TOPIC_POSTS = 20
+        MAX_FILTER_TOPICS = 100
+        READ_API_ERROR_KEY = "__discourse_read_error"
+        READ_SCOPE_OPTION_KEYS = %i[as_username as_user_id].freeze
+        TRUE_BOOLEAN_VALUES = [true, 1, "1", "t", "T", "true", "TRUE", "on", "ON"].freeze
+        FALSE_BOOLEAN_VALUES = [
+          false,
+          nil,
+          0,
+          "",
+          "0",
+          "f",
+          "F",
+          "false",
+          "FALSE",
+          "off",
+          "OFF",
+        ].freeze
+        TOPIC_POSTS_OPTION_KEYS = [*READ_SCOPE_OPTION_KEYS, :limit, :post_numbers].freeze
+        FILTER_TOPICS_OPTION_KEYS = [
+          :q,
+          :limit,
+          :page,
+          :with_private,
+          *READ_SCOPE_OPTION_KEYS,
+        ].freeze
+        SEARCH_OPTION_KEYS = [
+          :search_query,
+          :category,
+          :user,
+          :order,
+          :max_posts,
+          :tags,
+          :before,
+          :after,
+          :status,
+          :hyde,
+          :max_results,
+          :result_style,
+          :with_private,
+          *READ_SCOPE_OPTION_KEYS,
+        ].freeze
+
         def attach_discourse(mini_racer_context)
           mini_racer_context.attach(
             "_discourse_get_post",
-            ->(post_id) do
-              in_attached_function do
-                post = Post.find_by(id: post_id)
-                return nil if post.nil?
-                obj =
-                  recursive_as_json(
-                    PostSerializer.new(post, scope: system_guardian, root: false, add_raw: true),
+            ->(post_id, options) do
+              in_read_api_function do
+                guardian = resolve_read_guardian(options, allowed_keys: READ_SCOPE_OPTION_KEYS)
+                post = Post.find_by(id: positive_integer(post_id, name: "post_id"))
+                return nil if post.nil? || !guardian.can_see?(post)
+                serialize_post_for_tool(post, scope: guardian)
+              end
+            end,
+          )
+
+          mini_racer_context.attach(
+            "_discourse_get_topic_post",
+            ->(topic_id, post_number, options) do
+              in_read_api_function do
+                guardian = resolve_read_guardian(options, allowed_keys: READ_SCOPE_OPTION_KEYS)
+
+                topic = Topic.find_by(id: positive_integer(topic_id, name: "topic_id"))
+                return nil if topic.nil? || !guardian.can_see?(topic)
+
+                post =
+                  topic.posts.find_by(
+                    post_number: positive_integer(post_number, name: "post_number"),
                   )
-                topic_obj =
-                  recursive_as_json(
-                    ListableTopicSerializer.new(post.topic, scope: system_guardian, root: false),
-                  )
-                obj["topic"] = topic_obj
-                obj
+                return nil if post.nil? || !guardian.can_see?(post)
+                serialize_post_for_tool(post, scope: guardian)
+              end
+            end,
+          )
+
+          mini_racer_context.attach(
+            "_discourse_get_topic_posts",
+            ->(topic_id, options) do
+              in_read_api_function do
+                options = validate_options(options, allowed_keys: TOPIC_POSTS_OPTION_KEYS)
+                guardian = resolve_read_guardian(options, allowed_keys: nil)
+
+                topic = Topic.find_by(id: positive_integer(topic_id, name: "topic_id"))
+                return [] if topic.nil? || !guardian.can_see?(topic)
+
+                posts =
+                  topic.posts.secured(guardian).joins(:topic).preload(:user).order(:post_number)
+                posts = guardian.filter_hidden_posts(posts, category: topic.category)
+
+                if options.key?(:post_numbers)
+                  if options.key?(:limit)
+                    raise ::Discourse::InvalidParameters.new(
+                            "limit and post_numbers cannot be used together",
+                          )
+                  end
+                  unless options[:post_numbers].is_a?(Array)
+                    raise ::Discourse::InvalidParameters.new("post_numbers must be an array")
+                  end
+
+                  if options[:post_numbers].length > MAX_TOPIC_POSTS
+                    raise ::Discourse::InvalidParameters.new(
+                            "post_numbers cannot exceed #{MAX_TOPIC_POSTS} entries",
+                          )
+                  end
+
+                  post_numbers =
+                    options[:post_numbers]
+                      .map do |post_number|
+                        unless post_number.is_a?(Integer) && post_number.positive?
+                          raise ::Discourse::InvalidParameters.new(
+                                  "post_numbers must contain positive integers",
+                                )
+                        end
+                        post_number
+                      end
+                      .uniq
+                  posts = posts.where(post_number: post_numbers)
+                else
+                  if options.key?(:limit)
+                    limit = positive_integer_option(options[:limit], name: "limit")
+                    limit = [limit, MAX_TOPIC_POSTS].min
+                  else
+                    limit = MAX_TOPIC_POSTS
+                  end
+                  posts = posts.limit(limit)
+                end
+
+                serialized_topic = serialize_listable_topic_for_tool(topic, scope: guardian)
+                posts.map do |post|
+                  serialize_post_for_tool(post, scope: guardian, serialized_topic: serialized_topic)
+                end
               end
             end,
           )
 
           mini_racer_context.attach(
             "_discourse_get_topic",
-            ->(topic_id) do
-              in_attached_function do
-                topic = Topic.find_by(id: topic_id)
-                return nil if topic.nil?
-                serialize_topic_for_tool(topic, scope: system_guardian)
+            ->(topic_id, options) do
+              in_read_api_function do
+                guardian = resolve_read_guardian(options, allowed_keys: READ_SCOPE_OPTION_KEYS)
+                topic = Topic.find_by(id: positive_integer(topic_id, name: "topic_id"))
+                return nil if topic.nil? || !guardian.can_see?(topic)
+                serialize_topic_for_tool(topic, scope: guardian)
               end
             end,
           )
@@ -71,23 +189,30 @@ module DiscourseAi
           mini_racer_context.attach(
             "_discourse_filter_topics",
             ->(params) do
-              in_attached_function do
-                return { error: "params must be an object" } if !params.respond_to?(:symbolize_keys)
-
-                params = (params || {}).symbolize_keys
+              in_read_api_function do
+                params = validate_options(params, allowed_keys: FILTER_TOPICS_OPTION_KEYS)
                 query = params[:q].to_s
-                return { error: "Missing required parameter: q" } if query.blank?
+                if query.blank?
+                  raise ::Discourse::InvalidParameters.new("Missing required parameter: q")
+                end
 
-                page = params[:page].to_i
-                return { error: "page must be greater than or equal to 0" } if page.negative?
+                page = params.key?(:page) ? non_negative_integer(params[:page], name: "page") : 0
 
-                with_private = ActiveModel::Type::Boolean.new.cast(params[:with_private])
-                guardian = with_private ? system_guardian : Guardian.new
+                guardian =
+                  resolve_read_guardian(
+                    params,
+                    allowed_keys: nil,
+                    default_guardian: Guardian.new,
+                    allow_with_private: true,
+                  )
 
                 query_options = { guardian: guardian, q: query, page: page }
-                query_options[:per_page] = params[:limit].to_i if params.key?(:limit)
+                if params.key?(:limit)
+                  requested_limit = positive_integer_option(params[:limit], name: "limit")
+                  query_options[:per_page] = [requested_limit, MAX_FILTER_TOPICS].min
+                end
 
-                topic_list = TopicQuery.new(nil, **query_options).list_filter
+                topic_list = TopicQuery.new(guardian.user, **query_options).list_filter
 
                 {
                   query: query,
@@ -360,11 +485,18 @@ module DiscourseAi
           mini_racer_context.attach(
             "_discourse_search",
             ->(params) do
-              in_attached_function do
-                search_params = params.symbolize_keys
-                if search_params.delete(:with_private)
-                  search_params[:current_user] = ::Discourse.system_user
-                end
+              in_read_api_function do
+                search_params = validate_options(params, allowed_keys: SEARCH_OPTION_KEYS)
+                guardian =
+                  resolve_read_guardian(
+                    search_params,
+                    allowed_keys: nil,
+                    default_guardian: Guardian.new,
+                    allow_with_private: true,
+                  )
+
+                search_params = search_params.except(*READ_SCOPE_OPTION_KEYS, :with_private)
+                search_params[:current_user] = guardian.user if guardian.user
                 search_params[:result_style] = :detailed
                 results = DiscourseAi::Utils::Search.perform_search(**search_params)
                 recursive_as_json(results)
@@ -614,6 +746,122 @@ module DiscourseAi
 
         private
 
+        def in_read_api_function
+          in_attached_function { yield }
+        rescue ::Discourse::InvalidParameters, ArgumentError => error
+          { READ_API_ERROR_KEY => error.message }
+        end
+
+        # Positional IDs historically accept canonical numeric strings; security
+        # and collection options remain type-strict.
+        def positive_integer(value, name:)
+          parsed_value =
+            if value.is_a?(Integer)
+              value
+            elsif value.is_a?(String) && value.match?(/\A\d+\z/)
+              value.to_i
+            end
+
+          if !parsed_value || !parsed_value.positive?
+            raise ::Discourse::InvalidParameters.new("#{name} must be a positive integer")
+          end
+
+          parsed_value
+        end
+
+        def positive_integer_option(value, name:)
+          unless value.is_a?(Integer) && value.positive?
+            raise ::Discourse::InvalidParameters.new("#{name} must be a positive integer")
+          end
+
+          value
+        end
+
+        def non_negative_integer(value, name:)
+          unless value.is_a?(Integer) && !value.negative?
+            raise ::Discourse::InvalidParameters.new("#{name} must be greater than or equal to 0")
+          end
+
+          value
+        end
+
+        def boolean_option(value, name:)
+          return true if TRUE_BOOLEAN_VALUES.include?(value)
+          return false if FALSE_BOOLEAN_VALUES.include?(value)
+
+          raise ::Discourse::InvalidParameters.new("#{name} must be a boolean")
+        end
+
+        def validate_options(options, allowed_keys:)
+          unless options.respond_to?(:symbolize_keys)
+            raise ::Discourse::InvalidParameters.new("options must be an object")
+          end
+
+          options = options.symbolize_keys
+          unsupported_keys = options.keys - allowed_keys
+          if unsupported_keys.present?
+            raise ::Discourse::InvalidParameters.new(
+                    "Unsupported option(s): #{unsupported_keys.sort.join(", ")}",
+                  )
+          end
+
+          options
+        end
+
+        def resolve_read_guardian(
+          options,
+          allowed_keys:,
+          default_guardian: system_guardian,
+          allow_with_private: false
+        )
+          options = validate_options(options, allowed_keys: allowed_keys) if allowed_keys
+          has_username = options.key?(:as_username)
+          has_user_id = options.key?(:as_user_id)
+
+          if has_username && has_user_id
+            raise ::Discourse::InvalidParameters.new(
+                    "as_username and as_user_id cannot be used together",
+                  )
+          end
+
+          if options.key?(:with_private) && (has_username || has_user_id)
+            raise ::Discourse::InvalidParameters.new(
+                    "with_private cannot be used with as_username or as_user_id",
+                  )
+          end
+
+          with_private = false
+          if allow_with_private && options.key?(:with_private)
+            with_private = boolean_option(options[:with_private], name: "with_private")
+          end
+
+          return system_guardian if with_private
+          return default_guardian if !has_username && !has_user_id
+
+          user =
+            if has_username
+              username = options[:as_username]
+              unless username.is_a?(String) && username.present?
+                raise ::Discourse::InvalidParameters.new("as_username must be a non-empty string")
+              end
+              User.find_by_username(username)
+            else
+              user_id = positive_integer_option(options[:as_user_id], name: "as_user_id")
+              User.find_by(id: user_id)
+            end
+
+          if has_username && user && !user.id.positive?
+            raise ::Discourse::InvalidParameters.new(
+                    "as_username must identify a user with a positive ID",
+                  )
+          end
+
+          identity = has_username ? options[:as_username] : options[:as_user_id]
+          raise ::Discourse::InvalidParameters.new("User not found: #{identity}") if user.nil?
+
+          Guardian.new(user)
+        end
+
         def resolve_user(username)
           if username.present?
             User.find_by(username: username)
@@ -645,8 +893,20 @@ module DiscourseAi
           end
         end
 
+        def serialize_post_for_tool(post, scope:, serialized_topic: nil)
+          data =
+            recursive_as_json(PostSerializer.new(post, scope: scope, root: false, add_raw: true))
+          data["topic"] = serialized_topic ||
+            serialize_listable_topic_for_tool(post.topic, scope: scope)
+          data
+        end
+
+        def serialize_listable_topic_for_tool(topic, scope:)
+          recursive_as_json(ListableTopicSerializer.new(topic, scope: scope, root: false))
+        end
+
         def serialize_topic_for_tool(topic, scope:)
-          data = recursive_as_json(ListableTopicSerializer.new(topic, scope: scope, root: false))
+          data = serialize_listable_topic_for_tool(topic, scope: scope)
           data["url"] = topic.relative_url
           data["tags"] = topic.tags.map(&:name)
           data["first_post_id"] = topic.first_post&.id

--- a/plugins/discourse-ai/lib/ai_tool_scripts/preamble.js
+++ b/plugins/discourse-ai/lib/ai_tool_scripts/preamble.js
@@ -150,14 +150,26 @@
  *    the agent. The runner intentionally grants admin-level power to the script.
  *    Know these non-obvious defaults:
  *
- *    - Read ops (`getPost`, `getTopic`, `getUser`, `getAgent`) use the
- *      SystemUser scope. Results may include PMs, user emails, IP addresses,
- *      staff-category content, and other staff-only serializer fields. Do not
- *      return this data verbatim to the invoking user unless you've verified
- *      they're authorized to see it.
+ *    - Source reads (`getPost`, `getTopicPost`, `getTopicPosts`, `getTopic`)
+ *      use the SystemUser scope when no scope option is supplied. Results may
+ *      include PMs, staff-category content, and staff-only serializer fields.
+ *      Pass `as_user_id` (preferred because IDs survive renames) or
+ *      `as_username` to enforce that user's Guardian visibility.
  *
- *    - `search` and `filterTopics` default to public visibility. Pass
- *      `with_private: true` to elevate them to the SystemUser scope.
+ *    - `search` and `filterTopics` default to public visibility. Their user scope
+ *      options expand visibility to content that user can see; a staff identity
+ *      can be as privileged as `with_private: true`. Scope identities must come
+ *      from fixed admin-authored configuration or trusted runtime context. Never
+ *      populate them from tool parameters, model output, or other untrusted input.
+ *      Never combine identity scope with `with_private`. `with_private` accepts
+ *      booleans and, for compatibility, `"true"`/`"false"`, `"1"`/`"0"`, and
+ *      equivalent `t`/`f` or `on`/`off` forms. Scope-option conflicts, missing
+ *      users, malformed values, and unsupported option names throw a catchable
+ *      JavaScript error rather than falling back to a more privileged scope.
+ *
+ *    - Other privileged reads (`getUser`, `getAgent`) retain their SystemUser
+ *      behavior. They do not accept read scope options. Do not return privileged
+ *      data verbatim unless the invoking user is authorized to see it.
  *
  *    - Write ops (`createTopic`, `createPost`, `editPost`, `editTopic`,
  *      `createChatMessage`) enforce permissions via the Guardian of the user
@@ -185,33 +197,61 @@
  *
  *    discourse.search(params): Performs a Discourse search.
  *    Parameters:
- *      params (Object): Search parameters (e.g., { search_query: "keyword", with_private: true, max_results: 10 }).
- *                       By default this searches public content. `with_private: true` searches across all posts visible to the
- *                       SystemUser. `result_style: 'detailed'` is used by default.
+ *      params (Object): Supports `search_query`, `category`, `user`, `order`, `max_posts`, `tags`,
+ *                       `before`, `after`, `status`, `hyde`, `max_results`, `result_style`,
+ *                       `with_private`, `as_user_id`, and `as_username`.
+ *                       By default this searches public content. `with_private: true` searches as
+ *                       SystemUser. `as_user_id` or `as_username` instead scopes search through that
+ *                       user's Guardian. `result_style` is accepted for backwards compatibility,
+ *                       but `"detailed"` is always used.
  *    Returns: Object (Discourse search results structure, includes posts, topics, users etc.)
  *
  *    discourse.filterTopics(params): Filters topics using Discourse topic filter syntax.
  *    Parameters:
- *      params (Object): { q: string, limit?: number, page?: number, with_private?: boolean }
+ *      params (Object): { q: string, limit?: number, page?: number, with_private?: boolean,
+ *                         as_user_id?: number, as_username?: string }
  *                       `q` uses Discourse topic filter syntax (for example: "category:support order:created").
- *                       By default this only returns topics visible publicly. Pass `with_private: true` to elevate to the
- *                       SystemUser scope.
+ *                       By default this only returns topics visible publicly. Pass `with_private: true`
+ *                       for SystemUser scope, or a user scope option to use that user's Guardian.
  *    Returns: Object { query, page, limit, topics }
  *      query (string): The filter query that was executed.
  *      page (number): The page number used.
- *      limit (number): The effective per-page limit used.
+ *      limit (number): The effective per-page limit used (maximum 100).
  *      topics (Array<Object>): Topic summaries — same shape as `getTopic` (ListableTopicSerializer plus
  *                              `url`, `tags`, `first_post_id`, `category_id`, `category_name`,
  *                              `category_slug`, `views`, `like_count`).
  *
- *    discourse.getPost(post_id): Retrieves details for a specific post.
+ *    discourse.getPost(post_id, options?): Retrieves details for a specific post.
  *    Parameters:
  *      post_id (number): The ID of the post.
+ *      options (Object, optional): { as_user_id?: number, as_username?: string }.
+ *                                  Omission preserves the SystemUser read scope.
  *    Returns: Object (Post details including `raw`, nested `topic` object with ListableTopicSerializer structure) or null if not found/accessible.
  *
- *    discourse.getTopic(topic_id): Retrieves details for a specific topic.
+ *    discourse.getTopicPost(topic_id, post_number, options?): Retrieves one exact post by its topic coordinates.
+ *    Parameters:
+ *      topic_id (number): The topic ID.
+ *      post_number (number): The post number within the topic.
+ *      options (Object, optional): { as_user_id?: number, as_username?: string }.
+ *                                  Omission preserves the SystemUser read scope.
+ *    Returns: Object (same shape as `getPost`, including `raw` and nested `topic`) or null if not found/accessible.
+ *
+ *    discourse.getTopicPosts(topic_id, options?): Retrieves posts from a topic in post-number order.
+ *    Parameters:
+ *      topic_id (number): The topic ID.
+ *      options (Object, optional):
+ *        as_user_id (number): Scope the read through this user's Guardian (preferred).
+ *        as_username (string): Scope the read through this user's Guardian.
+ *        post_numbers (Array<number>): Return only these positive post numbers. At most 20 entries are accepted.
+ *        limit (number): Positive maximum when `post_numbers` is omitted (default 20; values above 20 are capped).
+ *                       Do not combine `limit` and `post_numbers`.
+ *    Returns: Array<Object> (each item has the same shape as `getPost`). Returns an empty array if the topic is not found or accessible.
+ *
+ *    discourse.getTopic(topic_id, options?): Retrieves details for a specific topic.
  *    Parameters:
  *      topic_id (number): The ID of the topic.
+ *      options (Object, optional): { as_user_id?: number, as_username?: string }.
+ *                                  Omission preserves the SystemUser read scope.
  *    Returns: Object (Topic details using ListableTopicSerializer structure, plus `url`, `tags`,
  *             `first_post_id`, `category_id`, `category_name`, `category_slug`, `views`, `like_count`)
  *             or null if not found/accessible.

--- a/plugins/discourse-ai/spec/lib/agents/tool_runner/discourse_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tool_runner/discourse_spec.rb
@@ -112,6 +112,329 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
         expect(result["category_name"]).to eq("Test Category")
         expect(result["category_slug"]).to eq("test-category")
       end
+
+      it "fetches an exact post by topic coordinates, including restricted topics" do
+        reply = Fabricate(:post, topic: topic)
+        private_post = Fabricate(:post, topic: pm_topic)
+        tool.update!(script: <<~JS)
+            function invoke(params) {
+              return {
+                exact: discourse.getTopicPost(params.topic_id, params.post_number),
+                missing: discourse.getTopicPost(params.topic_id, 999999),
+                privatePost: discourse.getTopicPost(params.private_topic_id, params.private_post_number)
+              };
+            }
+          JS
+
+        result =
+          tool.runner(
+            {
+              "topic_id" => topic.id,
+              "post_number" => reply.post_number,
+              "private_topic_id" => pm_topic.id,
+              "private_post_number" => private_post.post_number,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["exact"].slice("id", "topic_id", "post_number", "raw")).to eq(
+          "id" => reply.id,
+          "topic_id" => topic.id,
+          "post_number" => reply.post_number,
+          "raw" => reply.raw,
+        )
+        expect(result["exact"].dig("topic", "id")).to eq(topic.id)
+        expect(result["missing"]).to be_nil
+        expect(result["privatePost"]["id"]).to eq(private_post.id)
+      end
+
+      it "accepts null options and rejects malformed topic coordinates" do
+        tool.update!(script: <<~JS)
+            function errorMessage(callback) {
+              try {
+                callback();
+              } catch (error) {
+                return error.message;
+              }
+            }
+
+            function invoke(params) {
+              return {
+                nullOptions: discourse.getTopicPost(
+                  params.topic_id,
+                  params.post_number,
+                  null
+                ),
+                invalidTopicId: errorMessage(function() {
+                  discourse.getTopicPost("2abc", params.post_number);
+                }),
+                invalidPostNumber: errorMessage(function() {
+                  discourse.getTopicPost(params.topic_id, 2.9);
+                })
+              };
+            }
+          JS
+
+        result =
+          tool.runner(
+            { "topic_id" => topic.id, "post_number" => post.post_number },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["nullOptions"]["id"]).to eq(post.id)
+        expect(result["invalidTopicId"]).to eq("topic_id must be a positive integer")
+        expect(result["invalidPostNumber"]).to eq("post_number must be a positive integer")
+      end
+
+      it "fetches bounded topic posts and can filter by post number" do
+        replies = Fabricate.times(3, :post, topic: topic)
+        tool.update!(script: <<~JS)
+            function invoke(params) {
+              return {
+                limited: discourse.getTopicPosts(params.topic_id, { limit: 2 }),
+                selected: discourse.getTopicPosts(params.topic_id, {
+                  post_numbers: params.post_numbers
+                }),
+                missing: discourse.getTopicPosts(999999)
+              };
+            }
+          JS
+
+        selected_post_numbers = [replies.second.post_number, post.post_number]
+        result =
+          tool.runner(
+            { "topic_id" => topic.id, "post_numbers" => selected_post_numbers },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["limited"].map { |item| item["post_number"] }).to eq([1, 2])
+        expect(result["selected"].map { |item| item["post_number"] }).to eq(
+          selected_post_numbers.sort,
+        )
+        expect(result["missing"]).to eq([])
+      end
+
+      it "scopes topic post reads through a specified user's Guardian" do
+        group = Fabricate(:group)
+        allowed_user = Fabricate(:user)
+        denied_user = Fabricate(:user)
+        staged_user = Fabricate(:staged)
+        group.add(allowed_user)
+        private_category = Fabricate(:private_category, group: group)
+        private_topic = Fabricate(:topic, category: private_category)
+        private_post = Fabricate(:post, topic: private_topic)
+
+        tool.update!(script: <<~JS)
+            function invoke(params) {
+              return {
+                allowed: discourse.getTopicPost(params.topic_id, params.post_number, {
+                  as_username: params.allowed_username
+                }),
+                allowedById: discourse.getTopicPost(params.topic_id, params.post_number, {
+                  as_user_id: params.allowed_user_id
+                }),
+                denied: discourse.getTopicPost(params.topic_id, params.post_number, {
+                  as_user_id: params.denied_user_id
+                }),
+                staged: discourse.getTopicPost(params.topic_id, params.post_number, {
+                  as_user_id: params.staged_user_id
+                }),
+                deniedTopicPosts: discourse.getTopicPosts(params.topic_id, {
+                  as_user_id: params.denied_user_id
+                })
+              };
+            }
+          JS
+
+        result =
+          tool.runner(
+            {
+              "topic_id" => private_topic.id,
+              "post_number" => private_post.post_number,
+              "allowed_username" => allowed_user.username.upcase,
+              "allowed_user_id" => allowed_user.id,
+              "denied_user_id" => denied_user.id,
+              "staged_user_id" => staged_user.id,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["allowed"]["id"]).to eq(private_post.id)
+        expect(result["allowedById"]["id"]).to eq(private_post.id)
+        expect(result["denied"]).to be_nil
+        expect(result["staged"]).to be_nil
+        expect(result["deniedTopicPosts"]).to eq([])
+      end
+
+      it "omits hidden posts and whispers from Guardian-scoped topic collections" do
+        reader = Fabricate(:user)
+        visible_post = Fabricate(:post, topic: topic)
+        hidden_post = Fabricate(:post, topic: topic, hidden: true)
+        whisper = Fabricate(:whisper, topic: topic)
+
+        tool.update!(script: <<~JS)
+            function invoke(params) {
+              return {
+                collection: discourse.getTopicPosts(params.topic_id, {
+                  as_user_id: params.user_id,
+                  post_numbers: params.post_numbers
+                }),
+                exact: discourse.getTopicPost(params.topic_id, params.hidden_post_number, {
+                  as_user_id: params.user_id
+                })
+              };
+            }
+          JS
+
+        result =
+          tool.runner(
+            {
+              "topic_id" => topic.id,
+              "user_id" => reader.id,
+              "post_numbers" => [
+                visible_post.post_number,
+                hidden_post.post_number,
+                whisper.post_number,
+              ],
+              "hidden_post_number" => hidden_post.post_number,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["collection"].map { |item| item["id"] }).to eq([visible_post.id])
+        expect(result["exact"]).to be_nil
+      end
+
+      it "scopes private message collections to participants" do
+        sender = Fabricate(:user)
+        recipient = Fabricate(:user)
+        outsider = Fabricate(:user)
+        private_message = Fabricate(:private_message_topic, user: sender, recipient: recipient)
+        private_post = Fabricate(:post, topic: private_message, user: sender)
+
+        tool.update!(script: <<~JS)
+            function invoke(params) {
+              return {
+                participant: discourse.getTopicPosts(params.topic_id, {
+                  as_user_id: params.participant_id
+                }),
+                outsider: discourse.getTopicPosts(params.topic_id, {
+                  as_user_id: params.outsider_id
+                })
+              };
+            }
+          JS
+
+        result =
+          tool.runner(
+            {
+              "topic_id" => private_message.id,
+              "participant_id" => recipient.id,
+              "outsider_id" => outsider.id,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["participant"].map { |item| item["id"] }).to eq([private_post.id])
+        expect(result["outsider"]).to eq([])
+      end
+
+      it "rejects invalid and unsupported read scope options" do
+        scenarios = [
+          ["Unsupported option", '{ as_usernme: "validator" }'],
+          ["cannot be used together", '{ as_username: "validator", as_user_id: 1 }'],
+          ["as_username must be a non-empty string", '{ as_username: "" }'],
+          [
+            "as_username must identify a user with a positive ID",
+            "{ as_username: #{::Discourse.system_user.username.to_json} }",
+          ],
+          ["User not found", "{ as_user_id: 99999999 }"],
+          ["positive integer", "{ as_user_id: -1 }"],
+          ["options must be an object", '"validator"'],
+        ]
+
+        scenarios.each do |expected_error, options|
+          tool.update!(script: <<~JS)
+              function invoke(params) {
+                try {
+                  discourse.getTopicPost(params.topic_id, params.post_number, #{options});
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+
+          result =
+            tool.runner(
+              { "topic_id" => topic.id, "post_number" => post.post_number },
+              llm: nil,
+              bot_user: nil,
+            ).invoke
+
+          expect(result["error"]).to match(/#{expected_error}/)
+        end
+      end
+
+      it "caps topic post limits and rejects oversized selections" do
+        Fabricate.times(20, :post, topic: topic)
+        tool.update!(script: <<~JS)
+            function invoke(params) {
+              const oversizedLimit = discourse.getTopicPosts(params.topic_id, {
+                limit: 100000
+              });
+              try {
+                discourse.getTopicPosts(params.topic_id, {
+                  post_numbers: params.post_numbers
+                });
+              } catch (error) {
+                return { oversizedLimit, selectionError: error.message };
+              }
+            }
+          JS
+
+        post_numbers = topic.posts.order(:post_number).pluck(:post_number)
+        result =
+          tool.runner(
+            { "topic_id" => topic.id, "post_numbers" => post_numbers },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["oversizedLimit"].size).to eq(20)
+        expect(result["selectionError"]).to eq("post_numbers cannot exceed 20 entries")
+      end
+
+      it "rejects malformed and conflicting topic post collection options" do
+        scenarios = [
+          ["post_numbers must be an array", '{ post_numbers: "1,2" }'],
+          ["post_numbers must contain positive integers", '{ post_numbers: [1, "2"] }'],
+          ["limit must be a positive integer", '{ limit: "20" }'],
+          ["limit must be a positive integer", "{ limit: 0 }"],
+          ["limit must be a positive integer", "{ limit: -1 }"],
+          ["limit and post_numbers cannot be used together", "{ limit: 1, post_numbers: [1] }"],
+        ]
+
+        scenarios.each do |expected_error, options|
+          tool.update!(script: <<~JS)
+              function invoke(params) {
+                try {
+                  discourse.getTopicPosts(params.topic_id, #{options});
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+          result = tool.runner({ "topic_id" => topic.id }, llm: nil, bot_user: nil).invoke
+
+          expect(result["error"]).to match(/#{expected_error}/)
+        end
+      end
     end
 
     context "when using the topic filter API" do
@@ -174,8 +497,100 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
           tool.runner({ "q" => "category:#{category.slug}", "limit" => 2 }, llm: nil, bot_user: nil)
 
         result = runner.invoke
+        oversized_result =
+          tool.runner(
+            { "q" => "category:#{category.slug}", "limit" => 100_000 },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
 
         expect(result["topics"].size).to eq(2)
+        expect(oversized_result["limit"]).to eq(100)
+      end
+
+      it "returns catchable errors for invalid filter parameters" do
+        script = <<~JS
+          function errorMessage(callback) {
+            try {
+              callback();
+            } catch (error) {
+              return error.message;
+            }
+          }
+
+          function invoke(params) {
+            return {
+              missingQuery: errorMessage(function() {
+                discourse.filterTopics({});
+              }),
+              negativePage: errorMessage(function() {
+                discourse.filterTopics({ q: "order:latest", page: -1 });
+              }),
+              malformedPage: errorMessage(function() {
+                discourse.filterTopics({ q: "order:latest", page: "1" });
+              }),
+              unknownOption: errorMessage(function() {
+                discourse.filterTopics({ q: "order:latest", unexpected: true });
+              }),
+              scopeConflict: errorMessage(function() {
+                discourse.filterTopics({
+                  q: "order:latest",
+                  as_user_id: params.user_id,
+                  with_private: false
+                });
+              })
+            };
+          }
+        JS
+
+        result =
+          create_tool(script: script).runner(
+            { "user_id" => user.id },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result).to eq(
+          "missingQuery" => "Missing required parameter: q",
+          "negativePage" => "page must be greater than or equal to 0",
+          "malformedPage" => "page must be greater than or equal to 0",
+          "unknownOption" => "Unsupported option(s): unexpected",
+          "scopeConflict" => "with_private cannot be used with as_username or as_user_id",
+        )
+      end
+
+      it "applies authenticated topic filters as the scoped user" do
+        scoped_user = Fabricate(:user)
+        tracked_topic = Fabricate(:topic, category: category)
+        Fabricate(:topic_user_tracking, topic: tracked_topic, user: scoped_user)
+        Fabricate(:topic, category: category)
+
+        script = <<~JS
+          function invoke(params) {
+            return {
+              byId: discourse.filterTopics({
+                q: "in:tracking",
+                as_user_id: params.user_id
+              }),
+              byUsername: discourse.filterTopics({
+                q: "in:tracking",
+                as_username: params.username
+              })
+            };
+          }
+        JS
+
+        result =
+          create_tool(script: script).runner(
+            { "user_id" => scoped_user.id, "username" => scoped_user.username.upcase },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result.dig("byId", "topics").map { |topic| topic["id"] }).to eq([tracked_topic.id])
+        expect(result.dig("byUsername", "topics").map { |topic| topic["id"] }).to eq(
+          [tracked_topic.id],
+        )
       end
 
       it "requires with_private to include private categories" do
@@ -208,9 +623,74 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
             llm: nil,
             bot_user: nil,
           ).invoke
+        string_private_result =
+          tool.runner(
+            { "category" => private_category.slug, "with_private" => "true" },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+        string_public_result =
+          tool.runner(
+            { "category" => private_category.slug, "with_private" => "false" },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+        empty_string_public_result =
+          tool.runner(
+            { "category" => private_category.slug, "with_private" => "" },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
 
         expect(public_result["topics"]).to eq([])
         expect(private_result["topics"].map { |topic| topic["id"] }).to eq([private_topic.id])
+        expect(string_private_result["topics"].map { |topic| topic["id"] }).to eq(
+          [private_topic.id],
+        )
+        expect(string_public_result["topics"]).to eq([])
+        expect(empty_string_public_result["topics"]).to eq([])
+      end
+
+      it "scopes filtered topics through a stable user ID" do
+        group = Fabricate(:group)
+        allowed_user = Fabricate(:user)
+        denied_user = Fabricate(:user)
+        group.add(allowed_user)
+        private_category = Fabricate(:private_category, group: group)
+        private_topic = Fabricate(:topic, category: private_category)
+
+        script = <<~JS
+          function invoke(params) {
+            const query = "category:" + params.category;
+            return {
+              allowed: discourse.filterTopics({
+                q: query,
+                as_user_id: params.allowed_user_id
+              }),
+              denied: discourse.filterTopics({
+                q: query,
+                as_user_id: params.denied_user_id
+              })
+            };
+          }
+        JS
+
+        tool = create_tool(script: script)
+        result =
+          tool.runner(
+            {
+              "category" => private_category.slug,
+              "allowed_user_id" => allowed_user.id,
+              "denied_user_id" => denied_user.id,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result.dig("allowed", "topics").map { |topic| topic["id"] }).to eq(
+          [private_topic.id],
+        )
+        expect(result.dig("denied", "topics")).to eq([])
       end
     end
 
@@ -239,6 +719,57 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
 
         expect(topic_hash["id"]).to eq(topic.id)
       end
+
+      it "scopes getPost and getTopic through a stable user ID" do
+        group = Fabricate(:group)
+        allowed_user = Fabricate(:user)
+        denied_user = Fabricate(:user)
+        group.add(allowed_user)
+        private_category = Fabricate(:private_category, group: group)
+        private_topic = Fabricate(:topic, category: private_category)
+        private_post = Fabricate(:post, topic: private_topic)
+
+        script = <<~JS
+          function invoke(params) {
+            return {
+              legacyPost: discourse.getPost(params.post_id),
+              legacyTopic: discourse.getTopic(params.topic_id),
+              allowedPost: discourse.getPost(params.post_id, {
+                as_user_id: params.allowed_user_id
+              }),
+              deniedPost: discourse.getPost(params.post_id, {
+                as_user_id: params.denied_user_id
+              }),
+              allowedTopic: discourse.getTopic(params.topic_id, {
+                as_user_id: params.allowed_user_id
+              }),
+              deniedTopic: discourse.getTopic(params.topic_id, {
+                as_user_id: params.denied_user_id
+              })
+            };
+          }
+        JS
+
+        tool = create_tool(script: script)
+        result =
+          tool.runner(
+            {
+              "post_id" => private_post.id,
+              "topic_id" => private_topic.id,
+              "allowed_user_id" => allowed_user.id,
+              "denied_user_id" => denied_user.id,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["legacyPost"]["id"]).to eq(private_post.id)
+        expect(result["legacyTopic"]["id"]).to eq(private_topic.id)
+        expect(result["allowedPost"]["id"]).to eq(private_post.id)
+        expect(result["deniedPost"]).to be_nil
+        expect(result["allowedTopic"]["id"]).to eq(private_topic.id)
+        expect(result["deniedTopic"]).to be_nil
+      end
     end
 
     context "when using the search API" do
@@ -251,7 +782,10 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
 
         script = <<~JS
           function invoke(params) {
-            return discourse.search({ search_query: params.query });
+            return discourse.search({
+              search_query: params.query,
+              result_style: "compact"
+            });
           }
         JS
 
@@ -262,6 +796,122 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
 
         expect(result["rows"].length).to be > 0
         expect(result["rows"].first["title"]).to eq(topic.title)
+      end
+
+      it "scopes search through a specified user's Guardian" do
+        group = Fabricate(:group)
+        allowed_user = Fabricate(:user)
+        denied_user = Fabricate(:user)
+        group.add(allowed_user)
+        private_category = Fabricate(:private_category, group: group)
+        private_topic = Fabricate(:topic, category: private_category)
+        private_post = Fabricate(:post, topic: private_topic, raw: "private validator needlephrase")
+        SearchIndexer.index(private_post, force: true)
+
+        script = <<~JS
+          function invoke(params) {
+            return {
+              system: discourse.search({
+                search_query: params.query,
+                with_private: true
+              }),
+              allowed: discourse.search({
+                search_query: params.query,
+                as_user_id: params.allowed_user_id
+              }),
+              denied: discourse.search({
+                search_query: params.query,
+                as_user_id: params.denied_user_id
+              })
+            };
+          }
+        JS
+
+        tool = create_tool(script: script)
+        result =
+          tool.runner(
+            {
+              "query" => "private validator needlephrase",
+              "allowed_user_id" => allowed_user.id,
+              "denied_user_id" => denied_user.id,
+            },
+            llm: nil,
+            bot_user: nil,
+          ).invoke
+
+        expect(result["system"]["rows"].map { |row| row["title"] }).to eq([private_topic.title])
+        expect(result["allowed"]["rows"].map { |row| row["title"] }).to eq([private_topic.title])
+        expect(result["denied"]["rows"]).to eq([])
+      end
+
+      it "rejects conflicting and unknown search scope options" do
+        scripts = [
+          ["cannot be used", <<~JS],
+              function invoke(params) {
+                try {
+                  discourse.search({
+                    search_query: "banana",
+                    as_user_id: params.user_id,
+                    with_private: false
+                  });
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+          ["Unsupported option", <<~JS],
+              function invoke(params) {
+                try {
+                  discourse.search({
+                    search_query: "banana",
+                    as_user: params.user_id
+                  });
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+          ["with_private must be a boolean", <<~JS],
+              function invoke() {
+                try {
+                  discourse.search({
+                    search_query: "banana",
+                    with_private: "yes"
+                  });
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+          ["max_results must be a positive integer", <<~JS],
+              function invoke() {
+                try {
+                  discourse.search({
+                    search_query: "banana",
+                    max_results: 0
+                  });
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+          ["options must be an object", <<~JS],
+              function invoke() {
+                try {
+                  discourse.search(null);
+                } catch (error) {
+                  return { error: error.message };
+                }
+              }
+            JS
+        ]
+
+        scripts.each do |expected_error, script|
+          tool = create_tool(script: script)
+          result = tool.runner({ "user_id" => user.id }, llm: nil, bot_user: nil).invoke
+
+          expect(result["error"]).to match(/#{expected_error}/)
+        end
       end
     end
 


### PR DESCRIPTION
Allow AI tools to read posts, topic posts, topics, search results, and filtered topics through a specified user's Guardian. Validate options and surface catchable errors so tools fail closed while preserving legacy system-level access.
