### PR TITLE
FIX: Make an event's `url` reachable again

### DIFF
--- a/plugins/discourse-events/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-events/app/models/discourse_post_event/event.rb
@@ -53,6 +53,7 @@ module DiscoursePostEvent
     validate :raw_invitees_length
     validate :ends_before_start
     validate :allowed_custom_fields
+    validate :url_is_a_uri, if: :url_changed?
 
     def self.attributes_protected_by_default
       super - %w[id]
@@ -245,6 +246,12 @@ module DiscoursePostEvent
           I18n.t("discourse_post_event.errors.models.event.ends_at_before_starts_at"),
         )
       end
+    end
+
+    def url_is_a_uri
+      return if EventParser.valid_url?(url)
+
+      errors.add(:base, I18n.t("discourse_post_event.errors.models.event.invalid_url"))
     end
 
     def allowed_custom_fields

--- a/plugins/discourse-events/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-events/app/serializers/discourse_post_event/event_serializer.rb
@@ -27,6 +27,7 @@ module DiscoursePostEvent
     attributes :description_html
     attributes :location
     attributes :location_html
+    attributes :url_restates_location
     attributes :watching_invitee
     attributes :chat_enabled
     attributes :livestream
@@ -206,7 +207,18 @@ module DiscoursePostEvent
     end
 
     def location_html
-      EventParser.cook_inline(object.location, post: object.post)
+      @location_html ||=
+        EventParser.normalize_links(EventParser.cook_inline(object.location, post: object.post))
+    end
+
+    def url_restates_location
+      return false if object.location.blank?
+
+      EventParser.url_restates_location?(
+        object.url,
+        object.location,
+        cooked_location: location_html,
+      )
     end
   end
 end

--- a/plugins/discourse-events/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-events/app/serializers/discourse_post_event/event_serializer.rb
@@ -207,8 +207,7 @@ module DiscoursePostEvent
     end
 
     def location_html
-      @location_html ||=
-        EventParser.normalize_links(EventParser.cook_inline(object.location, post: object.post))
+      @location_html ||= EventParser.cook_location(object.location, post: object.post)
     end
 
     def url_restates_location

--- a/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -20,6 +20,7 @@ import PostEventBuilder from "discourse/plugins/discourse-events/discourse/compo
 import {
   defaultEventState,
   isLivestreamUrl,
+  livestreamSource,
   reconcileDefaultReminder,
 } from "discourse/plugins/discourse-events/discourse/lib/raw-event-helper";
 import DiscoursePostEventEvent from "discourse/plugins/discourse-events/discourse/models/discourse-post-event-event";
@@ -210,7 +211,7 @@ export default class CompactEventEditor extends Component {
 
   get isLivestreamUrl() {
     return isLivestreamUrl(
-      this.hasLocation ? this.location : this.url,
+      livestreamSource(this.location, this.url),
       this.siteSettings
     );
   }
@@ -317,19 +318,9 @@ export default class CompactEventEditor extends Component {
   }
 
   @action
-  onLocationInput(event) {
+  onLinkFieldInput(field, event) {
     const value = event.target.value;
-    this.location = value === "" ? null : value;
-    if (!this.isLivestreamUrl) {
-      this.livestream = false;
-    }
-    this.#emitChange();
-  }
-
-  @action
-  onUrlInput(event) {
-    const value = event.target.value;
-    this.url = value === "" ? null : value;
+    this[field] = value === "" ? null : value;
     if (!this.isLivestreamUrl) {
       this.livestream = false;
     }
@@ -818,7 +809,7 @@ export default class CompactEventEditor extends Component {
           value={{this.location}}
           class="composer-event__location-input"
           placeholder={{this.locationPlaceholder}}
-          {{on "input" this.onLocationInput}}
+          {{on "input" (fn this.onLinkFieldInput "location")}}
           {{on "focus" this.handleTextInputFocus}}
         />
         {{#if this.isLocationUrl}}
@@ -843,7 +834,7 @@ export default class CompactEventEditor extends Component {
           value={{this.url}}
           class="composer-event__url-input"
           placeholder={{i18n "discourse_post_event.composer.url_placeholder"}}
-          {{on "input" this.onUrlInput}}
+          {{on "input" (fn this.onLinkFieldInput "url")}}
           {{on "focus" this.handleTextInputFocus}}
         />
       </section>

--- a/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -53,6 +53,7 @@ export default class CompactEventEditor extends Component {
   @tracked closed;
   @tracked customFields;
   @tracked linkify;
+  #startedWithUrl = false;
   #previousRsvpStatus = "public";
   #lastInitialStateRef;
   @tracked _maxAttendeesOverride;
@@ -91,6 +92,7 @@ export default class CompactEventEditor extends Component {
     this.livestream = s.livestream;
     this.minimal = s.minimal;
     this.url = s.url;
+    this.#startedWithUrl ||= !!s.url;
     this.image = s.image;
     this.allowedGroups = s.allowedGroups;
     this.closed = s.closed;
@@ -216,6 +218,16 @@ export default class CompactEventEditor extends Component {
     return this.isLocationUrl ? "link" : "location-pin";
   }
 
+  get showUrlRow() {
+    return !!this.url || this.#startedWithUrl;
+  }
+
+  get locationPlaceholder() {
+    return this.showUrlRow
+      ? i18n("discourse_post_event.composer.location_placeholder")
+      : i18n("discourse_post_event.composer.location_or_url_placeholder");
+  }
+
   get displayLocation() {
     if (!this.hasLocation) {
       return null;
@@ -310,6 +322,13 @@ export default class CompactEventEditor extends Component {
     if (!this.isLivestreamUrl) {
       this.livestream = false;
     }
+    this.#emitChange();
+  }
+
+  @action
+  onUrlInput(event) {
+    const value = event.target.value;
+    this.url = value === "" ? null : value;
     this.#emitChange();
   }
 
@@ -634,6 +653,7 @@ export default class CompactEventEditor extends Component {
           this.recurrence = updatedEvent.recurrence || null;
           this.recurrenceUntil = updatedEvent.recurrenceUntil || null;
           this.url = updatedEvent.url || null;
+          this.#startedWithUrl ||= !!this.url;
           this.allowedGroups =
             (updatedEvent.rawInvitees || []).join(",") || null;
           this.image = updatedEvent.imageUpload?.short_url
@@ -793,9 +813,7 @@ export default class CompactEventEditor extends Component {
           type="text"
           value={{this.location}}
           class="composer-event__location-input"
-          placeholder={{i18n
-            "discourse_post_event.composer.location_placeholder"
-          }}
+          placeholder={{this.locationPlaceholder}}
           {{on "input" this.onLocationInput}}
           {{on "focus" this.handleTextInputFocus}}
         />
@@ -812,6 +830,20 @@ export default class CompactEventEditor extends Component {
         {{/if}}
       </div>
     </section>
+
+    {{#if this.showUrlRow}}
+      <section class="composer-event__url">
+        {{dIcon "link"}}
+        <input
+          type="text"
+          value={{this.url}}
+          class="composer-event__url-input"
+          placeholder={{i18n "discourse_post_event.composer.url_placeholder"}}
+          {{on "input" this.onUrlInput}}
+          {{on "focus" this.handleTextInputFocus}}
+        />
+      </section>
+    {{/if}}
 
     {{#if this.isLivestreamUrl}}
       <section class="composer-event__livestream">

--- a/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -209,8 +209,9 @@ export default class CompactEventEditor extends Component {
   }
 
   get isLivestreamUrl() {
-    return (
-      this.hasLocation && isLivestreamUrl(this.location, this.siteSettings)
+    return isLivestreamUrl(
+      this.hasLocation ? this.location : this.url,
+      this.siteSettings
     );
   }
 
@@ -329,6 +330,9 @@ export default class CompactEventEditor extends Component {
   onUrlInput(event) {
     const value = event.target.value;
     this.url = value === "" ? null : value;
+    if (!this.isLivestreamUrl) {
+      this.livestream = false;
+    }
     this.#emitChange();
   }
 

--- a/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -118,6 +118,10 @@ export default class DiscoursePostEvent extends Component {
     return !this.args.event?.creator;
   }
 
+  get displayUrl() {
+    return this.event?.urlRestatesLocation ? null : this.event?.url;
+  }
+
   get loadingDetails() {
     return this.isLoading && this.isPartialEvent;
   }
@@ -339,7 +343,7 @@ export default class DiscoursePostEvent extends Component {
               @outletArgs={{lazyHash
                 event=event
                 Section=(component InfoSection event=event)
-                Url=(component Url url=event.url)
+                Url=(component Url url=this.displayUrl)
                 Description=(component
                   Description
                   descriptionHtml=event.descriptionHtml
@@ -376,7 +380,7 @@ export default class DiscoursePostEvent extends Component {
                 </InfoSection>
               {{/if}}
               <DiscoursePostEventLocation @event={{event}} />
-              <Url @url={{event.url}} />
+              <Url @url={{this.displayUrl}} />
               <ChatChannel @event={{event}} />
 
               {{#if event.stats}}

--- a/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -119,7 +119,15 @@ export default class DiscoursePostEvent extends Component {
   }
 
   get displayUrl() {
-    return this.event?.urlRestatesLocation ? null : this.event?.url;
+    if (
+      this.event?.urlRestatesLocation ||
+      (this.event?.isZoomLivestream &&
+        this.event?.livestreamUrl === this.event?.url)
+    ) {
+      return null;
+    }
+
+    return this.event?.url;
   }
 
   get loadingDetails() {

--- a/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/location.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/location.gjs
@@ -4,6 +4,7 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 import openLinksInNewTab from "discourse/plugins/discourse-events/discourse/modifiers/open-links-in-new-tab";
 
 const BARE_URL_REGEX = /^https?:\/\/\S+$/;
+const SINGLE_ANCHOR_REGEX = /^<a\b[^>]*>(?:(?!<a\b)[\s\S])*<\/a>$/;
 
 export default class DiscoursePostEventLocation extends Component {
   get isBareLivestreamUrl() {
@@ -17,10 +18,16 @@ export default class DiscoursePostEventLocation extends Component {
     return this.isBareLivestreamUrl ? null : this.args.event?.locationHtml;
   }
 
+  get icon() {
+    return SINGLE_ANCHOR_REGEX.test((this.locationHtml ?? "").trim())
+      ? "link"
+      : "location-pin";
+  }
+
   <template>
     {{#if this.locationHtml}}
       <section class="event__section event-location">
-        {{dIcon "location-pin"}}
+        {{dIcon this.icon}}
 
         <span
           class="event-location__text"

--- a/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/url.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/url.gjs
@@ -1,11 +1,15 @@
 import Component from "@glimmer/component";
+import { prefixProtocol } from "discourse/lib/url";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 export default class DiscoursePostEventUrl extends Component {
   get url() {
-    return this.args.url.includes("://") || this.args.url.includes("mailto:")
-      ? this.args.url
-      : `https://${this.args.url}`;
+    return prefixProtocol(this.args.url);
+  }
+
+  // Mirrors `EventParser.display_link` on the server.
+  get label() {
+    return (this.args.url ?? "").trim().replace(/^https?:\/\//i, "");
   }
 
   <template>
@@ -18,7 +22,7 @@ export default class DiscoursePostEventUrl extends Component {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {{@url}}
+          {{this.label}}
         </a>
       </section>
     {{/if}}

--- a/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -152,8 +152,25 @@ export default class PostEventBuilder extends Component {
   syncLocationToEvent(value, { set }) {
     set("location", value);
     this.event.location = value;
+    this.#resetInvalidLivestream(set);
+  }
 
-    if (!isLivestreamUrl(value, this.siteSettings)) {
+  @action
+  syncUrlToEvent(value, { set }) {
+    set("url", value);
+    this.event.url = value;
+    this.#resetInvalidLivestream(set);
+  }
+
+  // Mirrors `Event#livestream_url` on the server: location takes precedence,
+  // url only carries the livestream when no location is set. A blank location
+  // counts as absent, matching what `buildParams` serializes.
+  #livestreamSource() {
+    return this.event.location?.trim() ? this.event.location : this.event.url;
+  }
+
+  #resetInvalidLivestream(set) {
+    if (!isLivestreamUrl(this.#livestreamSource(), this.siteSettings)) {
       set("livestream", false);
       this.event.livestream = false;
     }
@@ -338,7 +355,7 @@ export default class PostEventBuilder extends Component {
 
   get showLivestream() {
     return (
-      isLivestreamUrl(this.event.location, this.siteSettings) &&
+      isLivestreamUrl(this.#livestreamSource(), this.siteSettings) &&
       this.siteSettings.chat_enabled
     );
   }
@@ -879,7 +896,7 @@ export default class PostEventBuilder extends Component {
                     }}
                     @type="input"
                     @format="full"
-                    @onSet={{fn this.syncFieldToEvent "url"}}
+                    @onSet={{this.syncUrlToEvent}}
                     as |field|
                   >
                     <field.Control

--- a/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -28,6 +28,7 @@ import {
   defaultReminderFor,
   getCustomFieldNames,
   isLivestreamUrl,
+  livestreamSource,
   reconcileDefaultReminder,
 } from "../../lib/raw-event-helper";
 import CompactEventEditor from "../compact-event-editor";
@@ -149,24 +150,14 @@ export default class PostEventBuilder extends Component {
   }
 
   @action
-  syncLocationToEvent(value, { set }) {
-    set("location", value);
-    this.event.location = value;
+  syncLinkToEvent(field, value, { set }) {
+    set(field, value);
+    this.event[field] = value;
     this.#resetInvalidLivestream(set);
   }
 
-  @action
-  syncUrlToEvent(value, { set }) {
-    set("url", value);
-    this.event.url = value;
-    this.#resetInvalidLivestream(set);
-  }
-
-  // Mirrors `Event#livestream_url` on the server: location takes precedence,
-  // url only carries the livestream when no location is set. A blank location
-  // counts as absent, matching what `buildParams` serializes.
   #livestreamSource() {
-    return this.event.location?.trim() ? this.event.location : this.event.url;
+    return livestreamSource(this.event.location, this.event.url);
   }
 
   #resetInvalidLivestream(set) {
@@ -878,7 +869,7 @@ export default class PostEventBuilder extends Component {
                   @title={{i18n this.locationLabel}}
                   @type="input"
                   @format="full"
-                  @onSet={{this.syncLocationToEvent}}
+                  @onSet={{fn this.syncLinkToEvent "location"}}
                   as |field|
                 >
                   <field.Control
@@ -896,7 +887,7 @@ export default class PostEventBuilder extends Component {
                     }}
                     @type="input"
                     @format="full"
-                    @onSet={{this.syncUrlToEvent}}
+                    @onSet={{fn this.syncLinkToEvent "url"}}
                     as |field|
                   >
                     <field.Control

--- a/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -49,6 +49,7 @@ export default class PostEventBuilder extends Component {
     this.event.status === "standalone" ? "public" : this.event.status;
   @tracked previousMaxAttendees = this.event.maxAttendees || null;
   @tracked attendanceMode = this.#initAttendanceMode();
+  @tracked urlRevealed = !!this.event.url;
 
   // FormKit clones @data once on mount and treats it as immutable. Reading
   // tracked event properties from a getter would invalidate this on every
@@ -324,6 +325,17 @@ export default class PostEventBuilder extends Component {
     ];
   }
 
+  @action
+  revealUrl() {
+    this.urlRevealed = true;
+  }
+
+  get locationLabel() {
+    return this.urlRevealed
+      ? "discourse_post_event.builder_modal.location.label"
+      : "discourse_post_event.builder_modal.location.label_or_url";
+  }
+
   get showLivestream() {
     return (
       isLivestreamUrl(this.event.location, this.siteSettings) &&
@@ -491,6 +503,7 @@ export default class PostEventBuilder extends Component {
       // Entering advanced — re-snapshot from the (possibly compact-edited)
       // event before the form mounts.
       this.formData = this.#snapshotFormData();
+      this.urlRevealed ||= !!this.event.url;
       this.screen = "advanced";
     }
   }
@@ -845,9 +858,7 @@ export default class PostEventBuilder extends Component {
 
                 <form.Field
                   @name="location"
-                  @title={{i18n
-                    "discourse_post_event.builder_modal.location.label"
-                  }}
+                  @title={{i18n this.locationLabel}}
                   @type="input"
                   @format="full"
                   @onSet={{this.syncLocationToEvent}}
@@ -859,6 +870,34 @@ export default class PostEventBuilder extends Component {
                     }}
                   />
                 </form.Field>
+
+                {{#if this.urlRevealed}}
+                  <form.Field
+                    @name="url"
+                    @title={{i18n
+                      "discourse_post_event.builder_modal.url.label"
+                    }}
+                    @type="input"
+                    @format="full"
+                    @onSet={{fn this.syncFieldToEvent "url"}}
+                    as |field|
+                  >
+                    <field.Control
+                      placeholder={{i18n
+                        "discourse_post_event.builder_modal.url.placeholder"
+                      }}
+                    />
+                  </form.Field>
+                {{else}}
+                  <form.Container @format="full">
+                    <DButton
+                      @action={{this.revealUrl}}
+                      @icon="plus"
+                      @label="discourse_post_event.builder_modal.url.add"
+                      class="btn-default add-event-url"
+                    />
+                  </form.Container>
+                {{/if}}
 
                 {{#if this.showLivestream}}
                   <form.Field

--- a/plugins/discourse-events/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -64,6 +64,13 @@ export function isLivestreamUrl(url, siteSettings) {
   );
 }
 
+// Mirrors `Event#livestream_url` on the server: location takes precedence,
+// url only carries the livestream when no location is set. A blank location
+// counts as absent, matching what `buildParams` serializes.
+export function livestreamSource(location, url) {
+  return location?.trim() ? location : url;
+}
+
 export function defaultReminderFor({ startsAt, endsAt, allDay } = {}) {
   const start = startsAt ? moment(startsAt) : null;
   const end = endsAt ? moment(endsAt) : null;

--- a/plugins/discourse-events/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -51,6 +51,7 @@ export default class DiscoursePostEventEvent {
   @tracked rawInvitees;
   @tracked location;
   @tracked locationHtml;
+  @tracked urlRestatesLocation;
   @tracked url;
   @tracked description;
   @tracked descriptionHtml;
@@ -98,6 +99,7 @@ export default class DiscoursePostEventEvent {
     this.sampleInvitees = args.sample_invitees || [];
     this.location = args.location;
     this.locationHtml = args.location_html;
+    this.urlRestatesLocation = args.url_restates_location;
     this.url = args.url;
     this.description = args.description;
     this.descriptionHtml = args.description_html;
@@ -209,6 +211,7 @@ export default class DiscoursePostEventEvent {
     this.duration = event.duration;
     this.location = event.location;
     this.locationHtml = event.locationHtml;
+    this.urlRestatesLocation = event.urlRestatesLocation;
     this.url = event.url;
     this.timezone = event.timezone;
     this.showLocalTime = event.showLocalTime;

--- a/plugins/discourse-events/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
@@ -16,6 +16,7 @@ export const EVENT_ATTRIBUTES = {
   start: { default: null },
   end: { default: null },
   location: { default: null },
+  url: { default: null },
   maxAttendees: { default: null },
   reminders: { default: null },
   minimal: { default: null },

--- a/plugins/discourse-events/assets/stylesheets/common/composer-event-node-view.scss
+++ b/plugins/discourse-events/assets/stylesheets/common/composer-event-node-view.scss
@@ -127,6 +127,7 @@
 
   .composer-event__dates,
   .composer-event__location,
+  .composer-event__url,
   .composer-event__attendees,
   .composer-event__reminder,
   .composer-event__livestream {
@@ -375,7 +376,8 @@ input.composer-event__time-input[type="time"] {
   display: none;
 }
 
-.composer-event__location-input {
+.composer-event__location-input,
+.composer-event__url-input {
   width: 100%;
   cursor: text;
 }

--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -460,7 +460,9 @@ en:
       composer:
         name_placeholder: "Event name"
         end_date_placeholder: "End date"
-        location_placeholder: "Add location or URL"
+        location_or_url_placeholder: "Add location or URL"
+        location_placeholder: "Add location"
+        url_placeholder: "Add URL"
         max_attendees_placeholder: "Unlimited attendees"
         max_attendees_display:
           one: "Max %{count} attendee"
@@ -573,8 +575,13 @@ en:
           label: "Livestream"
           checkbox_label: "Embed the URL as a video and open livestream chat for attendees"
         location:
-          label: "Location or URL"
+          label: "Location"
+          label_or_url: "Location or URL"
           placeholder: "Add a location, link or something."
+        url:
+          label: "URL"
+          placeholder: "Optional"
+          add: "Add URL"
         description:
           label: "Description"
           placeholder: "Tell people a little bit more about your event. New lines and links are supported."

--- a/plugins/discourse-events/config/locales/server.en.yml
+++ b/plugins/discourse-events/config/locales/server.en.yml
@@ -146,6 +146,7 @@ en:
           end_must_be_a_valid_date: "End date must be a valid date."
           invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_four_weeks, every_day, every_weekday."
           invalid_timezone: "Timezone not recognized."
+          invalid_url: "URL must be a valid web address."
           acting_user_not_allowed_to_create_event: "Current user is not allowed to create events."
           acting_user_not_allowed_to_act_on_this_event: "Current user is not allowed to act on this event."
           invalid_allowed_groups: "Invalid allowed groups."

--- a/plugins/discourse-events/lib/discourse_post_event/email_renderer.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/email_renderer.rb
@@ -90,8 +90,7 @@ module DiscoursePostEvent
     end
 
     def cooked_location
-      @cooked_location ||=
-        EventParser.normalize_links(EventParser.cook_inline(event_node["data-location"], post:))
+      @cooked_location ||= EventParser.cook_location(event_node["data-location"], post:)
     end
 
     def location_row

--- a/plugins/discourse-events/lib/discourse_post_event/email_renderer.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/email_renderer.rb
@@ -89,21 +89,29 @@ module DiscoursePostEvent
       muted_row(label && CGI.escape_html(label))
     end
 
-    def location_row
-      location = event_node["data-location"]
-      return "" if location.blank?
+    def cooked_location
+      @cooked_location ||=
+        EventParser.normalize_links(EventParser.cook_inline(event_node["data-location"], post:))
+    end
 
-      muted_row(EventParser.cook_inline(location, post:))
+    def location_row
+      return "" if event_node["data-location"].blank?
+
+      muted_row(cooked_location)
     end
 
     def url_row
       url = event_node["data-url"].to_s.strip
+      location = event_node["data-location"]
       return "" if url.blank?
+      if location.present? && EventParser.url_restates_location?(url, location, cooked_location:)
+        return ""
+      end
 
       href = EventParser.linkable_url?(url) ? url : "https://#{url}"
       <<~HTML
         <tr>
-          <td style="padding: 0 12px 12px;"><a href="#{CGI.escape_html(href)}">#{CGI.escape_html(url)}</a></td>
+          <td style="padding: 0 12px 12px;"><a href="#{CGI.escape_html(href)}">#{CGI.escape_html(EventParser.display_link(url))}</a></td>
         </tr>
       HTML
     end

--- a/plugins/discourse-events/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/event_parser.rb
@@ -113,6 +113,18 @@ module DiscoursePostEvent
         end
     end
 
+    def self.cook_location(text, post: nil)
+      text = text.to_s
+      add_nofollow = post.nil? || post.add_nofollow?
+
+      Discourse
+        .cache
+        .fetch(
+          "post-event-location:#{INLINE_CACHE_VERSION}:#{Digest::SHA1.hexdigest(text)}:#{add_nofollow}",
+          expires_in: 1.week,
+        ) { normalize_links(cook_inline(text, post:)) }
+    end
+
     def self.inline_text(text)
       cooked = cook_inline(text)
       PrettyText.excerpt(cooked, cooked.length, strip_links: true, text_entities: true)
@@ -173,7 +185,7 @@ module DiscoursePostEvent
       return true if normalize_link(location) == target
 
       Nokogiri::HTML5
-        .fragment(cooked_location || cook_inline(location))
+        .fragment(cooked_location || cook_location(location))
         .css("a[href]")
         .any? { |anchor| normalize_link(anchor["href"]) == target }
     end

--- a/plugins/discourse-events/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/event_parser.rb
@@ -25,6 +25,7 @@ module DiscoursePostEvent
     ]
 
     LEGACY_ESCAPED_ATTRS = %w[data-location]
+    SCHEME_PREFIX = /\A[a-z][a-z0-9+.\-]*:/i
 
     def self.extract_events(post)
       cooked = PrettyText.cook(post.raw, topic_id: post.topic_id, user_id: post.user_id)
@@ -121,6 +122,60 @@ module DiscoursePostEvent
       url = url.to_s.downcase
       schemes = %w[http https mailto] | SiteSetting.allowed_href_schemes.split("|")
       schemes.any? { |scheme| url.start_with?("#{scheme}:") }
+    end
+
+    def self.valid_url?(value)
+      value = value.to_s.strip
+      return true if value.blank?
+      # Rejected before encoding, which would otherwise make a CR/LF payload parse.
+      return false if value.match?(/\s/)
+
+      candidate = value.match?(SCHEME_PREFIX) ? value : "https://#{value}"
+      uri = URI.parse(UrlHelper.encode(candidate))
+      uri.scheme == "mailto" ? uri.opaque.present? : uri.host.present?
+    rescue URI::Error, Addressable::URI::InvalidURIError
+      false
+    end
+
+    def self.normalize_link(value)
+      value.to_s.strip.downcase.sub(%r{\Ahttps?://}, "").sub(%r{/+\z}, "")
+    end
+
+    def self.display_link(value)
+      value.to_s.strip.sub(%r{\Ahttps?://}i, "")
+    end
+
+    # A location is cooked, so its links arrive as anchors. Present them the same
+    # way the url row is presented: no scheme on screen, https when the author
+    # did not write one. Anchors carrying custom text are left alone.
+    def self.normalize_links(html)
+      fragment = Nokogiri::HTML5.fragment(html.to_s)
+      anchors =
+        fragment.css("a[href]").select { |a| [a.text, "http://#{a.text}"].include?(a["href"]) }
+      return html if anchors.empty?
+
+      anchors.each do |anchor|
+        text = anchor.text
+        if anchor["href"] == text
+          anchor.content = display_link(text)
+        else
+          anchor["href"] = "https://#{text}"
+        end
+      end
+
+      fragment.to_html
+    end
+
+    def self.url_restates_location?(url, location, cooked_location: nil)
+      return false if url.blank? || location.blank?
+
+      target = normalize_link(url)
+      return true if normalize_link(location) == target
+
+      Nokogiri::HTML5
+        .fragment(cooked_location || cook_inline(location))
+        .css("a[href]")
+        .any? { |anchor| normalize_link(anchor["href"]) == target }
     end
 
     def self.to_markdown(node)

--- a/plugins/discourse-events/lib/discourse_post_event/event_validator.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/event_validator.rb
@@ -134,6 +134,12 @@ module DiscoursePostEvent
         end
       end
 
+      if extracted_event[:url].present?
+        if !EventParser.valid_url?(extracted_event[:url])
+          @post.errors.add(:base, I18n.t("discourse_post_event.errors.models.event.invalid_url"))
+        end
+      end
+
       true
     end
 

--- a/plugins/discourse-events/lib/discourse_post_event/event_validator.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/event_validator.rb
@@ -134,10 +134,8 @@ module DiscoursePostEvent
         end
       end
 
-      if extracted_event[:url].present?
-        if !EventParser.valid_url?(extracted_event[:url])
-          @post.errors.add(:base, I18n.t("discourse_post_event.errors.models.event.invalid_url"))
-        end
+      if !EventParser.valid_url?(extracted_event[:url])
+        @post.errors.add(:base, I18n.t("discourse_post_event.errors.models.event.invalid_url"))
       end
 
       true

--- a/plugins/discourse-events/spec/lib/discourse_post_event/event_parser_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_post_event/event_parser_spec.rb
@@ -343,9 +343,9 @@ describe DiscoursePostEvent::EventParser do
     end
   end
 
-  describe ".normalize_links" do
+  describe ".cook_location" do
     def present(location)
-      described_class.normalize_links(described_class.cook_inline(location))
+      described_class.cook_location(location)
     end
 
     it "upgrades an inferred scheme to https and keeps it off screen" do

--- a/plugins/discourse-events/spec/lib/discourse_post_event/event_parser_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_post_event/event_parser_spec.rb
@@ -288,4 +288,87 @@ describe DiscoursePostEvent::EventParser do
       expect(event[:"my.field"]).to eq("5")
     end
   end
+
+  describe ".valid_url?" do
+    it "accepts URIs, with or without a scheme" do
+      expect(described_class.valid_url?("https://zoom.us/j/1")).to eq(true)
+      expect(described_class.valid_url?("meet.google.com/phv-rbyy-gsh")).to eq(true)
+      expect(described_class.valid_url?("mailto:someone@example.com")).to eq(true)
+      expect(described_class.valid_url?("https://münchen.example/fest")).to eq(true)
+    end
+
+    it "accepts a blank value so the field can be cleared" do
+      expect(described_class.valid_url?(nil)).to eq(true)
+      expect(described_class.valid_url?("  ")).to eq(true)
+    end
+
+    it "rejects anything that would resolve nowhere" do
+      expect(described_class.valid_url?("Room 5")).to eq(false)
+      expect(described_class.valid_url?("[RSVP](https://zoom.us/j/1)")).to eq(false)
+      expect(described_class.valid_url?("https://example.com/\r\nX-INJECTED:evil")).to eq(false)
+    end
+  end
+
+  describe ".url_restates_location?" do
+    it "ignores scheme and a trailing slash" do
+      expect(described_class.url_restates_location?("https://zoom.us/j/1/", "zoom.us/j/1")).to eq(
+        true,
+      )
+    end
+
+    it "sees through a markdown link, since location is cooked" do
+      expect(
+        described_class.url_restates_location?(
+          "https://zoom.us/j/55",
+          "[RSVP](https://zoom.us/j/55)",
+        ),
+      ).to eq(true)
+    end
+
+    it "keeps a venue and a separate registration page apart" do
+      expect(
+        described_class.url_restates_location?("https://ti.to/x", "Discourse HQ, Denver"),
+      ).to eq(false)
+      expect(
+        described_class.url_restates_location?(
+          "https://meet.google.com/cuo",
+          "meet.google.com/phv",
+        ),
+      ).to eq(false)
+    end
+
+    it "is false when either side is blank" do
+      expect(described_class.url_restates_location?("https://zoom.us/j/1", nil)).to eq(false)
+      expect(described_class.url_restates_location?(nil, "zoom.us/j/1")).to eq(false)
+    end
+  end
+
+  describe ".normalize_links" do
+    def present(location)
+      described_class.normalize_links(described_class.cook_inline(location))
+    end
+
+    it "upgrades an inferred scheme to https and keeps it off screen" do
+      expect(present("meet.google.com/abc")).to eq(
+        '<a href="https://meet.google.com/abc" rel="noopener nofollow ugc">meet.google.com/abc</a>',
+      )
+    end
+
+    it "hides a scheme the author did write" do
+      expect(present("https://zoom.us/j/1")).to include(">zoom.us/j/1</a>")
+      expect(present("https://zoom.us/j/1")).to include('href="https://zoom.us/j/1"')
+    end
+
+    it "does not silently upgrade an explicit http link" do
+      expect(present("http://intranet.example/room")).to include(
+        'href="http://intranet.example/room"',
+      )
+      expect(present("http://intranet.example/room")).to include(">intranet.example/room</a>")
+    end
+
+    it "leaves custom link text and plain text alone" do
+      expect(present("[RSVP](https://zoom.us/j/55)")).to include(">RSVP</a>")
+      expect(present("Room 5")).to eq("Room 5")
+    end
+  end
 end

--- a/plugins/discourse-events/spec/lib/discourse_post_event/pretty_text_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_post_event/pretty_text_spec.rb
@@ -139,6 +139,32 @@ describe PrettyText do
 
           expect(result).to include('href="https://ftp://files.example.com"')
         end
+
+        it "keeps the url alongside a location that points somewhere else" do
+          post_with_venue =
+            create_post_with_event(
+              user_1,
+              'location="Discourse HQ" url="https://example.com/meeting"',
+            )
+          cooked = PrettyText.cook(post_with_venue.raw)
+          result = PrettyText.format_for_email(cooked, post_with_venue)
+
+          expect(result).to include("Discourse HQ")
+          expect(result).to include('href="https://example.com/meeting"')
+        end
+
+        it "drops the url row when it only restates the location" do
+          post_with_same_link =
+            create_post_with_event(
+              user_1,
+              'location="example.com/meeting" url="https://example.com/meeting/"',
+            )
+          cooked = PrettyText.cook(post_with_same_link.raw)
+          result = PrettyText.format_for_email(cooked, post_with_same_link)
+
+          expect(result).to include('href="https://example.com/meeting"')
+          expect(result).not_to include('href="https://example.com/meeting/"')
+        end
       end
 
       context "when the event has an image" do

--- a/plugins/discourse-events/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-events/spec/models/discourse_post_event/event_spec.rb
@@ -1529,3 +1529,33 @@ describe DiscoursePostEvent::Event, "#capacity" do
     expect(event.at_capacity?).to eq(true)
   end
 end
+
+describe DiscoursePostEvent::Event, "#url" do
+  fab!(:post)
+
+  before { SiteSetting.discourse_post_event_enabled = true }
+
+  it "accepts a URI, with or without a scheme" do
+    event = Fabricate.build(:event, post: post, url: "meet.google.com/phv-rbyy-gsh")
+
+    expect(event).to be_valid
+  end
+
+  it "rejects a value that would resolve nowhere" do
+    event = Fabricate.build(:event, post: post, url: "Room 5")
+
+    expect(event).not_to be_valid
+    expect(event.errors.full_messages.join).to include("valid web address")
+  end
+
+  it "leaves an existing bad url editable" do
+    event = Fabricate(:event, post: post)
+    event.update_column(:url, "Room 5")
+
+    event.reload.name = "Renamed"
+    expect(event).to be_valid
+
+    event.url = nil
+    expect(event).to be_valid
+  end
+end

--- a/plugins/discourse-events/spec/requests/api/schemas/json/events_index_detailed_response.json
+++ b/plugins/discourse-events/spec/requests/api/schemas/json/events_index_detailed_response.json
@@ -217,6 +217,9 @@
               "null"
             ]
           },
+          "url_restates_location": {
+            "type": "boolean"
+          },
           "watching_invitee": {
             "type": [
               "object",

--- a/plugins/discourse-events/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-events/spec/requests/events_controller_spec.rb
@@ -152,10 +152,10 @@ module DiscoursePostEvent
       end
 
       it "strips CR/LF from URL fields so a stored URL cannot inject ICS properties" do
-        Fabricate(
-          :event,
-          original_starts_at: 1.day.from_now,
-          url: "https://example.com/\r\nX-INJECTED:evil\r\n",
+        # Written past validation: the encoder has to hold for imported or legacy rows.
+        Fabricate(:event, original_starts_at: 1.day.from_now).update_column(
+          :url,
+          "https://example.com/\r\nX-INJECTED:evil\r\n",
         )
 
         get "/discourse-post-event/events.ics"

--- a/plugins/discourse-events/spec/system/post_event_spec.rb
+++ b/plugins/discourse-events/spec/system/post_event_spec.rb
@@ -30,7 +30,8 @@ describe "Post event" do
       post_event_form_page.fill_location(location)
       post_event_form_page.submit
 
-      expect(post_event_page).to have_location(location)
+      # the scheme stays on the link but is kept off the screen
+      expect(post_event_page).to have_location("123 Main St, Brisbane, Australia example.com")
       expect(page).to have_css(".event-location a[href='http://example.com']")
     end
   end

--- a/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
@@ -1,0 +1,92 @@
+import { fillIn, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import CompactEventEditor from "discourse/plugins/discourse-events/discourse/components/compact-event-editor";
+import { defaultEventState } from "discourse/plugins/discourse-events/discourse/lib/raw-event-helper";
+
+async function renderEditor(initialState, onChange = () => {}) {
+  await render(
+    <template>
+      <CompactEventEditor
+        @initialState={{initialState}}
+        @onChange={{onChange}}
+      />
+    </template>
+  );
+}
+
+function stateWith(overrides) {
+  return {
+    ...defaultEventState(),
+    name: "My event",
+    timezone: "UTC",
+    startsAt: moment("2026-07-01T10:00:00Z"),
+    endsAt: moment("2026-07-01T11:00:00Z"),
+    ...overrides,
+  };
+}
+
+module("Integration | Component | CompactEventEditor", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("exposes an existing url so it can be edited", async function (assert) {
+    const initialState = stateWith({ url: "https://meet.example.com/legacy" });
+    await renderEditor(initialState);
+
+    assert
+      .dom(".composer-event__url-input")
+      .hasValue(
+        "https://meet.example.com/legacy",
+        "a defined url is reachable on the compact screen, not just in advanced"
+      );
+  });
+
+  test("offers no url row for an event that has none", async function (assert) {
+    const initialState = stateWith({ location: "Room 5" });
+    await renderEditor(initialState);
+
+    assert
+      .dom(".composer-event__url-input")
+      .doesNotExist("adding a url is an advanced-screen action");
+    assert
+      .dom(".composer-event__location-input")
+      .hasAttribute(
+        "placeholder",
+        "Add location or URL",
+        "location covers both meanings while it is the only link field"
+      );
+  });
+
+  test("clearing the url keeps the row so it can be retyped", async function (assert) {
+    const initialState = stateWith({ url: "https://meet.example.com/legacy" });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    await fillIn(".composer-event__url-input", "");
+
+    assert.strictEqual(
+      lastState.url,
+      null,
+      "the cleared value is emitted so buildParams drops it"
+    );
+    assert
+      .dom(".composer-event__url-input")
+      .exists("the input is not yanked out from under the cursor");
+  });
+
+  test("narrows the location placeholder once url has its own row", async function (assert) {
+    const initialState = stateWith({
+      location: "Room 5",
+      url: "https://meet.example.com/legacy",
+    });
+    await renderEditor(initialState);
+
+    assert
+      .dom(".composer-event__location-input")
+      .hasAttribute(
+        "placeholder",
+        "Add location",
+        "location stops advertising URLs once url is a separate row"
+      );
+  });
+});

--- a/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
@@ -74,6 +74,89 @@ module("Integration | Component | CompactEventEditor", function (hooks) {
       .exists("the input is not yanked out from under the cursor");
   });
 
+  test("offers the livestream toggle when the url carries the livestream link", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const initialState = stateWith({ url: "https://zoom.us/j/123456789" });
+    await renderEditor(initialState);
+
+    assert
+      .dom(".composer-event__livestream")
+      .exists("a livestream link is recognized in either field");
+  });
+
+  test("does not offer livestream for a venue with a companion link", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const initialState = stateWith({
+      location: "Room 5",
+      url: "https://zoom.us/j/123456789",
+    });
+    await renderEditor(initialState);
+
+    assert
+      .dom(".composer-event__livestream")
+      .doesNotExist("the location takes precedence as the livestream source");
+  });
+
+  test("keeps the livestream flag when only the companion url changes", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const initialState = stateWith({
+      location: "https://zoom.us/j/123456789",
+      url: "https://example.com/tickets",
+      livestream: true,
+    });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    await fillIn(".composer-event__url-input", "https://example.com/register");
+
+    assert
+      .dom(".composer-event__livestream")
+      .exists("the location still carries the stream");
+    assert.true(lastState.livestream, "the flag survives a companion url edit");
+  });
+
+  test("ignores a whitespace-only location when the url carries the stream", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const initialState = stateWith({
+      url: "https://zoom.us/j/123456789",
+      livestream: true,
+    });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    await fillIn(".composer-event__location-input", " ");
+
+    assert
+      .dom(".composer-event__livestream")
+      .exists("a blank location does not shadow the url");
+    assert.true(
+      lastState.livestream,
+      "the flag matches what the save path would keep"
+    );
+  });
+
+  test("drops the livestream flag when the url stops being the livestream", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const initialState = stateWith({
+      url: "https://zoom.us/j/123456789",
+      livestream: true,
+    });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    await fillIn(".composer-event__url-input", "https://example.com/tickets");
+
+    assert.false(
+      lastState.livestream,
+      "livestream is reset so it is not submitted for a non-livestream url"
+    );
+  });
+
   test("narrows the location placeholder once url has its own row", async function (assert) {
     const initialState = stateWith({
       location: "Room 5",

--- a/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-location-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-location-test.gjs
@@ -19,6 +19,9 @@ module(
       assert
         .dom(".event-location")
         .includesText("Conference Room A", "shows the location text");
+      assert
+        .dom(".event-location .d-icon-location-pin")
+        .exists("a physical venue keeps the map pin");
     });
 
     test("renders server-rendered links and opens them in a new tab", async function (assert) {
@@ -39,6 +42,9 @@ module(
       assert
         .dom(".event-location")
         .includesText("(room 2)", "keeps the text around the link");
+      assert
+        .dom(".event-location .d-icon-location-pin")
+        .exists("a link plus surrounding text is still a place");
     });
 
     test("renders a URL-only location for non-Zoom events", async function (assert) {
@@ -53,6 +59,9 @@ module(
       assert
         .dom(".event-location a")
         .hasAttribute("href", "https://youtube.com/watch?v=123");
+      assert
+        .dom(".event-location .d-icon-link")
+        .exists("an online venue reads as a link, not a place");
     });
 
     test("does not render the URL for Zoom-only livestreams", async function (assert) {

--- a/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -136,4 +136,50 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
       .dom(".event-recurrence")
       .hasText("Every Thursday", "uses the date's weekday, not the prior day");
   });
+
+  test("renders location and url side by side when they differ", async function (assert) {
+    stubApi.call(
+      this,
+      buildEvent({
+        location: "Discourse HQ, Denver",
+        location_html: "Discourse HQ, Denver",
+        url: "https://ti.to/discourse/meetup",
+        url_restates_location: false,
+      })
+    );
+
+    const event = { id: 1 };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-location");
+
+    assert.dom(".event-location").includesText("Discourse HQ, Denver");
+    assert
+      .dom(".event-url a")
+      .hasAttribute(
+        "href",
+        "https://ti.to/discourse/meetup",
+        "a venue plus a registration page is a legitimate pairing"
+      );
+  });
+
+  test("renders the link once when url only restates location", async function (assert) {
+    stubApi.call(
+      this,
+      buildEvent({
+        location: "zoom.us/j/123",
+        location_html:
+          '<a href="http://zoom.us/j/123" rel="nofollow ugc">zoom.us/j/123</a>',
+        url: "https://zoom.us/j/123/",
+        url_restates_location: true,
+      })
+    );
+
+    const event = { id: 1 };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-location");
+
+    assert
+      .dom(".event-url")
+      .doesNotExist("the same link is not worth two rows");
+  });
 });

--- a/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -162,6 +162,29 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
       );
   });
 
+  test("hides the url row when it carries the zoom livestream", async function (assert) {
+    stubApi.call(
+      this,
+      buildEvent({
+        url: "https://zoom.us/j/123",
+        livestream: true,
+        livestream_url: "https://zoom.us/j/123",
+        is_zoom_livestream: true,
+        url_restates_location: false,
+      })
+    );
+
+    const event = { id: 1 };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-header");
+
+    assert
+      .dom(".event-url")
+      .doesNotExist(
+        "the zoom join UI presents the link, like a location-carried livestream"
+      );
+  });
+
   test("renders the link once when url only restates location", async function (assert) {
     stubApi.call(
       this,

--- a/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
@@ -242,6 +242,79 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
     );
   });
 
+  test("offers livestream when the url field carries the livestream link", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const event = eventWith({ url: "https://zoom.us/j/123456789" });
+    await renderAdvanced(event);
+
+    assert
+      .dom(`[data-name="livestream"]`)
+      .exists("a livestream link is recognized in either field");
+
+    await fillIn(`[data-name="url"] input`, "https://example.com/tickets");
+
+    assert
+      .dom(`[data-name="livestream"]`)
+      .doesNotExist("a plain link offers nothing to embed");
+    assert.false(
+      event.livestream,
+      "livestream is reset so it is not submitted for a non-livestream url"
+    );
+  });
+
+  test("keeps the livestream flag when only the companion url changes", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const event = eventWith({
+      location: "https://zoom.us/j/123456789",
+      url: "https://example.com/tickets",
+      livestream: true,
+    });
+    await renderAdvanced(event);
+
+    await fillIn(`[data-name="url"] input`, "https://example.com/register");
+
+    assert
+      .dom(`[data-name="livestream"]`)
+      .exists("the location still carries the stream");
+    assert.true(event.livestream, "the flag survives a companion url edit");
+  });
+
+  test("ignores a whitespace-only location when the url carries the stream", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const event = eventWith({
+      url: "https://zoom.us/j/123456789",
+      livestream: true,
+    });
+    await renderAdvanced(event);
+
+    await fillIn(`[data-name="location"] input`, " ");
+
+    assert
+      .dom(`[data-name="livestream"]`)
+      .exists("a blank location does not shadow the url");
+    assert.true(
+      event.livestream,
+      "the flag matches what the save path would keep"
+    );
+  });
+
+  test("the location takes precedence over the url as the livestream source", async function (assert) {
+    this.siteSettings.chat_enabled = true;
+
+    const event = eventWith({
+      location: "Discourse HQ, Denver",
+      url: "https://zoom.us/j/123456789",
+    });
+    await renderAdvanced(event);
+
+    assert
+      .dom(`[data-name="livestream"]`)
+      .doesNotExist("a venue event is not streamed from its companion link");
+  });
+
   test("advanced screen hides the url field behind an add button when unset", async function (assert) {
     const event = eventWith();
     await renderAdvanced(event);

--- a/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
@@ -5,6 +5,40 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import PostEventBuilder from "../../discourse/components/modal/post-event-builder";
 import DiscoursePostEventEvent from "../../discourse/models/discourse-post-event-event";
 
+function eventWith(attrs = {}) {
+  return DiscoursePostEventEvent.create({
+    name: "My event",
+    starts_at: "2022-07-01T10:00:00Z",
+    ends_at: "2022-07-01T11:00:00Z",
+    timezone: "UTC",
+    status: "public",
+    reminders: [],
+    raw_invitees: [],
+    custom_fields: {},
+    ...attrs,
+  });
+}
+
+async function renderAdvanced(event) {
+  const model = {
+    event,
+    initialScreen: "advanced",
+    onUpdate: () => {},
+    toolbarEvent: {},
+  };
+  const closeModal = () => {};
+
+  await render(
+    <template>
+      <PostEventBuilder
+        @inline={{true}}
+        @model={{model}}
+        @closeModal={{closeModal}}
+      />
+    </template>
+  );
+}
+
 module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
   setupRenderingTest(hooks);
 
@@ -23,38 +57,14 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
   });
 
   test("advanced screen renders an existing image upload as its URL", async function (assert) {
-    const event = DiscoursePostEventEvent.create({
-      name: "My event",
-      starts_at: "2022-07-01T10:00:00Z",
-      ends_at: "2022-07-01T11:00:00Z",
-      timezone: "UTC",
-      status: "public",
-      reminders: [],
-      raw_invitees: [],
-      custom_fields: {},
+    const event = eventWith({
       image_upload: {
         url: "/uploads/default/original/1X/test-event-image.png",
         short_url: "upload://test-event-image",
       },
     });
 
-    const model = {
-      event,
-      initialScreen: "advanced",
-      onUpdate: () => {},
-      toolbarEvent: {},
-    };
-    const closeModal = () => {};
-
-    await render(
-      <template>
-        <PostEventBuilder
-          @inline={{true}}
-          @model={{model}}
-          @closeModal={{closeModal}}
-        />
-      </template>
-    );
+    await renderAdvanced(event);
 
     assert
       .dom(`[data-name="imageUpload"] .file-uploader`)
@@ -71,34 +81,9 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
   test("advanced screen renders a custom field whose name contains a dash", async function (assert) {
     this.siteSettings.discourse_post_event_allowed_custom_fields = "field-aa";
 
-    const event = DiscoursePostEventEvent.create({
-      name: "My event",
-      starts_at: "2022-07-01T10:00:00Z",
-      ends_at: "2022-07-01T11:00:00Z",
-      timezone: "UTC",
-      status: "public",
-      reminders: [],
-      raw_invitees: [],
-      custom_fields: {},
-    });
+    const event = eventWith();
 
-    const model = {
-      event,
-      initialScreen: "advanced",
-      onUpdate: () => {},
-      toolbarEvent: {},
-    };
-    const closeModal = () => {};
-
-    await render(
-      <template>
-        <PostEventBuilder
-          @inline={{true}}
-          @model={{model}}
-          @closeModal={{closeModal}}
-        />
-      </template>
-    );
+    await renderAdvanced(event);
 
     assert
       .dom(`[data-name="customFields.field_aa"] input`)
@@ -108,36 +93,12 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
   test("clears livestream when the location stops being a URL", async function (assert) {
     this.siteSettings.chat_enabled = true;
 
-    const event = DiscoursePostEventEvent.create({
-      name: "My event",
-      starts_at: "2022-07-01T10:00:00Z",
-      ends_at: "2022-07-01T11:00:00Z",
-      timezone: "UTC",
-      status: "public",
-      reminders: [],
-      raw_invitees: [],
-      custom_fields: {},
+    const event = eventWith({
       location: "https://zoom.us/j/123456789",
       livestream: true,
     });
 
-    const model = {
-      event,
-      initialScreen: "advanced",
-      onUpdate: () => {},
-      toolbarEvent: {},
-    };
-    const closeModal = () => {};
-
-    await render(
-      <template>
-        <PostEventBuilder
-          @inline={{true}}
-          @model={{model}}
-          @closeModal={{closeModal}}
-        />
-      </template>
-    );
+    await renderAdvanced(event);
 
     assert
       .dom(`[data-name="livestream"]`)
@@ -256,5 +217,51 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
       "typed",
       "the compact edit does not revive the stale value"
     );
+  });
+
+  test("advanced screen exposes an existing url so it can be edited", async function (assert) {
+    const event = eventWith({ url: "https://meet.example.com/legacy" });
+    await renderAdvanced(event);
+
+    assert
+      .dom(`[data-name="url"] input`)
+      .hasValue(
+        "https://meet.example.com/legacy",
+        "a defined url is always reachable, never a hidden field"
+      );
+    assert
+      .dom(".add-event-url")
+      .doesNotExist("no add affordance while the field is already shown");
+
+    await fillIn(`[data-name="url"] input`, "");
+
+    assert.strictEqual(
+      event.url,
+      null,
+      "clearing the field clears the event url, so buildParams drops it"
+    );
+  });
+
+  test("advanced screen hides the url field behind an add button when unset", async function (assert) {
+    const event = eventWith();
+    await renderAdvanced(event);
+
+    assert.dom(`[data-name="url"] input`).doesNotExist("starts collapsed");
+    assert
+      .dom(`[data-name="location"] label`)
+      .includesText(
+        "Location or URL",
+        "location covers both meanings while it is the only link field"
+      );
+
+    await click(".add-event-url");
+
+    assert.dom(`[data-name="url"] input`).exists("the add button reveals it");
+    assert
+      .dom(`[data-name="location"] label`)
+      .doesNotIncludeText(
+        "or URL",
+        "the label narrows once url has its own field"
+      );
   });
 });

--- a/plugins/discourse-events/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-events/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -78,6 +78,17 @@ module("Integration | Component | RichEditorExtension", function (hooks) {
     );
   });
 
+  test("event preserves url through a round trip", async function (assert) {
+    await testMarkdown(
+      assert,
+      `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" location="meet.example.com/new" url="https://meet.example.com/old"]\n[/event]\n`,
+      (a) => {
+        a.dom(".composer-event-node").exists("Event node should be rendered");
+      },
+      `[event start="2025-03-21 15:41" location=meet.example.com/new url=https://meet.example.com/old status=public timezone=Europe/Paris]\n[/event]\n`
+    );
+  });
+
   test("event preserves custom fields with uppercase letters", async function (assert) {
     this.siteSettings.discourse_post_event_allowed_custom_fields = "dress_CODE";
 


### PR DESCRIPTION
Previously, an event that already carried a `url` kept rendering it on the card while offering no field to edit or clear it, because the URL input was removed without migrating the stored values or dropping them from the generated BBCode.

This change restores an editable URL field — always shown when a value exists, added on demand from the advanced screen — validates it as a URI since it also feeds the ICS `URL:` property and webhook payloads, and stops the card and email rendering the same link twice when `url` only restates `location`.

Following review feedback: the livestream checkbox now keys off the same effective URL the server validates — `location || url`, with a blank location counting as absent — so a livestream link carried by the `url` field is recognized when no location is set. The location keeps precedence when both are set, and the card treats a url-carried Zoom livestream like a location-carried one: the join UI replaces the plain link row.


<img width="1520" height="554" alt="card-both" src="https://github.com/user-attachments/assets/3fa7384f-4972-4bfa-a365-60c204089350" />
<img width="1520" height="520" alt="card-markdown-link" src="https://github.com/user-attachments/assets/a4293036-d094-488b-aabb-f047f4335795" />
<img width="1520" height="520" alt="card-same-link" src="https://github.com/user-attachments/assets/c0a794c8-ec5e-47a5-8e4d-7ac12331cca1" />
<img width="1520" height="520" alt="card-venue" src="https://github.com/user-attachments/assets/445d683e-f460-4854-8cd1-2c8a7b0d7be4" />
<img width="1360" height="700" alt="editor-advanced" src="https://github.com/user-attachments/assets/f7447c37-2ba4-4b04-a58e-817befb4fa65" />
<img width="1360" height="640" alt="editor-legacy" src="https://github.com/user-attachments/assets/12802673-710e-4df1-ae93-90fd82c71199" />

