### PR TITLE
UX: UC – Composer redesign : iteration and fixes

### DIFF
--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -287,6 +287,11 @@
 
     .composer-fields {
       grid-area: fields;
+
+      @include viewport.until(sm) {
+        max-width: 100vw;
+        box-sizing: border-box;
+      }
     }
 
     .d-editor-textarea-column {

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -164,20 +164,21 @@
   }
 
   .title-input {
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--primary-low);
+
     #reply-title {
       border: 0;
       padding: var(--space-4);
-      font-size: var(--font-up-4);
-      font-weight: bold;
+      font-weight: 600;
       margin-bottom: 0 !important;
       padding-bottom: var(--space-3) !important;
+      padding-right: var(--space-3) !important;
+      flex-basis: unset !important;
 
       &::placeholder {
         color: var(--primary-medium);
-      }
-
-      @include viewport.until(sm) {
-        font-size: var(--font-up-2);
       }
 
       &:focus {
@@ -187,10 +188,11 @@
 
     // TODO move to plugin css when UC is removed
     .suggest-titles-button {
-      right: var(--space-4) !important;
-      top: var(--space-4);
+      position: relative;
       bottom: unset !important;
+      right: unset !important;
       transform: none !important;
+      margin-inline-end: var(--space-3);
     }
   }
 

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -306,12 +306,10 @@
 
   // clean up selector once the uc- body class is no longer in the way
   .show-preview .d-editor-container.--markdown-editor-enabled {
-    .d-editor-textarea-column {
-      border-right: none;
-    }
-
     .d-editor-preview-wrapper {
-      margin-top: var(--space-2);
+      border-left: 1px solid var(--primary-low);
+      margin: 0;
+      padding: var(--space-2) var(--space-4);
     }
   }
 

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -44,14 +44,6 @@
 
   .reply-area {
     padding: 0 !important;
-
-    @include viewport.until(sm) {
-      &:has(.d-editor-textarea-wrapper.in-focus) {
-        .reply-to {
-          pointer-events: none;
-        }
-      }
-    }
   }
 
   .composer-controls {
@@ -243,6 +235,14 @@
         border-top-right-radius: var(--d-border-radius-large);
         padding-top: var(--space-4);
       }
+    }
+  }
+
+  @include viewport.until(sm) {
+    #reply-control.has-composer-fields
+      .reply-area:has(.d-editor-textarea-wrapper.in-focus)
+      .reply-to {
+      pointer-events: none;
     }
   }
 

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -145,6 +145,7 @@
     .select-kit.multi-select .multi-select-header {
       border: 0;
       padding: var(--space-3) var(--space-4);
+      border-radius: 0;
 
       &:active {
         border: 0;

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -234,6 +234,18 @@
         border-top-left-radius: var(--d-border-radius-large);
         border-top-right-radius: var(--d-border-radius-large);
         padding-top: var(--space-4);
+
+        &::before {
+          content: "";
+          position: absolute;
+          inset-block-start: var(--space-2);
+          inset-inline-start: 50%;
+          transform: translateX(-50%);
+          width: 15vw;
+          height: 5px;
+          background: var(--primary-medium);
+          border-radius: var(--d-border-radius-pill);
+        }
       }
     }
   }


### PR DESCRIPTION
Bunch of small fixes and changes; most notably:

* added a grippie on expanded editor for swipe-signaling
* rolledback integrated title

<img width="366" height="794" alt="CleanShot 2026-08-11 at 14 30 50" src="https://github.com/user-attachments/assets/27651bb5-258b-40e4-8ae1-e07317a6f21a" />
<img width="432" height="228" alt="CleanShot 2026-08-11 at 14 31 46" src="https://github.com/user-attachments/assets/8a43bd0b-be23-4105-afcd-4acd69acbc88" />

