### PR TITLE
FIX: Queue staged email topics with media for review

### DIFF
--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -168,15 +168,18 @@ class NewPostManager
       end
     elsif manager.args[:category]
       category = Category.find_by(id: manager.args[:category])
+      skip_topic_validations =
+        manager.args[:via_email] && manager.user.staged? && manager.args[:skip_validations]
 
-      unless manager.user.guardian.can_create_topic_on_category?(category)
+      unless skip_topic_validations || manager.user.guardian.can_create_topic_on_category?(category)
         result = NewPostResult.new(:created_post, false)
         result.errors.add(:base, I18n.t("js.errors.reasons.forbidden"))
         return result
       end
     end
 
-    result = manager.enqueue(reason)
+    creator_opts = skip_topic_validations ? { skip_validations: true } : {}
+    result = manager.enqueue(reason, creator_opts: creator_opts)
 
     if result.success? || (reason == :email_spam && is_first_post?(manager))
       I18n.with_locale(SiteSetting.default_locale) do

--- a/spec/fixtures/emails/new_user_with_media.eml
+++ b/spec/fixtures/emails/new_user_with_media.eml
@@ -1,0 +1,13 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: category@foo.com
+Subject: This is a topic from a complete stranger with media
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <32@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Hey, this is a topic from a complete stranger ;)
+
+![image](https://example.com/image.png)

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1019,6 +1019,15 @@ RSpec.describe Email::Receiver do
       expect { process(:new_user) }.to change(Topic, :count)
     end
 
+    it "queues an email with media from a stranger for review" do
+      SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_1]
+
+      expect { process(:new_user_with_media) }.to change(ReviewableQueuedPost, :count).by(1)
+
+      reviewable = ReviewableQueuedPost.order(:id).last
+      expect(reviewable.reviewable_scores.first.reason).to eq("contains_media")
+    end
+
     it "raises an UserNotFoundError if enable_staged_users is false " do
       SiteSetting.enable_staged_users = false
       expect { process(:new_user) }.to raise_error(Email::Receiver::UserNotFoundError)


### PR DESCRIPTION
This fixes a regression introduced by #42079.

#42079 started detecting embedded media directly from post content when
`image_sizes` is absent. This means staged users creating topics via incoming
email can now enter the `:contains_media` review path.

Categories with `email_in_allow_strangers` already allow these staged users to
create topics via email, and `Email::Receiver` passes `skip_validations` for
that path. However, `NewPostManager.default_handler` performs the normal topic
creation Guardian check before enqueueing the reviewable. Staged users do not
necessarily satisfy that check, so the incoming email is rejected with
`Access Denied` instead of being queued for review.

Preserve the existing staged incoming-email validation bypass when enqueueing
the topic so that the media is still reviewed.

The regression test verifies that a media-containing email from a staged
stranger:

- is accepted for a category which allows incoming email from strangers;
- is queued as a `ReviewableQueuedPost`; and
- retains `contains_media` as the review reason.

This preserves the media-review protection added in #42079 rather than
bypassing it.
