### PR TITLE
UX: Keep tooltips within the viewport and scroll their overflow

### DIFF
--- a/app/assets/stylesheets/common/float-kit/d-tooltip.scss
+++ b/app/assets/stylesheets/common/float-kit/d-tooltip.scss
@@ -23,11 +23,18 @@
   }
 
   &__inner-content {
+    box-sizing: border-box;
     display: flex;
-    overflow: hidden;
+    max-height: 60dvh;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     overflow-wrap: break-word;
     padding: 0.5rem;
-    align-items: center;
+
+    // `safe` so content taller than the cap starts at the top instead of being centred,
+    // which would put the first lines above the scrollport and out of reach
+    align-items: safe center;
   }
 
   &__content {

--- a/frontend/discourse/float-kit/components/d-float-body.gts
+++ b/frontend/discourse/float-kit/components/d-float-body.gts
@@ -5,6 +5,7 @@ import { modifier as modifierFn } from "ember-modifier";
 import DFloatPortal from "discourse/float-kit/components/d-float-portal";
 import type FloatKitInstance from "discourse/float-kit/lib/float-kit-instance";
 import { getScrollParent } from "discourse/float-kit/lib/get-scroll-parent";
+import { horizontalViewportInset } from "discourse/float-kit/lib/update-position";
 import FloatKitApplyFloatingUi from "discourse/float-kit/modifiers/apply-floating-ui";
 import FloatKitCloseOnEscape from "discourse/float-kit/modifiers/close-on-escape";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -164,12 +165,16 @@ export default class DFloatBody extends Component<DFloatBodySignature> {
   }
 
   get style() {
-    const maxWidth =
-      typeof this.options.maxWidth === "number"
-        ? `${this.options.maxWidth}px`
-        : this.options.maxWidth;
+    const { maxWidth } = this.options;
 
-    return trustHTML(`max-width: ${maxWidth}`);
+    // Only a number is clamped: a keyword like `none` or `unset` is invalid inside `min()`,
+    // which would drop the declaration and hand the float to whatever CSS sets `max-width`.
+    const value =
+      typeof maxWidth === "number"
+        ? `min(${maxWidth}px, calc(100dvw - ${horizontalViewportInset(this.options)}px))`
+        : maxWidth;
+
+    return trustHTML(`max-width: ${value}`);
   }
 
   <template>

--- a/frontend/discourse/float-kit/lib/constants.ts
+++ b/frontend/discourse/float-kit/lib/constants.ts
@@ -134,6 +134,9 @@ export interface TooltipOptions {
    * `"none"` alongside `matchTriggerWidth` — the two are both applied inline, so a numeric cap
    * silently wins over the matched width and a trigger wider than the cap gets a narrower
    * overlay.
+   *
+   * A number is additionally capped to the width the viewport leaves the float, so it can never
+   * overflow the document; a string is applied verbatim and gets no such cap.
    */
   maxWidth: number | string;
 

--- a/frontend/discourse/float-kit/lib/update-position.ts
+++ b/frontend/discourse/float-kit/lib/update-position.ts
@@ -220,6 +220,19 @@ function getPadding(options: PositioningOptions): Padding {
   );
 }
 
+/**
+ * The total horizontal clearance a float keeps from the viewport edges: the left and right
+ * {@link getPadding} sides added together. `shift` can only move a float, never shrink it, so a
+ * float wider than what is left over overflows the document instead of being fitted on screen.
+ */
+export function horizontalViewportInset(options: PositioningOptions): number {
+  const padding = getPadding(options);
+
+  return typeof padding === "number"
+    ? padding * 2
+    : (padding.left ?? 0) + (padding.right ?? 0);
+}
+
 function buildDetectOverflowOptions(
   options: PositioningOptions,
   padding: Padding

--- a/frontend/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
@@ -4,6 +4,7 @@ import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import {
   click,
+  find,
   render,
   settled,
   triggerEvent,
@@ -310,9 +311,78 @@ module("Integration | Component | FloatKit | DTooltip", function (hooks) {
     );
     await hover();
 
+    assert.dom(".fk-d-tooltip__content").hasStyle({ maxWidth: "20px" });
+
+    await close();
+
+    await render(
+      <template>
+        <DTooltip @inline={{true}} @label="label" @maxWidth={{100000}} />
+      </template>
+    );
+    await hover();
+
+    // 20 is the default left + right `getPadding` inset the clamp reserves
     assert
       .dom(".fk-d-tooltip__content")
-      .hasAttribute("style", /max-width: 20px;/);
+      .hasStyle(
+        { maxWidth: `${window.innerWidth - 20}px` },
+        "a numeric cap is clamped to the width the viewport leaves"
+      );
+  });
+
+  test("a keyword @maxWidth is applied verbatim", async function (assert) {
+    await render(
+      <template>
+        <DTooltip @inline={{true}} @label="label" @maxWidth="unset" />
+      </template>
+    );
+    await hover();
+
+    // asserting the declaration rather than the computed value: wrapping a keyword in `min()`
+    // is invalid CSS, and the browser drops such a declaration to the same computed `none`
+    assert
+      .dom(".fk-d-tooltip__content")
+      .hasAttribute("style", /max-width: unset;/);
+  });
+
+  test("content taller than the cap scrolls inside the tooltip", async function (assert) {
+    await render(
+      <template>
+        <DTooltip @inline={{true}} @label="label">
+          <div>
+            <div class="first-line">first line</div>
+            <div style="height: 4000px"></div>
+            <div class="last-line">last line</div>
+          </div>
+        </DTooltip>
+      </template>
+    );
+    await hover();
+
+    const content = find(".fk-d-tooltip__inner-content");
+    const scrollport = content.getBoundingClientRect();
+
+    assert.true(
+      content.clientHeight <= Math.ceil(window.innerHeight * 0.6),
+      "the content is capped to a fraction of the viewport"
+    );
+    assert.true(
+      content.scrollHeight > content.clientHeight,
+      "the overflowing content is scrollable rather than clipped"
+    );
+    assert.true(
+      find(".first-line").getBoundingClientRect().top >= scrollport.top,
+      "the top of the content is reachable rather than centred out of view"
+    );
+
+    content.scrollTop = content.scrollHeight;
+
+    assert.true(
+      find(".last-line").getBoundingClientRect().bottom <=
+        scrollport.bottom + 1,
+      "the bottom of the content is reachable"
+    );
   });
 
   test("applies position", async function (assert) {

--- a/plugins/footnote/spec/system/page_objects/components/inline_footnote.rb
+++ b/plugins/footnote/spec/system/page_objects/components/inline_footnote.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class InlineFootnote < PageObjects::Components::Base
+      CONTENT_SELECTOR = ".fk-d-tooltip__inner-content"
+
+      def open
+        find("a.expand-footnote").click
+      end
+
+      def within_screen?
+        settled { popup_within_screen? }
+      end
+
+      def scrollable?
+        content.evaluate_script("this.scrollHeight > this.clientHeight")
+      end
+
+      def scroll_to_bottom
+        content.scroll_to(:bottom)
+      end
+
+      def has_scrolled_to?(text)
+        tooltip.find("#{CONTENT_SELECTOR} p", text: text).evaluate_script(<<~JS)
+          (() => {
+            const scrollport = this.closest("#{CONTENT_SELECTOR}").getBoundingClientRect();
+
+            return this.getBoundingClientRect().bottom <= scrollport.bottom + 1;
+          })()
+        JS
+      end
+
+      def has_no_horizontal_page_scroll?
+        settled do
+          evaluate_script(
+            "document.documentElement.scrollWidth <= document.documentElement.clientWidth",
+          )
+        end
+      end
+
+      private
+
+      def tooltip
+        @tooltip ||= PageObjects::Components::Tooltips.new("inline-footnote")
+      end
+
+      def content
+        tooltip.find(CONTENT_SELECTOR)
+      end
+
+      # the float is animated and positioned asynchronously, so a geometry read taken right
+      # after it opens can measure it mid-flight
+      def settled(&block)
+        try_until_success { expect(block.call).to eq(true) }
+        true
+      rescue RSpec::Expectations::ExpectationNotMetError
+        false
+      end
+
+      def popup_within_screen?
+        tooltip.element.evaluate_script(<<~JS)
+          (() => {
+            const { top, bottom, left, right } = this.getBoundingClientRect();
+
+            return top >= 0 && left >= 0 &&
+              bottom <= window.innerHeight && right <= window.innerWidth;
+          })()
+        JS
+      end
+    end
+  end
+end

--- a/plugins/footnote/spec/system/read_long_footnote_spec.rb
+++ b/plugins/footnote/spec/system/read_long_footnote_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe "Reading a long inline footnote" do
+  fab!(:user)
+  fab!(:post) do
+    paragraphs = (1..10).map { |number| "    Paragraph #{number}. #{"word " * 60}" }.join("\n\n")
+
+    Fabricate(:post, raw: <<~MARKDOWN)
+      A footnote with a lot of content[^1]
+
+      [^1]: Start of the footnote.
+
+      #{paragraphs}
+
+          End of the footnote.
+    MARKDOWN
+  end
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:footnote) { PageObjects::Components::InlineFootnote.new }
+
+  before { sign_in(user) }
+
+  it "lets the user read a long footnote without the popup running off a narrow screen",
+     mobile: true do
+    resize_window(width: 320) do
+      topic_page.visit_topic(post.topic)
+
+      footnote.open
+
+      expect(footnote).to be_within_screen
+      expect(footnote).to have_no_horizontal_page_scroll
+      expect(footnote).to be_scrollable
+
+      footnote.scroll_to_bottom
+
+      expect(footnote).to have_scrolled_to("End of the footnote.")
+    end
+  end
+end

--- a/spec/system/page_objects/components/tooltips.rb
+++ b/spec/system/page_objects/components/tooltips.rb
@@ -11,6 +11,10 @@ module PageObjects
         @identifier = identifier
       end
 
+      def element(**kwargs)
+        page.find("#{SELECTOR}[data-identifier='#{identifier}']", **kwargs)
+      end
+
       def find(selector, **kwargs)
         page.find("#{SELECTOR}[data-identifier='#{identifier}'] #{selector}", **kwargs)
       end


### PR DESCRIPTION
FloatKit gives a tooltip a fixed `maxWidth` and no height limit at all. That is fine for the short labels most tooltips carry, but it breaks down as soon as one holds user content — footnotes, chat reaction lists and event descriptions all render arbitrary-length HTML into a tooltip, and the result is a popup bigger than the screen it has to fit on.

Neither axis recovers on its own, because floating-ui's `shift` can only *move* a float, never shrink it.

**Vertically** it clamps the popup flush under the header and leaves the rest below the fold. Because the float is re-anchored to its trigger on every scroll, its viewport rectangle never changes, so the hidden part cannot be reached by scrolling — the page just slides underneath it. Measured on a 390×664 phone with a long footnote: a 1557px popup with 945px permanently unreachable, and swiping inside it scrolled the page from 871 to 1381 while revealing nothing.

**Horizontally** the same clamp pins a 350px popup 10px from the left edge of a 320px screen, so the overflow joins the document's scrollable area and the whole page — header included — can be panned sideways (42px, growing with each pan).

## What changed

- `.fk-d-tooltip__inner-content` is bounded to `60dvh` and scrolls, which is what menus have done since they gained `overflow: auto`. Tooltips kept the `overflow: hidden` they were born with and were simply never revisited, so the asymmetry was drift rather than a decision.
- Alignment becomes `align-items: safe center` at the same time. The cross axis is the one being capped, so plain `center` would centre content that is too tall and push its first lines above the scrollport, where scrolling cannot follow — measured at 830px out of reach.
- `maxWidth` is clamped against the space the viewport actually leaves, derived from the same padding `shift` keeps clear so the two cannot disagree.
- Only *numeric* `maxWidth` values are clamped. The option also accepts CSS keywords (the user card passes `unset`), and wrapping a keyword in `min()` is invalid CSS — the browser would drop the declaration and hand the float to whatever stylesheet rule was previously being overridden.

`overflow-x` stays `hidden` rather than becoming `auto`: the same rule carries `overflow-wrap: break-word`, so `auto` on both axes would give tooltips a horizontal scrollbar for unbreakable content.

## Before / after

A long footnote on a 390px-wide phone, and the same popup after swiping inside it:

| | Before | After |
|---|---|---|
| popup height | 1557px | 400px |
| clipped below the fold | 945px | 0 |
| scrollable | no | yes (1157px of scroll) |
| swiping inside it | scrolls the page, popup unchanged | scrolls the footnote, page stays put |
| 320px screen | 352px wide, page pans 42px | 302px wide, no pan |

<img width="844" height="751" alt="footnote-height-before-after" src="https://github.com/user-attachments/assets/64a8107d-47c2-45f9-9a77-75f121ec8b8f" />
<img width="844" height="782" alt="footnote-narrow-before-after" src="https://github.com/user-attachments/assets/6dbfffaf-2885-4836-b020-3ee2d31ecfcb" />
<img width="844" height="751" alt="footnote-scroll-before-after" src="https://github.com/user-attachments/assets/9b0dade9-0238-4e44-b10f-2d48bbe0da57" />


## Testing

- `d-tooltip-test.gjs` gains a height/scroll test and a keyword-`maxWidth` test, and the two numeric `maxWidth` cases are folded into one. Each new assertion was checked to fail against the specific declaration it guards: dropping `safe`, `box-sizing`, or `max-height` each turn the scroll test red, and wrapping keywords in `min()` turns the keyword test red.
- A footnote system spec covers the end-to-end mobile case at 320px — real cooked content, real touch scroll, and the document-level horizontal overflow that a rendering test cannot observe.
- Ran the tooltip- and menu-heavy core system specs (cards, user tips, filter navigation, styleguide, localization menus, composer, bookmarks, chat reactions, calendar) — ~200 examples, no new failures.