### PR TITLE
DEV: Avoid `{{component}}` helper for plugin-supplied components

### DIFF
--- a/frontend/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/frontend/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -549,15 +549,14 @@ export default class BulkTopicActions extends Component {
             {{/if}}
 
             {{#if this.activeComponent}}
-              {{component
-                this.activeComponent
-                onRegisterAction=this.registerCustomAction
-                setSubmitDisabled=this.setSubmitDisabled
-                topics=this.activeComponentProps.topics
-                afterBulkAction=this.activeComponentProps.afterBulkAction
-                categoryId=this.activeComponentProps.categoryId
-                onPerform=this.activeComponentProps.onPerform
-              }}
+              <this.activeComponent
+                @onRegisterAction={{this.registerCustomAction}}
+                @setSubmitDisabled={{this.setSubmitDisabled}}
+                @topics={{this.activeComponentProps.topics}}
+                @afterBulkAction={{this.activeComponentProps.afterBulkAction}}
+                @categoryId={{this.activeComponentProps.categoryId}}
+                @onPerform={{this.activeComponentProps.onPerform}}
+              />
             {{/if}}
 
             {{#if this.isPinAction}}

--- a/frontend/discourse/app/components/sidebar/api-section.gjs
+++ b/frontend/discourse/app/components/sidebar/api-section.gjs
@@ -1,3 +1,5 @@
+import { hash } from "@ember/helper";
+import curryComponent from "ember-curry-component";
 import { and, eq, not } from "discourse/truth-helpers";
 import Section from "./section";
 import SectionLink from "./section-link";
@@ -53,9 +55,11 @@ const SidebarApiSection = <template>
           @didInsert={{link.didInsert}}
           @willDestroy={{link.willDestroy}}
           @content={{link.text}}
-          @contentComponent={{component
+          @contentComponent={{if
             link.contentComponent
-            status=link.contentComponentArgs
+            (curryComponent
+              link.contentComponent (hash status=link.contentComponentArgs)
+            )
           }}
           @suffixComponent={{link.suffixComponent}}
           @suffixArgs={{link.suffixArgs}}


### PR DESCRIPTION
The bulk-action modal's `setComponent` and sidebar section links' `contentComponent` were already documented as taking component classes, but rendering them through the `{{component}}` helper meant a string would silently resolve through the resolver. Angle-bracket invocation and `curryComponent` only accept classes, so string-based reliance can't creep in.