### PR TITLE
DEV: Add topic-category-link-wrapper outlet around the category link in topic title section

### DIFF
--- a/frontend/discourse/app/components/header/topic/info.gjs
+++ b/frontend/discourse/app/components/header/topic/info.gjs
@@ -149,7 +149,10 @@ export default class Info extends Component {
               <div class="categories-wrapper">
                 <PluginOutlet
                   @name="header-categories-wrapper"
-                  @outletArgs={{lazyHash category=@topicInfo.category}}
+                  @outletArgs={{lazyHash
+                    category=@topicInfo.category
+                    topic=@topicInfo
+                  }}
                 >
                   {{#if @topicInfo.category.parentCategory}}
                     {{#if

--- a/frontend/discourse/app/components/topic-category.gjs
+++ b/frontend/discourse/app/components/topic-category.gjs
@@ -12,13 +12,18 @@ import dDiscourseTags from "discourse/ui-kit/helpers/d-discourse-tags";
 export default class TopicCategory extends Component {
   <template>
     <div ...attributes>
-      {{#unless this.topic.isPrivateMessage}}
-        {{dBoundCategoryLink
-          this.topic.category
-          ancestors=this.topic.category.predecessors
-          hideParent=true
-        }}
-      {{/unless}}
+      <PluginOutlet
+        @name="topic-category-link-wrapper"
+        @outletArgs={{lazyHash category=this.topic.category topic=this.topic}}
+      >
+        {{#unless this.topic.isPrivateMessage}}
+          {{dBoundCategoryLink
+            this.topic.category
+            ancestors=this.topic.category.predecessors
+            hideParent=true
+          }}
+        {{/unless}}
+      </PluginOutlet>
       <div class="topic-header-extra">
         {{#if this.siteSettings.tagging_enabled}}
           <div class="list-tags">


### PR DESCRIPTION
Mirrors the existing header-categories-wrapper around the category in the docked topic header. Available in normal and nested replies mode.

Also adds the topic as an arg to the header-categories-wrapper outlet. 

Now plugins/themes can customize the category link area the same way in both locations. Will support displaying extra info inline with the category/tags in a customer plugin.