### PR TITLE
DEV: Remove unused custom component hook from category edit panels

### DIFF
--- a/frontend/discourse/admin/components/edit-category-panel.gjs
+++ b/frontend/discourse/admin/components/edit-category-panel.gjs
@@ -1,22 +1,7 @@
 /* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from "@ember/component";
 import { computed } from "@ember/object";
-import { getOwner } from "@ember/owner";
 import { classNameBindings } from "@ember-decorators/component";
-
-export default class EditCategoryPanel extends Component {
-  get resolvedComponent() {
-    return getOwner(this).resolveRegistration(this.customComponent);
-  }
-
-  <template>
-    <this.resolvedComponent
-      @tab={{this.tab}}
-      @selectedTab={{this.selectedTab}}
-      @category={{this.category}}
-    />
-  </template>
-}
 
 /** @returns { any } */
 export function buildCategoryPanel(tab) {
@@ -25,7 +10,7 @@ export function buildCategoryPanel(tab) {
     "activeTab:active",
     `:edit-category-tab-${tab}`
   )
-  class BuiltCategoryPanel extends EditCategoryPanel {
+  class BuiltCategoryPanel extends Component {
     @computed("selectedTab")
     get activeTab() {
       return this.selectedTab === tab;


### PR DESCRIPTION
`EditCategoryPanel` rendered a `customComponent` resolved by name through the resolver, but nothing has ever passed one since the hook shipped in 2015. Plugin category tabs use `registerEditCategoryTab` with component classes instead. `buildCategoryPanel` now extends `Component` directly and the empty base class is gone.