### PR TITLE
FIX: Revalidate artifact sharing policies

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
@@ -15,11 +15,11 @@ module DiscourseAi
         post = Post.find_by(id: artifact.post_id)
         raise Discourse::NotFound if post.blank? || post.topic.blank?
 
-        if artifact.public?
-          # no guardian needed
-        else
-          raise Discourse::NotFound if !guardian.can_see?(post)
-        end
+        shared_conversation = SharedAiConversation.find_by(target: post.topic) if artifact.public?
+        artifact_is_public =
+          artifact.public? && (shared_conversation.blank? || shared_conversation.publicly_visible?)
+
+        raise Discourse::NotFound if !artifact_is_public && !guardian.can_see?(post)
 
         name = artifact.name
         artifact_version = nil

--- a/plugins/discourse-ai/spec/requests/ai_bot/artifacts_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/artifacts_controller_spec.rb
@@ -120,6 +120,52 @@ RSpec.describe DiscourseAi::AiBot::ArtifactsController do
       end
     end
 
+    it "hides artifacts and future versions when their conversation share is invalidated" do
+      llm_model = Fabricate(:llm_model, name: "artifact-sharing-model")
+      toggle_enabled_bots(bots: [llm_model])
+      SiteSetting.ai_bot_enabled = true
+      SiteSetting.ai_bot_public_sharing_allowed_groups = "10"
+      Group.user_trust_level_change!(user.id, user.trust_level)
+
+      bot_user = llm_model.reload.user
+      topic.topic_allowed_users.where.not(user_id: user.id).delete_all
+      topic.topic_allowed_users.create!(user: bot_user)
+      post.update_columns(
+        cooked: "<div class='ai-artifact' data-ai-artifact-id='#{artifact.id}'></div>",
+      )
+
+      shared_conversation = SharedAiConversation.share_conversation(user, topic)
+      expect(shared_conversation.publicly_visible?).to eq(true)
+      expect(artifact.reload.public?).to eq(true)
+
+      topic.topic_allowed_users.create!(user: Fabricate(:user))
+      artifact_version =
+        artifact.create_new_version(html: "<div>Future private artifact version</div>")
+
+      get "/discourse-ai/ai-bot/shared-ai-conversations/#{shared_conversation.share_key}.json"
+      shared_conversation_status = response.status
+
+      get artifact.url
+      artifact_response = {
+        status: response.status,
+        body: response.status == 200 ? parse_srcdoc(response.body) : response.body,
+      }
+
+      get AiArtifact.url(artifact.id, artifact_version.version_number)
+      artifact_version_response = {
+        status: response.status,
+        body: response.status == 200 ? parse_srcdoc(response.body) : response.body,
+      }
+
+      aggregate_failures do
+        expect(shared_conversation_status).to eq(404)
+        expect(artifact_response[:status]).to eq(404)
+        expect(artifact_response[:body]).not_to include(artifact.html)
+        expect(artifact_version_response[:status]).to eq(404)
+        expect(artifact_version_response[:body]).not_to include(artifact_version.html)
+      end
+    end
+
     it "sanitizes CSS to prevent style tag breakout" do
       sign_in(user)
       malicious_css = '</style><script>alert("XSS from CSS")</script><style>'


### PR DESCRIPTION
## Summary

Correctly revalidate AI conversation sharing policies before serving AI artifacts to anonymous users. This prevents access to artifacts and their subsequent versions when a previously public share becomes invalid, such as when a private message's membership changes.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1441

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>