### PR TITLE
FIX: Enforce post-level visibility on Poll operations

### DIFF
--- a/plugins/poll/app/controllers/discourse_poll/polls_controller.rb
+++ b/plugins/poll/app/controllers/discourse_poll/polls_controller.rb
@@ -4,6 +4,7 @@ class DiscoursePoll::PollsController < ::ApplicationController
   requires_plugin DiscoursePoll::PLUGIN_NAME
 
   before_action :ensure_logged_in, except: %i[voters grouped_poll_results]
+  before_action :ensure_can_see_post
 
   def vote
     post_id = params.require(:post_id)
@@ -91,5 +92,14 @@ class DiscoursePoll::PollsController < ::ApplicationController
         render_json_error e.message
       end
     end
+  end
+
+  private
+
+  def ensure_can_see_post
+    post = Post.find_by(id: params.require(:post_id))
+    return if !post || !guardian.can_see_topic?(post.topic)
+
+    guardian.ensure_can_see!(post)
   end
 end

--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -168,6 +168,12 @@ class DiscoursePoll::Poll
         return
       end
 
+      # user must be able to see the post
+      unless guardian.can_see?(post)
+        raise DiscoursePoll::Error.new I18n.t("poll.user_cant_post_in_topic") if raise_errors
+        return
+      end
+
       # either staff member or OP
       unless post.user_id == user&.id || user&.staff?
         if raise_errors
@@ -311,7 +317,14 @@ class DiscoursePoll::Poll
   end
 
   def self.grouped_poll_results(user, post_id, poll_name, user_field_name)
-    raise Discourse::InvalidParameters.new(:post_id) if !Post.where(id: post_id).exists?
+    post = Post.find_by(id: post_id)
+    raise Discourse::InvalidParameters.new(:post_id) unless post
+
+    guardian = Guardian.new(user)
+    if !guardian.can_see?(post)
+      raise DiscoursePoll::Error.new I18n.t("poll.user_cant_post_in_topic")
+    end
+
     poll =
       Poll.includes(:poll_options, :poll_votes, post: :topic).find_by(
         post_id: post_id,
@@ -320,7 +333,6 @@ class DiscoursePoll::Poll
     raise Discourse::InvalidParameters.new(:poll_name) unless poll
 
     # user must be allowed to post in topic
-    guardian = Guardian.new(user)
     if !guardian.can_create_post?(poll.post.topic)
       raise DiscoursePoll::Error.new I18n.t("poll.user_cant_post_in_topic")
     end
@@ -512,6 +524,10 @@ class DiscoursePoll::Poll
 
       # user must be allowed to post in topic
       guardian = Guardian.new(user)
+      if !guardian.can_see?(post)
+        raise DiscoursePoll::Error.new I18n.t("poll.user_cant_post_in_topic")
+      end
+
       if !guardian.can_create_post?(post.topic)
         raise DiscoursePoll::Error.new I18n.t("poll.user_cant_post_in_topic")
       end

--- a/plugins/poll/spec/controllers/polls_controller_spec.rb
+++ b/plugins/poll/spec/controllers/polls_controller_spec.rb
@@ -135,6 +135,36 @@ RSpec.describe DiscoursePoll::PollsController do
       expect(message.group_ids).to contain_exactly(group.id)
     end
 
+    it "blocks topic participants from voting on a staff whisper" do
+      visible_post = Fabricate(:post, topic: topic)
+      whisper =
+        Fabricate(
+          :post,
+          topic: topic,
+          user: Fabricate(:admin),
+          post_type: Post.types[:whisper],
+          raw: "[poll]\n- Staff-only option\n- Another staff-only option\n[/poll]",
+        )
+      secret_option = whisper.polls.first.poll_options.first
+
+      expect(user.guardian.can_see?(visible_post)).to eq(true)
+      expect(user.guardian.can_see?(whisper)).to eq(false)
+
+      put :vote,
+          params: {
+            post_id: whisper.id,
+            poll_name: "poll",
+            options: [secret_option.digest],
+          },
+          format: :json
+
+      aggregate_failures do
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).not_to include(secret_option.html)
+        expect(PollVote.exists?(poll_option: secret_option, user: user)).to eq(false)
+      end
+    end
+
     it "requires at least 1 valid option" do
       put :vote, params: { post_id: poll.id, poll_name: "poll", options: %w[A B] }, format: :json
 

--- a/plugins/poll/spec/lib/poll_spec.rb
+++ b/plugins/poll/spec/lib/poll_spec.rb
@@ -31,6 +31,29 @@ RSpec.describe DiscoursePoll::Poll do
     RAW
 
   describe ".vote" do
+    it "does not allow votes on posts the user cannot see" do
+      visible_post = Fabricate(:post)
+      whisper =
+        Fabricate(
+          :post,
+          topic: visible_post.topic,
+          user: Fabricate(:admin),
+          post_type: Post.types[:whisper],
+          raw: "[poll]\n- Staff-only option\n[/poll]",
+        )
+      poll_option = whisper.polls.first.poll_options.first
+
+      expect(user.guardian.can_create_post?(whisper.topic)).to eq(true)
+      expect(user.guardian.can_see?(whisper)).to eq(false)
+
+      aggregate_failures do
+        expect {
+          DiscoursePoll::Poll.vote(user, whisper.id, "poll", [poll_option.digest])
+        }.to raise_error(DiscoursePoll::Error, I18n.t("poll.user_cant_post_in_topic"))
+        expect(PollVote.exists?(poll_option: poll_option, user: user)).to eq(false)
+      end
+    end
+
     it "should only allow one vote per user for a regular poll" do
       poll = post_with_regular_poll.polls.first
 


### PR DESCRIPTION
## Summary

Enforce Guardian post visibility before poll lookup, serialization, grouped-field loading, or voting in the poll controller and shared poll lifecycle methods, preventing users from reading or voting on polls in posts they cannot see.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1876

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>