### PR TITLE
UX: Show users X of Y languages selected.

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1950,6 +1950,7 @@ content_localization:
     area: "localization"
   content_localization_max_locales:
     default: 10
+    client: true
     type: integer
     hidden: true
   content_localization_crawler_param:

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -46,7 +46,6 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "admin-plugin-icon",
   "admin-reports-show-query-params",
   "admin-theme-card-show-full-controls",
-  "ai-translation-max-locales-warning",
   "bulk-select-in-nav-controls",
   "can-create-topic-button",
   "category-available-views",

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -46,6 +46,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "admin-plugin-icon",
   "admin-reports-show-query-params",
   "admin-theme-card-show-full-controls",
+  "ai-translation-max-locales-warning",
   "bulk-select-in-nav-controls",
   "can-create-topic-button",
   "category-available-views",

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -598,6 +598,25 @@ export default class AiTranslations extends Component {
                 }}</label>
             </div>
             <div class="setting-value">
+              {{#if this.siteSettings.content_localization_max_locales}}
+                <div class="ai-translations__locale-info">
+                  <p class="ai-translations__locale-count">
+                    {{i18n
+                      "discourse_ai.translations.locale_count"
+                      count=this.selectedLocales.length
+                      max=this.siteSettings.content_localization_max_locales
+                    }}
+                  </p>
+                  <PluginOutlet
+                    @name="ai-translations-locale-info"
+                    @connectorTagName="div"
+                    @outletArgs={{lazyHash
+                      localesCount=this.selectedLocales.length
+                      maxLocales=this.siteSettings.content_localization_max_locales
+                    }}
+                  />
+                </div>
+              {{/if}}
               <div class="ai-translations__locale-input-row">
                 <MultiSelect
                   @value={{this.selectedLocales}}
@@ -633,30 +652,14 @@ export default class AiTranslations extends Component {
                   />
                 {{/if}}
               </div>
-              {{#if this.siteSettings.content_localization_max_locales}}
-                <div class="ai-translations__locale-info">
-                  <p class="ai-translations__locale-count">
-                    {{i18n
-                      "discourse_ai.translations.locale_count"
-                      count=this.selectedLocales.length
-                      max=this.siteSettings.content_localization_max_locales
-                    }}
-                  </p>
-                  <PluginOutlet
-                    @name="ai-translations-locale-info"
-                    @connectorTagName="div"
-                    @outletArgs={{lazyHash
-                      localesCount=this.selectedLocales.length
-                      maxLocales=this.siteSettings.content_localization_max_locales
-                    }}
-                  />
-                </div>
-              {{/if}}
             </div>
           </div>
           <div class="setting">
             <div class="setting-label">
               <label>{{i18n "discourse_ai.translations.category_scope"}}</label>
+              <div class="desc ai-translations__category-scope-desc">{{i18n
+                  "discourse_ai.translations.category_scope_description"
+                }}</div>
             </div>
             <div class="setting-value">
               <div class="ai-translations__category-input-row">
@@ -730,9 +733,6 @@ export default class AiTranslations extends Component {
                   </div>
                 {{/if}}
               </div>
-              <div class="desc">{{i18n
-                  "discourse_ai.translations.category_scope_description"
-                }}</div>
             </div>
           </div>
         </div>

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -10,6 +10,7 @@ import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import Category from "discourse/models/category";
 import CategorySelector from "discourse/select-kit/components/category-selector";
 import ComboBox from "discourse/select-kit/components/combo-box";
@@ -29,6 +30,7 @@ export default class AiTranslations extends Component {
   @service aiCredits;
   @service router;
   @service siteSettings;
+  @service toasts;
 
   @tracked overviewGeneration = 0;
   @tracked expandedTargetType = null;
@@ -98,6 +100,15 @@ export default class AiTranslations extends Component {
 
   get creditLimitReached() {
     return this.creditStatus?.hard_limit_reached === true;
+  }
+
+  get maxLocaleWarning() {
+    return applyValueTransformer(
+      "ai-translation-max-locales-warning",
+      i18n("discourse_ai.translations.max_locales_reached", {
+        max: this.siteSettings.content_localization_max_locales,
+      })
+    );
   }
 
   get creditLimitWarningMessage() {
@@ -206,6 +217,18 @@ export default class AiTranslations extends Component {
 
   @action
   updateSelectedLocales(locales) {
+    if (
+      this.siteSettings.content_localization_max_locales &&
+      locales.length > this.siteSettings.content_localization_max_locales
+    ) {
+      this.toasts.error({
+        duration: "short",
+        data: {
+          message: this.maxLocaleWarning,
+        },
+      });
+      return;
+    }
     this.selectedLocales = locales;
   }
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -633,14 +633,25 @@ export default class AiTranslations extends Component {
                   />
                 {{/if}}
               </div>
-              <PluginOutlet
-                @name="ai-translations-locale-info"
-                @connectorTagName="div"
-                @outletArgs={{lazyHash
-                  localesCount=this.selectedLocales.length
-                  maxLocales=this.siteSettings.content_localization_max_locales
-                }}
-              />
+              {{#if this.siteSettings.content_localization_max_locales}}
+                <div class="ai-translations__locale-info">
+                  <p class="ai-translations__locale-count">
+                    {{i18n
+                      "discourse_ai.translations.locale_count"
+                      count=this.selectedLocales.length
+                      max=this.siteSettings.content_localization_max_locales
+                    }}
+                  </p>
+                  <PluginOutlet
+                    @name="ai-translations-locale-info"
+                    @connectorTagName="div"
+                    @outletArgs={{lazyHash
+                      localesCount=this.selectedLocales.length
+                      maxLocales=this.siteSettings.content_localization_max_locales
+                    }}
+                  />
+                </div>
+              {{/if}}
             </div>
           </div>
           <div class="setting">

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -6,11 +6,12 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import moment from "moment";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
-import { applyValueTransformer } from "discourse/lib/transformer";
 import Category from "discourse/models/category";
 import CategorySelector from "discourse/select-kit/components/category-selector";
 import ComboBox from "discourse/select-kit/components/combo-box";
@@ -102,13 +103,16 @@ export default class AiTranslations extends Component {
     return this.creditStatus?.hard_limit_reached === true;
   }
 
-  get maxLocaleWarning() {
-    return applyValueTransformer(
-      "ai-translation-max-locales-warning",
-      i18n("discourse_ai.translations.max_locales_reached", {
-        max: this.siteSettings.content_localization_max_locales,
-      })
-    );
+  get maxLocaleToast() {
+    const max = this.siteSettings.content_localization_max_locales;
+    return {
+      duration: "short",
+      data: {
+        message: i18n("discourse_ai.translations.max_locales_reached", {
+          max,
+        }),
+      },
+    };
   }
 
   get creditLimitWarningMessage() {
@@ -221,12 +225,7 @@ export default class AiTranslations extends Component {
       this.siteSettings.content_localization_max_locales &&
       locales.length > this.siteSettings.content_localization_max_locales
     ) {
-      this.toasts.error({
-        duration: "short",
-        data: {
-          message: this.maxLocaleWarning,
-        },
-      });
+      this.toasts.error(this.maxLocaleToast);
       return;
     }
     this.selectedLocales = locales;
@@ -634,6 +633,14 @@ export default class AiTranslations extends Component {
                   />
                 {{/if}}
               </div>
+              <PluginOutlet
+                @name="ai-translations-locale-info"
+                @connectorTagName="div"
+                @outletArgs={{lazyHash
+                  localesCount=this.selectedLocales.length
+                  maxLocales=this.siteSettings.content_localization_max_locales
+                }}
+              />
             </div>
           </div>
           <div class="setting">

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -66,6 +66,19 @@
     }
   }
 
+  &__locale-info {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+
+  &__locale-count {
+    margin: 0;
+    font-size: var(--font-down-1);
+    color: var(--primary-high);
+  }
+
   .settings .setting {
     padding: var(--space-2);
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -10,6 +10,10 @@
     margin-block: var(--space-3);
   }
 
+  &__language-switcher label {
+    font-weight: 600;
+  }
+
   &__toggle-container {
     margin-block-end: var(--space-3);
   }
@@ -70,13 +74,20 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    margin-top: var(--space-2);
+    margin-block-end: var(--space-2);
   }
 
   &__locale-count {
     margin: 0;
     font-size: var(--font-down-1);
     color: var(--primary-high);
+  }
+
+  &__category-scope-desc {
+    padding: 0;
+    margin-block-end: var(--space-2);
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
   }
 
   .settings .setting {

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -439,6 +439,7 @@ en:
         description: "Automatically translate all content on your forum to the user's preferred language"
         supported_locales: "Supported languages"
         max_locales_reached: "You can only select up to %{max} languages."
+        locale_count: "Using %{count} of %{max} available languages."
         category_scope: "Categories"
         category_scope_description: "Choose whether automatic translations apply to content in all categories, public categories, or selected categories."
         cached_results_notice: "Showing cached results from %{relative_time}."

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -438,6 +438,7 @@ en:
         title: "Translations"
         description: "Automatically translate all content on your forum to the user's preferred language"
         supported_locales: "Supported languages"
+        max_locales_reached: "You can only select up to %{max} languages."
         category_scope: "Categories"
         category_scope_description: "Choose whether automatic translations apply to content in all categories, public categories, or selected categories."
         cached_results_notice: "Showing cached results from %{relative_time}."

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-translations-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-translations-test.gjs
@@ -3,6 +3,8 @@ import { click, find, render, settled, waitUntil } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { i18n } from "discourse-i18n";
 import AiTranslations from "discourse/plugins/discourse-ai/discourse/components/ai-translations";
 
 class AiCreditsStub extends Service {
@@ -195,6 +197,65 @@ module("Integration | Component | AiTranslations", function (hooks) {
     assert
       .dom(toggle)
       .isDisabled("the toggle stays disabled after saving no locales");
+  });
+
+  test("shows the locale count and blocks selections beyond the max", async function (assert) {
+    this.siteSettings.content_localization_max_locales = 2;
+    this.siteSettings.available_locales = [
+      { name: "English", value: "en" },
+      { name: "French", value: "fr" },
+      { name: "Spanish", value: "es" },
+    ];
+
+    await render(<template><AiTranslations @model={{this.model}} /></template>);
+
+    assert
+      .dom(".ai-translations__locale-count")
+      .hasText(
+        i18n("discourse_ai.translations.locale_count", { count: 2, max: 2 }),
+        "renders the locale usage count"
+      );
+
+    const locales = selectKit(
+      ".ai-translations__locale-input-row .multi-select"
+    );
+    await locales.expand();
+    await locales.selectRowByValue("es");
+
+    const toasts = this.owner.lookup("service:toasts");
+    assert.strictEqual(
+      toasts.activeToasts.length,
+      1,
+      "selecting a locale beyond the max shows a toast"
+    );
+    assert.strictEqual(
+      toasts.activeToasts[0].options.data.message,
+      i18n("discourse_ai.translations.max_locales_reached", { max: 2 }),
+      "the toast explains the limit"
+    );
+
+    assert.strictEqual(
+      locales.header().value(),
+      "en,fr",
+      "the selection is unchanged"
+    );
+    assert
+      .dom(".ai-translations__locale-count")
+      .hasText(
+        i18n("discourse_ai.translations.locale_count", { count: 2, max: 2 }),
+        "the count is unchanged"
+      );
+    assert
+      .dom(".ai-translations__locale-input-row .setting-controls")
+      .doesNotExist("no save controls appear for the rejected selection");
+  });
+
+  test("hides the locale count when no max is configured", async function (assert) {
+    this.siteSettings.content_localization_max_locales = 0;
+
+    await render(<template><AiTranslations @model={{this.model}} /></template>);
+
+    assert.dom(".ai-translations__locale-info").doesNotExist();
   });
 
   test("enables the language switcher along with translations", async function (assert) {


### PR DESCRIPTION
This PR surfaces the MAX allowed languages in the selector. Currently this information is not available, and users are presented a vague error when trying to add more.

|Before|After|
| -- | -- |
|<img width="2936" height="1860" alt="CleanShot 2026-08-11 at 13 49 41@2x" src="https://github.com/user-attachments/assets/e67ab045-d53e-4751-a6dd-96d4e0cdd7cd" />|<img width="2400" height="1726" alt="core-01-under-limit" src="https://github.com/user-attachments/assets/9539cbb4-6417-45b4-b51e-8acabbeed000" />|
|<img width="2858" height="1862" alt="CleanShot 2026-08-11 at 13 50 06@2x" src="https://github.com/user-attachments/assets/36bc4061-415d-448c-9529-3acdfce7338b" />|<img width="2400" height="1726" alt="core-02-at-limit" src="https://github.com/user-attachments/assets/a44bd6a8-c14d-4b37-8243-d00990980c96" />|
|<img width="3606" height="1846" alt="CleanShot 2026-08-11 at 13 50 21@2x" src="https://github.com/user-attachments/assets/a9c274b0-068f-45a7-a8a5-c5cd06f54e31" />|<img width="2400" height="1726" alt="core-03-toast-over-limit" src="https://github.com/user-attachments/assets/d7919450-bda1-4196-8636-d88beb74c551" />|


