### PR TITLE
DEV: Give each checkout its own qunit ports

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -3,6 +3,7 @@
 require "optparse"
 require "shellwords"
 require "json"
+require "digest"
 require "fileutils"
 require "socket"
 require "uri"
@@ -13,6 +14,14 @@ require_relative "../lib/chrome_installed_checker"
 class QunitRunner
   DEFAULT_BROWSER_START_TIMEOUT = 45
   DEFAULT_BROWSER_INACTIVITY_TIMEOUT = 30
+
+  # Base ports for the three servers a run needs. Each checkout claims one slot in every band,
+  # so runs from different checkouts never contend for the same port. The bands must not
+  # overlap, which caps the number of slots.
+  DEVTOOLS_PORT_BASE = 3_001
+  RAILS_PORT_BASE = 4_566
+  TESTEM_PORT_BASE = 7_357
+  PORT_BAND_SIZE = 250
 
   def initialize(args)
     @file_paths = []
@@ -282,6 +291,15 @@ class QunitRunner
     parallel = !@plugin_targets.any? && present_string(@parallel)
     reuse_build = ENV["QUNIT_REUSE_BUILD"] == "1" || !@standalone_mode
 
+    # On CI a run owns its container, so nothing else can claim these ports. Leave them alone
+    # there and let the existing fallbacks handle it: ember-cli's own port finder for testem, and
+    # the CI branch in testem.js for the browser.
+    if !ENV["CI"]
+      testem_port =
+        next_available_port(ENV["QUNIT_TESTEM_PORT"] || (TESTEM_PORT_BASE + port_offset))
+      env["QUNIT_REMOTE_DEBUGGING_PORT"] = devtools_port(parallel).to_s
+    end
+
     query = build_query
 
     args = []
@@ -290,9 +308,11 @@ class QunitRunner
     if @qunit_path
       env["THEME_TEST_PAGES"] = build_theme_test_pages(query)
       args += %w[pnpm testem ci -f testem.js]
+      args += ["--port", testem_port.to_s] if testem_port
       args += ["--parallel", parallel.to_s] if parallel
     else
       args = %w[pnpm ember exam]
+      args += ["--test-port", testem_port.to_s] if testem_port
       args += ["--query", query] if query && !query.empty?
       args += ["--filter", filter] if filter
       args += ["--file-path", file_path_filter] if file_path_filter
@@ -402,7 +422,7 @@ class QunitRunner
     ensure_pnpm_installed!
     install_node_dependencies!
 
-    @rails_port = next_available_port(4_566)
+    @rails_port = next_available_port(ENV["TEST_SERVER_PORT"] || (RAILS_PORT_BASE + port_offset))
     server_env = build_server_environment(@rails_port)
     server_pid = nil
     log_path = File.join(rails_root, "tmp", "test_server_#{@rails_port}.log")
@@ -456,18 +476,46 @@ class QunitRunner
     abort err.message
   end
 
+  # Derives this checkout's slot within each port band. Runs started at the same moment from
+  # different checkouts would otherwise all probe the same base port, find it free, and race to
+  # bind it: the probe and the bind are seconds apart, so the loser fails with EADDRINUSE.
+  # Deriving the slot from the path keeps each checkout on its own port, and keeps that port
+  # stable so it stays a predictable address to attach a debugger to.
+  def port_offset
+    @port_offset ||= Digest::MD5.hexdigest(rails_root).to_i(16) % PORT_BAND_SIZE
+  end
+
+  # Every browser a run launches receives the same argument list, so a fixed port would have all
+  # workers of a parallel run fight over it. A parallel run has no single browser to attach to
+  # anyway, so let the OS assign a port to each one.
+  def devtools_port(parallel)
+    return 0 if parallel
+
+    next_available_port(ENV["QUNIT_REMOTE_DEBUGGING_PORT"] || (DEVTOOLS_PORT_BASE + port_offset))
+  end
+
   def next_available_port(start_port)
-    port = (ENV["TEST_SERVER_PORT"] || start_port).to_i
+    port = start_port.to_i
     port += 1 while !port_available?(port)
     port
   end
 
   def port_available?(port)
-    server = TCPServer.open(port)
+    %w[127.0.0.1 ::1].all? { |host| bindable?(host, port) }
+  end
+
+  # Probes both loopback families, because a server that binds only one of them still makes the
+  # port unusable for a server that binds the other: Chrome's debugging port has been observed
+  # listening on 127.0.0.1 in one run and [::1] in another.
+  def bindable?(host, port)
+    server = TCPServer.open(host, port)
     server.close
     true
   rescue Errno::EADDRINUSE
     false
+  rescue Errno::EADDRNOTAVAIL, SocketError
+    # This machine cannot bind the family at all, so nothing can be listening on it either.
+    true
   end
 
   def build_server_environment(server_port)
@@ -711,4 +759,4 @@ class QunitRunner
   end
 end
 
-QunitRunner.new(ARGV).run
+QunitRunner.new(ARGV).run if $PROGRAM_NAME == __FILE__

--- a/frontend/discourse/testem.js
+++ b/frontend/discourse/testem.js
@@ -13,6 +13,11 @@ const sandboxDisabled =
     (process.env.DISCOURSE_DISABLE_BROWSER_SANDBOX || "").toLowerCase()
   );
 
+// bin/qunit derives a port that does not clash with the other checkouts on the machine. Direct
+// invocations keep the historical fixed port, which stays a predictable address to attach to.
+const remoteDebuggingPort =
+  process.env.QUNIT_REMOTE_DEBUGGING_PORT ?? (process.env.CI ? 0 : 3001);
+
 class Reporter extends TapReporter {
   failReports = [];
   deprecationCounts = new Map();
@@ -280,7 +285,7 @@ module.exports = {
       "--disable-software-rasterizer",
       "--disable-search-engine-choice-screen",
       "--mute-audio",
-      `--remote-debugging-port=${process.env.CI ? 0 : 3001}`,
+      `--remote-debugging-port=${remoteDebuggingPort}`,
       "--window-size=1440,900",
       "--enable-precise-memory-info",
       "--js-flags=--max_old_space_size=4096",
@@ -294,7 +299,7 @@ module.exports = {
       "--disable-software-rasterizer",
       "--disable-search-engine-choice-screen",
       "--mute-audio",
-      `--remote-debugging-port=${process.env.CI ? 0 : 3001}`,
+      `--remote-debugging-port=${remoteDebuggingPort}`,
       "--window-size=1440,900",
       "--enable-precise-memory-info",
       "--js-flags=--max_old_space_size=4096",

--- a/spec/tasks/qunit_cli_spec.rb
+++ b/spec/tasks/qunit_cli_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+load Rails.root.join("bin/qunit").to_s
+
 describe "bin/qunit" do
   def run(*args, env: {})
+    # Unset CI so the expectations hold both on a developer machine and on CI itself, where the
+    # browser port is deliberately left to the OS.
+    env = { "CI" => nil }.merge(env)
     out, err, status = Open3.capture3(env, "bin/qunit", "--dry-run", *args, chdir: Rails.root.to_s)
 
     parsed_args, parsed_env =
@@ -30,8 +35,11 @@ describe "bin/qunit" do
       "QUNIT_BROWSER_WATCHDOG" => "1",
       "QUNIT_BROWSER_START_TIMEOUT" => "45",
       "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "30",
+      "QUNIT_REMOTE_DEBUGGING_PORT" => a_string_matching(/\A\d+\z/),
     }
   end
+
+  let(:derived_test_port) { ["--test-port", a_string_matching(/\A\d+\z/)] }
 
   it "runs all core tests by default" do
     result = run
@@ -43,6 +51,7 @@ describe "bin/qunit" do
         "pnpm",
         "ember",
         "exam",
+        *derived_test_port,
         "--query",
         "target=core&testem=1",
         "--random",
@@ -70,6 +79,7 @@ describe "bin/qunit" do
         "pnpm",
         "ember",
         "exam",
+        *derived_test_port,
         "--query",
         "target=core&testem=1",
         "--file-path",
@@ -99,6 +109,7 @@ describe "bin/qunit" do
         "pnpm",
         "ember",
         "exam",
+        *derived_test_port,
         "--query",
         "testem=1",
         "--random",
@@ -127,6 +138,7 @@ describe "bin/qunit" do
         "pnpm",
         "ember",
         "exam",
+        *derived_test_port,
         "--query",
         "testem=1",
         "--random",
@@ -155,6 +167,7 @@ describe "bin/qunit" do
         "pnpm",
         "ember",
         "exam",
+        *derived_test_port,
         "--query",
         "target=chat&testem=1",
         "--file-path",
@@ -245,5 +258,111 @@ describe "bin/qunit" do
 
     expect(result.status).to eq(1)
     expect(result.err).to include("--browser-inactivity-timeout must be greater than 0")
+  end
+
+  describe "port derivation" do
+    let(:runner) { QunitRunner.new(["--dry-run"]) }
+
+    def offset_for(path)
+      runner.instance_variable_set(:@rails_root, path)
+      runner.instance_variable_set(:@port_offset, nil)
+      runner.send(:port_offset)
+    end
+
+    it "keeps every derived port inside its own band" do
+      band = QunitRunner::PORT_BAND_SIZE
+
+      expect(offset_for("/some/checkout")).to be_between(0, band - 1)
+    end
+
+    it "derives a stable offset for the same checkout" do
+      expect(offset_for("/some/checkout")).to eq(offset_for("/some/checkout"))
+    end
+
+    it "derives different offsets for different checkouts" do
+      offsets = %w[/a/main /a/worktrees/one /a/worktrees/two].map { |path| offset_for(path) }
+
+      expect(offsets.uniq.size).to eq(3)
+    end
+
+    it "gives concurrent worktrees non-overlapping port bands" do
+      expect(QunitRunner::RAILS_PORT_BASE + QunitRunner::PORT_BAND_SIZE).to be <
+        QunitRunner::TESTEM_PORT_BASE
+      expect(QunitRunner::DEVTOOLS_PORT_BASE + QunitRunner::PORT_BAND_SIZE).to be <
+        QunitRunner::RAILS_PORT_BASE
+    end
+
+    it "treats a port bound on either address family as unavailable" do
+      server = TCPServer.open("127.0.0.1", 0)
+      port = server.addr[1]
+
+      begin
+        expect(runner.send(:port_available?, port)).to eq(false)
+      ensure
+        server.close
+      end
+    end
+  end
+
+  describe "port selection" do
+    def band_for(base)
+      (base...(base + QunitRunner::PORT_BAND_SIZE))
+    end
+
+    def test_port(result)
+      result.args[result.args.index("--test-port") + 1].to_i
+    end
+
+    it "runs the Rails server, testem and the browser on derived ports" do
+      result = run("--standalone")
+
+      expect(result.env["UNICORN_PORT"].to_i).to be_in(band_for(QunitRunner::RAILS_PORT_BASE))
+      expect(result.env["QUNIT_REMOTE_DEBUGGING_PORT"].to_i).to be_in(
+        band_for(QunitRunner::DEVTOOLS_PORT_BASE),
+      )
+      expect(test_port(result)).to be_in(band_for(QunitRunner::TESTEM_PORT_BASE))
+    end
+
+    it "picks the same ports on every run from the same checkout" do
+      first = run("--standalone")
+      second = run("--standalone")
+
+      expect(first.env["UNICORN_PORT"]).to eq(second.env["UNICORN_PORT"])
+      expect(first.env["QUNIT_REMOTE_DEBUGGING_PORT"]).to eq(
+        second.env["QUNIT_REMOTE_DEBUGGING_PORT"],
+      )
+      expect(test_port(first)).to eq(test_port(second))
+    end
+
+    it "walks past a derived port that is already bound" do
+      derived = run("--standalone").env["UNICORN_PORT"].to_i
+      server = TCPServer.open("127.0.0.1", derived)
+
+      begin
+        expect(run("--standalone").env["UNICORN_PORT"].to_i).to be > derived
+      ensure
+        server.close
+      end
+    end
+
+    it "lets TEST_SERVER_PORT override the derived Rails port" do
+      free = TCPServer.open("127.0.0.1", 0)
+      port = free.addr[1]
+      free.close
+
+      result = run("--standalone", env: { "TEST_SERVER_PORT" => port.to_s })
+      expect(result.env["UNICORN_PORT"]).to eq(port.to_s)
+    end
+
+    it "lets the OS assign a browser port for every worker of a parallel run" do
+      expect(run(env: { "QUNIT_PARALLEL" => "4" }).env["QUNIT_REMOTE_DEBUGGING_PORT"]).to eq("0")
+    end
+
+    it "leaves the testem and browser ports untouched when running on CI" do
+      result = run(env: { "CI" => "1" })
+
+      expect(result.args).not_to include("--test-port")
+      expect(result.env).not_to include("QUNIT_REMOTE_DEBUGGING_PORT")
+    end
   end
 end


### PR DESCRIPTION
Concurrent `bin/qunit` runs from different checkouts contend for the same ports, which makes local runs fail in ways that read like test failures rather than startup failures.

Two distinct races are involved. ember-cli's port finder probes 7357 and testem binds it seconds later, so a run started inside that window loses the race and dies with `EADDRINUSE`. Separately, the browser's remote debugging port is hardcoded to 3001 outside CI for every browser instance, so concurrent runs collide, and every worker of a `--parallel` run collides with its own siblings. Two runs can appear to coexist on 3001 by landing on different address families, one on `127.0.0.1` and one on `[::1]`, which makes the collision look intermittent.

`bin/qunit` now derives a stable per-checkout slot from a digest of the checkout path and applies it to three non-overlapping bands: 3001 for the browser, 4566 for Rails, 7357 for testem. Different checkouts therefore never contend, and because the slot is derived rather than searched, each checkout keeps the same ports run after run and stays a predictable address to attach a debugger to, which is the ergonomic that motivated pinning 3001 in the first place. The testem port is passed through as `--test-port` (`--port` on the theme path) and the browser port through `QUNIT_REMOTE_DEBUGGING_PORT`, which `testem.js` reads. A `--parallel` run gets an OS-assigned browser port instead, since there is no single browser to attach to.

`next_available_port` still walks as a fallback, and it now probes both loopback families. It previously bound the wildcard address while the test server binds `127.0.0.1`, so a port genuinely held on `127.0.0.1` could be reported as available.

CI behavior is unchanged. Both derived ports are skipped there, leaving ember-cli's port finder and the existing `CI` branch in `testem.js` in charge.

Coverage spans the offset derivation (stability across runs, distinctness across checkouts, band containment), the fallback walk past an occupied port, the address-family probe, `TEST_SERVER_PORT` precedence, the parallel case, and the CI opt-out.
