### PR TITLE
DEV: Expose the Landlock ABI through SafeExec

### DIFF
--- a/lib/discourse/safe_exec.rb
+++ b/lib/discourse/safe_exec.rb
@@ -74,7 +74,13 @@ module Discourse
     end
 
     def self.landlock_supported?
-      ::Landlock.supported?
+      landlock_abi_version.positive?
+    end
+
+    def self.landlock_abi_version
+      ::Landlock.abi_version
+    rescue ::Landlock::Error
+      0
     end
 
     def self.default_read_paths

--- a/lib/discourse/safe_exec.rb
+++ b/lib/discourse/safe_exec.rb
@@ -74,7 +74,7 @@ module Discourse
     end
 
     def self.landlock_supported?
-      landlock_abi_version.positive?
+      ::Landlock.supported?
     end
 
     def self.landlock_abi_version

--- a/spec/lib/discourse/safe_exec_spec.rb
+++ b/spec/lib/discourse/safe_exec_spec.rb
@@ -19,20 +19,6 @@ RSpec.describe Discourse::SafeExec do
     end
   end
 
-  describe ".landlock_supported?" do
-    it "returns true when the Landlock ABI is positive" do
-      allow(Landlock).to receive(:abi_version).and_return(6)
-
-      expect(described_class.landlock_supported?).to eq(true)
-    end
-
-    it "returns false when the Landlock ABI is zero" do
-      allow(Landlock).to receive(:abi_version).and_return(0)
-
-      expect(described_class.landlock_supported?).to eq(false)
-    end
-  end
-
   describe ".capture" do
     it "delegates sandboxed execution to Landlock" do
       status = instance_double(Process::Status, exited?: true, exitstatus: 0)

--- a/spec/lib/discourse/safe_exec_spec.rb
+++ b/spec/lib/discourse/safe_exec_spec.rb
@@ -3,6 +3,36 @@
 require "discourse/safe_exec"
 
 RSpec.describe Discourse::SafeExec do
+  describe ".landlock_abi_version" do
+    it "returns the Landlock ABI version" do
+      allow(Landlock).to receive(:abi_version).and_return(6)
+
+      expect(described_class.landlock_abi_version).to eq(6)
+    end
+
+    it "returns zero when the ABI cannot be queried" do
+      allow(Landlock).to receive(:abi_version).and_raise(
+        Landlock::SyscallError.new("landlock_create_ruleset", Errno::EPERM::Errno),
+      )
+
+      expect(described_class.landlock_abi_version).to eq(0)
+    end
+  end
+
+  describe ".landlock_supported?" do
+    it "returns true when the Landlock ABI is positive" do
+      allow(Landlock).to receive(:abi_version).and_return(6)
+
+      expect(described_class.landlock_supported?).to eq(true)
+    end
+
+    it "returns false when the Landlock ABI is zero" do
+      allow(Landlock).to receive(:abi_version).and_return(0)
+
+      expect(described_class.landlock_supported?).to eq(false)
+    end
+  end
+
   describe ".capture" do
     it "delegates sandboxed execution to Landlock" do
       status = instance_double(Process::Status, exited?: true, exitstatus: 0)


### PR DESCRIPTION
SafeExec previously exposed only a boolean support check, so callers could not inspect the kernel capability level without reaching into the Landlock dependency.

This commit adds `Discourse::SafeExec.landlock_abi_version`. Landlock query errors return zero, giving callers a stable unavailable value. The existing `landlock_supported?` predicate remains unchanged.