### PR TITLE
DEV: Remove the alt dashboard version query param

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -208,14 +208,7 @@ class Admin::DashboardController < Admin::StaffController
   end
 
   def dashboard_improvements?
-    dashboard_improvements_enabled =
-      UpcomingChanges.enabled_for_user?(:dashboard_improvements, current_user)
-
-    if params[:version] == "alt"
-      !dashboard_improvements_enabled
-    else
-      dashboard_improvements_enabled
-    end
+    UpcomingChanges.enabled_for_user?(:dashboard_improvements, current_user)
   end
 
   def parse_reports_items_payload

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -27,13 +27,12 @@ export default class AdminDashboardController extends Controller {
   @tracked range = DEFAULT_PERIOD;
   @tracked start_date = null;
   @tracked end_date = null;
-  @tracked version = null;
   @tracked loadedSections = null;
   @tracked loadingSections = false;
   @tracked sectionsFetchError = false;
   @autoTrackedArray problems;
 
-  queryParams = ["range", "start_date", "end_date", "version"];
+  queryParams = ["range", "start_date", "end_date"];
 
   isLoading = false;
   dashboardFetchedAt = null;
@@ -166,11 +165,7 @@ export default class AdminDashboardController extends Controller {
     }
 
     try {
-      const model = await AdminDashboard.fetch({
-        startDate,
-        endDate,
-        version: this.version,
-      });
+      const model = await AdminDashboard.fetch({ startDate, endDate });
 
       if (id !== this._sectionsLoadId) {
         return;
@@ -202,9 +197,6 @@ export default class AdminDashboardController extends Controller {
   }
 
   get showRedesign() {
-    if (this.version === "alt") {
-      return !this.siteSettings.dashboard_improvements;
-    }
     return this.siteSettings.dashboard_improvements;
   }
 
@@ -262,7 +254,7 @@ export default class AdminDashboardController extends Controller {
     ) {
       this.set("isLoading", true);
 
-      AdminDashboard.fetch({ version: this.version })
+      AdminDashboard.fetch()
         .then((model) => {
           let properties = {
             dashboardFetchedAt: new Date(),

--- a/frontend/discourse/admin/models/admin-dashboard.js
+++ b/frontend/discourse/admin/models/admin-dashboard.js
@@ -8,16 +8,13 @@ const GENERAL_ATTRIBUTES = [
 ];
 
 export default class AdminDashboard extends EmberObject {
-  static async fetch({ startDate, endDate, version } = {}) {
+  static async fetch({ startDate, endDate } = {}) {
     const data = {};
     if (startDate) {
       data.start_date = moment(startDate).format("YYYY-MM-DD");
     }
     if (endDate) {
       data.end_date = moment(endDate).format("YYYY-MM-DD");
-    }
-    if (version) {
-      data.version = version;
     }
 
     const json = await ajax("/admin/dashboard.json", { data });

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -386,25 +386,6 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body["configuration"]).to be_present
       end
 
-      it "is returned with version=alt when the admin is not included" do
-        group = Fabricate(:group)
-        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
-
-        get "/admin/dashboard.json", params: { version: "alt" }
-
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["sections"]).to be_present
-        expect(response.parsed_body["configuration"]).to be_present
-      end
-
-      it "is omitted with version=alt when enabled for the admin" do
-        get "/admin/dashboard.json", params: { version: "alt" }
-
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["sections"]).to be_nil
-        expect(response.parsed_body["configuration"]).to be_nil
-      end
-
       it "falls back to default dates when date params are malformed" do
         get "/admin/dashboard.json", params: { start_date: "garbage", end_date: "also-garbage" }
 


### PR DESCRIPTION
The dashboard improvements are in beta and enabled everywhere, so the `?version=alt` toggle for previewing the other dashboard is no longer needed.