### PR TITLE
DEV: Refactor `exception` controller

### DIFF
--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import Controller, { inject as controller } from "@ember/controller";
+import Controller from "@ember/controller";
 import { action, computed } from "@ember/object";
 import { service } from "@ember/service";
 import {
@@ -17,10 +17,9 @@ import { autoTrackedArray } from "discourse/lib/tracked-tools";
 const PROBLEMS_CHECK_MINUTES = 1;
 
 export default class AdminDashboardController extends Controller {
-  @service router;
   @service siteSettings;
+  @service exception;
   @service loadingSlider;
-  @controller("exception") exceptionController;
 
   @tracked loadingProblems = false;
   @tracked problemsFetchedAt;
@@ -275,8 +274,7 @@ export default class AdminDashboardController extends Controller {
           this.setProperties(properties);
         })
         .catch((e) => {
-          this.exceptionController.set("thrown", e.jqXHR);
-          this.router.replaceWith("exception");
+          this.exception.show(e.jqXHR);
         })
         .finally(() => {
           this.set("isLoading", false);

--- a/frontend/discourse/admin/controllers/admin/dashboard/general.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard/general.js
@@ -1,4 +1,3 @@
-import { inject as controller } from "@ember/controller";
 import { computed } from "@ember/object";
 import { service } from "@ember/service";
 import { REPORT_MODES } from "discourse/admin/lib/constants";
@@ -16,9 +15,8 @@ function staticReport(reportType) {
 }
 
 export default class AdminDashboardGeneralController extends AdminDashboardTabController {
-  @service router;
   @service siteSettings;
-  @controller("exception") exceptionController;
+  @service exception;
 
   isLoading = false;
   dashboardFetchedAt = null;
@@ -170,8 +168,7 @@ export default class AdminDashboardGeneralController extends AdminDashboardTabCo
           });
         })
         .catch((e) => {
-          this.exceptionController.set("thrown", e.jqXHR);
-          this.router.replaceWith("exception");
+          this.exception.show(e.jqXHR);
         })
         .finally(() => this.set("isLoading", false));
     }

--- a/frontend/discourse/app/controllers/exception.js
+++ b/frontend/discourse/app/controllers/exception.js
@@ -1,14 +1,15 @@
-import { cached } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
-import { action, computed, set } from "@ember/object";
+import { action } from "@ember/object";
 import { schedule } from "@ember/runloop";
+import { service } from "@ember/service";
 import DiscourseURL from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
 
 /**
  * You can throw an instance of this error during a route's beforeModel/model/afterModel hooks.
- * It will be caught by the top-level ApplicationController, and cause this Exception controller/template
- * to be rendered without changing the URL.
+ * It will be caught by the application route's error handler, and cause this Exception
+ * controller/template to be rendered without changing the URL.
  */
 export class RouteException {
   status;
@@ -23,57 +24,49 @@ export class RouteException {
 
 // The controller for the nice error page
 export default class ExceptionController extends Controller {
-  thrown;
-  lastTransition;
+  @service exception;
 
   // Handling for the detailed_404 setting (which actually creates 403s)
 
   // TODO
   // make ajax requests to /srv/status with exponential backoff
   // if one succeeds, set networkFixed to true, which puts a "Fixed!" message on the page
-  networkFixed = false;
+  @tracked networkFixed = false;
 
-  loading = false;
+  @tracked loading = false;
 
-  @computed("thrown.status")
+  get thrown() {
+    return this.exception.thrown;
+  }
+
+  get lastTransition() {
+    return this.exception.lastTransition;
+  }
+
   get isNotFound() {
     return this.thrown?.status === 404;
   }
 
-  @computed("thrown.status")
   get isForbidden() {
     return this.thrown?.status === 403;
   }
 
-  @computed("thrown.status")
   get isServer() {
     return this.thrown?.status >= 500;
   }
 
-  @computed("isNetwork")
   get isUnknown() {
     return this.isNetwork == null;
   }
 
-  @computed("thrown.responseJSON.extras.html")
   get errorHtml() {
     return this.thrown?.responseJSON?.extras?.html;
   }
 
-  set errorHtml(value) {
-    set(this, "thrown.responseJSON.extras.html", value);
-  }
-
-  @computed("thrown.requestedUrl")
   get requestUrl() {
     return this.thrown?.requestedUrl;
   }
 
-  set requestUrl(value) {
-    set(this, "thrown.requestedUrl", value);
-  }
-
-  @computed("thrown")
   get isNetwork() {
     // never made it on the wire
     if (this.thrown && this.thrown.readyState === 0) {
@@ -88,7 +81,6 @@ export default class ExceptionController extends Controller {
     return false;
   }
 
-  @computed("isNetwork", "thrown.status", "thrown")
   get reason() {
     if (this.thrown?.reason) {
       return this.thrown.reason;
@@ -100,21 +92,11 @@ export default class ExceptionController extends Controller {
       return i18n("errors.reasons.not_found");
     } else if (this.thrown?.status === 403) {
       return i18n("errors.reasons.forbidden");
-    } else if (this.thrown === null) {
-      return i18n("errors.reasons.unknown");
     } else {
-      // TODO
       return i18n("errors.reasons.unknown");
     }
   }
 
-  @computed(
-    "networkFixed",
-    "isNetwork",
-    "thrown.status",
-    "thrown.statusText",
-    "thrown"
-  )
   get desc() {
     if (this.thrown?.desc) {
       return this.thrown.desc;
@@ -130,10 +112,7 @@ export default class ExceptionController extends Controller {
       return i18n("errors.desc.server", {
         status: this.thrown?.status + " " + this.thrown?.statusText,
       });
-    } else if (this.thrown === null) {
-      return i18n("errors.desc.unknown");
     } else {
-      // TODO
       return i18n("errors.desc.unknown");
     }
   }
@@ -165,7 +144,6 @@ export default class ExceptionController extends Controller {
     };
   }
 
-  @computed("networkFixed", "isNetwork", "lastTransition")
   get enabledButtons() {
     if (this.networkFixed) {
       return [this.buttons.ButtonLoadPage];
@@ -183,7 +161,7 @@ export default class ExceptionController extends Controller {
     // Strip off subfolder
     const currentURL = DiscourseURL.router.location.getURL();
     if (this.lastTransition?.method === "replace") {
-      this.setProperties({ lastTransition: null, thrown: null });
+      this.exception.clear();
       // Can't use routeTo because it handles navigation to the same page
       DiscourseURL.handleURL(currentURL);
     } else {
@@ -193,13 +171,13 @@ export default class ExceptionController extends Controller {
 
   @action
   tryLoading() {
-    this.set("loading", true);
+    this.loading = true;
 
     schedule("afterRender", () => {
       const transition = this.lastTransition;
-      this.setProperties({ lastTransition: null, thrown: null });
+      this.exception.clear();
       transition.retry();
-      this.set("loading", false);
+      this.loading = false;
     });
   }
 }

--- a/frontend/discourse/app/routes/application.js
+++ b/frontend/discourse/app/routes/application.js
@@ -20,6 +20,7 @@ export default class ApplicationRoute extends DiscourseRoute {
   @service composer;
   @service currentUser;
   @service dialog;
+  @service exception;
   @service documentTitle;
   @service embedAuthFlow;
   @service historyStore;
@@ -130,7 +131,6 @@ export default class ApplicationRoute extends DiscourseRoute {
   @action
   error(err, transition) {
     const xhrOrErr = err.jqXHR ? err.jqXHR : err;
-    const exceptionController = this.controllerFor("exception");
     let shouldBubble = false;
 
     const themeOrPluginSource = identifySource(err);
@@ -154,11 +154,6 @@ export default class ApplicationRoute extends DiscourseRoute {
       }
     }
 
-    exceptionController.setProperties({
-      lastTransition: transition,
-      thrown: xhrOrErr,
-    });
-
     if (transition.intent.url) {
       if (transition.method === "replace") {
         DiscourseURL.replaceState(transition.intent.url);
@@ -167,7 +162,7 @@ export default class ApplicationRoute extends DiscourseRoute {
       }
     }
 
-    this.intermediateTransitionTo("exception");
+    this.exception.show(xhrOrErr, transition);
     return shouldBubble;
   }
 

--- a/frontend/discourse/app/services/exception.js
+++ b/frontend/discourse/app/services/exception.js
@@ -1,0 +1,27 @@
+import { tracked } from "@glimmer/tracking";
+import { getOwner } from "@ember/owner";
+import Service from "@ember/service";
+
+export default class Exception extends Service {
+  @tracked thrown = null;
+  @tracked lastTransition = null;
+
+  /**
+   * Renders the error page in place of the current route's content, leaving the
+   * URL untouched so that a reload retries the page the user asked for.
+   *
+   * @param {unknown} thrown - The error or failed XHR to display
+   * @param {Transition} [lastTransition] - Transition to retry via the "try again" button
+   */
+  show(thrown, lastTransition = null) {
+    this.thrown = thrown;
+    this.lastTransition = lastTransition;
+    // eslint-disable-next-line ember/no-private-routing-service -- `intermediateTransitionTo` is not exposed on the router service
+    getOwner(this).lookup("router:main").intermediateTransitionTo("exception");
+  }
+
+  clear() {
+    this.thrown = null;
+    this.lastTransition = null;
+  }
+}

--- a/frontend/discourse/tests/acceptance/exception-test.js
+++ b/frontend/discourse/tests/acceptance/exception-test.js
@@ -1,0 +1,37 @@
+import {
+  resetOnerror,
+  settled,
+  setupOnerror,
+  visit,
+} from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
+
+acceptance("Exception page", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/badges.json", () => helper.response(500, {}));
+  });
+
+  test("renders the error page when a route fails to load", async function (assert) {
+    await visit("/");
+
+    // the error intentionally bubbles after the exception page renders
+    setupOnerror(() => {});
+
+    try {
+      await visit("/badges");
+    } catch {}
+    await settled();
+
+    assert.dom(".error-page").exists();
+    assert
+      .dom(".error-page .reason")
+      .hasText(i18n("errors.reasons.server"), "shows the server error reason");
+    assert
+      .dom(".error-page .buttons .btn-primary")
+      .exists("offers recovery buttons");
+
+    resetOnerror();
+  });
+});


### PR DESCRIPTION
- Remove computed properties
- Move interface to service, so that other code doesn't need to use the private router or inject the controller