### PR TITLE
DEV: add selectedCount to multi-select-header

### DIFF
--- a/frontend/discourse/select-kit/components/multi-select.gjs
+++ b/frontend/discourse/select-kit/components/multi-select.gjs
@@ -31,6 +31,7 @@ import MultiSelectHeader from "./multi-select/multi-select-header";
   caretDownIcon: "caretIcon",
   caretUpIcon: "caretIcon",
   useHeaderFilter: false,
+  useHeaderSelectedCount: false,
 })
 @pluginApiIdentifiers(["multi-select"])
 export default class MultiSelect extends SelectKitComponent {

--- a/frontend/discourse/select-kit/components/multi-select/multi-select-header.gjs
+++ b/frontend/discourse/select-kit/components/multi-select/multi-select-header.gjs
@@ -9,7 +9,7 @@ import {
 import FormatSelectedContent from "discourse/select-kit/components/multi-select/format-selected-content";
 import { resolveComponent } from "discourse/select-kit/components/select-kit";
 import SelectKitHeaderComponent from "discourse/select-kit/components/select-kit/select-kit-header";
-import { or } from "discourse/truth-helpers";
+import { and, or } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 @tagName("summary")
@@ -66,6 +66,17 @@ export default class MultiSelectHeader extends SelectKitHeaderComponent {
       {{#each this.icons as |iconName|}}
         {{dIcon iconName}}
       {{/each}}
+
+      {{#if
+        (and
+          this.selectKit.options.useHeaderSelectedCount
+          this.selectedContent.length
+        )
+      }}
+        <span
+          class="multi-select-header__selected-count"
+        >{{this.selectedContent.length}}</span>
+      {{/if}}
 
       {{#if this.selectKit.options.useHeaderFilter}}
         <div class="select-kit-header--filter">

--- a/frontend/discourse/tests/integration/components/select-kit/multi-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/multi-select-test.gjs
@@ -135,4 +135,61 @@ module("Integration | Component | SelectKit | MultiSelect", function (hooks) {
       .dom(".selected-content")
       .doesNotExist("doesn't render an empty content div");
   });
+
+  test("useHeaderSelectedCount=true", async function (assert) {
+    setDefaultState(this, { value: [1, 2] });
+
+    await render(
+      <template>
+        <MultiSelect
+          @value={{this.value}}
+          @content={{this.content}}
+          @options={{hash useHeaderSelectedCount=true}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".multi-select-header__selected-count")
+      .hasText("2", "shows the number of selected items in the header");
+
+    await this.subject.expand();
+    await this.subject.selectRowByValue(3);
+
+    assert
+      .dom(".multi-select-header__selected-count")
+      .hasText("3", "updates the count when the selection changes");
+  });
+
+  test("useHeaderSelectedCount=true with no selection", async function (assert) {
+    setDefaultState(this);
+
+    await render(
+      <template>
+        <MultiSelect
+          @value={{this.value}}
+          @content={{this.content}}
+          @options={{hash useHeaderSelectedCount=true}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".multi-select-header__selected-count")
+      .doesNotExist("doesn't render a count when nothing is selected");
+  });
+
+  test("useHeaderSelectedCount=false", async function (assert) {
+    setDefaultState(this, { value: [1, 2] });
+
+    await render(
+      <template>
+        <MultiSelect @value={{this.value}} @content={{this.content}} />
+      </template>
+    );
+
+    assert
+      .dom(".multi-select-header__selected-count")
+      .doesNotExist("doesn't render a count by default");
+  });
 });


### PR DESCRIPTION
This change adds an opt-in `useHeaderSelectedCount` select-kit option that renders the selection count inside the multi-select header. It default to false.

Needed in context of the UC:composer redesign