### PR TITLE
DEV: Increase default user API rate limits

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -250,8 +250,8 @@ s3_role_session_name =
 s3_asset_cdn_url =
 
 ### rate limits apply to all sites
-max_user_api_reqs_per_minute = 20
-max_user_api_reqs_per_day = 2880
+max_user_api_reqs_per_minute = 50
+max_user_api_reqs_per_day = 4000
 
 max_admin_api_reqs_per_minute = 60
 


### PR DESCRIPTION
These defaults are a little bit too low when building tools which gather multiple plugins doing their own requests, especially at start of the tool.