### PR TITLE
FIX: ignore_by_title should not be treated as a regex

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2539,6 +2539,7 @@ en:
     auto_generated_allowlist: "List of email addresses that won't be checked for auto-generated content. Example: foo@bar.com|discourse@bar.com"
     block_auto_generated_emails: "Block incoming emails identified as being auto generated."
     ignore_by_title: "Ignore incoming emails based on their title."
+    ignore_by_title_regex: "Ignore incoming emails based on their title using a regular expression."
     mailgun_api_key: "Mailgun Secret API key used to verify webhook messages."
     sendgrid_verification_key: "Sendgrid verification key used to verify webhook messages."
     aws_sns_topic_arn_allowlist: "SNS topic ARNs allowed to send Amazon SES bounce webhook notifications."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2364,6 +2364,9 @@ email:
     list_type: simple
     default: ""
     area: "email"
+  ignore_by_title_regex:
+    default: ""
+    area: "email"
   mailgun_api_key:
     default: ""
     regex: '^((key-)?\h{32}|\h{32}-\h{8}-\h{8})$'

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -150,8 +150,17 @@ module Email
     end
 
     def is_blocked?
-      return false if SiteSetting.ignore_by_title.blank?
-      Regexp.new(SiteSetting.ignore_by_title, Regexp::IGNORECASE) =~ @mail.subject
+      if SiteSetting.ignore_by_title.present?
+        escaped_regex =
+          SiteSetting.ignore_by_title.split("|").map { |s| Regexp.escape(s) }.join("|")
+        return true if Regexp.new(escaped_regex, Regexp::IGNORECASE) =~ @mail.subject
+      end
+      if SiteSetting.ignore_by_title_regex.present?
+        if Regexp.new(SiteSetting.ignore_by_title_regex, Regexp::IGNORECASE) =~ @mail.subject
+          return true
+        end
+      end
+      false
     end
 
     def create_incoming_email

--- a/spec/fixtures/emails/auto_generated_subject.eml
+++ b/spec/fixtures/emails/auto_generated_subject.eml
@@ -1,0 +1,10 @@
+Return-Path: <foo@bar.com>
+From: Foo Bar <foo@bar.com>
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Subject: [AUTO GENERATED] Some subject
+Message-ID: <3@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+Some thing.

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -932,8 +932,23 @@ RSpec.describe Email::Receiver do
       expect { process(:tl4_user) }.to change(Topic, :count)
     end
 
-    it "ignores by case-insensitive title" do
-      SiteSetting.ignore_by_title = "foo"
+    it "ignores by case-insensitive title (single)" do
+      SiteSetting.ignore_by_title = "[auto generated]"
+      expect { process(:auto_generated_subject) }.to_not change(Topic, :count)
+    end
+
+    it "does not treat ignore_by_title as a regex" do
+      SiteSetting.ignore_by_title = "[auto generated]"
+      expect { process(:ignored) }.to raise_error(Email::Receiver::StrangersNotAllowedError)
+    end
+
+    it "ignores by case-insensitive title (multiple)" do
+      SiteSetting.ignore_by_title = "not_the_ignored_string|foo|not_the_other_ignored_string"
+      expect { process(:ignored) }.to_not change(Topic, :count)
+    end
+
+    it "ignores by case-insensitive title (regex)" do
+      SiteSetting.ignore_by_title_regex = "t[ah]is.is"
       expect { process(:ignored) }.to_not change(Topic, :count)
     end
 


### PR DESCRIPTION
The site setting name or description does not label this as a regex, so it
should not be used as one. If it is, this can cause unintentional silent mail
dropping (seen in the wild) when it's set to e.g. `[string]` to match a common
subject prefix pattern.

Adds an explicit regex for those who want to use it as such.
