### PR TITLE
UX: Name the chat pinned banner in its dismissal labels

### DIFF
--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -68,8 +68,8 @@ en:
       pinned_messages:
         title: "Pinned messages"
         close: "Close pinned messages"
-        dismiss: "Dismiss for me"
-        show: "Show pinned messages"
+        dismiss: "Dismiss pinned banner for me"
+        show: "Show pinned banner"
         pinned_by_you: "Pinned by you"
         pinned_by_user: "Pinned by %{username}"
       pinned_bar:


### PR DESCRIPTION
"Show pinned messages" in the pins panel footer read as if it would reveal the list the user was already looking at, when it actually restores the dismissed banner. Name the banner in both footer labels, keeping the personal scope on dismissal so it doesn't read as hiding the banner for everyone.
