### PR TITLE
DEV: Lint `docs/developer-guides` in the pre-commit hook

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -239,7 +239,26 @@ class LefthookLinter
     end
 
     # Check if file extension is lintable
-    lintable_extensions = %w[rb rake js gjs cjs mjs ts gts mts cts hbs scss css yml yaml thor]
+    lintable_extensions = %w[
+      rb
+      rake
+      js
+      gjs
+      cjs
+      mjs
+      ts
+      gts
+      mts
+      cts
+      hbs
+      scss
+      css
+      yml
+      yaml
+      thor
+      md
+      json
+    ]
     lintable_extensions.include?(ext)
   end
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,6 +35,14 @@ pre-commit:
         - "plugins/**/*.{js,gjs,ts,gts,mts,cts,scss,css,cjs,mjs}"
         - "themes/**/*.{js,gjs,ts,gts,mts,cts,scss,css,cjs,mjs}"
       run: pnpm pprettier --list-different {staged_files}
+    # docs/developer-guides is its own pnpm workspace package with its own
+    # prettier config. It needs `root` so prettier runs with that directory as
+    # its cwd: the repo-root .prettierignore ignores **/*.md, so a run from the
+    # root silently checks nothing and exits 0.
+    developer-docs-prettier:
+      root: &developer_docs_root "docs/developer-guides/"
+      glob: &developer_docs_glob "docs/developer-guides/**/*.{md,json,mjs,yml}"
+      run: pnpm prettier --list-different {staged_files}
     eslint:
       glob: &eslint_glob
         - "frontend/**/*.{js,gjs,ts,gts,mts,cts,cjs,mjs}"
@@ -62,6 +70,10 @@ fix-staged:
     prettier:
       glob: *prettier_glob
       run: pnpm pprettier --write {staged_files}
+    developer-docs-prettier:
+      root: *developer_docs_root
+      glob: *developer_docs_glob
+      run: pnpm prettier --write {staged_files}
     eslint:
       glob: *eslint_glob
       run: pnpm eslint --fix --no-warn-ignored {staged_files}
@@ -101,6 +113,11 @@ lint-files:
       files: *working_tree_files
       glob: *prettier_glob
       run: pnpm pprettier --list-different {files}
+    developer-docs-prettier:
+      files: *working_tree_files
+      root: *developer_docs_root
+      glob: *developer_docs_glob
+      run: pnpm prettier --list-different {files}
     eslint:
       files: *working_tree_files
       glob: *eslint_glob
@@ -126,6 +143,11 @@ fix-files:
       files: *working_tree_files
       glob: *prettier_glob
       run: pnpm pprettier --write {files}
+    developer-docs-prettier:
+      files: *working_tree_files
+      root: *developer_docs_root
+      glob: *developer_docs_glob
+      run: pnpm prettier --write {files}
     eslint:
       files: *working_tree_files
       glob: *eslint_glob


### PR DESCRIPTION
Markdown under `docs/developer-guides` can currently be committed and pushed unformatted, then fail `developer-docs-lint.yml` minutes later in a job nobody runs locally. The same file has failed that job twice, and both times every local check passed, `bin/lint` included.

The obvious fix does not work. `docs/developer-guides` is its own pnpm workspace package with its own prettier config, and the repo-root `.prettierignore` carries a blanket `**/*.md`, so widening the existing `prettier` glob produces a command that runs, prints "Checked 0 files" and exits 0. CI escapes that only because prettier resolves `.prettierignore` from its cwd and the workflow sets `working-directory: docs/developer-guides`.

The new `developer-docs-prettier` lefthook command reproduces that condition with `root: docs/developer-guides/`, so prettier runs with the package as its cwd and picks up the same config and ignore rules CI does. It covers `{md,json,mjs,yml}` to match the package's own `lint` script, and is registered in `pre-commit`, `fix-staged`, `lint-files` and `fix-files` so both the commit gate and the working-tree `bin/lint` paths are covered.

`bin/lint` needed a separate fix: `.md` and `.json` were missing from its lintable extensions, so it discarded those files before lefthook ran and still reported "All lints passed". Non-docs JSON reaching lefthook is inert, since no other command's glob matches it.

Verified by breaking formatting on purpose and confirming the hook, a real `git commit` and `bin/lint` all go red, that `--fix` and `fix-staged` rewrite the file, and that a commit touching no docs files skips the new command.