### PR TITLE
FIX: Stop letter avatar cleanup threads crashing on tmpdir removal

### DIFF
--- a/lib/image_magick.rb
+++ b/lib/image_magick.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "tmpdir"
 
 # Runs ImageMagick under the Landlock sandbox (via Discourse::SafeExec) so a
@@ -41,7 +42,9 @@ module ImageMagick
   def self.run(*command, read:, write:, timeout:, failure_message:)
     # A private scratch dir keeps ImageMagick's disk-backed pixel cache inside
     # the write allowlist, so large images that spill to disk still succeed.
-    Dir.mktmpdir("discourse-imagemagick-") do |scratch|
+    scratch = Dir.mktmpdir("discourse-imagemagick-")
+
+    begin
       Discourse::SafeExec.capture(
         *command,
         env: {
@@ -61,7 +64,25 @@ module ImageMagick
         failure_message:,
         seccomp_deny_network: true,
       )
+    ensure
+      remove_scratch(scratch)
     end
   end
   private_class_method :run
+
+  # Helper libraries (eg fontconfig) can still be populating their cache under
+  # the scratch dir while it is being torn down, which makes a strict removal
+  # raise ENOTEMPTY. Retry, then give up: losing a scratch dir is not worth
+  # failing the caller, and this often runs on a thread with no handler.
+  def self.remove_scratch(scratch, attempts: 3)
+    FileUtils.remove_entry(scratch)
+  rescue StandardError => e
+    attempts -= 1
+    if e.is_a?(Errno::ENOTEMPTY) && attempts > 0
+      sleep 0.05
+      retry
+    end
+    FileUtils.remove_entry(scratch, true)
+  end
+  private_class_method :remove_scratch
 end

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -109,16 +109,24 @@ class LetterAvatar
     end
 
     def image_magick_version
-      @image_magick_version ||=
-        begin
-          Thread.new do
-            sleep 2
-            cleanup_old
-          end
-          Digest::MD5.hexdigest(
-            ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
-          )
-        end
+      return @image_magick_version if @image_magick_version
+
+      # Memoize before kicking off cleanup: cleanup_old asks for the cache path,
+      # which comes back here, and an unset memo makes it shell out and spawn
+      # another cleanup thread of its own.
+      @image_magick_version =
+        Digest::MD5.hexdigest(
+          ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
+        )
+
+      Thread.new do
+        sleep 2
+        cleanup_old
+      rescue StandardError => e
+        Discourse.warn_exception(e, message: "Failed to clean up old letter avatars")
+      end
+
+      @image_magick_version
     end
 
     def cleanup_old


### PR DESCRIPTION
System spec runs sometimes aborted a thread with a large backtrace:

```
/Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2326:in 'Dir.rmdir': Directory not empty @ dir_s_rmdir - /var/folders/5p/qgy49b1s0412dz106dj2t5ww0000gn/T/discourse-imagemagick-20260813-44025-vodxks/fontconfig
(Errno::ENOTEMPTY)
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2326:in 'block in FileUtils::Entry_#remove_dir1'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2337:in 'FileUtils::Entry_#platform_support'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2325:in 'FileUtils::Entry_#remove_dir1'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2318:in 'FileUtils::Entry_#remove'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:1453:in 'block in FileUtils.remove_entry'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2379:in 'block (2 levels) in FileUtils::Entry_#postorder_traverse'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2383:in 'FileUtils::Entry_#postorder_traverse'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2378:in 'block in FileUtils::Entry_#postorder_traverse'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2377:in 'Array#each'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:2377:in 'FileUtils::Entry_#postorder_traverse'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/fileutils.rb:1451:in 'FileUtils.remove_entry'
  from /Users/mb/.asdf/installs/ruby/3.4.6/lib/ruby/3.4.0/tmpdir.rb:114:in 'Dir.mktmpdir'
  from /Users/mb/repos/discourse/lib/image_magick.rb:44:in 'ImageMagick.run'
  from /Users/mb/repos/discourse/lib/image_magick.rb:34:in 'ImageMagick.magick'
  from /Users/mb/repos/discourse/lib/letter_avatar.rb:119:in 'LetterAvatar.image_magick_version'
  from /Users/mb/repos/discourse/lib/letter_avatar.rb:27:in 'LetterAvatar.version'
  from /Users/mb/repos/discourse/lib/letter_avatar.rb:31:in 'LetterAvatar.cache_path'
  from /Users/mb/repos/discourse/lib/letter_avatar.rb:125:in 'LetterAvatar.cleanup_old'
  from /Users/mb/repos/discourse/lib/letter_avatar.rb:116:in 'block in LetterAvatar.image_magick_version'
```

Two causes. ImageMagick.run used the block form of Dir.mktmpdir, which
removes the tree strictly. HOME and XDG_CACHE_HOME point into that
scratch dir, so fontconfig builds its cache there and anything written
between the directory listing and the rmdir raises ENOTEMPTY. Removal
now retries and then falls back to a forced removal.

LetterAvatar.image_magick_version also spawned its cleanup thread before
memoizing, and cleanup_old asks for the cache path, which comes back
into image_magick_version with the memo still unset - so every call
shelled out to magick again and spawned another cleanup thread. Memoize
first, and rescue in the thread so a failed cleanup is a logged warning.
