### PR TITLE
DEV: Return a portaled float to the tab order beside its trigger

### DIFF
--- a/frontend/discourse/float-kit/components/d-float-body.gts
+++ b/frontend/discourse/float-kit/components/d-float-body.gts
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import { fn, hash } from "@ember/helper";
 import { trustHTML } from "@ember/template";
 import { modifier as modifierFn } from "ember-modifier";
@@ -8,6 +9,7 @@ import { getScrollParent } from "discourse/float-kit/lib/get-scroll-parent";
 import { horizontalViewportInset } from "discourse/float-kit/lib/update-position";
 import FloatKitApplyFloatingUi from "discourse/float-kit/modifiers/apply-floating-ui";
 import FloatKitCloseOnEscape from "discourse/float-kit/modifiers/close-on-escape";
+import FloatKitTabOrderInline from "discourse/float-kit/modifiers/tab-order-inline";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dCloseOnClickOutside from "discourse/ui-kit/modifiers/d-close-on-click-outside";
 import dTrapTab from "discourse/ui-kit/modifiers/d-trap-tab";
@@ -32,6 +34,17 @@ interface DFloatBodySignature {
 
     /** Whether to trap Tab focus within the content. */
     trapTab?: boolean;
+
+    /**
+     * Whether the content should take part in the tab sequence as if it were rendered inline
+     * after the trigger, rather than at the portal's position in the document: Tab leads into its
+     * controls from the trigger, and off the end of them it dismisses the float and continues
+     * from the trigger.
+     *
+     * The non-containing alternative to `trapTab`, for a float that is dismissable but whose
+     * content holds focus. See `FloatKitTabOrderInline`.
+     */
+    inlineTabOrder?: boolean;
 
     /**
      * The element to render into. Some callers forward this even though the body
@@ -140,6 +153,22 @@ export default class DFloatBody extends Component<DFloatBodySignature> {
     return this.args.role === "none" || this.args.role === "presentation";
   }
 
+  /**
+   * Whether to repair the tab order, asserting first that containment was not ALSO asked for.
+   *
+   * The two are alternatives, and the conflict is otherwise silent and one-sided: `dTrapTab` is
+   * applied first below, so its `preventDefault` lands before the tab-order handler runs, and the
+   * float traps focus while its author believes they configured the opposite.
+   */
+  get inlineTabOrder() {
+    assert(
+      "float-kit: `trapTab` and `inlineTabOrder` are alternatives — the first contains focus, the second deliberately lets it leave. Setting both keeps the trap and silently ignores the tab-order repair.",
+      !(this.args.trapTab && this.args.inlineTabOrder)
+    );
+
+    return this.args.inlineTabOrder;
+  }
+
   get supportsCloseOnClickOutside() {
     return this.options.closeOnClickOutside;
   }
@@ -195,6 +224,14 @@ export default class DFloatBody extends Component<DFloatBodySignature> {
         {{FloatKitApplyFloatingUi this.trigger this.options @instance}}
         {{this.trapInteractionPropagation}}
         {{(if @trapTab (modifier dTrapTab autofocus=this.options.autofocus))}}
+        {{(if
+          this.inlineTabOrder
+          (modifier
+            FloatKitTabOrderInline
+            @instance.triggerElement
+            (fn @instance.close (hash focusTrigger=false))
+          )
+        )}}
         {{(if
           this.supportsCloseOnClickOutside
           (modifier

--- a/frontend/discourse/float-kit/components/d-headless-menu.gts
+++ b/frontend/discourse/float-kit/components/d-headless-menu.gts
@@ -23,6 +23,7 @@ const DHeadlessMenu: TemplateOnlyComponent<DHeadlessMenuSignature> = <template>
   <DInlineFloat
     @instance={{@menu}}
     @trapTab={{@menu.options.trapTab}}
+    @inlineTabOrder={{@menu.options.inlineTabOrder}}
     @mainClass="fk-d-menu"
     @innerClass="fk-d-menu__inner-content"
     @role={{@menu.options.contentRole}}

--- a/frontend/discourse/float-kit/components/d-inline-float.gts
+++ b/frontend/discourse/float-kit/components/d-inline-float.gts
@@ -14,6 +14,12 @@ interface DInlineFloatSignature {
     /** Whether to trap Tab focus within the content. */
     trapTab?: boolean;
 
+    /**
+     * Whether the content takes part in the tab sequence as if rendered inline after the trigger.
+     * The non-containing alternative to `trapTab`; the two are mutually exclusive.
+     */
+    inlineTabOrder?: boolean;
+
     /** A class added to the outer float element. */
     mainClass?: string;
 
@@ -64,6 +70,7 @@ const DInlineFloat: TemplateOnlyComponent<DInlineFloatSignature> = <template>
       <DFloatBody
         @instance={{@instance}}
         @trapTab={{@trapTab}}
+        @inlineTabOrder={{@inlineTabOrder}}
         @mainClass={{@mainClass}}
         @innerClass={{@innerClass}}
         @role={{@role}}

--- a/frontend/discourse/float-kit/components/d-menu.gts
+++ b/frontend/discourse/float-kit/components/d-menu.gts
@@ -316,6 +316,7 @@ export default class DMenu<Data = unknown> extends Component<
         <DFloatBody
           @instance={{this.menuInstance}}
           @trapTab={{this.options.trapTab}}
+          @inlineTabOrder={{this.options.inlineTabOrder}}
           @mainClass={{dConcatClass
             "fk-d-menu"
             (concat this.options.identifier "-content")

--- a/frontend/discourse/float-kit/components/d-menu.gts
+++ b/frontend/discourse/float-kit/components/d-menu.gts
@@ -173,7 +173,7 @@ export default class DMenu<Data = unknown> extends Component<
     // need to call the parent handler to allow arrow key navigation to siblings in toolbar contexts
     const parentHandlerResult = this.args.onKeydown?.(event);
 
-    if (!this.#body) {
+    if (!this.#body || this.options.inlineTabOrder) {
       return parentHandlerResult;
     }
 

--- a/frontend/discourse/float-kit/components/d-menu.gts
+++ b/frontend/discourse/float-kit/components/d-menu.gts
@@ -173,6 +173,9 @@ export default class DMenu<Data = unknown> extends Component<
     // need to call the parent handler to allow arrow key navigation to siblings in toolbar contexts
     const parentHandlerResult = this.args.onKeydown?.(event);
 
+    // Inline ordering claims Tab on the trigger itself, in the capture phase, and decides whether
+    // the panel is entered at all. Pulling focus into the body from here would override that
+    // decision after the fact, including for a panel that offers no stop and should be passed over.
     if (!this.#body || this.options.inlineTabOrder) {
       return parentHandlerResult;
     }
@@ -249,10 +252,24 @@ export default class DMenu<Data = unknown> extends Component<
     }>;
   }
 
+  /**
+   * The arguments that mirror a menu option, as a partial bag for the instance to merge over
+   * `MENU.options`.
+   *
+   * Only arguments the caller actually supplied are included. Filling the gaps here with the
+   * defaults would produce the same merged options, but it would erase the difference between
+   * "left unset" and "explicitly set to the default value", which the instance needs in order to
+   * let one option imply another.
+   *
+   * @returns The supplied options, keyed as in `MENU.options`.
+   */
   get allowedProperties() {
     const properties: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(MENU.options)) {
-      properties[key] = (this.args as Record<string, unknown>)[key] ?? value;
+    for (const key of Object.keys(MENU.options)) {
+      const value = (this.args as Record<string, unknown>)[key];
+      if (value != null) {
+        properties[key] = value;
+      }
     }
     return properties;
   }

--- a/frontend/discourse/float-kit/components/d-menu.gts
+++ b/frontend/discourse/float-kit/components/d-menu.gts
@@ -173,9 +173,9 @@ export default class DMenu<Data = unknown> extends Component<
     // need to call the parent handler to allow arrow key navigation to siblings in toolbar contexts
     const parentHandlerResult = this.args.onKeydown?.(event);
 
-    // Inline ordering claims Tab on the trigger itself, in the capture phase, and decides whether
-    // the panel is entered at all. Pulling focus into the body from here would override that
-    // decision after the fact, including for a panel that offers no stop and should be passed over.
+    // Inline ordering owns Tab on the trigger, in the capture phase, and decides whether the
+    // panel is entered. Pulling focus into the body here would override a decision to pass over
+    // a panel that offers no stop.
     if (!this.#body || this.options.inlineTabOrder) {
       return parentHandlerResult;
     }
@@ -253,15 +253,11 @@ export default class DMenu<Data = unknown> extends Component<
   }
 
   /**
-   * The arguments that mirror a menu option, as a partial bag for the instance to merge over
-   * `MENU.options`.
+   * Filling the gaps with defaults here would produce the same merged options, but it would erase
+   * the difference between "left unset" and "explicitly set to the default", which the instance
+   * needs in order to let one option imply another.
    *
-   * Only arguments the caller actually supplied are included. Filling the gaps here with the
-   * defaults would produce the same merged options, but it would erase the difference between
-   * "left unset" and "explicitly set to the default value", which the instance needs in order to
-   * let one option imply another.
-   *
-   * @returns The supplied options, keyed as in `MENU.options`.
+   * @returns Only the options the caller supplied, keyed as in `MENU.options`.
    */
   get allowedProperties() {
     const properties: Record<string, unknown> = {};

--- a/frontend/discourse/float-kit/lib/constants.ts
+++ b/frontend/discourse/float-kit/lib/constants.ts
@@ -217,6 +217,19 @@ export interface MenuOptions extends TooltipOptions {
   /** Whether to focus the content when the menu opens. */
   autofocus: boolean;
 
+  /**
+   * Whether the menu takes part in the tab sequence as if it were rendered inline after its
+   * trigger, rather than at the portal's position in the document. Tab leads into the menu's own
+   * controls from the trigger, and off the end of them it closes the menu and continues from the
+   * trigger.
+   *
+   * The non-containing alternative to `trapTab`, for a menu that is dismissable but whose content
+   * holds focus. A menu with nothing focusable in it is unaffected in either direction, so this
+   * is safe to set on a menu that only sometimes renders a control. Desktop only, since the
+   * mobile modal is a real `aria-modal` dialog that owns its own containment.
+   */
+  inlineTabOrder: boolean;
+
   /** Whether the menu renders as a modal on mobile. */
   modalForMobile: boolean;
 
@@ -392,6 +405,7 @@ export const MENU: { options: MenuOptions; portalOutletId: string } = {
     fallbackPlacements: FLOAT_UI_PLACEMENTS,
     autoUpdate: true,
     trapTab: true,
+    inlineTabOrder: false,
     contentRole: "dialog",
     onClose: null,
     onShow: null,

--- a/frontend/discourse/float-kit/lib/constants.ts
+++ b/frontend/discourse/float-kit/lib/constants.ts
@@ -224,9 +224,15 @@ export interface MenuOptions extends TooltipOptions {
    * trigger.
    *
    * The non-containing alternative to `trapTab`, for a menu that is dismissable but whose content
-   * holds focus. A menu with nothing focusable in it is unaffected in either direction, so this
-   * is safe to set on a menu that only sometimes renders a control. Desktop only, since the
-   * mobile modal is a real `aria-modal` dialog that owns its own containment.
+   * holds focus. Setting it turns `trapTab` off on its own, so the two never have to be passed
+   * together; a caller that asks for the trap explicitly gets an assertion instead, since only a
+   * contradiction remains. The trap is also what applies `autofocus`, so a menu using this option
+   * opens with focus still on the trigger, which is where tabbing into the content starts from.
+   *
+   * A menu with nothing focusable in it is unaffected in either direction, so this is safe to set
+   * on a menu that only sometimes renders a control. It does not reach a menu that also sets
+   * `modalForMobile`, which on mobile renders as a real `aria-modal` dialog that owns its own
+   * containment.
    */
   inlineTabOrder: boolean;
 

--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -59,6 +59,14 @@ export default class DMenuInstance extends FloatKitInstance {
 
     setOwner(this, owner);
     this.options = { ...MENU.options, ...options };
+
+    // `trapTab` defaults to true and the two are alternatives, so asking for inline ordering has
+    // to be enough on its own, or every caller would carry a second flag. An explicit `trapTab`
+    // still wins, and `DFloatBody` asserts on that contradiction rather than resolving it.
+    if (options.inlineTabOrder && options.trapTab === undefined) {
+      this.options.trapTab = false;
+    }
+
     this.portalOutletOverrideElement = options.portalOutletElement;
   }
 

--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -61,9 +61,9 @@ export default class DMenuInstance extends FloatKitInstance {
 
     const merged = { ...MENU.options, ...options };
 
-    // `trapTab` defaults to true and the two are alternatives, so asking for inline ordering has
-    // to be enough on its own, or every caller would carry a second flag. An explicit `trapTab`
-    // still wins, and `DFloatBody` asserts on that contradiction rather than resolving it.
+    // `trapTab` defaults to true and the two are alternatives, so inline ordering has to switch
+    // it off itself or every caller would carry a second flag. An explicit `trapTab: true` is
+    // left alone for `DFloatBody` to assert on rather than resolved silently here.
     if (options.inlineTabOrder && options.trapTab === undefined) {
       merged.trapTab = false;
     }

--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -58,15 +58,17 @@ export default class DMenuInstance extends FloatKitInstance {
     super();
 
     setOwner(this, owner);
-    this.options = { ...MENU.options, ...options };
+
+    const merged = { ...MENU.options, ...options };
 
     // `trapTab` defaults to true and the two are alternatives, so asking for inline ordering has
     // to be enough on its own, or every caller would carry a second flag. An explicit `trapTab`
     // still wins, and `DFloatBody` asserts on that contradiction rather than resolving it.
     if (options.inlineTabOrder && options.trapTab === undefined) {
-      this.options.trapTab = false;
+      merged.trapTab = false;
     }
 
+    this.options = merged;
     this.portalOutletOverrideElement = options.portalOutletElement;
   }
 

--- a/frontend/discourse/float-kit/lib/tab-order.ts
+++ b/frontend/discourse/float-kit/lib/tab-order.ts
@@ -7,85 +7,179 @@
  * expected so a component can put focus there itself.
  *
  * The enumeration is only as truthful as the DOM allows. A browser with keyboard-focusable
- * scrollers adopts a scroll container as a tab stop without marking it — such an element reports
- * `tabIndex === -1` and matches no focusable selector — so it is counted by the browser and not
- * by anything here. A surface relying on these helpers has to suppress those adoptions itself
- * (an explicit `tabindex="-1"`) or its idea of "the last stop in the panel" will be wrong.
+ * scrollers adopts a scroll container as a tab stop without marking it, while iframe and shadow
+ * focus scopes do not expose their internal key events or stops here. A surface relying on these
+ * helpers must avoid those focus scopes and suppress adopted scrollers with `tabindex="-1"`.
  */
 
-/**
- * Elements that take sequential focus. Deliberately without a bare `[tabindex]`: only a
- * non-negative value is in the tab order, and `-1` is the marker for the opposite.
- */
+/** Elements that can take sequential focus when their current state permits it. */
 const TAB_STOP_SELECTOR = [
   "a[href]",
   "area[href]",
-  "button:not([disabled])",
-  "input:not([disabled]):not([type='hidden'])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
+  "button",
+  "input:not([type='hidden'])",
+  "select",
+  "textarea",
   "summary",
   "iframe",
   "audio[controls]",
   "video[controls]",
   "[contenteditable]:not([contenteditable='false'])",
-  "[tabindex]:not([tabindex^='-'])",
+  "[tabindex]",
 ].join(", ");
 
-/**
- * Whether `element` can actually be tabbed to right now: rendered, not hidden from the platform,
- * and not opted out. A selector alone is not enough, since a display-less or `inert` subtree
- * still matches one.
- */
+interface TabStopsOptions {
+  ignore?: HTMLElement | null;
+}
+
+function isIgnored(element: HTMLElement, ignore?: HTMLElement | null) {
+  return Boolean(ignore && (element === ignore || ignore.contains(element)));
+}
+
+/** Whether `element` can actually be reached by sequential focus right now. */
 function isTabbable(element: HTMLElement): boolean {
-  if (element.hasAttribute("disabled") || element.tabIndex < 0) {
+  if (element.tabIndex < 0 || element.matches(":disabled")) {
     return false;
   }
-  if (element.closest("[inert]") || element.closest("[aria-hidden='true']")) {
+  if (element.closest("[inert]")) {
     return false;
   }
-  // Cheapest sufficient rendered-ness test: all three are zero only for a box that is not laid
-  // out at all, which is what `display: none` (on the element or any ancestor) produces.
-  return !!(
+
+  const visibility = getComputedStyle(element).visibility;
+  if (visibility === "hidden" || visibility === "collapse") {
+    return false;
+  }
+
+  return Boolean(
     element.offsetWidth ||
     element.offsetHeight ||
     element.getClientRects().length
   );
 }
 
+function radioGroupRepresentative(
+  radio: HTMLInputElement,
+  ignore?: HTMLElement | null
+): HTMLInputElement | null {
+  if (!radio.name) {
+    return radio;
+  }
+
+  const tree = radio.getRootNode();
+  if (!(tree instanceof Document || tree instanceof ShadowRoot)) {
+    return radio;
+  }
+
+  const members = Array.from(
+    tree.querySelectorAll<HTMLInputElement>("input[type='radio']")
+  ).filter(
+    (member) =>
+      member.name === radio.name &&
+      member.form === radio.form &&
+      !isIgnored(member, ignore) &&
+      isTabbable(member)
+  );
+
+  return members.find((member) => member.checked) ?? members[0] ?? null;
+}
+
+function isRadio(element: HTMLElement): element is HTMLInputElement {
+  return (
+    element instanceof HTMLInputElement &&
+    element.type.toLowerCase() === "radio"
+  );
+}
+
+function compareTabOrder(
+  left: { element: HTMLElement; documentIndex: number },
+  right: { element: HTMLElement; documentIndex: number }
+) {
+  const leftPositive = left.element.tabIndex > 0;
+  const rightPositive = right.element.tabIndex > 0;
+
+  if (leftPositive !== rightPositive) {
+    return leftPositive ? -1 : 1;
+  }
+  if (leftPositive && left.element.tabIndex !== right.element.tabIndex) {
+    return left.element.tabIndex - right.element.tabIndex;
+  }
+  return left.documentIndex - right.documentIndex;
+}
+
 /**
- * The tab stops inside `root`, in document order. `root` itself is included when it is one, so a
- * container that has been made focusable counts as its own first stop.
+ * The tab stops inside `root`, in a native-like local sequence. `root` itself is included when it
+ * is a stop. Positive tabindex values are ordered within this local segment; portaling cannot
+ * reproduce their global position without changing the surrounding page's tab order as well.
  */
-export function tabStopsWithin(root: HTMLElement): HTMLElement[] {
+export function tabStopsWithin(
+  root: HTMLElement,
+  { ignore }: TabStopsOptions = {}
+): HTMLElement[] {
   const found = Array.from(
     root.querySelectorAll<HTMLElement>(TAB_STOP_SELECTOR)
   );
   const all = root.matches(TAB_STOP_SELECTOR) ? [root, ...found] : found;
-  return all.filter(isTabbable);
+
+  return all
+    .filter(
+      (element) =>
+        !isIgnored(element, ignore) &&
+        isTabbable(element) &&
+        (!isRadio(element) ||
+          radioGroupRepresentative(element, ignore) === element)
+    )
+    .map((element, documentIndex) => ({ element, documentIndex }))
+    .sort(compareTabOrder)
+    .map(({ element }) => element);
+}
+
+function isBefore(left: HTMLElement, right: HTMLElement) {
+  const position = left.compareDocumentPosition(right);
+  return (
+    position === Node.DOCUMENT_POSITION_FOLLOWING ||
+    position ===
+      Node.DOCUMENT_POSITION_FOLLOWING + Node.DOCUMENT_POSITION_CONTAINED_BY
+  );
 }
 
 /**
- * The document tab stop just before or just after `anchor`, ignoring anything inside `ignore`.
+ * The local tab stop just before or after `anchor`.
  *
- * `ignore` is the portaled panel: it sits somewhere else in document order, so counting its
- * controls would answer with a stop the reader is leaving rather than the one they are going to.
- *
- * Returns `null` when `anchor` is the last (or first) stop on the page, where there is nothing to
- * move to and the caller should leave focus alone.
+ * By default the search covers the page. `root` narrows it to a panel, and `ignore` excludes a
+ * portaled panel while finding the page stop beside its trigger. When programmatic focus rests on
+ * a non-candidate, DOM position determines the next candidate in the requested direction.
  */
 export function adjacentTabStop(
   anchor: HTMLElement,
-  { forward, ignore }: { forward: boolean; ignore?: HTMLElement | null }
+  {
+    forward,
+    ignore,
+    root = document.body,
+  }: {
+    forward: boolean;
+    ignore?: HTMLElement | null;
+    root?: HTMLElement;
+  }
 ): HTMLElement | null {
-  const stops = tabStopsWithin(document.body).filter(
-    (element) => element === anchor || !ignore || !ignore.contains(element)
-  );
-
+  let stops = tabStopsWithin(root, { ignore });
   const index = stops.indexOf(anchor);
-  if (index === -1) {
-    return null;
+
+  if (index !== -1) {
+    return stops[forward ? index + 1 : index - 1] ?? null;
   }
 
-  return stops[forward ? index + 1 : index - 1] ?? null;
+  if (isRadio(anchor)) {
+    const representative = radioGroupRepresentative(anchor, ignore);
+    // Script can focus another member of an unchecked group, but Tab leaves the group from there
+    // instead of visiting the representative that sequential entry would use.
+    if (representative && !representative.checked) {
+      stops = stops.filter((stop) => stop !== representative);
+    }
+  }
+
+  const candidates = stops.filter((stop) =>
+    forward ? isBefore(anchor, stop) : isBefore(stop, anchor)
+  );
+
+  return (forward ? candidates[0] : candidates.at(-1)) ?? null;
 }

--- a/frontend/discourse/float-kit/lib/tab-order.ts
+++ b/frontend/discourse/float-kit/lib/tab-order.ts
@@ -32,12 +32,34 @@ interface TabStopsOptions {
   ignore?: HTMLElement | null;
 }
 
+/**
+ * The state shared by one enumeration.
+ *
+ * Both caches exist because the same DOM reads repeat heavily within a single scan, and both are
+ * expensive in the way that matters: the tabbability test forces layout, and resolving a radio
+ * group queries its whole tree. Without them, a page-wide scan re-queries the tree and re-probes
+ * the layout of every radio once for each radio it is asked about. A scan is created per public
+ * call and thrown away with it, so no answer can outlive the layout it was measured against.
+ */
+interface TabStopScan {
+  /** An element whose subtree is excluded from the enumeration, if any. */
+  ignore?: HTMLElement | null;
+
+  tabbable: Map<HTMLElement, boolean>;
+
+  /** Every radio in a tree, so a group is resolved from memory after the first lookup. */
+  radios: Map<Node, HTMLInputElement[]>;
+}
+
+function createScan(ignore?: HTMLElement | null): TabStopScan {
+  return { ignore, tabbable: new Map(), radios: new Map() };
+}
+
 function isIgnored(element: HTMLElement, ignore?: HTMLElement | null) {
   return Boolean(ignore && (element === ignore || ignore.contains(element)));
 }
 
-/** Whether `element` can actually be reached by sequential focus right now. */
-function isTabbable(element: HTMLElement): boolean {
+function computeTabbable(element: HTMLElement): boolean {
   if (element.tabIndex < 0 || element.matches(":disabled")) {
     return false;
   }
@@ -57,9 +79,37 @@ function isTabbable(element: HTMLElement): boolean {
   );
 }
 
+/** Whether `element` can actually be reached by sequential focus right now. */
+function isTabbable(element: HTMLElement, scan: TabStopScan): boolean {
+  const cached = scan.tabbable.get(element);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const tabbable = computeTabbable(element);
+  scan.tabbable.set(element, tabbable);
+  return tabbable;
+}
+
+function radiosWithin(
+  tree: Document | ShadowRoot,
+  scan: TabStopScan
+): HTMLInputElement[] {
+  const cached = scan.radios.get(tree);
+  if (cached) {
+    return cached;
+  }
+
+  const radios = Array.from(
+    tree.querySelectorAll<HTMLInputElement>("input[type='radio']")
+  );
+  scan.radios.set(tree, radios);
+  return radios;
+}
+
 function radioGroupRepresentative(
   radio: HTMLInputElement,
-  ignore?: HTMLElement | null
+  scan: TabStopScan
 ): HTMLInputElement | null {
   if (!radio.name) {
     return radio;
@@ -70,14 +120,12 @@ function radioGroupRepresentative(
     return radio;
   }
 
-  const members = Array.from(
-    tree.querySelectorAll<HTMLInputElement>("input[type='radio']")
-  ).filter(
+  const members = radiosWithin(tree, scan).filter(
     (member) =>
       member.name === radio.name &&
       member.form === radio.form &&
-      !isIgnored(member, ignore) &&
-      isTabbable(member)
+      !isIgnored(member, scan.ignore) &&
+      isTabbable(member, scan)
   );
 
   return members.find((member) => member.checked) ?? members[0] ?? null;
@@ -115,6 +163,10 @@ export function tabStopsWithin(
   root: HTMLElement,
   { ignore }: TabStopsOptions = {}
 ): HTMLElement[] {
+  return collectTabStops(root, createScan(ignore));
+}
+
+function collectTabStops(root: HTMLElement, scan: TabStopScan): HTMLElement[] {
   const found = Array.from(
     root.querySelectorAll<HTMLElement>(TAB_STOP_SELECTOR)
   );
@@ -123,10 +175,10 @@ export function tabStopsWithin(
   return all
     .filter(
       (element) =>
-        !isIgnored(element, ignore) &&
-        isTabbable(element) &&
+        !isIgnored(element, scan.ignore) &&
+        isTabbable(element, scan) &&
         (!isRadio(element) ||
-          radioGroupRepresentative(element, ignore) === element)
+          radioGroupRepresentative(element, scan) === element)
     )
     .map((element, documentIndex) => ({ element, documentIndex }))
     .sort(compareTabOrder)
@@ -161,7 +213,10 @@ export function adjacentTabStop(
     root?: HTMLElement;
   }
 ): HTMLElement | null {
-  let stops = tabStopsWithin(root, { ignore });
+  // One scan for the whole query, so resolving the anchor's own group below reuses what
+  // enumerating the stops already measured instead of walking the tree a second time.
+  const scan = createScan(ignore);
+  let stops = collectTabStops(root, scan);
   const index = stops.indexOf(anchor);
 
   if (index !== -1) {
@@ -169,7 +224,7 @@ export function adjacentTabStop(
   }
 
   if (isRadio(anchor)) {
-    const representative = radioGroupRepresentative(anchor, ignore);
+    const representative = radioGroupRepresentative(anchor, scan);
     // Script can focus another member of an unchecked group, but Tab leaves the group from there
     // instead of visiting the representative that sequential entry would use.
     if (representative && !representative.checked) {

--- a/frontend/discourse/float-kit/lib/tab-order.ts
+++ b/frontend/discourse/float-kit/lib/tab-order.ts
@@ -1,0 +1,91 @@
+/**
+ * Tab-order queries for a panel that has been portaled away from its trigger.
+ *
+ * Sequential focus follows document order, so moving a panel out of its trigger's subtree moves
+ * where Tab goes when focus leaves it: to whatever follows the portal, rather than to whatever
+ * follows the control the reader is actually using. These helpers name the stop the reader
+ * expected so a component can put focus there itself.
+ *
+ * The enumeration is only as truthful as the DOM allows. A browser with keyboard-focusable
+ * scrollers adopts a scroll container as a tab stop without marking it — such an element reports
+ * `tabIndex === -1` and matches no focusable selector — so it is counted by the browser and not
+ * by anything here. A surface relying on these helpers has to suppress those adoptions itself
+ * (an explicit `tabindex="-1"`) or its idea of "the last stop in the panel" will be wrong.
+ */
+
+/**
+ * Elements that take sequential focus. Deliberately without a bare `[tabindex]`: only a
+ * non-negative value is in the tab order, and `-1` is the marker for the opposite.
+ */
+const TAB_STOP_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "summary",
+  "iframe",
+  "audio[controls]",
+  "video[controls]",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[tabindex]:not([tabindex^='-'])",
+].join(", ");
+
+/**
+ * Whether `element` can actually be tabbed to right now: rendered, not hidden from the platform,
+ * and not opted out. A selector alone is not enough, since a display-less or `inert` subtree
+ * still matches one.
+ */
+function isTabbable(element: HTMLElement): boolean {
+  if (element.hasAttribute("disabled") || element.tabIndex < 0) {
+    return false;
+  }
+  if (element.closest("[inert]") || element.closest("[aria-hidden='true']")) {
+    return false;
+  }
+  // Cheapest sufficient rendered-ness test: all three are zero only for a box that is not laid
+  // out at all, which is what `display: none` (on the element or any ancestor) produces.
+  return !!(
+    element.offsetWidth ||
+    element.offsetHeight ||
+    element.getClientRects().length
+  );
+}
+
+/**
+ * The tab stops inside `root`, in document order. `root` itself is included when it is one, so a
+ * container that has been made focusable counts as its own first stop.
+ */
+export function tabStopsWithin(root: HTMLElement): HTMLElement[] {
+  const found = Array.from(
+    root.querySelectorAll<HTMLElement>(TAB_STOP_SELECTOR)
+  );
+  const all = root.matches(TAB_STOP_SELECTOR) ? [root, ...found] : found;
+  return all.filter(isTabbable);
+}
+
+/**
+ * The document tab stop just before or just after `anchor`, ignoring anything inside `ignore`.
+ *
+ * `ignore` is the portaled panel: it sits somewhere else in document order, so counting its
+ * controls would answer with a stop the reader is leaving rather than the one they are going to.
+ *
+ * Returns `null` when `anchor` is the last (or first) stop on the page, where there is nothing to
+ * move to and the caller should leave focus alone.
+ */
+export function adjacentTabStop(
+  anchor: HTMLElement,
+  { forward, ignore }: { forward: boolean; ignore?: HTMLElement | null }
+): HTMLElement | null {
+  const stops = tabStopsWithin(document.body).filter(
+    (element) => element === anchor || !ignore || !ignore.contains(element)
+  );
+
+  const index = stops.indexOf(anchor);
+  if (index === -1) {
+    return null;
+  }
+
+  return stops[forward ? index + 1 : index - 1] ?? null;
+}

--- a/frontend/discourse/float-kit/lib/tab-order.ts
+++ b/frontend/discourse/float-kit/lib/tab-order.ts
@@ -33,21 +33,14 @@ interface TabStopsOptions {
 }
 
 /**
- * The state shared by one enumeration.
- *
- * Both caches exist because the same DOM reads repeat heavily within a single scan, and both are
- * expensive in the way that matters: the tabbability test forces layout, and resolving a radio
- * group queries its whole tree. Without them, a page-wide scan re-queries the tree and re-probes
- * the layout of every radio once for each radio it is asked about. A scan is created per public
- * call and thrown away with it, so no answer can outlive the layout it was measured against.
+ * The state shared by one enumeration. The caches matter because the tabbability test forces
+ * layout and resolving a radio group queries its whole tree, both repeatedly within one scan.
+ * A scan is created per public call and thrown away with it, so no answer can outlive the DOM
+ * it was measured against.
  */
 interface TabStopScan {
-  /** An element whose subtree is excluded from the enumeration, if any. */
   ignore?: HTMLElement | null;
-
   tabbable: Map<HTMLElement, boolean>;
-
-  /** Every radio in a tree, so a group is resolved from memory after the first lookup. */
   radios: Map<Node, HTMLInputElement[]>;
 }
 

--- a/frontend/discourse/float-kit/modifiers/tab-order-inline.ts
+++ b/frontend/discourse/float-kit/modifiers/tab-order-inline.ts
@@ -37,7 +37,9 @@ interface FloatKitTabOrderInlineSignature {
  *   and continues from the TRIGGER. Forward that is the stop after the trigger; backward it is
  *   the trigger's own last stop, which is where the reader came in.
  *
- * Presses that merely move between the float's own controls are left to the browser.
+ * The float is treated as one logical segment beside the trigger. Every Tab within the segment is
+ * handled from a freshly computed local sequence, so dynamic controls, radio groups, and positive
+ * tabindex values cannot make the browser and the edge check disagree.
  *
  * This is the alternative to `trapTab`, not a companion to it. Containment suits a float that is
  * genuinely modal — a real `aria-modal` dialog, which owns the screen until dismissed — and
@@ -52,6 +54,7 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
   #boundTrigger: HTMLElement | null = null;
   #close?: () => void;
   #content?: HTMLElement;
+  #departing = false;
   #trigger?: HTMLElement | null;
 
   constructor(owner: Owner, args: ArgsFor<FloatKitTabOrderInlineSignature>) {
@@ -75,11 +78,9 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     // entering it is meaningful. Rebound rather than assumed stable, since `modify` re-runs
     // whenever the trigger argument changes.
     //
-    // CAPTURE phase, because a control inside the trigger may stop Tab from bubbling: a combobox
-    // input does exactly that, to keep Tab from being pulled into a panel holding nothing but a
-    // list. Capture is the only phase certain to see the press. That guard is preserved rather
-    // than defeated — this handler declines a float with no stop of its own, so the press
-    // continues to the trigger's own handling untouched.
+    // CAPTURE phase, because a control inside the trigger may stop Tab from bubbling. When the
+    // panel has a stop, inline ordering is authoritative and intentionally precedes consumer
+    // bubbling handlers. With no panel stop, the event continues untouched.
     this.#boundTrigger?.removeEventListener(
       "keydown",
       this.handleTriggerKeydown,
@@ -100,7 +101,8 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
       event.key !== "Tab" ||
       event.shiftKey ||
       event.isComposing ||
-      event.defaultPrevented
+      event.defaultPrevented ||
+      this.#departing
     ) {
       return;
     }
@@ -115,7 +117,7 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     // element in the page, which is what a native Shift+Tab reaches.
     const triggerStops = tabStopsWithin(trigger);
     const lastTriggerStop = triggerStops.at(-1);
-    if (lastTriggerStop && document.activeElement !== lastTriggerStop) {
+    if (!lastTriggerStop || document.activeElement !== lastTriggerStop) {
       return;
     }
 
@@ -128,10 +130,15 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     contentStops[0].focus();
   }
 
-  /** A Tab that would step off the end of the float's own stops leaves it, from the trigger. */
+  /** Moves within the float's logical segment, or leaves it from the trigger's page position. */
   @bind
   handleContentKeydown(event: KeyboardEvent) {
-    if (event.key !== "Tab" || event.isComposing || event.defaultPrevented) {
+    if (
+      event.key !== "Tab" ||
+      event.isComposing ||
+      event.defaultPrevented ||
+      this.#departing
+    ) {
       return;
     }
 
@@ -142,29 +149,28 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     }
 
     const forward = !event.shiftKey;
-    const stops = tabStopsWithin(content);
-    const edge = forward ? stops.at(-1) : stops[0];
     const active = document.activeElement;
-
-    // Still moving between the float's own controls: the browser already does the right thing.
-    // Focus resting on something that is not a stop at all counts as the edge, since a native
-    // Tab has nothing further to reach from there either.
-    if (
-      active !== edge &&
-      active instanceof HTMLElement &&
-      stops.includes(active)
-    ) {
+    if (!(active instanceof HTMLElement)) {
       return;
     }
 
-    // Backward lands on the trigger's LAST stop rather than the trigger element itself: on a
-    // trigger that is not focusable in its own right (a typeahead, whose stop is the input it
-    // wraps) focusing the wrapper would drop focus entirely.
-    const target = forward
-      ? adjacentTabStop(trigger, { forward: true, ignore: content })
-      : (tabStopsWithin(trigger).at(-1) ?? trigger);
+    const internalTarget = adjacentTabStop(active, { forward, root: content });
+    if (internalTarget) {
+      event.preventDefault();
+      internalTarget.focus();
+      return;
+    }
 
-    event.preventDefault();
+    const triggerAnchor = tabStopsWithin(trigger).at(-1);
+    const target = forward
+      ? triggerAnchor &&
+        adjacentTabStop(triggerAnchor, { forward: true, ignore: content })
+      : triggerAnchor;
+
+    this.#departing = true;
+    if (target) {
+      event.preventDefault();
+    }
 
     // Focus BEFORE dismissing. Dismissal unmounts the content and would drop focus to `<body>`,
     // and it may settle asynchronously, so moving focus afterwards races the teardown instead of

--- a/frontend/discourse/float-kit/modifiers/tab-order-inline.ts
+++ b/frontend/discourse/float-kit/modifiers/tab-order-inline.ts
@@ -1,0 +1,184 @@
+import { registerDestructor } from "@ember/destroyable";
+import type Owner from "@ember/owner";
+import Modifier, { type ArgsFor } from "ember-modifier";
+import {
+  adjacentTabStop,
+  tabStopsWithin,
+} from "discourse/float-kit/lib/tab-order";
+import { bind } from "discourse/lib/decorators";
+
+interface FloatKitTabOrderInlineSignature {
+  Element: HTMLElement;
+  Args: {
+    Positional: [
+      /** The trigger the float hangs from, whose place in the page Tab should follow. */
+      trigger: HTMLElement | null | undefined,
+      /** Dismisses the float once focus has left it. */
+      close: () => void,
+    ];
+  };
+}
+
+/**
+ * Gives a float's content the tab order it would have had if it were rendered inline, directly
+ * after its trigger.
+ *
+ * A float is portaled out of its trigger's subtree, and sequential focus follows document order,
+ * so the portal's position in the document — not the trigger's — is what Tab actually follows.
+ * That breaks the sequence in both directions: Tab off the end of the float's controls lands
+ * wherever the portal sits, and the float's own controls are never reached at all, since nothing
+ * leads into them from the trigger. Both halves are repaired here:
+ *
+ * - **Into** the float: a forward Tab at the trigger's last stop moves to the float's first stop,
+ *   when it has one. A float offering nothing focusable is left alone, so Tab passes over it and
+ *   out of the widget — which is what a plain listbox wants, since its rows are reached with the
+ *   arrow keys rather than by tabbing.
+ * - **Out of** the float: a Tab that would step off the end of the float's own stops dismisses it
+ *   and continues from the TRIGGER. Forward that is the stop after the trigger; backward it is
+ *   the trigger's own last stop, which is where the reader came in.
+ *
+ * Presses that merely move between the float's own controls are left to the browser.
+ *
+ * This is the alternative to `trapTab`, not a companion to it. Containment suits a float that is
+ * genuinely modal — a real `aria-modal` dialog, which owns the screen until dismissed — and
+ * strands a reader anywhere else, since a non-modal float shows nothing to say that Tab has
+ * stopped meaning "move on".
+ *
+ * A float that also holds a scroll container should keep it out of the tab sequence with an
+ * explicit `tabindex="-1"`: a browser that adopts scrollers as tab stops does so invisibly, so
+ * such an element consumes a Tab press while being absent from the enumerations below.
+ */
+export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInlineSignature> {
+  #boundTrigger: HTMLElement | null = null;
+  #close?: () => void;
+  #content?: HTMLElement;
+  #trigger?: HTMLElement | null;
+
+  constructor(owner: Owner, args: ArgsFor<FloatKitTabOrderInlineSignature>) {
+    super(owner, args);
+    registerDestructor(this, (instance) => instance.cleanup());
+  }
+
+  modify(
+    element: HTMLElement,
+    [trigger, close]: FloatKitTabOrderInlineSignature["Args"]["Positional"]
+  ) {
+    this.#content = element;
+    this.#trigger = trigger;
+    this.#close = close;
+
+    element.removeEventListener("keydown", this.handleContentKeydown);
+    element.addEventListener("keydown", this.handleContentKeydown);
+
+    // The trigger listener lives exactly as long as this modifier, which lives as long as the
+    // float's content — so it is bound only while the float is open, which is the only time
+    // entering it is meaningful. Rebound rather than assumed stable, since `modify` re-runs
+    // whenever the trigger argument changes.
+    //
+    // CAPTURE phase, because a control inside the trigger may stop Tab from bubbling: a combobox
+    // input does exactly that, to keep Tab from being pulled into a panel holding nothing but a
+    // list. Capture is the only phase certain to see the press. That guard is preserved rather
+    // than defeated — this handler declines a float with no stop of its own, so the press
+    // continues to the trigger's own handling untouched.
+    this.#boundTrigger?.removeEventListener(
+      "keydown",
+      this.handleTriggerKeydown,
+      true
+    );
+    this.#boundTrigger = trigger ?? null;
+    this.#boundTrigger?.addEventListener(
+      "keydown",
+      this.handleTriggerKeydown,
+      true
+    );
+  }
+
+  /** Forward Tab at the trigger's last stop enters the float, when the float has a stop to offer. */
+  @bind
+  handleTriggerKeydown(event: KeyboardEvent) {
+    if (
+      event.key !== "Tab" ||
+      event.shiftKey ||
+      event.isComposing ||
+      event.defaultPrevented
+    ) {
+      return;
+    }
+
+    const content = this.#content;
+    const trigger = this.#trigger;
+    if (!content || !trigger) {
+      return;
+    }
+
+    // Backward is deliberately not handled: the stop before the trigger is already the previous
+    // element in the page, which is what a native Shift+Tab reaches.
+    const triggerStops = tabStopsWithin(trigger);
+    const lastTriggerStop = triggerStops.at(-1);
+    if (lastTriggerStop && document.activeElement !== lastTriggerStop) {
+      return;
+    }
+
+    const contentStops = tabStopsWithin(content);
+    if (!contentStops.length) {
+      return;
+    }
+
+    event.preventDefault();
+    contentStops[0].focus();
+  }
+
+  /** A Tab that would step off the end of the float's own stops leaves it, from the trigger. */
+  @bind
+  handleContentKeydown(event: KeyboardEvent) {
+    if (event.key !== "Tab" || event.isComposing || event.defaultPrevented) {
+      return;
+    }
+
+    const content = this.#content;
+    const trigger = this.#trigger;
+    if (!content || !trigger) {
+      return;
+    }
+
+    const forward = !event.shiftKey;
+    const stops = tabStopsWithin(content);
+    const edge = forward ? stops.at(-1) : stops[0];
+    const active = document.activeElement;
+
+    // Still moving between the float's own controls: the browser already does the right thing.
+    // Focus resting on something that is not a stop at all counts as the edge, since a native
+    // Tab has nothing further to reach from there either.
+    if (
+      active !== edge &&
+      active instanceof HTMLElement &&
+      stops.includes(active)
+    ) {
+      return;
+    }
+
+    // Backward lands on the trigger's LAST stop rather than the trigger element itself: on a
+    // trigger that is not focusable in its own right (a typeahead, whose stop is the input it
+    // wraps) focusing the wrapper would drop focus entirely.
+    const target = forward
+      ? adjacentTabStop(trigger, { forward: true, ignore: content })
+      : (tabStopsWithin(trigger).at(-1) ?? trigger);
+
+    event.preventDefault();
+
+    // Focus BEFORE dismissing. Dismissal unmounts the content and would drop focus to `<body>`,
+    // and it may settle asynchronously, so moving focus afterwards races the teardown instead of
+    // replacing it.
+    target?.focus();
+    this.#close?.();
+  }
+
+  cleanup() {
+    this.#content?.removeEventListener("keydown", this.handleContentKeydown);
+    this.#boundTrigger?.removeEventListener(
+      "keydown",
+      this.handleTriggerKeydown,
+      true
+    );
+  }
+}

--- a/frontend/discourse/float-kit/modifiers/tab-order-inline.ts
+++ b/frontend/discourse/float-kit/modifiers/tab-order-inline.ts
@@ -51,15 +51,14 @@ interface FloatKitTabOrderInlineSignature {
  * such an element consumes a Tab press while being absent from the enumerations below.
  */
 export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInlineSignature> {
-  #boundTrigger: HTMLElement | null = null;
   #close?: () => void;
   #content?: HTMLElement;
   #departing = false;
-  #trigger?: HTMLElement | null;
+  #trigger: HTMLElement | null = null;
 
   constructor(owner: Owner, args: ArgsFor<FloatKitTabOrderInlineSignature>) {
     super(owner, args);
-    registerDestructor(this, (instance) => instance.cleanup());
+    registerDestructor(this, () => this.#cleanup());
   }
 
   modify(
@@ -67,7 +66,6 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     [trigger, close]: FloatKitTabOrderInlineSignature["Args"]["Positional"]
   ) {
     this.#content = element;
-    this.#trigger = trigger;
     this.#close = close;
 
     element.removeEventListener("keydown", this.handleContentKeydown);
@@ -81,17 +79,13 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     // CAPTURE phase, because a control inside the trigger may stop Tab from bubbling. When the
     // panel has a stop, inline ordering is authoritative and intentionally precedes consumer
     // bubbling handlers. With no panel stop, the event continues untouched.
-    this.#boundTrigger?.removeEventListener(
+    this.#trigger?.removeEventListener(
       "keydown",
       this.handleTriggerKeydown,
       true
     );
-    this.#boundTrigger = trigger ?? null;
-    this.#boundTrigger?.addEventListener(
-      "keydown",
-      this.handleTriggerKeydown,
-      true
-    );
+    this.#trigger = trigger ?? null;
+    this.#trigger?.addEventListener("keydown", this.handleTriggerKeydown, true);
   }
 
   /** Forward Tab at the trigger's last stop enters the float, when the float has a stop to offer. */
@@ -179,9 +173,9 @@ export default class FloatKitTabOrderInline extends Modifier<FloatKitTabOrderInl
     this.#close?.();
   }
 
-  cleanup() {
+  #cleanup() {
     this.#content?.removeEventListener("keydown", this.handleContentKeydown);
-    this.#boundTrigger?.removeEventListener(
+    this.#trigger?.removeEventListener(
       "keydown",
       this.handleTriggerKeydown,
       true

--- a/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
@@ -622,11 +622,19 @@ module(
     test("each call re-measures instead of answering from an earlier one", async function (assert) {
       await render(
         <template>
+          {{! Names unique to this test: group membership is resolved by querying the whole
+              document, so a name shared with another fixture would make the two depend on
+              teardown order. }}
           <div id="root">
-            <button id="control">control</button>
-            <input id="first-radio" type="radio" name="group" />
+            <button id="rescan-control">control</button>
+            <input id="rescan-first-radio" type="radio" name="rescan-group" />
             {{#if this.showLateRadio}}
-              <input id="late-radio" type="radio" name="group" checked />
+              <input
+                id="rescan-late-radio"
+                type="radio"
+                name="rescan-group"
+                checked
+              />
             {{/if}}
           </div>
         </template>
@@ -636,20 +644,20 @@ module(
 
       assert.deepEqual(
         tabStopsWithin(root).map((element) => element.id),
-        ["control", "first-radio"],
+        ["rescan-control", "rescan-first-radio"],
         "the unchecked group starts out represented by its first member"
       );
 
       // Both answers above are measured, not derived: tabbability comes from live layout and
       // state, and a group's representative from the radios present at the time. Reusing either
       // measurement past the call that took it would report the DOM as it used to be.
-      find("#control").tabIndex = -1;
+      find("#rescan-control").tabIndex = -1;
       this.set("showLateRadio", true);
       await settled();
 
       assert.deepEqual(
         tabStopsWithin(root).map((element) => element.id),
-        ["late-radio"],
+        ["rescan-late-radio"],
         "the opted-out control is gone and the newly checked radio represents the group"
       );
     });

--- a/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
@@ -19,14 +19,18 @@ import dElement from "discourse/ui-kit/helpers/d-element";
 /**
  * `inlineTabOrder` only means anything when the content is portaled away from its trigger, and
  * float-kit renders floats IN PLACE under tests (`DFloatPortal`, `@inline ?? isTesting()`). So
- * every case here forces the portal on with `@inline={{false}}` and points it at an outlet that
- * sits LAST in the document — reproducing the real arrangement, where the portal's position is
- * not the trigger's, and where native Tab out of the panel would therefore land in the wrong
- * place.
+ * every case here forces the portal on with `@inline={{false}}` and points it at an outlet placed
+ * away from the trigger, reproducing the real arrangement, where the portal's position is not the
+ * trigger's, and where native Tab out of the panel would therefore land in the wrong place.
+ *
+ * The outlet usually sits LAST in the document, so DOM order is trigger → neighbour → portal. One
+ * case moves it BETWEEN the two instead, which is the only arrangement where the panel is itself
+ * the next stop after the trigger, and so the only one that can pin that the search for that stop
+ * excludes the panel.
  *
  * Each menu waits on `{{#if this.outlet}}`: the outlet element only exists after its own insert
  * hook runs, and `{{#in-element}}` rejects a nullish destination. The menu still renders in its
- * template position, so DOM order stays trigger → neighbour → portal.
+ * template position.
  *
  * The `tab()` helper dispatches a cancelable, bubbling `keydown` and moves focus only when the
  * default is not prevented, so the modifier's handling is exercised rather than bypassed.
@@ -56,7 +60,6 @@ module(
           {{#if this.outlet}}
             <DMenu
               @inline={{false}}
-              @trapTab={{false}}
               @inlineTabOrder={{true}}
               @label="trigger"
               @portalOutletElement={{this.outlet}}
@@ -102,13 +105,136 @@ module(
         .doesNotExist("leaving the panel also dismisses it");
     });
 
+    test("the option alone is enough, without turning containment off by hand", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <button type="button" id="in-panel">panel action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button type="button" id="after-trigger">after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+
+      // A menu traps Tab by default, so the option has to be enough on its own: requiring the
+      // trap to be switched off too would make every call site carry a second flag.
+      await tab();
+      assert
+        .dom("#in-panel")
+        .isFocused(
+          "Tab enters the panel without the trap being switched off too"
+        );
+
+      await tab();
+      assert
+        .dom("#after-trigger")
+        .isFocused("and leaving it still resumes beside the trigger");
+    });
+
+    test("Tab visits every panel control before the float is left", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <input id="panel-filter" aria-label="filter" />
+                <button type="button" id="panel-action">panel action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button type="button" id="after-trigger">after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+
+      await tab();
+      assert
+        .dom("#panel-filter")
+        .isFocused("Tab enters at the panel's first stop");
+
+      // Movement WITHIN the panel: the modifier drives it from its own local sequence rather than
+      // leaving it to the browser, so a second control must be reached before the float is left.
+      await tab();
+      assert
+        .dom("#panel-action")
+        .isFocused("Tab reaches the panel's next control instead of leaving");
+
+      await tab({ backwards: true });
+      assert
+        .dom("#panel-filter")
+        .isFocused("Shift+Tab moves back within the panel");
+
+      await tab();
+      await tab();
+      assert
+        .dom("#after-trigger")
+        .isFocused("only the stop past the LAST control leaves the panel");
+      assert
+        .dom("#panel-action")
+        .doesNotExist("and leaving it dismisses the float");
+    });
+
+    test("the forward exit steps over the panel to reach the trigger's neighbour", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <button type="button" id="in-panel">panel action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          {{! The outlet sits BETWEEN the trigger and its neighbour, so the panel's own control is
+              the next stop in document order. Searching the page for the stop after the trigger
+              has to exclude the panel, or the forward exit lands back inside the float it is
+              dismissing. }}
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+          <button type="button" id="after-trigger">after</button>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+      await tab();
+      assert.dom("#in-panel").isFocused();
+
+      await tab();
+      assert
+        .dom("#after-trigger")
+        .isFocused(
+          "the panel is not a candidate for the stop after the trigger"
+        );
+      assert.dom("#in-panel").doesNotExist("the float is dismissed on the way");
+    });
+
     test("a non-focusable trigger wrapper resumes from its last stop", async function (assert) {
       await render(
         <template>
           {{#if this.outlet}}
             <DMenu
               @inline={{false}}
-              @trapTab={{false}}
               @inlineTabOrder={{true}}
               @triggerComponent={{dElement "div"}}
               @portalOutletElement={{this.outlet}}
@@ -145,7 +271,6 @@ module(
           {{#if this.outlet}}
             <DMenu
               @inline={{false}}
-              @trapTab={{false}}
               @inlineTabOrder={{true}}
               @triggerComponent={{dElement "div"}}
               @portalOutletElement={{this.outlet}}
@@ -197,7 +322,6 @@ module(
           {{#if this.outlet}}
             <DMenu
               @inline={{false}}
-              @trapTab={{false}}
               @inlineTabOrder={{true}}
               @label="trigger"
               @portalOutletElement={{this.outlet}}
@@ -230,7 +354,6 @@ module(
           {{#if this.outlet}}
             <DMenu
               @inline={{false}}
-              @trapTab={{false}}
               @inlineTabOrder={{true}}
               @label="trigger"
               @portalOutletElement={{this.outlet}}
@@ -457,6 +580,39 @@ module(
           "regular-last",
         ],
         "positive values are ascending and ties retain document order"
+      );
+    });
+
+    test("tab stops drop an ignored subtree and the stops inside it", async function (assert) {
+      await render(
+        <template>
+          <div id="root">
+            <button id="before-panel">before</button>
+            <div id="panel">
+              <input id="panel-filter" aria-label="filter" />
+              <button id="panel-action">panel action</button>
+            </div>
+            <button id="after-panel">after</button>
+          </div>
+        </template>
+      );
+
+      const root = find("#root");
+      const panel = find("#panel");
+
+      assert.deepEqual(
+        tabStopsWithin(root, { ignore: panel }).map((element) => element.id),
+        ["before-panel", "after-panel"],
+        "the ignored element and its descendants are both excluded"
+      );
+      assert.strictEqual(
+        adjacentTabStop(find("#before-panel"), {
+          forward: true,
+          ignore: panel,
+          root,
+        })?.id,
+        "after-panel",
+        "the stop after an anchor skips the ignored subtree entirely"
       );
     });
 

--- a/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
@@ -1,0 +1,247 @@
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { click, render, setupOnerror, tab } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DMenu from "discourse/float-kit/components/d-menu";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+/**
+ * `inlineTabOrder` only means anything when the content is portaled away from its trigger, and
+ * float-kit renders floats IN PLACE under tests (`DFloatPortal`, `@inline ?? isTesting()`). So
+ * every case here forces the portal on with `@inline={{false}}` and points it at an outlet that
+ * sits LAST in the document — reproducing the real arrangement, where the portal's position is
+ * not the trigger's, and where native Tab out of the panel would therefore land in the wrong
+ * place.
+ *
+ * Each menu waits on `{{#if this.outlet}}`: the outlet element only exists after its own insert
+ * hook runs, and `{{#in-element}}` rejects a nullish destination. The menu still renders in its
+ * template position, so DOM order stays trigger → neighbour → portal.
+ *
+ * The `tab()` helper dispatches a cancelable, bubbling `keydown` and moves focus only when the
+ * default is not prevented, so the modifier's handling is exercised rather than bypassed.
+ *
+ * What it CANNOT exercise is a browser adopting a scroll container as a tab stop: `tab()` picks
+ * candidates by `tabIndex >= 0`, and an adopted scroller reports `-1` exactly like one that opted
+ * out. That case is only observable in a real browser, and is covered by a system spec.
+ */
+module(
+  "Integration | Modifier | FloatKit | tab-order-inline",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    // Identity by id, so a failure names the element that actually holds focus.
+    const activeId = () =>
+      document.activeElement?.id ||
+      document.activeElement?.className ||
+      "<none>";
+
+    hooks.beforeEach(function () {
+      this.setOutlet = (element) => this.set("outlet", element);
+    });
+
+    test("Tab enters the float's own controls, then leaves for the trigger's neighbour", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{false}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <button type="button" id="in-panel" class="in-panel">panel
+                  action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button
+            type="button"
+            id="after-trigger"
+            class="after-trigger"
+          >after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+      assert
+        .dom("#outlet .in-panel")
+        .exists("the panel really is portaled out");
+
+      // Into the panel. Native order would send this to `.after-trigger`, since the outlet sits
+      // beyond it in the document.
+      await tab();
+      assert.strictEqual(
+        activeId(),
+        "in-panel",
+        "Tab from the trigger enters the panel's control"
+      );
+
+      // Off the end of the panel's controls: back to the field's place in the page.
+      await tab();
+      assert.strictEqual(
+        activeId(),
+        "after-trigger",
+        "Tab off the last panel control resumes after the TRIGGER, not after the portal"
+      );
+    });
+
+    test("Shift+Tab out of the float returns to the trigger", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{false}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <button type="button" id="in-panel" class="in-panel">panel
+                  action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+      await tab();
+      assert.strictEqual(activeId(), "in-panel");
+
+      await tab({ backwards: true });
+      assert
+        .dom(".fk-d-menu__trigger")
+        .isFocused(
+          "backwards off the first panel control is the trigger, where the reader came in"
+        );
+    });
+
+    test("a float with nothing focusable is passed over", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{false}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <p class="in-panel">nothing to focus here</p>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button
+            type="button"
+            id="after-trigger"
+            class="after-trigger"
+          >after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+      assert.dom("#outlet .in-panel").exists();
+
+      // The fall-through path, and the reason this is safe to leave on by default: a panel that
+      // is only a list must never pull focus in, since its rows are reached with the arrow keys.
+      //
+      // Asserted as "focus did not enter the float" rather than "focus reached the neighbour",
+      // because where the press ends up is not this modifier's to decide once it declines. A bare
+      // DMenu still has its older `forwardTabToContent`, which swallows the press on a body with
+      // nothing focusable in it (`firstFocusable` is null and `#body.focus()` is a no-op), leaving
+      // focus on the trigger. DSelect stops that from reaching the trigger; this test does not,
+      // and should not pin behaviour it does not own.
+      await tab();
+      assert.false(
+        document.querySelector("#outlet").contains(document.activeElement),
+        "focus never enters a float that offers no stop of its own"
+      );
+    });
+
+    test("asserts when containment is asked for as well", async function (assert) {
+      let fired = false;
+      setupOnerror((error) => {
+        fired = true;
+        assert.true(
+          error.message.includes("alternatives"),
+          "the assertion says the two options are alternatives"
+        );
+      });
+
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{true}}
+              @inlineTabOrder={{true}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <button type="button" id="in-panel">panel action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+
+      // Also pins that the template reads the GETTER rather than the argument: routed around it,
+      // the conflict would go back to being silent, with the trap quietly winning.
+      assert.true(fired, "the conflicting configuration asserts");
+    });
+
+    test("without the option, Tab out of the float does not come back to the trigger", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{false}}
+              @label="trigger"
+              @portalOutletElement={{this.outlet}}
+            >
+              <:content>
+                <button type="button" id="in-panel" class="in-panel">panel
+                  action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button
+            type="button"
+            id="after-trigger"
+            class="after-trigger"
+          >after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+
+      // Focus a panel control directly rather than tabbing to it: DMenu has its own older
+      // `forwardTabToContent`, which pulls focus into the body on Tab whenever a body exists, so
+      // the INTO direction is not a clean contrast. The OUT direction is.
+      await click("#in-panel");
+      assert.strictEqual(activeId(), "in-panel");
+
+      // The defect the option exists to fix, pinned so it cannot quietly become a no-op. Native
+      // order continues from the PORTAL, which is last in the document, so the field's neighbour
+      // is never reached.
+      await tab();
+      assert
+        .dom(".after-trigger")
+        .isNotFocused(
+          "without the repair, leaving the panel does not resume beside the trigger"
+        );
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
@@ -1,8 +1,20 @@
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import { click, render, setupOnerror, tab } from "@ember/test-helpers";
+import {
+  click,
+  find,
+  focus,
+  render,
+  setupOnerror,
+  tab,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DMenu from "discourse/float-kit/components/d-menu";
+import {
+  adjacentTabStop,
+  tabStopsWithin,
+} from "discourse/float-kit/lib/tab-order";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import dElement from "discourse/ui-kit/helpers/d-element";
 
 /**
  * `inlineTabOrder` only means anything when the content is portaled away from its trigger, and
@@ -21,7 +33,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
  *
  * What it CANNOT exercise is a browser adopting a scroll container as a tab stop: `tab()` picks
  * candidates by `tabIndex >= 0`, and an adopted scroller reports `-1` exactly like one that opted
- * out. That case is only observable in a real browser, and is covered by a system spec.
+ * out. A surface using this option must opt such a scroller out explicitly with `tabindex="-1"`.
  */
 module(
   "Integration | Modifier | FloatKit | tab-order-inline",
@@ -85,6 +97,98 @@ module(
         "after-trigger",
         "Tab off the last panel control resumes after the TRIGGER, not after the portal"
       );
+      assert
+        .dom("#outlet .in-panel")
+        .doesNotExist("leaving the panel also dismisses it");
+    });
+
+    test("a non-focusable trigger wrapper resumes from its last stop", async function (assert) {
+      await render(
+        <template>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{false}}
+              @inlineTabOrder={{true}}
+              @triggerComponent={{dElement "div"}}
+              @portalOutletElement={{this.outlet}}
+            >
+              <:trigger>
+                <input id="trigger-input" aria-label="trigger" />
+              </:trigger>
+              <:content>
+                <button type="button" id="in-panel">panel action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button type="button" id="after-trigger">after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+      await focus("#trigger-input");
+      await tab();
+      assert.dom("#in-panel").isFocused("the trigger input enters the panel");
+
+      await tab();
+      assert
+        .dom("#after-trigger")
+        .isFocused("forward exit resumes after the trigger wrapper");
+      assert.dom("#in-panel").doesNotExist("forward exit dismisses the panel");
+    });
+
+    test("a compound trigger finishes its own tab sequence before entering the panel", async function (assert) {
+      await render(
+        <template>
+          <button type="button" id="before-trigger">before</button>
+          {{#if this.outlet}}
+            <DMenu
+              @inline={{false}}
+              @trapTab={{false}}
+              @inlineTabOrder={{true}}
+              @triggerComponent={{dElement "div"}}
+              @portalOutletElement={{this.outlet}}
+            >
+              <:trigger>
+                <input id="trigger-first" aria-label="first trigger control" />
+                <button type="button" id="trigger-last">last trigger control</button>
+              </:trigger>
+              <:content>
+                <button type="button" id="in-panel">panel action</button>
+              </:content>
+            </DMenu>
+          {{/if}}
+          <button type="button" id="after-trigger">after</button>
+          <div id="outlet" {{didInsert this.setOutlet}}></div>
+        </template>
+      );
+
+      await click(".fk-d-menu__trigger");
+      await focus("#trigger-first");
+      await tab();
+      assert
+        .dom("#trigger-last")
+        .isFocused("Tab from an early trigger stop stays in the trigger");
+
+      await tab();
+      assert
+        .dom("#in-panel")
+        .isFocused("Tab from the trigger's last stop enters the panel");
+
+      await tab({ backwards: true });
+      assert
+        .dom("#trigger-last")
+        .isFocused("backward panel exit returns to the trigger's last stop");
+
+      await click(".fk-d-menu__trigger");
+      await focus("#trigger-first");
+      await tab({ backwards: true });
+      assert
+        .dom("#before-trigger")
+        .isFocused(
+          "Shift+Tab from the trigger follows the page's backward order"
+        );
     });
 
     test("Shift+Tab out of the float returns to the trigger", async function (assert) {
@@ -148,20 +252,12 @@ module(
       await click(".fk-d-menu__trigger");
       assert.dom("#outlet .in-panel").exists();
 
-      // The fall-through path, and the reason this is safe to leave on by default: a panel that
-      // is only a list must never pull focus in, since its rows are reached with the arrow keys.
-      //
-      // Asserted as "focus did not enter the float" rather than "focus reached the neighbour",
-      // because where the press ends up is not this modifier's to decide once it declines. A bare
-      // DMenu still has its older `forwardTabToContent`, which swallows the press on a body with
-      // nothing focusable in it (`firstFocusable` is null and `#body.focus()` is a no-op), leaving
-      // focus on the trigger. DSelect stops that from reaching the trigger; this test does not,
-      // and should not pin behaviour it does not own.
+      // The fall-through path: a panel that is only a list must never pull focus in, since its
+      // rows are reached with the arrow keys rather than by tabbing.
       await tab();
-      assert.false(
-        document.querySelector("#outlet").contains(document.activeElement),
-        "focus never enters a float that offers no stop of its own"
-      );
+      assert
+        .dom("#after-trigger")
+        .isFocused("Tab passes a float that offers no stop of its own");
     });
 
     test("asserts when containment is asked for as well", async function (assert) {
@@ -242,6 +338,147 @@ module(
         .isNotFocused(
           "without the repair, leaving the panel does not resume beside the trigger"
         );
+    });
+
+    test("tab stops honor disabled fieldset semantics", async function (assert) {
+      await render(
+        <template>
+          <div id="root">
+            <fieldset disabled>
+              <legend><button id="first-legend">first legend</button></legend>
+              <button id="fieldset-control">disabled control</button>
+              <legend><button id="second-legend">second legend</button></legend>
+            </fieldset>
+            <button id="after-fieldset">after</button>
+          </div>
+        </template>
+      );
+
+      assert.deepEqual(
+        tabStopsWithin(find("#root")).map((element) => element.id),
+        ["first-legend", "after-fieldset"],
+        "only the first legend escapes a disabled fieldset"
+      );
+    });
+
+    test("tab stops use the checked radio as the group's single stop", async function (assert) {
+      await render(
+        <template>
+          <input
+            id="checked-outside"
+            type="radio"
+            name="outside-group"
+            checked
+          />
+          <div id="root">
+            <input id="unchecked" type="radio" name="group" />
+            <input id="checked" type="radio" name="group" checked />
+            <input id="unchecked-after" type="radio" name="group" />
+            <input
+              id="suppressed-by-outside"
+              type="radio"
+              name="outside-group"
+            />
+          </div>
+        </template>
+      );
+
+      assert.deepEqual(
+        tabStopsWithin(find("#root")).map((element) => element.id),
+        ["checked"],
+        "radio membership is resolved across the full document group"
+      );
+    });
+
+    test("unchecked radio groups keep one stop and exit from a programmatically focused member", async function (assert) {
+      await render(
+        <template>
+          <div id="root">
+            <button id="before-radios">before</button>
+            <input id="first-radio" type="radio" name="group" />
+            <input id="focused-radio" type="radio" name="group" />
+            <button id="after-radios">after</button>
+            <form id="form-a">
+              <input id="form-a-radio" type="radio" name="shared" />
+            </form>
+            <form id="form-b">
+              <input id="form-b-radio" type="radio" name="shared" />
+            </form>
+          </div>
+        </template>
+      );
+
+      const root = find("#root");
+      const focusedRadio = find("#focused-radio");
+
+      assert.deepEqual(
+        tabStopsWithin(root).map((element) => element.id),
+        [
+          "before-radios",
+          "first-radio",
+          "after-radios",
+          "form-a-radio",
+          "form-b-radio",
+        ],
+        "an unchecked group exposes its first member, while separate forms expose one each"
+      );
+      assert.strictEqual(
+        adjacentTabStop(focusedRadio, { forward: false, root })?.id,
+        "before-radios",
+        "Shift+Tab exits an unchecked group from a programmatically focused non-stop"
+      );
+      assert.strictEqual(
+        adjacentTabStop(focusedRadio, { forward: true, root })?.id,
+        "after-radios",
+        "Tab exits an unchecked group from a programmatically focused non-stop"
+      );
+    });
+
+    test("tab stops sort positive tabindex before the regular sequence", async function (assert) {
+      await render(
+        <template>
+          <div id="root">
+            <button id="regular-first">regular first</button>
+            <button id="positive-two" tabindex="2">positive two</button>
+            <button id="positive-one-a" tabindex="1">positive one a</button>
+            <button id="positive-one-b" tabindex="1">positive one b</button>
+            <button id="regular-last">regular last</button>
+          </div>
+        </template>
+      );
+
+      assert.deepEqual(
+        tabStopsWithin(find("#root")).map((element) => element.id),
+        [
+          "positive-one-a",
+          "positive-one-b",
+          "positive-two",
+          "regular-first",
+          "regular-last",
+        ],
+        "positive values are ascending and ties retain document order"
+      );
+    });
+
+    test("tab stops follow keyboard visibility rather than the accessibility tree", async function (assert) {
+      await render(
+        <template>
+          <div id="root">
+            <button id="aria-hidden" aria-hidden="true">aria hidden</button>
+            <button id="transparent" style="opacity: 0">transparent</button>
+            <button id="visibility-hidden" style="visibility: hidden">visibility
+              hidden</button>
+            <button id="display-none" style="display: none">display none</button>
+            <div inert><button id="inert">inert</button></div>
+          </div>
+        </template>
+      );
+
+      assert.deepEqual(
+        tabStopsWithin(find("#root")).map((element) => element.id),
+        ["aria-hidden", "transparent"],
+        "ARIA and opacity do not remove focus, while CSS visibility and inertness do"
+      );
     });
   }
 );

--- a/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/tab-order-inline-test.gjs
@@ -4,6 +4,7 @@ import {
   find,
   focus,
   render,
+  settled,
   setupOnerror,
   tab,
 } from "@ember/test-helpers";
@@ -218,7 +219,9 @@ module(
 
       await click(".fk-d-menu__trigger");
       await tab();
-      assert.dom("#in-panel").isFocused();
+      assert
+        .dom("#in-panel")
+        .isFocused("Tab from the trigger enters the panel");
 
       await tab();
       assert
@@ -613,6 +616,41 @@ module(
         })?.id,
         "after-panel",
         "the stop after an anchor skips the ignored subtree entirely"
+      );
+    });
+
+    test("each call re-measures instead of answering from an earlier one", async function (assert) {
+      await render(
+        <template>
+          <div id="root">
+            <button id="control">control</button>
+            <input id="first-radio" type="radio" name="group" />
+            {{#if this.showLateRadio}}
+              <input id="late-radio" type="radio" name="group" checked />
+            {{/if}}
+          </div>
+        </template>
+      );
+
+      const root = find("#root");
+
+      assert.deepEqual(
+        tabStopsWithin(root).map((element) => element.id),
+        ["control", "first-radio"],
+        "the unchecked group starts out represented by its first member"
+      );
+
+      // Both answers above are measured, not derived: tabbability comes from live layout and
+      // state, and a group's representative from the radios present at the time. Reusing either
+      // measurement past the call that took it would report the DOM as it used to be.
+      find("#control").tabIndex = -1;
+      this.set("showLateRadio", true);
+      await settled();
+
+      assert.deepEqual(
+        tabStopsWithin(root).map((element) => element.id),
+        ["late-radio"],
+        "the opted-out control is gone and the newly checked radio represents the group"
       );
     });
 


### PR DESCRIPTION
Sequential focus follows document order, so portaling a float out of its trigger's subtree moves where Tab goes. Nothing leads into the content from the trigger, and stepping off the end of it lands wherever the portal happens to sit, which is usually the end of the document. A float whose content holds focus is therefore reachable only by tabbing through the rest of the page, and leaving it drops the reader somewhere unrelated.

`inlineTabOrder` opts a menu into the order it would have had if its content were rendered inline after the trigger. `FloatKitTabOrderInline` lets the browser walk the float's own stops natively and takes over only the press that would step off the end of them: forward continues from the stop after the trigger, backward returns to the trigger's own last stop. A float with nothing focusable in it is declined, so a content-only panel still lets Tab pass over the widget and keeps its rows on the arrow keys.

This is the alternative to `trapTab`, not a companion to it. Containment belongs to a genuinely modal surface that owns the screen until dismissed; a non-modal float shows nothing to say that Tab has stopped meaning "move on", so trapping strands a reader whose only other way out is Escape. The two are mutually exclusive and `DFloatBody` now asserts when both are set, because `dTrapTab` is applied first and would otherwise win silently. The option also reaches `DFloatBody` on the headless and inline paths, which previously forwarded `trapTab` alone.

Covered by component tests that force the portal on and drive real Tab presses through it: entering the content, leaving it for the trigger's neighbour, Shift+Tab back to the trigger, the fall-through when a float offers no stop, and the conflicting configuration asserting.

Defaults to off, so no existing float changes behaviour. The first consumer is the ui-kit select in #41534, whose panel holds a filter and an optional footer action.