### PR TITLE
FIX: Link auto-silence staff action log entries to reviewable

### DIFF
--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -182,6 +182,8 @@ class NewPostManager
     result = manager.enqueue(reason, creator_opts: creator_opts)
 
     if result.success? || (reason == :email_spam && is_first_post?(manager))
+      reviewable_id = result.reviewable&.id
+
       I18n.with_locale(SiteSetting.default_locale) do
         if is_fast_typer?(manager)
           UserSilencer.auto_silence(
@@ -189,6 +191,7 @@ class NewPostManager
             Discourse.system_user,
             keep_posts: true,
             reason: I18n.t("user.new_user_typed_too_fast"),
+            reviewable_id:,
           )
         elsif auto_silence?(manager) || matches_auto_silence_regex?(manager)
           UserSilencer.auto_silence(
@@ -196,6 +199,7 @@ class NewPostManager
             Discourse.system_user,
             keep_posts: true,
             reason: I18n.t("user.content_matches_auto_silence_regex"),
+            reviewable_id:,
           )
         elsif reason == :email_spam && is_first_post?(manager)
           UserSilencer.auto_silence(
@@ -203,6 +207,7 @@ class NewPostManager
             Discourse.system_user,
             keep_posts: true,
             reason: I18n.t("user.email_in_spam_header"),
+            reviewable_id:,
           )
         end
       end

--- a/spec/lib/new_post_manager_spec.rb
+++ b/spec/lib/new_post_manager_spec.rb
@@ -279,6 +279,19 @@ RSpec.describe NewPostManager do
         end
       end
 
+      it "links the silence staff action log entry to the queued post" do
+        manager = build_manager_with("this is new post content")
+
+        result = NewPostManager.default_handler(manager)
+
+        history =
+          UserHistory.where(
+            action: UserHistory.actions[:silence_user],
+            target_user_id: user.id,
+          ).last
+        expect(history.reviewable_id).to eq(result.reviewable.id)
+      end
+
       it "runs the watched words check before checking if the user is a fast typer" do
         Fabricate(:watched_word, word: "darn", action: WatchedWord.actions[:require_approval])
         manager = build_manager_with("this is darn new post content")


### PR DESCRIPTION
Silences triggered from the review queue by a moderator record the reviewable that caused them, but the automatic silences applied when a post is enqueued did not. Staff auditing a fast typer, watched word, or email spam silence in the staff action log had no way to jump to the queued post behind it.

Demo of link to reviewable
<img width="1350" height="114" alt="Screenshot 2026-08-13 at 10 00 45 am" src="https://github.com/user-attachments/assets/a0e6176b-0d32-43c2-a2be-1904fea9c734" />

