### PR TITLE
UX: Prevent long URLs from overflowing traffic breakdowns

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -254,7 +254,7 @@
   }
 
   &__row-link {
-    @include ellipsis;
+    display: block;
     min-width: 0;
     color: inherit;
     text-decoration: none;
@@ -311,9 +311,17 @@
   }
 
   &__dimension-label {
-    display: inline-flex;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
     gap: var(--space-2);
+    min-width: 0;
+    width: 100%;
+  }
+
+  &__dimension-text {
+    @include ellipsis;
+    grid-column: 2;
     min-width: 0;
   }
 

--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -255,7 +255,9 @@
 
   &__row-link {
     display: block;
+    flex: 1 1 auto;
     min-width: 0;
+    overflow: hidden;
     color: inherit;
     text-decoration: none;
 
@@ -275,7 +277,7 @@
     align-items: center;
     align-self: stretch;
     justify-content: flex-end;
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     min-width: 0;
     margin-block: calc(-1 * var(--space-1));
     margin-inline-end: calc(-1 * var(--space-2));
@@ -363,8 +365,13 @@
   }
 
   &__pageviews {
+    width: 1%;
     white-space: nowrap;
     text-align: end;
+
+    @include viewport.until(md) {
+      width: auto;
+    }
 
     .d-table__mobile-label {
       text-align: start;

--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -341,7 +341,21 @@
 }
 
 .site-traffic-breakdown-modal {
+  &__dimension {
+    max-width: 0;
+    overflow: hidden;
+
+    .site-traffic-explorer__row-link {
+      display: block;
+    }
+
+    @include viewport.until(md) {
+      max-width: none;
+    }
+  }
+
   &__pageviews {
+    white-space: nowrap;
     text-align: end;
 
     .d-table__mobile-label {

--- a/frontend/discourse/admin/components/site-traffic-explorer-breakdown-card.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-breakdown-card.gjs
@@ -177,6 +177,7 @@ export default class SiteTrafficExplorerBreakdownCard extends Component {
                       href={{rowLink.href}}
                       rel={{rowLink.rel}}
                       target={{rowLink.target}}
+                      title={{row.label}}
                       class="site-traffic-explorer__row-link"
                     >
                       <SiteTrafficExplorerDimensionLabel

--- a/frontend/discourse/admin/components/site-traffic-explorer-breakdown-modal.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-breakdown-modal.gjs
@@ -46,7 +46,9 @@ export default class SiteTrafficExplorerBreakdownModal extends Component {
           <tbody class="d-table__body">
             {{#each this.rows as |row|}}
               <tr class="d-table__row">
-                <td class="d-table__cell --overview">
+                <td
+                  class="d-table__cell --overview site-traffic-breakdown-modal__dimension"
+                >
                   {{#let (@model.rowLink row) as |rowLink|}}
                     {{#if rowLink}}
                       <a

--- a/frontend/discourse/admin/components/site-traffic-explorer-breakdown-modal.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-breakdown-modal.gjs
@@ -55,6 +55,7 @@ export default class SiteTrafficExplorerBreakdownModal extends Component {
                         href={{rowLink.href}}
                         rel={{rowLink.rel}}
                         target={{rowLink.target}}
+                        title={{row.label}}
                         class="site-traffic-explorer__row-link"
                       >
                         <SiteTrafficExplorerDimensionLabel

--- a/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
@@ -30,7 +30,7 @@ export default class SiteTrafficExplorerDimensionLabel extends Component {
       {{else if (eq @dimension "browsers")}}
         {{dIcon (this.browserIcon @row.value)}}
       {{/if}}
-      <span>{{@row.label}}</span>
+      <span class="site-traffic-explorer__dimension-text">{{@row.label}}</span>
     </span>
   </template>
 }

--- a/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
@@ -394,6 +394,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     traffic.expand("pages")
 
     expect(traffic).to have_expanded_table(title: "Top URLs", column: "URL")
+    expect(traffic).to have_expanded_url_link(label: additional_path)
 
     traffic.filter_expanded_row(label: additional_path)
 

--- a/spec/system/page_objects/pages/admin_site_traffic_explorer.rb
+++ b/spec/system/page_objects/pages/admin_site_traffic_explorer.rb
@@ -107,7 +107,7 @@ module PageObjects
 
       def has_url_link?(card:, label:, href:)
         within("[data-test-site-traffic-card='#{card}']") do
-          has_css?("a[href='#{href}']", exact_text: label)
+          has_css?("a[href='#{href}'][title='#{label}']", exact_text: label)
         end
       end
 
@@ -156,6 +156,11 @@ module PageObjects
         has_css?(selector, text: title) &&
           has_css?("#{selector} .d-table__header-cell", exact_text: column) &&
           has_css?("#{selector} .d-table__body .d-table__row")
+      end
+
+      def has_expanded_url_link?(label:)
+        selector = ".site-traffic-breakdown-modal[role='dialog']"
+        has_css?("#{selector} a[href='#{label}'][title='#{label}']", exact_text: label)
       end
 
       def filter_expanded_row(label:)


### PR DESCRIPTION
<img width="340" height="152" alt="Screenshot 2026-08-13 at 12 33 19 PM" src="https://github.com/user-attachments/assets/ab949213-300e-47f9-ade2-9936c9fdcbbd" />
<img width="312" height="128" alt="Screenshot 2026-08-13 at 12 33 23 PM" src="https://github.com/user-attachments/assets/ce696a12-ab1b-46fa-8779-4c4d7197f6d4" />
<img width="619" height="225" alt="Screenshot 2026-08-13 at 12 33 37 PM" src="https://github.com/user-attachments/assets/b2a71bd5-2f69-4901-b76b-bcfef7125104" />
<img width="589" height="215" alt="Screenshot 2026-08-13 at 12 33 41 PM" src="https://github.com/user-attachments/assets/bbd22007-dc0e-49f9-b0a3-e70209ab10a1" />
