### PR TITLE
FIX: Avoid recursive letter avatar cleanup threads

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1305,7 +1305,10 @@ module Discourse
         require "actionview_precompiler"
         ActionviewPrecompiler.precompile
       end,
-      Thread.new { LetterAvatar.image_magick_version },
+      Thread.new do
+        LetterAvatar.image_magick_version
+        LetterAvatar.cleanup_old
+      end,
       Thread.new { SvgSprite.core_svgs },
       Thread.new { EmberAssets.script_chunks(exception: false) },
       Thread.new do

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -110,15 +110,9 @@ class LetterAvatar
 
     def image_magick_version
       @image_magick_version ||=
-        begin
-          Thread.new do
-            sleep 2
-            cleanup_old
-          end
-          Digest::MD5.hexdigest(
-            ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
-          )
-        end
+        Digest::MD5.hexdigest(
+          ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
+        )
     end
 
     def cleanup_old

--- a/spec/lib/letter_avatar_spec.rb
+++ b/spec/lib/letter_avatar_spec.rb
@@ -5,14 +5,14 @@ require "letter_avatar"
 RSpec.describe LetterAvatar do
   describe ".cleanup_old" do
     it "removes stale cache directories" do
-      path = LetterAvatar.cache_path
+      cache_path = LetterAvatar.cache_path
+      parent_path = File.dirname(cache_path)
+      stale_path = File.join(parent_path, "stale")
+      FileUtils.mkdir_p([cache_path, stale_path])
 
-      FileUtils.mkdir_p(path + "junk")
-      LetterAvatar.generate("test", 100)
+      described_class.cleanup_old
 
-      LetterAvatar.cleanup_old
-
-      expect(Dir.entries(File.dirname(path)).length).to eq(3)
+      expect(Dir.children(parent_path)).to contain_exactly(File.basename(cache_path))
     end
   end
 


### PR DESCRIPTION
Letter avatar version preloading started a second background thread, waited two seconds, and then removed stale cache directories. Cleanup asks for the cache path, so a slow version calculation could re-enter the unset memo and launch more ImageMagick commands and cleanup threads.

This commit runs cleanup in the existing joined Rails preload thread after the ImageMagick version is memoized. Cleanup therefore finishes before workers fork without an arbitrary delay. The cleanup spec now constructs cache directories directly so it tests deletion without depending on ImageMagick rendering.