### PR TITLE
FIX: Handle no ACL permissions on create

### DIFF
--- a/.skills/discourse-acl-authoring/references/manager-and-plugin-integration.md
+++ b/.skills/discourse-acl-authoring/references/manager-and-plugin-integration.md
@@ -116,18 +116,19 @@ The service resolves `target_type` from `Site.access_control_target_classes`, in
 - the current user would have no permission after the change; or
 - the current user would lose any permission declared by `loss_warning_permissions`.
 
-The first case uses `access_control_list.errors.user_will_not_have_permission`. For configured loss warnings, define a target-specific server translation:
+The first case uses `access_control_list.errors.user_will_not_have_permission` for an existing target and `access_control_list.errors.user_will_not_have_permission_on_create` when `target_id` is omitted. For configured loss warnings, define target-specific server translations for both editing and creation:
 
 ```yaml
 en:
   access_control_list:
     errors:
       "Plugin::Target_user_will_lose_permission": "You will no longer be able to manage this target. Continue?"
+      "Plugin::Target_user_will_lose_permission_on_create": "If you create this target with these permissions, you will not be able to manage it. Continue?"
 ```
 
-The suffix is `#{target_class.acl_target_key}_user_will_lose_permission`. Keep this translation in the plugin when the ACL target is plugin-owned.
+The suffixes are `#{target_class.acl_target_key}_user_will_lose_permission` and `#{target_class.acl_target_key}_user_will_lose_permission_on_create`. Keep these translations in the plugin when the ACL target is plugin-owned.
 
-The service evaluates only the proposed ACL. It does not load the target or compare the proposal with persisted ACL rows, and `target_id` is not currently used by the service. Treat “loss” as an inference that the authorized editor already holds the configured permission.
+The service evaluates only the proposed ACL. It does not load the target or compare the proposal with persisted ACL rows. `target_id` only selects edit wording when present; omitting it selects creation wording. Treat “loss” as an inference that the authorized editor already holds the configured permission.
 
 This endpoint evaluates the proposed ACL for confirmation UX; it does not authorize access to the target or replace enforcement in the actual write service. Browser confirmation is not passed as proof to `AccessControlListManager`, so an API client can bypass the prompt. If confirmation must be server-enforced, extend the write contract and re-evaluate there before mutation.
 

--- a/.skills/discourse-acl-authoring/references/testing-and-review.md
+++ b/.skills/discourse-acl-authoring/references/testing-and-review.md
@@ -15,6 +15,7 @@ For target models:
 For `AccessControlList::EvaluateModification`:
 
 - Unknown target types fail model lookup.
+- Requests with a target id use edit wording, while requests without one use creation wording.
 - Mandatory ACL entries are included before evaluating the current user's proposed access.
 - Direct user and group grants applying to the current user are recognized.
 - Losing all access fails `user_will_have_permission`.

--- a/app/controllers/access_control_lists_controller.rb
+++ b/app/controllers/access_control_lists_controller.rb
@@ -28,13 +28,18 @@ class AccessControlListsController < ApplicationController
       on_success { render json: success_json.merge({ current_user_will_lose_permissions: false }) }
       on_failed_contract { |contract| render_json_error(contract.errors.full_messages) }
       on_model_not_found(:target_type_klass) { raise Discourse::InvalidParameters }
-      on_failed_policy(:user_will_not_lose_permission) do |target_type_klass:|
+      on_failed_policy(:user_will_not_lose_permission) do |params:, target_type_klass:|
         # NOTE: The target type class (e.g. a Kanban::Board, or Category) will need to define
         # the translation key here in server.en.yml
+        suffix =
+          if params.target_id.present?
+            "user_will_lose_permission"
+          else
+            "user_will_lose_permission_on_create"
+          end
+
         render_json_error(
-          I18n.t(
-            "access_control_list.errors.#{target_type_klass.acl_target_key}_user_will_lose_permission",
-          ),
+          I18n.t("access_control_list.errors.#{target_type_klass.acl_target_key}_#{suffix}"),
           {
             extras: {
               current_user_will_lose_permission: true,
@@ -43,9 +48,16 @@ class AccessControlListsController < ApplicationController
           },
         )
       end
-      on_failed_policy(:user_will_have_permission) do
+      on_failed_policy(:user_will_have_permission) do |params:|
+        suffix =
+          if params.target_id.present?
+            "user_will_not_have_permission"
+          else
+            "user_will_not_have_permission_on_create"
+          end
+
         render_json_error(
-          I18n.t("access_control_list.errors.user_will_not_have_permission"),
+          I18n.t("access_control_list.errors.#{suffix}"),
           { extras: { current_user_will_lose_permission: true } },
         )
       end

--- a/app/services/access_control_list/evaluate_modification.rb
+++ b/app/services/access_control_list/evaluate_modification.rb
@@ -5,6 +5,7 @@ class AccessControlList::EvaluateModification
 
   params do
     attribute :new_acl, :array
+    attribute :target_id, :integer
     attribute :target_type, :string
 
     validates :target_type, presence: true

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -64,6 +64,7 @@ en:
   access_control_list:
     errors:
       user_will_not_have_permission: "If you remove this ACL entry you will lose access to this entity."
+      user_will_not_have_permission_on_create: "If you create this entity with these permissions, you will not have access to it. Continue?"
 
   topic_category_changed: "From %{from} to %{to}"
   topic_tag_changed:

--- a/spec/requests/access_control_lists_controller_spec.rb
+++ b/spec/requests/access_control_lists_controller_spec.rb
@@ -3,6 +3,20 @@
 RSpec.describe AccessControlListsController do
   fab!(:current_user, :user)
 
+  class EvaluateModificationRequestTestTarget < ActiveRecord::Base
+    include AclTarget
+
+    self.table_name = "posts"
+
+    def self.acl_target_key
+      "evaluate_modification_request_test_target"
+    end
+
+    def self.loss_warning_permissions
+      ["manage"]
+    end
+  end
+
   describe "#search_grantees" do
     before { sign_in(current_user) }
 
@@ -47,6 +61,84 @@ RSpec.describe AccessControlListsController do
       get "/access-control/grantees/search.json", params: { term: "acl_search" }
 
       expect(response.status).to eq(403)
+    end
+  end
+
+  describe "#evaluate" do
+    fab!(:group)
+
+    before do
+      sign_in(current_user)
+      group.add(current_user)
+      I18n.backend.store_translations(
+        :en,
+        access_control_list: {
+          errors: {
+            evaluate_modification_request_test_target_user_will_lose_permission:
+              "You will lose permission if you make this change. Continue?",
+            evaluate_modification_request_test_target_user_will_lose_permission_on_create:
+              "You will not have permission if you create this target. Continue?",
+          },
+        },
+      )
+    end
+
+    it "returns creation-specific wording when a new target would lose a warning permission" do
+      post "/access-control/evaluate.json",
+           params: {
+             target_type: "EvaluateModificationRequestTestTarget",
+             new_acl: [{ type: "group", id: group.id, permission: "view" }],
+           },
+           as: :json
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body).to eq(
+        {
+          "errors" => ["You will not have permission if you create this target. Continue?"],
+          "extras" => {
+            "current_user_will_lose_permission" => true,
+            "loss_warning_permissions" => ["manage"],
+          },
+        },
+      )
+    end
+
+    it "retains edit wording when an existing target would lose a warning permission" do
+      post "/access-control/evaluate.json",
+           params: {
+             target_id: Fabricate(:post).id,
+             target_type: "EvaluateModificationRequestTestTarget",
+             new_acl: [{ type: "group", id: group.id, permission: "view" }],
+           },
+           as: :json
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body["errors"]).to contain_exactly(
+        "You will lose permission if you make this change. Continue?",
+      )
+    end
+
+    it "returns generic creation wording when a new target would grant no access" do
+      EvaluateModificationRequestTestTarget.stubs(:loss_warning_permissions).returns([])
+
+      post "/access-control/evaluate.json",
+           params: {
+             target_type: "EvaluateModificationRequestTestTarget",
+             new_acl: [],
+           },
+           as: :json
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body).to eq(
+        {
+          "errors" => [
+            I18n.t("access_control_list.errors.user_will_not_have_permission_on_create"),
+          ],
+          "extras" => {
+            "current_user_will_lose_permission" => true,
+          },
+        },
+      )
     end
   end
 end

--- a/spec/services/access_control_list/evaluate_modification_spec.rb
+++ b/spec/services/access_control_list/evaluate_modification_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe AccessControlList::EvaluateModification do
   describe described_class::Contract, type: :model do
+    it { is_expected.to allow_values(nil, 1).for(:target_id) }
     it { is_expected.to validate_presence_of(:target_type) }
   end
 


### PR DESCRIPTION
Followup a0de88db7b9785b2ae886885ab831e19af186405

This extends the /evaluate endpoint for ACLs to handle the case
where, when creating something like a kanban board, the user
would end up with insufficient permissions (determined by
the ACL target) to further access the new entity.

For example, if a regular user can create a kanban board,
but they do not add themselves or a group they are in to
the Manage permissions ACL, then they will not be able to access
the board after creation.
