### PR TITLE
DEV: Disallow anonymous_users group for styleguide_allowed_groups

### DIFF
--- a/plugins/styleguide/config/settings.yml
+++ b/plugins/styleguide/config/settings.yml
@@ -10,5 +10,6 @@ plugins:
     client: false
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     validator: "AtLeastOneGroupValidator"
     area: "group_permissions"

--- a/plugins/styleguide/spec/integration/access_spec.rb
+++ b/plugins/styleguide/spec/integration/access_spec.rb
@@ -34,15 +34,6 @@ RSpec.describe "SiteSetting.styleguide_allowed_groups" do
         expect(response.status).to eq(404)
       end
 
-      context "when styleguide_allowed_groups includes anonymous_users" do
-        before { SiteSetting.styleguide_allowed_groups = "#{Group::AUTO_GROUPS[:anonymous_users]}" }
-
-        it "shows the styleguide" do
-          get "/styleguide"
-          expect(response.status).to eq(200)
-        end
-      end
-
       context "when granular_anonymous_and_logged_in_groups_permissions is not enabled" do
         before { SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false }
 

--- a/plugins/styleguide/spec/requests/styleguide/styleguide_controller_spec.rb
+++ b/plugins/styleguide/spec/requests/styleguide/styleguide_controller_spec.rb
@@ -4,24 +4,6 @@ RSpec.describe Styleguide::StyleguideController do
   before { SiteSetting.styleguide_enabled = true }
 
   describe "#index" do
-    context "when styleguide_allowed_groups includes anonymous and logged in users" do
-      before do
-        SiteSetting.styleguide_allowed_groups =
-          "#{Group::AUTO_GROUPS[:anonymous_users]}|#{Group::AUTO_GROUPS[:logged_in_users]}"
-      end
-
-      it "allows access for anonymous users" do
-        get "/styleguide"
-        expect(response.status).to eq(200)
-      end
-
-      it "allows access for logged in users" do
-        sign_in(Fabricate(:user))
-        get "/styleguide"
-        expect(response.status).to eq(200)
-      end
-    end
-
     context "when styleguide_allowed_groups is set to staff" do
       before { SiteSetting.styleguide_allowed_groups = Group::AUTO_GROUPS[:staff] }
 

--- a/plugins/styleguide/spec/system/smoke_test_spec.rb
+++ b/plugins/styleguide/spec/system/smoke_test_spec.rb
@@ -150,19 +150,6 @@ RSpec.describe "Styleguide Smoke Test" do
     end
   end
 
-  context "when the styleguide is enabled for everyone" do
-    before do
-      Capybara.reset_sessions!
-      SiteSetting.styleguide_allowed_groups = Group::AUTO_GROUPS[:anonymous_users]
-    end
-
-    it "renders a page using HighlightedCode for anonymous users" do
-      visit "/styleguide/atoms/font-scale"
-      expect(styleguide).to have_heading("Font System")
-      expect(page).to have_css("code.hljs")
-    end
-  end
-
   context "when the styleguide is only enabled for staff" do
     before { SiteSetting.styleguide_allowed_groups = Group::AUTO_GROUPS[:staff] }
 


### PR DESCRIPTION
Not much point in allowing this, and I doubt this is the case
anywhere in the wild. I also doubt more than a handful of sites
even have this plugin enabled, it's more of a developer tool.
