### PR TITLE
FEATURE: Add fields to the schedule workflow node payload

### DIFF
--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/schedule/payload.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/schedule/payload.rb
@@ -17,14 +17,17 @@ module DiscourseWorkflows
             "readable_date" =>
               "#{local_time.strftime("%B")} #{local_time.day.ordinalize} #{local_time.year}, #{readable_time}",
             "readable_time" => readable_time,
+            "date" => local_time.strftime("%Y-%m-%d"),
             "day_of_week" => local_time.strftime("%A"),
             "year" => local_time.strftime("%Y"),
             "month" => local_time.strftime("%B"),
+            "month_number" => local_time.strftime("%m"),
             "day_of_month" => local_time.strftime("%d"),
             "hour" => local_time.strftime("%H"),
             "minute" => local_time.strftime("%M"),
             "second" => local_time.strftime("%S"),
             "timezone" => "#{timezone} (UTC#{local_time.formatted_offset})",
+            "time" => local_time.strftime("%H:%M:%S"),
           }
         end
       end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/schedule/payload_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/schedule/payload_spec.rb
@@ -3,20 +3,23 @@
 RSpec.describe DiscourseWorkflows::Nodes::Schedule::Payload do
   describe ".build" do
     it "returns compatible timestamp fields", :aggregate_failures do
-      payload = described_class.build(time: Time.utc(2026, 3, 18, 9, 0), timezone: "UTC")
+      payload = described_class.build(time: Time.utc(2026, 3, 18, 14, 0), timezone: "UTC")
 
       expect(payload).to include(
-        "timestamp" => "2026-03-18T09:00:00.000Z",
-        "readable_date" => "March 18th 2026, 9:00:00 am",
-        "readable_time" => "9:00:00 am",
+        "timestamp" => "2026-03-18T14:00:00.000Z",
+        "readable_date" => "March 18th 2026, 2:00:00 pm",
+        "readable_time" => "2:00:00 pm",
+        "date" => "2026-03-18",
         "day_of_week" => "Wednesday",
         "year" => "2026",
         "month" => "March",
+        "month_number" => "03",
         "day_of_month" => "18",
-        "hour" => "09",
+        "hour" => "14",
         "minute" => "00",
         "second" => "00",
         "timezone" => "UTC (UTC+00:00)",
+        "time" => "14:00:00",
       )
       expect(payload).to match_node_output_schema(DiscourseWorkflows::Nodes::Schedule::V1)
     end


### PR DESCRIPTION
Adds the following schedule payload items:

* date, which is the date of the schedule run in YYYY-MM-DD
* month_number, which is the month number of the schedule run (1-12)
* time, which is the combined 24 hour time of the schedule run in HH:MM:SS format

This can be helpful when using the schedule data to get e.g.
a week/month/time that adds or subtracts from the schedule run date/time.
