### PR TITLE
FIX: Correct site traffic explorer pageview total and minor link behaviours

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -261,6 +261,10 @@
     color: inherit;
     text-decoration: none;
 
+    &:visited {
+      color: inherit;
+    }
+
     &:focus-visible {
       color: var(--tertiary);
       text-decoration: underline;

--- a/app/services/admin_dashboard_site_traffic_explorer.rb
+++ b/app/services/admin_dashboard_site_traffic_explorer.rb
@@ -316,9 +316,7 @@ class AdminDashboardSiteTrafficExplorer
       series_rows AS (
         SELECT
           created_at::date AS date,
-          COUNT(*) FILTER (
-            WHERE :traffic_type_filtered OR NOT likely_crawler
-          )::integer AS pageviews,
+          COUNT(*)::integer AS pageviews,
           COUNT(*) FILTER (
             WHERE NOT likely_crawler AND user_id IS NOT NULL
           )::integer AS logged_in_human_pageviews,

--- a/frontend/discourse/admin/components/site-traffic-explorer-breakdown-card.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-breakdown-card.gjs
@@ -108,7 +108,11 @@ export default class SiteTrafficExplorerBreakdownCard extends Component {
     }
 
     if (["top_urls", "entry_urls"].includes(this.activeTab.dimension)) {
-      return { href: getURL(row.value) };
+      return {
+        href: getURL(row.value),
+        rel: "noopener noreferrer",
+        target: "_blank",
+      };
     }
 
     return null;
@@ -177,7 +181,6 @@ export default class SiteTrafficExplorerBreakdownCard extends Component {
                       href={{rowLink.href}}
                       rel={{rowLink.rel}}
                       target={{rowLink.target}}
-                      title={{row.label}}
                       class="site-traffic-explorer__row-link"
                     >
                       <SiteTrafficExplorerDimensionLabel

--- a/frontend/discourse/admin/components/site-traffic-explorer-breakdown-modal.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-breakdown-modal.gjs
@@ -55,7 +55,6 @@ export default class SiteTrafficExplorerBreakdownModal extends Component {
                         href={{rowLink.href}}
                         rel={{rowLink.rel}}
                         target={{rowLink.target}}
-                        title={{row.label}}
                         class="site-traffic-explorer__row-link"
                       >
                         <SiteTrafficExplorerDimensionLabel

--- a/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
@@ -1,8 +1,14 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { service } from "@ember/service";
+import { modifier } from "ember-modifier";
 import { countryFlag } from "discourse/admin/lib/format-country";
 import { eq } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
+import dOnResize from "discourse/ui-kit/modifiers/d-on-resize";
 
 const BROWSER_ICONS = {
   edge: "fab-microsoft",
@@ -13,6 +19,24 @@ const BROWSER_ICONS = {
 };
 
 export default class SiteTrafficExplorerDimensionLabel extends Component {
+  @service tooltip;
+
+  @tracked isTruncated = false;
+
+  registerTooltip = modifier((element, [content, isTruncated]) => {
+    if (!isTruncated) {
+      return;
+    }
+
+    const tooltip = this.tooltip.register(element, {
+      content,
+      triggers: { desktop: ["hover"], mobile: [] },
+      untriggers: { desktop: ["hover"], mobile: [] },
+    });
+
+    return () => tooltip.destroy();
+  });
+
   @action
   countryFlag(value) {
     return countryFlag(value);
@@ -23,6 +47,16 @@ export default class SiteTrafficExplorerDimensionLabel extends Component {
     return BROWSER_ICONS[value] ?? BROWSER_ICONS.unknown;
   }
 
+  @action
+  measure(element) {
+    this.isTruncated = element.scrollWidth > element.clientWidth;
+  }
+
+  @action
+  measureResize(entries) {
+    this.measure(entries[0].target);
+  }
+
   <template>
     <span class="site-traffic-explorer__dimension-label">
       {{#if (eq @dimension "countries")}}
@@ -30,7 +64,13 @@ export default class SiteTrafficExplorerDimensionLabel extends Component {
       {{else if (eq @dimension "browsers")}}
         {{dIcon (this.browserIcon @row.value)}}
       {{/if}}
-      <span class="site-traffic-explorer__dimension-text">{{@row.label}}</span>
+      <span
+        class="site-traffic-explorer__dimension-text"
+        {{didInsert this.measure}}
+        {{didUpdate this.measure @row.label}}
+        {{dOnResize this.measureResize}}
+        {{this.registerTooltip @row.label this.isTruncated}}
+      >{{@row.label}}</span>
     </span>
   </template>
 }

--- a/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
@@ -1,14 +1,8 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import didUpdate from "@ember/render-modifiers/modifiers/did-update";
-import { service } from "@ember/service";
-import { modifier } from "ember-modifier";
 import { countryFlag } from "discourse/admin/lib/format-country";
 import { eq } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
-import dOnResize from "discourse/ui-kit/modifiers/d-on-resize";
 
 const BROWSER_ICONS = {
   edge: "fab-microsoft",
@@ -19,24 +13,6 @@ const BROWSER_ICONS = {
 };
 
 export default class SiteTrafficExplorerDimensionLabel extends Component {
-  @service tooltip;
-
-  @tracked isTruncated = false;
-
-  registerTooltip = modifier((element, [content, isTruncated]) => {
-    if (!isTruncated) {
-      return;
-    }
-
-    const tooltip = this.tooltip.register(element, {
-      content,
-      triggers: { desktop: ["hover"], mobile: [] },
-      untriggers: { desktop: ["hover"], mobile: [] },
-    });
-
-    return () => tooltip.destroy();
-  });
-
   @action
   countryFlag(value) {
     return countryFlag(value);
@@ -47,16 +23,6 @@ export default class SiteTrafficExplorerDimensionLabel extends Component {
     return BROWSER_ICONS[value] ?? BROWSER_ICONS.unknown;
   }
 
-  @action
-  measure(element) {
-    this.isTruncated = element.scrollWidth > element.clientWidth;
-  }
-
-  @action
-  measureResize(entries) {
-    this.measure(entries[0].target);
-  }
-
   <template>
     <span class="site-traffic-explorer__dimension-label">
       {{#if (eq @dimension "countries")}}
@@ -64,13 +30,9 @@ export default class SiteTrafficExplorerDimensionLabel extends Component {
       {{else if (eq @dimension "browsers")}}
         {{dIcon (this.browserIcon @row.value)}}
       {{/if}}
-      <span
-        class="site-traffic-explorer__dimension-text"
-        {{didInsert this.measure}}
-        {{didUpdate this.measure @row.label}}
-        {{dOnResize this.measureResize}}
-        {{this.registerTooltip @row.label this.isTruncated}}
-      >{{@row.label}}</span>
+      <span class="site-traffic-explorer__dimension-text" title={{@row.label}}>
+        {{@row.label}}
+      </span>
     </span>
   </template>
 }

--- a/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
@@ -91,6 +91,29 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
     context "when the query succeeds" do
       it { is_expected.to run_successfully }
 
+      it "includes likely crawlers unless traffic types exclude them" do
+        Fabricate(
+          :browser_pageview_event,
+          session_id: "likely-crawler",
+          source: BrowserPageviewEvent::SOURCE_BEACON,
+          score: CrawlerScorer::BOT_SCORE_THRESHOLD + 1,
+          created_at: Time.zone.local(2026, 5, 10, 11),
+        )
+
+        default_summary = result.traffic[:summary].slice("pageviews", "distinct_sessions")
+        human_summary =
+          described_class.call(params: params.merge(traffic_type: "logged_in,anonymous")).traffic[
+            :summary
+          ].slice("pageviews", "distinct_sessions")
+
+        expect([default_summary, human_summary]).to eq(
+          [
+            { "pageviews" => 12, "distinct_sessions" => 12 },
+            { "pageviews" => 11, "distinct_sessions" => 11 },
+          ],
+        )
+      end
+
       it "classifies supported major browsers and groups other user agents as unknown" do
         browsers = result.traffic.dig(:dimensions, "browsers")
 

--- a/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
@@ -91,29 +91,6 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
     context "when the query succeeds" do
       it { is_expected.to run_successfully }
 
-      it "includes likely crawlers unless traffic types exclude them" do
-        Fabricate(
-          :browser_pageview_event,
-          session_id: "likely-crawler",
-          source: BrowserPageviewEvent::SOURCE_BEACON,
-          score: CrawlerScorer::BOT_SCORE_THRESHOLD + 1,
-          created_at: Time.zone.local(2026, 5, 10, 11),
-        )
-
-        default_summary = result.traffic[:summary].slice("pageviews", "distinct_sessions")
-        human_summary =
-          described_class.call(params: params.merge(traffic_type: "logged_in,anonymous")).traffic[
-            :summary
-          ].slice("pageviews", "distinct_sessions")
-
-        expect([default_summary, human_summary]).to eq(
-          [
-            { "pageviews" => 12, "distinct_sessions" => 12 },
-            { "pageviews" => 11, "distinct_sessions" => 11 },
-          ],
-        )
-      end
-
       it "classifies supported major browsers and groups other user agents as unknown" do
         browsers = result.traffic.dig(:dimensions, "browsers")
 

--- a/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
@@ -180,9 +180,9 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     expect(traffic).to have_page_title
     expect(traffic).to have_date_range("May 1, 2026 – May 12, 2026")
     expect(traffic).to have_no_filter_pills
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
     expect(traffic).to have_metric(label: "Distinct sessions", value: "3")
-    expect(traffic).to have_metric(label: "Logged-in share", value: "67%")
+    expect(traffic).to have_metric(label: "Logged-in share", value: "50%")
     expect(traffic).to have_metric(label: "Bounce rate", value: "67%")
     expect(traffic).to have_metric(label: "Average session duration", value: "20s")
     expect(traffic).to have_series_total(label: "logged-in-human", value: "2")
@@ -208,7 +208,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
 
     traffic.go_back
     expect(traffic).to have_no_filter_pills
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
 
     traffic.go_forward
     expect(traffic).to have_filter_pill(dimension: "traffic_type", label: "Logged in")
@@ -221,7 +221,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
 
     traffic.remove_filter("traffic_type", label: "Anonymous")
     expect(traffic).to have_no_filter_pills
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
 
     traffic.visit(start_date: "2026-05-01", end_date: "2026-05-12", traffic_type: "likely_crawler")
     expect(traffic).to have_filter_pill(dimension: "traffic_type", label: "Likely crawlers")
@@ -234,7 +234,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
       "/admin/dashboard/site-traffic-explorer?end_date=2026-05-12&range=custom&start_date=2026-05-01&traffic_type=likely_crawler",
     )
     traffic.remove_filter("traffic_type", label: "Likely crawlers")
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
 
     expect(traffic).to have_card_tabs(card: "acquisition", tabs: %w[Referrers Countries Networks])
     expect(traffic).to have_card_tabs(card: "pages", tabs: ["Top URLs", "Entry URLs"])
@@ -261,7 +261,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
 
     traffic.filter_row(card: "acquisition", label: "Direct / unknown")
     expect(traffic).to have_filter_pill(dimension: "referrer", label: "Direct / unknown")
-    expect(traffic).to have_metric(label: "Pageviews", value: "1")
+    expect(traffic).to have_metric(label: "Pageviews", value: "2")
     expect(page).to have_current_path(
       "/admin/dashboard/site-traffic-explorer?end_date=2026-05-12&range=custom&referrer=&start_date=2026-05-01",
     )
@@ -290,7 +290,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     traffic.select_tab(card: "visitors", tab: "Browsers")
     traffic.filter_row(card: "visitors", label: "Chrome")
     expect(traffic).to have_filter_pill(dimension: "browser", label: "Chrome")
-    expect(traffic).to have_metric(label: "Pageviews", value: "2")
+    expect(traffic).to have_metric(label: "Pageviews", value: "3")
     expect(page).to have_current_path(
       "/admin/dashboard/site-traffic-explorer?browser=chrome&end_date=2026-05-12&range=custom&start_date=2026-05-01",
     )
@@ -299,8 +299,8 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     traffic.select_tab(card: "acquisition", tab: "Countries")
     traffic.filter_row(card: "acquisition", label: "United States")
     expect(traffic).to have_filter_pill(dimension: "country", label: "United States")
-    expect(traffic).to have_metric(label: "Pageviews", value: "2")
-    expect(traffic).to have_metric(label: "Logged-in share", value: "100%")
+    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Logged-in share", value: "67%")
     expect(traffic).to have_metric(label: "Distinct sessions", value: "2")
     expect(traffic).to have_metric(label: "Bounce rate", value: "50%")
     expect(page).to have_current_path(
@@ -308,14 +308,14 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     )
 
     traffic.remove_filter("country")
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
     traffic.select_tab(card: "acquisition", tab: "Countries")
     traffic.filter_row(card: "acquisition", label: "United Kingdom")
     expect(traffic).to have_filter_pill(dimension: "country", label: "United Kingdom")
     expect(traffic).to have_metric(label: "Pageviews", value: "1")
 
     traffic.remove_filter("country")
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
     traffic.select_tab(card: "acquisition", tab: "Countries")
     traffic.filter_row(card: "acquisition", label: "United States")
     expect(traffic).to have_filter_pill(dimension: "country", label: "United States")
@@ -353,7 +353,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     traffic.remove_filter("ip")
 
     expect(traffic).to have_no_filter_pills
-    expect(traffic).to have_metric(label: "Pageviews", value: "3")
+    expect(traffic).to have_metric(label: "Pageviews", value: "4")
 
     traffic.select_date_preset("Last 7 days")
 

--- a/spec/system/page_objects/pages/admin_site_traffic_explorer.rb
+++ b/spec/system/page_objects/pages/admin_site_traffic_explorer.rb
@@ -107,7 +107,7 @@ module PageObjects
 
       def has_url_link?(card:, label:, href:)
         within("[data-test-site-traffic-card='#{card}']") do
-          has_css?("a[href='#{href}'][title='#{label}']", exact_text: label)
+          has_css?("a[href='#{href}']", exact_text: label)
         end
       end
 
@@ -160,7 +160,7 @@ module PageObjects
 
       def has_expanded_url_link?(label:)
         selector = ".site-traffic-breakdown-modal[role='dialog']"
-        has_css?("#{selector} a[href='#{label}'][title='#{label}']", exact_text: label)
+        has_css?("#{selector} a[href='#{label}']", exact_text: label)
       end
 
       def filter_expanded_row(label:)


### PR DESCRIPTION
Previously, the unfiltered Site Traffic Explorer omitted likely crawlers from its pageview total while its session total included them, so the headline metrics described different populations. Traffic links also reused the current tab and changed color after being visited, while truncated ASN names did not expose their full value.

This commit includes every selected traffic type in pageview totals, leaving explicit traffic-type filters responsible for exclusions. It also opens traffic links in a new tab, keeps visited links visually consistent, and adds native titles to truncated dimension labels.