### PR TITLE
UX: Fix site traffic dimension label spacing

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -317,17 +317,20 @@
   }
 
   &__dimension-label {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    display: flex;
     align-items: center;
-    gap: var(--space-2);
     min-width: 0;
     width: 100%;
   }
 
+  &__dimension-prefix {
+    flex: 0 0 auto;
+    margin-inline-end: var(--space-2);
+  }
+
   &__dimension-text {
     @include ellipsis;
-    grid-column: 2;
+    flex: 1 1 auto;
     min-width: 0;
   }
 

--- a/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-dimension-label.gjs
@@ -26,9 +26,15 @@ export default class SiteTrafficExplorerDimensionLabel extends Component {
   <template>
     <span class="site-traffic-explorer__dimension-label">
       {{#if (eq @dimension "countries")}}
-        <span aria-hidden="true">{{this.countryFlag @row.value}}</span>
+        <span
+          class="site-traffic-explorer__dimension-prefix"
+          aria-hidden="true"
+        >{{this.countryFlag @row.value}}</span>
       {{else if (eq @dimension "browsers")}}
-        {{dIcon (this.browserIcon @row.value)}}
+        {{dIcon
+          (this.browserIcon @row.value)
+          class="site-traffic-explorer__dimension-prefix"
+        }}
       {{/if}}
       <span class="site-traffic-explorer__dimension-text" title={{@row.label}}>
         {{@row.label}}


### PR DESCRIPTION
### Before

<img width="360" height="190" alt="Before" src="https://github.com/user-attachments/assets/34741577-1a18-4d2f-97d7-7065657043a0" />

### After

<img width="360" height="190" alt="After" src="https://github.com/user-attachments/assets/07d4370f-5fc0-4a0a-9968-236c7cc106f0" />
