### PR TITLE
UX: UC – composer redesign > add tag counter on mobile

### DIFF
--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -106,6 +106,12 @@
       .d-icon-tag {
         color: var(--primary-low-mid) !important;
       }
+
+      .multi-select-header__selected-count {
+        @include viewport.from(sm) {
+          display: none;
+        }
+      }
     }
 
     .has-selection {

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -544,6 +544,9 @@ export default class ComposerContainer extends Component {
                               minimum=this.composer.model.minimumRequiredTags
                               icon=(if this.composerRedesign "tag")
                               prioritizeRecentTags=true
+                              useHeaderSelectedCount=(if
+                                this.composerRedesign true
+                              )
                             }}
                           />
                           <PluginOutlet


### PR DESCRIPTION
<img width="732" height="1586" alt="CleanShot 2026-08-13 at 16 48 13@2x" src="https://github.com/user-attachments/assets/bba8df15-4753-4fbe-985e-2b3a34e403cf" />
