### PR TITLE
UX: fit review queue images to the content box

### DIFF
--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -264,6 +264,11 @@
       padding: var(--review-item-padding);
       border-radius: var(--d-border-radius);
 
+      img:not(.avatar, .emoji) {
+        max-width: 100%;
+        height: auto;
+      }
+
       .lightbox-wrapper img {
         display: block;
       }


### PR DESCRIPTION
Images in the review queue could render at their natural size and spill out of the post content box, which made moderating a post with a large image awkward. The topic stream caps images with a rule on `.cooked`, but the review queue renders into `.review-item__post-content`, so nothing applied there.

This is most visible on posts waiting for approval, since their content is cooked straight from the raw text and never goes through the image resizing that a published post gets.

- Cap images in `.review-item__post-content` at the width of the box and let the height follow.
- Leave avatars and emoji alone so they keep their own sizing.