### PR TITLE
FIX: Handle PostgreSQL read-only errors correctly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,7 +152,7 @@ class ApplicationController < ActionController::Base
   rescue_from PG::ReadOnlySqlTransaction do |e|
     Discourse.received_postgres_readonly!
     Rails.logger.error("#{e.class} #{e.message}: #{e.backtrace.join("\n")}")
-    rescue_with_handler(Discourse::ReadOnly) || raise
+    rescue_with_handler(Discourse::ReadOnly.new) || raise
   end
 
   rescue_from ActionController::ParameterMissing do |e|

--- a/app/controllers/test_requests_controller.rb
+++ b/app/controllers/test_requests_controller.rb
@@ -19,5 +19,9 @@ class TestRequestsController < ApplicationController
 
       render json: net_http_get
     end
+
+    def test_postgres_readonly
+      raise PG::ReadOnlySqlTransaction, "cannot execute INSERT in a read-only transaction"
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1984,6 +1984,7 @@ Discourse::Application.routes.draw do
       # Routes that are only used for testing
       get "/test_net_http_timeouts" => "test_requests#test_net_http_timeouts"
       get "/test_net_http_headers" => "test_requests#test_net_http_headers"
+      get "/test_postgres_readonly" => "test_requests#test_postgres_readonly"
     end
 
     # This catch-all route should always be last

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -3,6 +3,20 @@
 RSpec.describe ApplicationController do
   fab!(:user)
 
+  describe "handling PostgreSQL read-only errors" do
+    after { Discourse.clear_postgres_readonly! }
+
+    it "returns a read-only response" do
+      get "/test_postgres_readonly.json"
+
+      expect(response.status).to eq(503)
+      expect(response.parsed_body).to eq(
+        "errors" => [I18n.t("read_only_mode_enabled")],
+        "error_type" => "read_only",
+      )
+    end
+  end
+
   describe "shared session key" do
     before { SiteSetting.long_polling_base_url = "https://mb.example.com/" }
 


### PR DESCRIPTION
Pass an exception instance to the read-only handler so requests return 503 instead of 500.