### PR TITLE
UX: fix z-index of chat actions when in livestream modal

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/components/livestream/modal/mobile-embeddable-chat-modal.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/livestream/modal/mobile-embeddable-chat-modal.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
+import bodyClass from "discourse/helpers/body-class";
 import { lock, unlock } from "discourse/lib/body-scroll-lock";
 import DModal from "discourse/ui-kit/d-modal";
 import EmbeddableChatChannel from "../embeddable-chat-channel";
@@ -67,6 +68,8 @@ export default class MobileEmbeddableChatModal extends Component {
   }
 
   <template>
+    {{bodyClass "livestream-chat-modal-active"}}
+
     <DModal
       @closeModal={{@closeModal}}
       class="livestream-chat-modal"

--- a/plugins/discourse-events/assets/stylesheets/common/livestream.scss
+++ b/plugins/discourse-events/assets/stylesheets/common/livestream.scss
@@ -162,3 +162,12 @@ body.chat-enabled.livestream-topic.confirmed-event-assistance {
     display: none;
   }
 }
+
+// we need to raise the z-index of the actions outlet
+// so they appear above the modal
+.livestream-chat-modal-active {
+  .chat-message-actions-desktop-outlet {
+    position: relative;
+    z-index: z("max");
+  }
+}


### PR DESCRIPTION
In the livestream feature of the Events plugin we show chat in a modal, but actions are rendered in a separate portal outside of the modal, and end up rendering behind it. When the modal is active we need to elevate the z-index of the action portal to appear above the modal. 

Before:
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/2132c9dd-d2f7-4ee9-9f79-e2f6a870ce4b" />


After:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f79edf44-8f07-44dc-a74f-80d6414b478b" />
