### PR TITLE
DEV: Add external drag targets and auto-scroll

### DIFF
--- a/app/assets/stylesheets/common/ui-kit/d-drag-and-drop.scss
+++ b/app/assets/stylesheets/common/ui-kit/d-drag-and-drop.scss
@@ -44,10 +44,14 @@
   }
 }
 
-/* Every target draws from one position vocabulary, so "a drop would land above
-   this row" has one visual meaning across consumers. */
+/* Both target flavours draw from one position vocabulary, because "a drop would
+   land above this row" means the same thing whether the payload came from
+   another element or from outside the window. An external target only reaches
+   these once it has been given an `axis` or a `position`; without one it gets
+   the single class below instead. */
 
-[data-drop-target] {
+[data-drop-target],
+[data-drop-target-external] {
   &.--drag-above {
     position: relative;
 
@@ -97,6 +101,13 @@
      sibling positions. */
 
   &.--drag-inside {
+    outline: 2px solid var(--d-drag-indicator-color);
+    outline-offset: -2px;
+  }
+}
+
+[data-drop-target-external] {
+  &.--drag-over-external {
     outline: 2px solid var(--d-drag-indicator-color);
     outline-offset: -2px;
   }

--- a/frontend/discourse/app/services/drag-and-drop.ts
+++ b/frontend/discourse/app/services/drag-and-drop.ts
@@ -5,6 +5,27 @@ import {
   type ElementDragPayload,
   monitorForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import {
+  type ExternalDragPayload as NativeExternalDragPayload,
+  monitorForExternal,
+  type NativeMediaType,
+} from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
+import {
+  containsFiles,
+  getFiles,
+} from "@atlaskit/pragmatic-drag-and-drop/external/file";
+import {
+  containsHTML,
+  getHTML,
+} from "@atlaskit/pragmatic-drag-and-drop/external/html";
+import {
+  containsText,
+  getText,
+} from "@atlaskit/pragmatic-drag-and-drop/external/text";
+import {
+  containsURLs,
+  getURLs,
+} from "@atlaskit/pragmatic-drag-and-drop/external/url";
 
 /** The in-flight element drag, as the source described it. */
 export interface DragPayload {
@@ -43,6 +64,113 @@ export const DRAG_BODY = "discourse:dragBody";
  */
 export function dragTypeOf(data?: Record<string, unknown>) {
   return data?.type as string | undefined;
+}
+
+/**
+ * The in-flight external drag, with the read helpers bound to it so consumers
+ * never reach for the underlying library themselves.
+ */
+export interface ExternalDragPayload {
+  /**
+   * Native MIME types declared by the incoming drag (e.g. `"Files"`,
+   * `"text/plain"`, `"text/uri-list"`).
+   */
+  types: NativeMediaType[];
+
+  /**
+   * The `DataTransferItem` list snapshotted at drag start. Browsers expose `kind`
+   * and `type` here even when `dataTransfer.getData(…)` is blocked during
+   * `dragover` for security.
+   */
+  items: DataTransferItem[];
+
+  /**
+   * Reads the string payload for a given MIME type. Returns `null` when the type
+   * is absent or the browser withholds string data during the current drag
+   * phase; completed drop callbacks normally receive the readable payload.
+   */
+  getStringData: (mediaType: string) => string | null;
+
+  containsFiles: () => boolean;
+  getFiles: () => File[];
+  containsHTML: () => boolean;
+  getHTML: () => string | null;
+  containsText: () => boolean;
+  getText: () => string | null;
+  containsURLs: () => boolean;
+  getURLs: () => string[];
+}
+
+/**
+ * Vocabulary `acceptsExternal()` understands. Each key delegates to the
+ * matching native-payload predicate so the service and external-target surfaces
+ * share one vocabulary.
+ */
+const EXTERNAL_KIND_PREDICATES = Object.freeze({
+  files: containsFiles,
+  html: containsHTML,
+  text: containsText,
+  urls: containsURLs,
+});
+
+/** A kind of external payload, as named by `accepts` / `acceptsExternal()`. */
+export type ExternalDragKind = keyof typeof EXTERNAL_KIND_PREDICATES;
+
+/**
+ * Wraps the underlying library's raw external payload
+ * (`{types, items, getStringData}`) with the `contains*` / `get*` helpers bound
+ * to it, so a consumer calls `source.getFiles()` rather than importing the
+ * library's helpers itself.
+ *
+ * Lives here rather than beside either drop target because both targets and this
+ * service need it, and the external target already imports from the element one
+ * — a copy in either would close an import cycle the moment a third reader
+ * appeared.
+ *
+ * @param source - The raw payload the library reports.
+ */
+export function decorateExternalSource(
+  source: NativeExternalDragPayload
+): ExternalDragPayload {
+  return {
+    types: source.types,
+    items: source.items,
+    getStringData: (mediaType) => source.getStringData(mediaType),
+    containsFiles: () => containsFiles({ source }),
+    getFiles: () => getFiles({ source }),
+    containsHTML: () => containsHTML({ source }),
+    getHTML: () => getHTML({ source }),
+    containsText: () => containsText({ source }),
+    getText: () => getText({ source }),
+    containsURLs: () => containsURLs({ source }),
+    getURLs: () => getURLs({ source }),
+  };
+}
+
+/**
+ * Whether an incoming external drag is one of the named kinds.
+ *
+ * An empty or missing filter matches every external drag, mirroring how the
+ * element target treats an absent `accepts`. Shared so everything filtering on
+ * this vocabulary agrees on what a kind name means; the element-side
+ * counterpart is `matchesDragType`.
+ *
+ * @param accepts - The kind filter as the consumer supplied it.
+ * @param source - The raw payload the underlying library reports.
+ */
+export function matchesExternalKind(
+  accepts: ExternalDragKind | ExternalDragKind[] | undefined,
+  source: NativeExternalDragPayload
+) {
+  const kinds = accepts ? (Array.isArray(accepts) ? accepts : [accepts]) : [];
+  if (kinds.length === 0) {
+    return true;
+  }
+  return kinds.some((kind) => {
+    const predicate = EXTERNAL_KIND_PREDICATES[kind];
+    // Unknown kind names fail closed — better than silently matching.
+    return predicate ? predicate({ source }) : false;
+  });
 }
 
 /**
@@ -94,12 +222,13 @@ export function normalizeDragSource(
 }
 
 /**
- * Tracks the in-flight `dDragAndDropSource` / `dDragAndDropTarget` element
- * drag pair.
+ * Tracks in-flight drags from both the `dDragAndDropSource` /
+ * `dDragAndDropTarget` element pair and the OS-level payloads wired through
+ * `dDragAndDropExternalTarget`.
  *
- * Element drag state is populated first-hand by the singleton monitor this
- * service registers on construction. Per-element modifiers do not each carry
- * their own monitor; this is the observer.
+ * Both states are populated first-hand by singleton monitors this service
+ * registers on construction. Per-element modifiers do not each carry their own
+ * monitor; these are the observers.
  *
  * Lives as a service rather than a module slot so test setup
  * (`setupTest` / `setupRenderingTest`) gets a fresh instance per test.
@@ -114,6 +243,8 @@ export function normalizeDragSource(
 export default class DragAndDropService extends Service {
   @tracked currentDrag: DragPayload | null = null;
 
+  @tracked currentExternalDrag: ExternalDragPayload | null = null;
+
   constructor(...args: ConstructorParameters<typeof Service>) {
     super(...args);
     // Registering a monitor subscribes to the library's drag stream. It does
@@ -125,7 +256,7 @@ export default class DragAndDropService extends Service {
     // modifier does not push state here, the service derives it first-hand.
     // Only drags carrying a `type` are tracked, so a foreign draggable with
     // none of its own stays invisible here.
-    const cleanup = monitorForElements({
+    const cleanupElements = monitorForElements({
       canMonitor: ({ source }) =>
         !this.isDestroying &&
         !this.isDestroyed &&
@@ -150,12 +281,33 @@ export default class DragAndDropService extends Service {
         this.clearCurrentDrag();
       },
     });
-    registerDestructor(this, cleanup);
+    // Guarded the same way as the element monitor above: a drag still in flight
+    // when the service is torn down would otherwise write tracked state on a
+    // destroyed object.
+    const cleanupExternal = monitorForExternal({
+      canMonitor: () => !this.isDestroying && !this.isDestroyed,
+      onDragStart: ({ source }) => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+        this.currentExternalDrag = decorateExternalSource(source);
+      },
+      onDrop: () => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+        this.currentExternalDrag = null;
+      },
+    });
+    registerDestructor(this, () => {
+      cleanupElements();
+      cleanupExternal();
+    });
   }
 
-  /** Whether an element drag is in flight. */
+  /** Whether an element or external drag is in flight. */
   get isDragging() {
-    return !!this.currentDrag;
+    return !!(this.currentDrag || this.currentExternalDrag);
   }
 
   /**
@@ -189,6 +341,40 @@ export default class DragAndDropService extends Service {
       return accepts.includes(this.currentDrag.type);
     }
     return this.currentDrag.type === accepts;
+  }
+
+  /**
+   * Does the in-flight external drag carry one of the supplied kinds?
+   *
+   * The vocabulary mirrors the `accepts` argument on
+   * `dDragAndDropExternalTarget`: `"files"`, `"html"`, `"text"`, `"urls"`, or
+   * an array of those. A nullish filter matches nothing.
+   */
+  acceptsExternal(kinds?: ExternalDragKind | ExternalDragKind[] | null) {
+    if (!this.currentExternalDrag || !kinds) {
+      return false;
+    }
+    const list = Array.isArray(kinds) ? kinds : [kinds];
+    return list.some((kind) => {
+      const predicate = EXTERNAL_KIND_PREDICATES[kind];
+      return predicate ? this.#callExternalPredicate(predicate) : false;
+    });
+  }
+
+  /**
+   * Re-runs a native-payload predicate against the live external drag. Done
+   * lazily rather than cached so it receives the original source shape.
+   */
+  #callExternalPredicate(
+    predicate: (typeof EXTERNAL_KIND_PREDICATES)[ExternalDragKind]
+  ) {
+    return predicate({
+      source: {
+        types: this.currentExternalDrag.types,
+        items: this.currentExternalDrag.items,
+        getStringData: this.currentExternalDrag.getStringData,
+      },
+    });
   }
 }
 

--- a/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-auto-scroll.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-auto-scroll.ts
@@ -1,0 +1,188 @@
+import type { ElementDragPayload } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import type { ExternalDragPayload as NativeExternalDragPayload } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
+import {
+  autoScrollForElements,
+  autoScrollWindowForElements,
+} from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import {
+  autoScrollForExternal,
+  autoScrollWindowForExternal,
+} from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/external";
+import { modifier } from "ember-modifier";
+import {
+  type ExternalDragKind,
+  matchesExternalKind,
+} from "discourse/services/drag-and-drop";
+import { matchesDragType } from "discourse/ui-kit/modifiers/d-drag-and-drop-monitor";
+
+/** Which direction the container is allowed to scroll while a drag is in flight. */
+export type AutoScrollAxis = "vertical" | "horizontal" | "all";
+
+/** What gets scrolled: the element the modifier sits on, or the window. */
+export type AutoScrollTarget = "element" | "window";
+
+interface DDragAndDropAutoScrollSignature {
+  /** The scroll container, or a sentinel when `target` is `"window"`. */
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      /**
+       * Only drags whose resolved `type` matches engage the auto-scroll. Omit to
+       * engage on any element drag (rare).
+       */
+      types?: string | string[];
+
+      /**
+       * Also auto-scroll for drags coming from outside the window, engaging on
+       * these external kinds. Opt-in and separate from `types` because the two
+       * describe different drags: `types` names a discriminator our own sources
+       * stamp, which a payload dragged in from another application has no way of
+       * carrying. Omit it and an external drag scrolls nothing.
+       */
+      accepts?: ExternalDragKind | ExternalDragKind[];
+
+      /** Defaults to `"vertical"`. */
+      axis?: AutoScrollAxis;
+
+      /**
+       * `"element"` (default) scrolls the host element; `"window"` scrolls the
+       * window and ignores the element.
+       *
+       * Decides which registration to make rather than being consulted per
+       * callback, so changing it replaces the registration instead of taking
+       * effect within it.
+       */
+      target?: AutoScrollTarget;
+    };
+    Positional: [];
+  };
+}
+
+/**
+ * The auto-scroll's named args, for a consumer driving
+ * {@link registerDragAndDropAutoScroll} imperatively rather than through the
+ * modifier.
+ */
+export type DragAndDropAutoScrollArgs =
+  DDragAndDropAutoScrollSignature["Args"]["Named"] & {
+    /** The scroll container. Required when `target` is `"element"`. */
+    element?: HTMLElement;
+  };
+
+/**
+ * Wraps element and window auto-scroll behind one shape. Used by the
+ * default-exported modifier below, and exported so a consumer can register
+ * auto-scroll imperatively when a template modifier does not fit — parallel to
+ * `registerDragAndDropMonitor`.
+ *
+ * Library-agnostic by design: the auto-scroll dependency is imported only here.
+ *
+ * @param getArgsRef - Closure returning the latest args. `types` and `axis` are
+ *   re-read on every callback, so a caller driving this imperatively can change
+ *   what its closure returns and have the change take without re-registering.
+ *   `target` and `element` are read once, here, to decide which registration to
+ *   make, so changing either needs a fresh one.
+ *
+ *   Through the modifier below that distinction does not arise: the closure is
+ *   invoked in the modifier body, which consumes every arg it reads, so changing
+ *   any of them re-runs the modifier and replaces the registration. That is
+ *   accepted rather than worked around — auto-scroll args rarely change, and a
+ *   replacement between drags costs nothing.
+ * @returns Cleanup function. Caller invokes it once on teardown.
+ */
+export function registerDragAndDropAutoScroll(
+  getArgsRef: () => DragAndDropAutoScrollArgs
+) {
+  const matchesType = ({ source }: { source: ElementDragPayload }) =>
+    matchesDragType(getArgsRef().types, source);
+
+  const matchesKind = ({ source }: { source: NativeExternalDragPayload }) =>
+    matchesExternalKind(getArgsRef().accepts, source);
+
+  const getAllowedAxis = () => getArgsRef().axis ?? "vertical";
+
+  const args = getArgsRef();
+  const scrollsWindow = args.target === "window";
+
+  const cleanups = [
+    scrollsWindow
+      ? autoScrollWindowForElements({ canScroll: matchesType, getAllowedAxis })
+      : autoScrollForElements({
+          element: args.element,
+          canScroll: matchesType,
+          getAllowedAxis,
+        }),
+  ];
+
+  // The two adapters are independent registrations, so an external drag scrolls
+  // only where a consumer asked for it. Registering one unconditionally would
+  // start scrolling every container for every file dragged over the window.
+  if (args.accepts) {
+    cleanups.push(
+      scrollsWindow
+        ? autoScrollWindowForExternal({
+            canScroll: matchesKind,
+            getAllowedAxis,
+          })
+        : autoScrollForExternal({
+            element: args.element,
+            canScroll: matchesKind,
+            getAllowedAxis,
+          })
+    );
+  }
+
+  return () => cleanups.forEach((cleanup) => cleanup());
+}
+
+/**
+ * Enables auto-scroll while a compatible drag is in flight. Every arg is
+ * documented on {@link DragAndDropAutoScrollArgs}.
+ *
+ * Attach to a scroll container to auto-scroll that container when
+ * the cursor approaches its edges:
+ *
+ * ```hbs
+ * <div class="scroll-container"
+ *   {{dDragAndDropAutoScroll types=(array "card") axis="vertical"}}
+ * >
+ * ```
+ *
+ * Attach to a sentinel element with `target="window"`
+ * to auto-scroll the document body / window instead:
+ *
+ * ```hbs
+ * <span class="visually-hidden"
+ *   {{dDragAndDropAutoScroll target="window" types=this.acceptedTypes}}
+ * ></span>
+ * ```
+ *
+ * Add `accepts` to scroll for payloads dragged in from outside the window too,
+ * which is a separate registration and does not happen without it:
+ *
+ * ```hbs
+ * <div class="scroll-container"
+ *   {{dDragAndDropAutoScroll types=(array "card") accepts="urls"}}
+ * >
+ * ```
+ *
+ * Guide to choosing between the gesture primitives:
+ * `docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md`
+ *
+ * @see The `dDragAndDropTarget` modifier, which this complements — auto-scroll moves the
+ *   container, it never accepts a drop of its own.
+ */
+export default modifier<DDragAndDropAutoScrollSignature>(
+  (element, _positional, args) =>
+    // The closure is the shape the registrar reads args through, not a way of
+    // avoiding consumption: it is invoked in the body, so every arg it reads is
+    // consumed here and any change re-runs this modifier. See the note on
+    // `registerDragAndDropAutoScroll` for why that is fine.
+    registerDragAndDropAutoScroll(() => ({
+      types: args.types,
+      accepts: args.accepts,
+      axis: args.axis ?? "vertical",
+      target: args.target ?? "element",
+      element,
+    }))
+);

--- a/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-external-target.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-external-target.ts
@@ -1,0 +1,422 @@
+import {
+  dropTargetForExternal,
+  type ExternalDragPayload as NativeExternalDragPayload,
+  type ExternalDropTargetEventBasePayload,
+  type ExternalDropTargetGetFeedbackArgs,
+} from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
+import { modifier } from "ember-modifier";
+import {
+  decorateExternalSource,
+  type ExternalDragKind,
+  type ExternalDragPayload,
+  matchesExternalKind,
+} from "discourse/services/drag-and-drop";
+import {
+  createEnterLeavePairing,
+  createPositionIndicator,
+  type DropAxis,
+  type DropEffect,
+  type DropPosition,
+  isDeepestTarget,
+  resolveDropPosition,
+} from "discourse/ui-kit/modifiers/d-drag-and-drop-target";
+
+/** The pointer position as the underlying library reports it. */
+type DragInput = ExternalDropTargetGetFeedbackArgs["input"];
+
+/** The drag's initial, previous and current locations. */
+type DragLocation = ExternalDropTargetEventBasePayload["location"];
+
+/** What a synchronous gate (`canDrop`, `getDropEffect`) is asked about. */
+export interface ExternalDropTargetFeedback {
+  /** The incoming payload, with the read helpers bound to it. */
+  source: ExternalDragPayload;
+
+  /** Where the pointer is. */
+  input: DragInput;
+
+  /** This target's element. */
+  element: Element;
+}
+
+/** What a lifecycle callback is told. */
+export interface ExternalDropTargetEvent {
+  /** The incoming payload, with the read helpers bound to it. */
+  source: ExternalDragPayload;
+
+  /**
+   * Where the drop would land, `null` when the drag has left and also when the
+   * target asked for no position at all — see `axis`.
+   */
+  position: DropPosition | null;
+
+  /** The drag's location history. */
+  location: DragLocation;
+
+  /** This target's element. */
+  element: Element;
+}
+
+/**
+ * State modifier class toggled on the target while a compatible external drag
+ * is hovering, for a target that resolves no position: it is a single
+ * destination, so there is only one thing to say about it. A target that does
+ * resolve a position uses the element variant's `--drag-above` / `--drag-below`
+ * / `--drag-inside` instead, and never both — the two answer the same question
+ * at different resolutions.
+ */
+const INDICATOR_CLASS = "--drag-over-external";
+
+interface DDragAndDropExternalTargetSignature {
+  /** The element to register as a drop target. */
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      /**
+       * Filters which external drag kinds engage the target. Omit to accept any
+       * external drag.
+       */
+      accepts?: ExternalDragKind | ExternalDragKind[];
+
+      /**
+       * A fixed drop position. When set, `axis` and the midpoint logic are
+       * ignored. Supplying it opts the target into resolving a position at all —
+       * see `axis`.
+       */
+      position?: DropPosition;
+
+      /**
+       * Drives the indicator class selection and the midpoint position math,
+       * exactly as on the element target.
+       *
+       * Supplying either this or `position` is what opts a target into
+       * resolving a position: without one, callbacks are told `position: null`
+       * and the indicator is the single `--drag-over-external` class. Most
+       * external targets want that — a drop zone is one destination, not a slot
+       * in a list. Reach for an axis when the target IS a slot, such as a row a
+       * dragged-in link should land above or below.
+       */
+      axis?: DropAxis;
+
+      /** Synchronous gate. Returning `false` refuses the drop. */
+      canDrop?: (feedback: ExternalDropTargetFeedback) => boolean | void;
+
+      /** Determines the cursor feedback browsers show during the drag. */
+      getDropEffect?: (feedback: ExternalDropTargetFeedback) => DropEffect;
+
+      /**
+       * `false` to suppress the `--drag-over-external` indicator class. Defaults
+       * to `true`.
+       */
+      indicator?: boolean;
+
+      /**
+       * This target became the one a drop would land on, with a compatible
+       * external drag in flight. Usually the cursor entering it, but also a
+       * nested target that was covering it going away, so it can fire without
+       * the cursor moving.
+       */
+      onDragEnter?: (event: ExternalDropTargetEvent) => void;
+
+      /**
+       * The drag progressed. Throttled; fires when the input or the drop-target
+       * hierarchy updates while this target is active.
+       */
+      onDrag?: (event: ExternalDropTargetEvent) => void;
+
+      /**
+       * This target stopped being the one a drop would land on. The cursor
+       * leaving it, or a nested target taking over while the cursor is still
+       * inside it. `position` is `null`.
+       *
+       * Tracks the role rather than the callbacks: fires only for a target that
+       * had taken the role, and only once each time it gives it up, whether or
+       * not an `onDragEnter` was supplied to observe it being taken.
+       *
+       * Not every taking is given up here, though. A drop ends the drag without
+       * a leave, and so does the target being torn down mid-drag, so drag-time
+       * state has to be released on the consumer's own destruction too.
+       */
+      onDragLeave?: (event: ExternalDropTargetEvent) => void;
+
+      /** The drag was released on this target. */
+      onDrop?: (event: ExternalDropTargetEvent) => void;
+    };
+    Positional: [];
+  };
+}
+
+/**
+ * The external drop target's named args, for a consumer driving
+ * {@link registerDragAndDropExternalTarget} imperatively rather than through the
+ * modifier.
+ */
+export type DragAndDropExternalTargetArgs =
+  DDragAndDropExternalTargetSignature["Args"]["Named"];
+
+/**
+ * Imperative external drop-target registration. Wraps the native adapter with
+ * the deepest-target filter, the `--drag-over-external` indicator class, and the
+ * decorated-source payload the modifier exposes.
+ *
+ * Use this directly when you've captured an element ref outside your
+ * own template (e.g. via `didInsert` on a sibling marker, or after
+ * walking the DOM) and can't attach the `{{dDragAndDropExternalTarget}}`
+ * modifier. The modifier itself is a thin wrapper around this
+ * function for the template-based common case.
+ *
+ * Library-agnostic by design: the dependency is imported only by the ui-kit
+ * modifier files. Consumers talk to this helper rather than the adapter
+ * directly.
+ *
+ * @param element - The element to register as a drop target.
+ * @param getArgsRef - Closure returning the latest args. Adapter callbacks read
+ *   this on every invocation, so arg changes take effect without re-registering.
+ * @returns Cleanup function. Caller invokes it once on teardown (modifier
+ *   destroy, component willDestroy, etc.).
+ */
+export function registerDragAndDropExternalTarget(
+  element: Element,
+  getArgsRef: () => DragAndDropExternalTargetArgs
+) {
+  let isIndicating = false;
+  const positionIndicator = createPositionIndicator(element);
+
+  const resolvePosition = (input: DragInput): DropPosition | null => {
+    const { position, axis } = getArgsRef();
+    if (!position && !axis) {
+      return null;
+    }
+    return resolveDropPosition(element, input, { position, axis });
+  };
+
+  const showIndicator = (position: DropPosition | null) => {
+    if (position) {
+      positionIndicator.apply(position, getArgsRef().axis ?? "y");
+      return;
+    }
+    if (isIndicating) {
+      return;
+    }
+    element.classList.add(INDICATOR_CLASS);
+    isIndicating = true;
+  };
+
+  const clearIndicator = () => {
+    positionIndicator.clear();
+    if (!isIndicating) {
+      return;
+    }
+    element.classList.remove(INDICATOR_CLASS);
+    isIndicating = false;
+  };
+
+  const acceptsSource = (sourcePayload: NativeExternalDragPayload) =>
+    matchesExternalKind(getArgsRef().accepts, sourcePayload);
+
+  const isDeepest = (location: DragLocation) =>
+    isDeepestTarget(location, element);
+
+  const pairing = createEnterLeavePairing();
+
+  /**
+   * Closes an open enter, if there is one. Mirrors the element target: an
+   * ancestor superseded by one of its own children is never sent a leave by the
+   * adapter, so it has to synthesise one or the enter stays open for the rest of
+   * the drag.
+   */
+  const reportLeave = (
+    source: NativeExternalDragPayload,
+    location: DragLocation
+  ) =>
+    pairing.leave(() =>
+      getArgsRef().onDragLeave?.({
+        source: decorateExternalSource(source),
+        position: null,
+        location,
+        element,
+      })
+    );
+
+  // See the note in `registerDragAndDropSource`.
+  element.setAttribute("data-drop-target-external", "");
+
+  // One gate for feedback time and drop time, as on the element target:
+  // consumers put authorization in `canDrop`, so re-asking at drop is the
+  // difference between refusing and acting on stale permission.
+  const passesGate = (source: NativeExternalDragPayload, input: DragInput) => {
+    if (!acceptsSource(source)) {
+      return false;
+    }
+    const args = getArgsRef();
+    if (!args.canDrop) {
+      return true;
+    }
+    return (
+      args.canDrop({
+        source: decorateExternalSource(source),
+        input,
+        element,
+      }) !== false
+    );
+  };
+
+  const cleanup = dropTargetForExternal({
+    element,
+    canDrop: ({ source, input }) => passesGate(source, input),
+    getDropEffect: ({ source, input }) => {
+      const args = getArgsRef();
+      return args.getDropEffect?.({
+        source: decorateExternalSource(source),
+        input,
+        element,
+      });
+    },
+    onDragEnter: ({ source, location }) => {
+      // Ceasing to be the deepest target makes any indicator this element is
+      // showing stale, and an ancestor is kept in the hierarchy rather than
+      // sent a leave, so clearing here is the only chance to drop it.
+      if (!isDeepest(location)) {
+        clearIndicator();
+        reportLeave(source, location);
+        return;
+      }
+      const args = getArgsRef();
+      const position = resolvePosition(location.current.input);
+      if (args.indicator !== false) {
+        showIndicator(position);
+      }
+      pairing.enter(() =>
+        args.onDragEnter?.({
+          source: decorateExternalSource(source),
+          position,
+          location,
+          element,
+        })
+      );
+    },
+    onDrag: ({ source, location }) => {
+      if (!isDeepest(location)) {
+        clearIndicator();
+        reportLeave(source, location);
+        return;
+      }
+      const args = getArgsRef();
+      const position = resolvePosition(location.current.input);
+      if (args.indicator !== false) {
+        showIndicator(position);
+      }
+      // Taking over as the deepest target without a fresh enter; see the element
+      // target, which pairs the same way.
+      pairing.enter(() =>
+        args.onDragEnter?.({
+          source: decorateExternalSource(source),
+          position,
+          location,
+          element,
+        })
+      );
+      args.onDrag?.({
+        source: decorateExternalSource(source),
+        position,
+        location,
+        element,
+      });
+    },
+    onDragLeave: ({ source, location }) => {
+      clearIndicator();
+      reportLeave(source, location);
+    },
+    onDrop: ({ source, location }) => {
+      clearIndicator();
+      pairing.reset();
+      if (!isDeepest(location)) {
+        return;
+      }
+      // The adapter reuses the target stack from the last `dragover` and never
+      // re-asks `canDrop` at drop time, so a gate that flipped false in the
+      // final moments before release would otherwise still act.
+      if (!passesGate(source, location.current.input)) {
+        return;
+      }
+      getArgsRef().onDrop?.({
+        source: decorateExternalSource(source),
+        position: resolvePosition(location.current.input),
+        location,
+        element,
+      });
+    },
+  });
+
+  return () => {
+    cleanup();
+    clearIndicator();
+    element.removeAttribute("data-drop-target-external");
+  };
+}
+
+/**
+ * Marks an element as a drop target for **external** drags — files,
+ * URLs, HTML, text dragged into the window from outside (OS file
+ * manager, another browser tab, etc.). Thin Ember-modifier wrapper
+ * around {@link registerDragAndDropExternalTarget}. Every arg is documented on
+ * {@link DragAndDropExternalTargetArgs}, and the payload every callback
+ * receives on {@link ExternalDragPayload}.
+ *
+ * Pair with the existing `dDragAndDropTarget` modifier for
+ * element-to-element drags; the two adapters are independent and can coexist on
+ * the same element. The external adapter does not call `preventDefault`, so it
+ * also coexists with another consumer of the same native `dragover` / `drop`
+ * events.
+ *
+ * Files:
+ *
+ * ```hbs
+ * <div {{dDragAndDropExternalTarget
+ *   accepts="files"
+ *   onDrop=this.handleFileDrop
+ * }}>...</div>
+ * ```
+ *
+ * Multiple kinds:
+ *
+ * ```hbs
+ * <div {{dDragAndDropExternalTarget
+ *   accepts=(array "files" "urls")
+ *   onDragEnter=this.highlight
+ *   onDragLeave=this.unhighlight
+ *   onDrop=this.handleDrop
+ * }}>...</div>
+ * ```
+ *
+ * A slot rather than a destination — `axis` opts into the element target's
+ * before/after position, for a row an incoming payload should land beside:
+ *
+ * ```hbs
+ * <li {{dDragAndDropExternalTarget
+ *   accepts="urls"
+ *   axis="y"
+ *   onDrop=this.insertBeside
+ * }}>...</li>
+ * ```
+ *
+ * Nested targets: only the deepest accepted target receives the
+ * lifecycle callbacks, so an ancestor decorated with this modifier
+ * doesn't double-handle a drop the child already claimed. An ancestor that
+ * should stay lit throughout should therefore read `@service dragAndDrop`
+ * rather than register a target of its own.
+ *
+ * Guide to choosing between the gesture primitives:
+ * `docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md`
+ *
+ * This modifier hands the consumer the raw payload and stops; it does not upload
+ * anything.
+ */
+export default modifier<DDragAndDropExternalTargetSignature>(
+  (element, _positional, args) =>
+    // Pass `args` through to the closure WITHOUT reading any property of
+    // it here. Reading args.X inside the body would mark its tag consumed
+    // and force the modifier to re-run (re-registering the adapter) on every
+    // change. The closure reads fresh values inside the adapter callbacks.
+    registerDragAndDropExternalTarget(element, () => args)
+);

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^2.1.4",
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-javascript": "^6.2.5",

--- a/frontend/discourse/tests/helpers/ui-kit/drag-and-drop-helper.ts
+++ b/frontend/discourse/tests/helpers/ui-kit/drag-and-drop-helper.ts
@@ -155,3 +155,61 @@ function registeredElementFor(rowSelector: string) {
   const row = document.querySelector(rowSelector);
   return (row?.querySelector("[draggable]") ?? row) as Element;
 }
+
+/** How an external drag is aimed at its target. */
+interface ExternalDragOptions {
+  /**
+   * Shared payload that must travel across every event so the drag library can
+   * correlate them.
+   */
+  dataTransfer: DataTransfer;
+
+  /** Coordinates merged over the target element's center. */
+  coordinates?: Partial<ClientPoint>;
+}
+
+/**
+ * Brings an external drag over a target and leaves it hovering there, without
+ * dropping.
+ *
+ * Deliberately no `dragstart`: a drag that began outside the page never fires
+ * one, and its absence is exactly what routes the drag to the external adapter
+ * rather than the element one. A test that starts with `dragstart` is testing
+ * the wrong adapter.
+ *
+ * Stops short of the drop so a caller can assert on the hovering state — the
+ * indicator classes, or what a lifecycle callback was told — which a completed
+ * drop would already have cleared. Use {@link simulateExternalDrag} when the
+ * drop itself is the subject.
+ *
+ * @param targetSelector - CSS selector for the target element.
+ * @param options - The shared payload and any coordinate override.
+ */
+export async function externalDragOver(
+  targetSelector: string,
+  { dataTransfer, coordinates }: ExternalDragOptions
+) {
+  const target = { ...centerOf(targetSelector), ...coordinates };
+  await dragEvent(targetSelector, "dragenter", { dataTransfer, ...target });
+  await dragEvent(targetSelector, "dragover", { dataTransfer, ...target });
+}
+
+/**
+ * Drives a complete external drag onto a target and drops it there.
+ *
+ * The external counterpart to {@link simulateDrag}, and the same frame-per-event
+ * rule applies. Coordinates matter here as much as they do for an element drag:
+ * a target resolving a drop position from the pointer reads them, and a bare
+ * center only ever exercises the `after` branch of a midpoint comparison.
+ *
+ * @param targetSelector - CSS selector for the target element.
+ * @param options - The shared payload and any coordinate override.
+ */
+export async function simulateExternalDrag(
+  targetSelector: string,
+  { dataTransfer, coordinates }: ExternalDragOptions
+) {
+  const target = { ...centerOf(targetSelector), ...coordinates };
+  await externalDragOver(targetSelector, { dataTransfer, coordinates });
+  await dragEvent(targetSelector, "drop", { dataTransfer, ...target });
+}

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-auto-scroll-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-auto-scroll-test.gjs
@@ -1,0 +1,70 @@
+import { find, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { dragEvent } from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+import dDragAndDropAutoScroll from "discourse/ui-kit/modifiers/d-drag-and-drop-auto-scroll";
+import dDragAndDropExternalTarget from "discourse/ui-kit/modifiers/d-drag-and-drop-external-target";
+
+module(
+  "Integration | ui-kit | Modifier | dDragAndDropAutoScroll",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    module("external auto-scroll", function () {
+      function textTransfer() {
+        const dataTransfer = new DataTransfer();
+        dataTransfer.setData("text/plain", "dropped text");
+        return dataTransfer;
+      }
+
+      /**
+       * Holds a drag near the container's bottom edge across several frames.
+       * Auto-scroll runs off its own animation-frame loop and eases in over time,
+       * so a single event moves nothing measurable.
+       */
+      async function hoverNearBottomEdge(selector, dataTransfer) {
+        const { left, bottom, width } = find(selector).getBoundingClientRect();
+        const point = { clientX: left + width / 2, clientY: bottom - 2 };
+
+        await dragEvent(selector, "dragenter", { dataTransfer, ...point });
+        for (let frame = 0; frame < 12; frame++) {
+          await dragEvent(selector, "dragover", { dataTransfer, ...point });
+        }
+      }
+
+      const scroller = <template>
+        <div
+          id="scroller"
+          style="height: 100px; overflow-y: auto"
+          {{dDragAndDropExternalTarget accepts="text"}}
+          {{dDragAndDropAutoScroll accepts=@accepts}}
+        >
+          <div style="height: 600px">tall</div>
+        </div>
+      </template>;
+
+      test("external auto-scroll moves the container for a drag from outside the window", async function (assert) {
+        await render(<template><scroller @accepts="text" /></template>);
+
+        await hoverNearBottomEdge("#scroller", textTransfer());
+
+        assert.true(
+          find("#scroller").scrollTop > 0,
+          "holding a drag against the bottom edge scrolls the container down"
+        );
+      });
+
+      test("external auto-scroll stays off until a consumer asks for it", async function (assert) {
+        await render(<template><scroller /></template>);
+
+        await hoverNearBottomEdge("#scroller", textTransfer());
+
+        assert.strictEqual(
+          find("#scroller").scrollTop,
+          0,
+          "a container that named no external kinds is not scrolled by one"
+        );
+      });
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-external-target-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-external-target-test.gjs
@@ -1,0 +1,760 @@
+import { tracked } from "@glimmer/tracking";
+import { find, render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  centerOf,
+  dragEvent,
+  externalDragOver,
+  simulateExternalDrag,
+} from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+import dDragAndDropExternalTarget from "discourse/ui-kit/modifiers/d-drag-and-drop-external-target";
+
+module(
+  "Integration | ui-kit | Modifier | dDragAndDropExternalTarget",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("registration marker follows the target lifecycle", async function (assert) {
+      const state = new (class {
+        @tracked show = true;
+      })();
+
+      await render(
+        <template>
+          {{#if state.show}}
+            <div
+              id="external-target"
+              {{dDragAndDropExternalTarget accepts="files"}}
+            >external target</div>
+          {{/if}}
+        </template>
+      );
+
+      const target = find("#external-target");
+      assert.true(
+        target.hasAttribute("data-drop-target-external"),
+        "the target is marked while registered"
+      );
+
+      state.show = false;
+      await settled();
+
+      assert.false(
+        target.hasAttribute("data-drop-target-external"),
+        "destroying the target removes its marker"
+      );
+    });
+
+    module("external target behaviour", function () {
+      function fileTransfer() {
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(
+          new File(["payload"], "a.txt", { type: "text/plain" })
+        );
+        return dataTransfer;
+      }
+
+      function textTransfer() {
+        const dataTransfer = new DataTransfer();
+        dataTransfer.setData("text/plain", "dropped text");
+        return dataTransfer;
+      }
+
+      test("hands the consumer a payload it can read without importing the library", async function (assert) {
+        let seen = null;
+        const onDrop = ({ source }) => {
+          seen = {
+            containsFiles: source.containsFiles(),
+            names: source.getFiles().map((file) => file.name),
+          };
+        };
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              {{dDragAndDropExternalTarget accepts="files" onDrop=onDrop}}
+            >ext</div>
+          </template>
+        );
+
+        await simulateExternalDrag("#ext", { dataTransfer: fileTransfer() });
+
+        assert.deepEqual(
+          seen,
+          { containsFiles: true, names: ["a.txt"] },
+          "the decorated source answers about its own payload and returns the files"
+        );
+      });
+
+      test("accepts filters which external kinds engage the target", async function (assert) {
+        const drops = [];
+        const onFilesDrop = () => drops.push("files");
+        const onTextDrop = () => drops.push("text");
+
+        await render(
+          <template>
+            <div
+              id="files-only"
+              {{dDragAndDropExternalTarget accepts="files" onDrop=onFilesDrop}}
+            >files</div>
+            <div
+              id="text-only"
+              {{dDragAndDropExternalTarget accepts="text" onDrop=onTextDrop}}
+            >text</div>
+          </template>
+        );
+
+        await simulateExternalDrag("#files-only", {
+          dataTransfer: textTransfer(),
+        });
+
+        assert.deepEqual(
+          drops,
+          [],
+          "a text drag does not reach a target that only accepts files"
+        );
+        assert
+          .dom("#files-only")
+          .doesNotHaveClass(
+            "--drag-over-external",
+            "and it lights no indicator on the way past"
+          );
+
+        await simulateExternalDrag("#text-only", {
+          dataTransfer: textTransfer(),
+        });
+
+        assert.deepEqual(
+          drops,
+          ["text"],
+          "the same drag reaches the target whose kind it matches"
+        );
+      });
+
+      test("canDrop refuses a drop the accepts filter would have allowed", async function (assert) {
+        let drops = 0;
+        const onDrop = () => drops++;
+        const canDrop = () => false;
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              {{dDragAndDropExternalTarget
+                accepts="files"
+                canDrop=canDrop
+                onDrop=onDrop
+              }}
+            >ext</div>
+          </template>
+        );
+
+        await simulateExternalDrag("#ext", { dataTransfer: fileTransfer() });
+
+        assert.strictEqual(drops, 0, "the synchronous gate refuses the drop");
+      });
+
+      test("a gate that turns false after the last dragover refuses the drop", async function (assert) {
+        let allowed = true;
+        let drops = 0;
+        const canDrop = () => allowed;
+        const onDrop = () => drops++;
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              {{dDragAndDropExternalTarget
+                accepts="files"
+                canDrop=canDrop
+                onDrop=onDrop
+              }}
+            >ext</div>
+          </template>
+        );
+
+        const dataTransfer = fileTransfer();
+        await externalDragOver("#ext", { dataTransfer });
+
+        // The library settles its target stack at the last dragover and does not
+        // re-ask the gate at drop, so refusing here is this modifier's own doing.
+        allowed = false;
+        await dragEvent("#ext", "drop", {
+          dataTransfer,
+          ...centerOf("#ext"),
+        });
+
+        assert.strictEqual(
+          drops,
+          0,
+          "a permission withdrawn before release does not act"
+        );
+      });
+
+      test("indicator=false suppresses the hover class without refusing the drop", async function (assert) {
+        let drops = 0;
+        const onDrop = () => drops++;
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              {{dDragAndDropExternalTarget
+                accepts="files"
+                indicator=false
+                onDrop=onDrop
+              }}
+            >ext</div>
+          </template>
+        );
+
+        const dataTransfer = fileTransfer();
+        await externalDragOver("#ext", { dataTransfer });
+
+        assert
+          .dom("#ext")
+          .doesNotHaveClass(
+            "--drag-over-external",
+            "the hover class is suppressed"
+          );
+
+        await dragEvent("#ext", "drop", { dataTransfer, ...centerOf("#ext") });
+
+        assert.strictEqual(
+          drops,
+          1,
+          "suppressing the indicator does not suppress the drop"
+        );
+      });
+
+      test("external drop position resolves either side of the cursor midpoint", async function (assert) {
+        const drops = [];
+        const onDrop = (payload) => drops.push(payload.position);
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget
+                accepts="text"
+                axis="y"
+                onDrop=onDrop
+              }}
+            >ext</div>
+          </template>
+        );
+
+        const rect = find("#ext").getBoundingClientRect();
+
+        await simulateExternalDrag("#ext", {
+          dataTransfer: textTransfer(),
+          coordinates: { clientY: rect.top + 5 },
+        });
+        await simulateExternalDrag("#ext", {
+          dataTransfer: textTransfer(),
+          coordinates: { clientY: rect.top + rect.height - 5 },
+        });
+
+        assert.deepEqual(
+          drops,
+          ["before", "after"],
+          "an external drop lands before or after the target depending on which side of its midpoint the cursor is"
+        );
+      });
+
+      test("external drop position drives the same indicator classes the element target uses", async function (assert) {
+        await render(
+          <template>
+            <div
+              id="ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget accepts="text" axis="y"}}
+            >ext</div>
+          </template>
+        );
+
+        const rect = find("#ext").getBoundingClientRect();
+        const dataTransfer = textTransfer();
+
+        await externalDragOver("#ext", {
+          dataTransfer,
+          coordinates: { clientY: rect.top + 5 },
+        });
+
+        assert
+          .dom("#ext")
+          .hasClass("--drag-above", "the indicator marks the upper half")
+          .doesNotHaveClass(
+            "--drag-over-external",
+            "and the positionless hover class is not also applied"
+          );
+
+        await externalDragOver("#ext", {
+          dataTransfer,
+          coordinates: { clientY: rect.top + rect.height - 5 },
+        });
+
+        assert
+          .dom("#ext")
+          .hasClass("--drag-below", "crossing the midpoint swaps the indicator")
+          .doesNotHaveClass(
+            "--drag-above",
+            "rather than accumulating both positions"
+          );
+      });
+
+      test("external drop position honours the x axis", async function (assert) {
+        const drops = [];
+        const onDrop = (payload) => drops.push(payload.position);
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              style="width: 200px"
+              {{dDragAndDropExternalTarget
+                accepts="text"
+                axis="x"
+                onDrop=onDrop
+              }}
+            >ext</div>
+          </template>
+        );
+
+        const rect = find("#ext").getBoundingClientRect();
+
+        await simulateExternalDrag("#ext", {
+          dataTransfer: textTransfer(),
+          coordinates: { clientX: rect.left + 5 },
+        });
+
+        assert.deepEqual(
+          drops,
+          ["before"],
+          "the midpoint is measured along the named axis"
+        );
+        assert
+          .dom("#ext")
+          .doesNotHaveClass(
+            "--drag-above",
+            "and the class comes from the x vocabulary, not the y one"
+          );
+      });
+
+      test("external drop position takes a fixed position over the midpoint", async function (assert) {
+        const drops = [];
+        const onDrop = (payload) => drops.push(payload.position);
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget
+                accepts="text"
+                position="inside"
+                onDrop=onDrop
+              }}
+            >ext</div>
+          </template>
+        );
+
+        const rect = find("#ext").getBoundingClientRect();
+        const dataTransfer = textTransfer();
+
+        await externalDragOver("#ext", {
+          dataTransfer,
+          coordinates: { clientY: rect.top + 5 },
+        });
+
+        assert
+          .dom("#ext")
+          .hasClass(
+            "--drag-inside",
+            "a fixed position ignores which half the cursor is in"
+          );
+
+        await dragEvent("#ext", "drop", {
+          dataTransfer,
+          clientY: rect.top + 5,
+          clientX: rect.left + 5,
+        });
+
+        assert.deepEqual(drops, ["inside"], "and reports itself on the drop");
+      });
+
+      test("external drop position is null once the drag leaves", async function (assert) {
+        const seen = [];
+        const onDragEnter = (payload) => seen.push(["enter", payload.position]);
+        const onDragLeave = (payload) => seen.push(["leave", payload.position]);
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget
+                accepts="text"
+                axis="y"
+                onDragEnter=onDragEnter
+                onDragLeave=onDragLeave
+              }}
+            >ext</div>
+          </template>
+        );
+
+        const rect = find("#ext").getBoundingClientRect();
+        const dataTransfer = textTransfer();
+
+        await externalDragOver("#ext", {
+          dataTransfer,
+          coordinates: { clientY: rect.top + 5 },
+        });
+        await dragEvent("#ext", "dragleave", {
+          dataTransfer,
+          ...centerOf("#ext"),
+        });
+
+        assert.deepEqual(
+          seen,
+          [
+            ["enter", "before"],
+            ["leave", null],
+          ],
+          "the position is where a drop would have landed while hovering, and nothing once there is nowhere to land"
+        );
+        assert
+          .dom("#ext")
+          .doesNotHaveClass("--drag-above", "and the indicator is dropped");
+      });
+
+      test("external drop position stays out of the way when neither arg is given", async function (assert) {
+        const drops = [];
+        const onDrop = (payload) => drops.push(payload.position);
+
+        await render(
+          <template>
+            <div
+              id="ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget accepts="text" onDrop=onDrop}}
+            >ext</div>
+          </template>
+        );
+
+        const rect = find("#ext").getBoundingClientRect();
+        const dataTransfer = textTransfer();
+
+        await externalDragOver("#ext", {
+          dataTransfer,
+          coordinates: { clientY: rect.top + 5 },
+        });
+
+        assert
+          .dom("#ext")
+          .hasClass(
+            "--drag-over-external",
+            "a target that asked for no position keeps the single hover class"
+          )
+          .doesNotHaveClass(
+            "--drag-above",
+            "rather than being opted into the positional vocabulary"
+          );
+
+        await dragEvent("#ext", "drop", {
+          dataTransfer,
+          clientY: rect.top + 5,
+          clientX: rect.left + 5,
+        });
+
+        assert.deepEqual(
+          drops,
+          [null],
+          "and reports no position, because it was never asked to resolve one"
+        );
+      });
+    });
+
+    module("nested external targets", function () {
+      test("an ancestor drops its indicator once a child becomes deepest", async function (assert) {
+        await render(
+          <template>
+            <div
+              id="outer-ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget accepts="files"}}
+            >
+              outer
+              <div
+                id="inner-ext"
+                {{dDragAndDropExternalTarget accepts="files"}}
+              >inner</div>
+            </div>
+          </template>
+        );
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(
+          new File(["x"], "a.txt", { type: "text/plain" })
+        );
+        const outerRect = find("#outer-ext").getBoundingClientRect();
+
+        // No `dragstart`: a drag that begins outside the page is what makes this
+        // the external adapter's rather than the element adapter's.
+        await dragEvent("#outer-ext", "dragenter", {
+          dataTransfer,
+          clientX: outerRect.left + 5,
+          clientY: outerRect.top + 5,
+        });
+        await dragEvent("#outer-ext", "dragover", {
+          dataTransfer,
+          clientX: outerRect.left + 5,
+          clientY: outerRect.top + 5,
+        });
+
+        assert
+          .dom("#outer-ext")
+          .hasClass(
+            "--drag-over-external",
+            "the ancestor paints its indicator while it is the deepest target"
+          );
+
+        await dragEvent("#inner-ext", "dragenter", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+        await dragEvent("#inner-ext", "dragover", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+
+        assert
+          .dom("#inner-ext")
+          .hasClass("--drag-over-external", "the child takes the indicator");
+        assert
+          .dom("#outer-ext")
+          .doesNotHaveClass(
+            "--drag-over-external",
+            "and the ancestor gives it up, so only one zone is lit at a time"
+          );
+      });
+
+      test("an external ancestor that never received an enter receives no leave", async function (assert) {
+        const events = [];
+        const onOuterEnter = () => events.push("outer:enter");
+        const onOuterLeave = () => events.push("outer:leave");
+        // The deepest target is the positive control, as in the element target's
+        // equivalent: without it, dispatching no lifecycle callback at all would
+        // satisfy the assertion below.
+        const onInnerEnter = () => events.push("inner:enter");
+        const onInnerLeave = () => events.push("inner:leave");
+
+        await render(
+          <template>
+            <div
+              id="outer-ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget
+                accepts="files"
+                onDragEnter=onOuterEnter
+                onDragLeave=onOuterLeave
+              }}
+            >
+              outer
+              <div
+                id="inner-ext"
+                {{dDragAndDropExternalTarget
+                  accepts="files"
+                  onDragEnter=onInnerEnter
+                  onDragLeave=onInnerLeave
+                }}
+              >inner</div>
+            </div>
+            <div
+              id="away-ext"
+              {{dDragAndDropExternalTarget accepts="files"}}
+            >away</div>
+          </template>
+        );
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(
+          new File(["x"], "a.txt", { type: "text/plain" })
+        );
+
+        // Straight onto the child, so the ancestor is in the stack but never the
+        // deepest and so never forwards an enter.
+        await dragEvent("#inner-ext", "dragenter", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+        await dragEvent("#inner-ext", "dragover", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+        await dragEvent("#away-ext", "dragenter", {
+          dataTransfer,
+          ...centerOf("#away-ext"),
+        });
+        await dragEvent("#away-ext", "dragover", {
+          dataTransfer,
+          ...centerOf("#away-ext"),
+        });
+
+        assert.deepEqual(
+          events,
+          ["inner:enter", "inner:leave"],
+          "the deepest target is entered and left as a pair, and the ancestor that was never entered is never left"
+        );
+      });
+
+      test("an external target that becomes deepest without a fresh enter is entered and left", async function (assert) {
+        const events = [];
+        let drags = 0;
+
+        const onOuterEnter = () => events.push("outer:enter");
+        const onOuterDrag = () => drags++;
+        const onOuterLeave = () => events.push("outer:leave");
+
+        await render(
+          <template>
+            <div
+              id="outer-ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget
+                accepts="files"
+                onDragEnter=onOuterEnter
+                onDrag=onOuterDrag
+                onDragLeave=onOuterLeave
+              }}
+            >
+              outer
+              <div
+                id="inner-ext"
+                {{dDragAndDropExternalTarget accepts="files"}}
+              >inner</div>
+            </div>
+            <div
+              id="away-ext"
+              {{dDragAndDropExternalTarget accepts="files"}}
+            >away</div>
+          </template>
+        );
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(
+          new File(["x"], "a.txt", { type: "text/plain" })
+        );
+        const outerRect = find("#outer-ext").getBoundingClientRect();
+
+        // Onto the child first, so the ancestor joins the hierarchy while the
+        // child is deepest and its own enter is swallowed.
+        await dragEvent("#inner-ext", "dragenter", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+        await dragEvent("#inner-ext", "dragover", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+
+        // Back onto the ancestor's own area. It becomes deepest without a fresh
+        // enter, because it never left the hierarchy.
+        await dragEvent("#outer-ext", "dragover", {
+          dataTransfer,
+          clientX: outerRect.left + 5,
+          clientY: outerRect.top + 5,
+        });
+
+        await dragEvent("#away-ext", "dragenter", {
+          dataTransfer,
+          ...centerOf("#away-ext"),
+        });
+        await dragEvent("#away-ext", "dragover", {
+          dataTransfer,
+          ...centerOf("#away-ext"),
+        });
+
+        assert.true(
+          drags > 0,
+          "the ancestor was told about the drag once it was the deepest target"
+        );
+        assert.deepEqual(
+          events,
+          ["outer:enter", "outer:leave"],
+          "so it is entered when it takes over and left when it gives up, matching the element target"
+        );
+      });
+
+      test("an external ancestor superseded by a child is left before the drop lands", async function (assert) {
+        const events = [];
+        const onOuterEnter = () => events.push("outer:enter");
+        const onOuterLeave = () => events.push("outer:leave");
+        const onInnerDrop = () => events.push("inner:drop");
+
+        await render(
+          <template>
+            <div
+              id="outer-ext"
+              style="height: 100px"
+              {{dDragAndDropExternalTarget
+                accepts="files"
+                onDragEnter=onOuterEnter
+                onDragLeave=onOuterLeave
+              }}
+            >
+              outer
+              <div
+                id="inner-ext"
+                {{dDragAndDropExternalTarget
+                  accepts="files"
+                  onDrop=onInnerDrop
+                }}
+              >inner</div>
+            </div>
+          </template>
+        );
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(
+          new File(["x"], "a.txt", { type: "text/plain" })
+        );
+        const outerRect = find("#outer-ext").getBoundingClientRect();
+
+        // The ancestor's own area first, so it is genuinely entered.
+        await dragEvent("#outer-ext", "dragenter", {
+          dataTransfer,
+          clientX: outerRect.left + 5,
+          clientY: outerRect.top + 5,
+        });
+        await dragEvent("#outer-ext", "dragover", {
+          dataTransfer,
+          clientX: outerRect.left + 5,
+          clientY: outerRect.top + 5,
+        });
+
+        await dragEvent("#inner-ext", "dragenter", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+        await dragEvent("#inner-ext", "dragover", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+        await dragEvent("#inner-ext", "drop", {
+          dataTransfer,
+          ...centerOf("#inner-ext"),
+        });
+
+        assert.deepEqual(
+          events,
+          ["outer:enter", "outer:leave", "inner:drop"],
+          "the ancestor is left as soon as the child takes over, so a drop never lands with its enter still open"
+        );
+      });
+    });
+  }
+);

--- a/frontend/discourse/tests/unit/services/drag-and-drop-test.js
+++ b/frontend/discourse/tests/unit/services/drag-and-drop-test.js
@@ -2,6 +2,24 @@ import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 
+async function externalDragEvent(type, dataTransfer) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, {
+    clientX: 1,
+    clientY: 1,
+    dataTransfer,
+    relatedTarget: null,
+  });
+  document.body.dispatchEvent(event);
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function externalTextDataTransfer() {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData("text/plain", "external payload");
+  return dataTransfer;
+}
+
 module("Unit | Service | drag-and-drop", function (hooks) {
   setupTest(hooks);
 
@@ -90,5 +108,88 @@ module("Unit | Service | drag-and-drop", function (hooks) {
       this.dragAndDrop.accepts(undefined),
       "an omitted filter accepts nothing either"
     );
+  });
+
+  test("tracks and filters an external drag", async function (assert) {
+    const dataTransfer = externalTextDataTransfer();
+
+    await externalDragEvent("dragenter", dataTransfer);
+
+    assert.true(this.dragAndDrop.isDragging, "an external drag is in flight");
+    assert.true(
+      this.dragAndDrop.currentExternalDrag.containsText(),
+      "the decorated payload reports its native kind"
+    );
+    assert.strictEqual(
+      this.dragAndDrop.currentExternalDrag.getText(),
+      null,
+      "the hover-time service snapshot does not claim access to string data the browser withholds until drop"
+    );
+    assert.true(
+      this.dragAndDrop.acceptsExternal("text"),
+      "the matching external vocabulary is accepted"
+    );
+    assert.false(
+      this.dragAndDrop.acceptsExternal("files"),
+      "a different external kind is rejected"
+    );
+
+    await externalDragEvent("drop", dataTransfer);
+
+    assert.strictEqual(
+      this.dragAndDrop.currentExternalDrag,
+      null,
+      "the external payload is cleared after drop"
+    );
+    assert.false(
+      this.dragAndDrop.isDragging,
+      "the drag is no longer in flight"
+    );
+  });
+
+  test("external monitor ignores drag start while service is destroying", async function (assert) {
+    const dataTransfer = externalTextDataTransfer();
+
+    Object.defineProperty(this.dragAndDrop, "isDestroying", {
+      configurable: true,
+      value: true,
+    });
+    await externalDragEvent("dragenter", dataTransfer);
+
+    assert.false(
+      Boolean(this.dragAndDrop.currentExternalDrag),
+      "a destroying service does not record a newly-started external drag"
+    );
+
+    delete this.dragAndDrop.isDestroying;
+    await externalDragEvent("drop", dataTransfer);
+  });
+
+  test("external monitor ignores drop after service destruction begins", async function (assert) {
+    const dataTransfer = externalTextDataTransfer();
+    await externalDragEvent("dragenter", dataTransfer);
+    const externalDrag = this.dragAndDrop.currentExternalDrag;
+
+    assert.true(
+      Boolean(externalDrag),
+      "the service records the external drag before destruction"
+    );
+
+    // Stubbed rather than really destroyed, as the sibling test does: a real
+    // destroy also tears the monitor down, so the drop would be ignored even if
+    // the guard under test were missing.
+    Object.defineProperty(this.dragAndDrop, "isDestroying", {
+      configurable: true,
+      value: true,
+    });
+    await externalDragEvent("drop", dataTransfer);
+
+    assert.strictEqual(
+      this.dragAndDrop.currentExternalDrag,
+      externalDrag,
+      "a destroying service ignores the in-flight external drag's drop callback"
+    );
+
+    delete this.dragAndDrop.isDestroying;
   });
 });

--- a/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-external-errors-test.gts
+++ b/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-external-errors-test.gts
@@ -1,0 +1,31 @@
+// Negative type assertions for external targets and auto-scroll: every
+// invocation below MUST fail to compile. They are quarantined here because a
+// `@glint-expect-error` suppresses reporting elsewhere in its file, which would
+// let a positive assertion pass against a broken declaration. Positives live in
+// d-drag-and-drop-external-test.gts.
+import dDragAndDropAutoScroll from "discourse/ui-kit/modifiers/d-drag-and-drop-auto-scroll";
+import dDragAndDropExternalTarget, {
+  ExternalDropTargetEvent,
+} from "discourse/ui-kit/modifiers/d-drag-and-drop-external-target";
+import dDragAndDropTarget from "discourse/ui-kit/modifiers/d-drag-and-drop-target";
+
+declare function onExternalDrop(event: ExternalDropTargetEvent): void;
+
+const Negatives = <template>
+  {{! @glint-expect-error - the external vocabulary is a closed set of kinds, unlike the free-form drag types the element target filters on }}
+  <div {{dDragAndDropExternalTarget accepts="images"}}></div>
+
+  {{! @glint-expect-error - both targets resolve position the same way, so the external one rejects the same axes }}
+  <div {{dDragAndDropExternalTarget accepts="urls" axis="z"}}></div>
+
+  {{! @glint-expect-error - auto-scroll moves the host element or the window }}
+  <div {{dDragAndDropAutoScroll target="document"}}></div>
+
+  {{! @glint-expect-error - auto-scroll filters external drags by the same closed set of kinds the external target does }}
+  <div {{dDragAndDropAutoScroll accepts="images"}}></div>
+
+  {{! @glint-expect-error - the element and external targets report different payloads }}
+  <li {{dDragAndDropTarget accepts="link" onDrop=onExternalDrop}}></li>
+</template>;
+
+export default Negatives;

--- a/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-external-test.gts
+++ b/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-external-test.gts
@@ -1,0 +1,48 @@
+// Positive template invocations for external targets and auto-scroll, asserting
+// each Signature resolves in template position. Keep this file free of Glint
+// directives: a single `@glint-expect-error` anywhere makes Glint stop reporting
+// every other error in the file, so a broken declaration would pass unnoticed.
+// Negatives live in d-drag-and-drop-external-errors-test.gts.
+import { array } from "@ember/helper";
+import dDragAndDropAutoScroll from "discourse/ui-kit/modifiers/d-drag-and-drop-auto-scroll";
+import dDragAndDropExternalTarget, {
+  ExternalDropTargetEvent,
+} from "discourse/ui-kit/modifiers/d-drag-and-drop-external-target";
+
+declare const noop: () => void;
+declare const acceptedTypes: string[];
+declare function onExternalDrop(event: ExternalDropTargetEvent): void;
+
+const Positives = <template>
+  {{! The external target speaks the kind vocabulary, not drag types }}
+  <div
+    {{dDragAndDropExternalTarget accepts="files" onDrop=onExternalDrop}}
+  ></div>
+  <div
+    {{dDragAndDropExternalTarget
+      accepts=(array "files" "urls")
+      indicator=false
+      onDragEnter=noop
+      onDrop=noop
+    }}
+  ></div>
+
+  {{! An external target is a slot rather than a destination once it takes a
+      position, and speaks the same vocabulary the element target does }}
+  <li {{dDragAndDropExternalTarget accepts="urls" axis="y" onDrop=noop}}></li>
+  <li
+    {{dDragAndDropExternalTarget accepts="urls" position="inside" onDrop=noop}}
+  ></li>
+
+  {{! Auto-scroll defaults to the host element, or takes the window }}
+  <div {{dDragAndDropAutoScroll types="card" axis="vertical"}}></div>
+  <span {{dDragAndDropAutoScroll target="window" types=acceptedTypes}}></span>
+
+  {{! Scrolling for a drag from outside the window is a separate opt-in, and
+      speaks the kind vocabulary rather than the drag types beside it }}
+  <div
+    {{dDragAndDropAutoScroll types="card" accepts=(array "urls" "files")}}
+  ></div>
+</template>;
+
+export default Positives;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop':
         specifier: ^1.7.4
         version: 1.8.1
+      '@atlaskit/pragmatic-drag-and-drop-auto-scroll':
+        specifier: ^2.1.4
+        version: 2.1.5
       '@codemirror/autocomplete':
         specifier: ^6.20.3
         version: 6.20.3
@@ -976,6 +979,9 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@atlaskit/pragmatic-drag-and-drop-auto-scroll@2.1.5':
+    resolution: {integrity: sha512-InLvVhZAHPBfv3CxuG4AfOQuhNJjaFy69YBfodPMWtRFQNQAKa9Yb3vL9Ho6qsD9qKUBuJa4A5k7QddaXQ4Eyw==}
 
   '@atlaskit/pragmatic-drag-and-drop@1.8.1':
     resolution: {integrity: sha512-uXWNPpL8n4OmTVbduH7nq8pk8htqGo/prR5cYEE8sVCPJGAUMWn6lzvWTfI+4VCeQvHiDRODVz4YzH06OVAxhw==}
@@ -8465,6 +8471,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@atlaskit/pragmatic-drag-and-drop-auto-scroll@2.1.5':
+    dependencies:
+      '@atlaskit/pragmatic-drag-and-drop': 1.8.1
+      '@babel/runtime': 7.29.7
 
   '@atlaskit/pragmatic-drag-and-drop@1.8.1':
     dependencies:


### PR DESCRIPTION
Previously, the shared drag-and-drop layer handled registered element sources but not incoming external payloads or edge-driven scrolling.

This change adds typed external targets, nested lifecycle handling, positional feedback, reactive state, and opt-in element and external auto-scroll.
