### PR TITLE
DEV: Add accessible reorder affordances

### DIFF
--- a/app/assets/stylesheets/common/ui-kit/_index.scss
+++ b/app/assets/stylesheets/common/ui-kit/_index.scss
@@ -5,3 +5,4 @@
 
 @import "d-pointer-drag";
 @import "d-resize-separator";
+@import "d-drag-and-drop";

--- a/app/assets/stylesheets/common/ui-kit/_index.scss
+++ b/app/assets/stylesheets/common/ui-kit/_index.scss
@@ -3,6 +3,8 @@
    stylesheets not yet moved out of `common/components/` still live there; new
    ui-kit styles belong here. */
 
-@import "d-pointer-drag";
-@import "d-resize-separator";
 @import "d-drag-and-drop";
+@import "d-drag-handle";
+@import "d-pointer-drag";
+@import "d-reorder-buttons";
+@import "d-resize-separator";

--- a/app/assets/stylesheets/common/ui-kit/d-drag-and-drop.scss
+++ b/app/assets/stylesheets/common/ui-kit/d-drag-and-drop.scss
@@ -1,0 +1,103 @@
+/* Default treatment for the drag-and-drop vocabulary. The source and target
+   registrars stamp `data-drag-source` / `data-drop-target` on their host for
+   the lifetime of the registration, and toggle the state modifiers below
+   during a drag. Selectors are gated on the attribute rather than the class
+   alone so they cannot reach an unrelated element that happens to use the same
+   state name. Override by raising specificity, by setting `content: none` on
+   the pseudo-element to drop just the line, or by passing `indicator=false` to
+   opt out entirely.
+
+   The colour is its own custom property rather than a generic accent token, so
+   a theme or a single surface can retune drag feedback without moving every
+   other accent border in the app. It defaults to full-strength `--tertiary`:
+   the generic accent resolves to a tint blended toward the surface, which reads
+   acceptably on a dark panel but washes out against a lighter one and does not
+   reach the 3:1 WCAG 1.4.11 asks of a non-text UI component. */
+
+:root {
+  --d-drag-indicator-color: var(--tertiary);
+}
+
+@mixin d-drag-line-horizontal {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--d-drag-indicator-color);
+  pointer-events: none;
+}
+
+@mixin d-drag-line-vertical {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--d-drag-indicator-color);
+  pointer-events: none;
+}
+
+[data-drag-source] {
+  &.--dragging {
+    opacity: 0.5;
+  }
+}
+
+/* Every target draws from one position vocabulary, so "a drop would land above
+   this row" has one visual meaning across consumers. */
+
+[data-drop-target] {
+  &.--drag-above {
+    position: relative;
+
+    &::before {
+      @include d-drag-line-horizontal;
+      top: -1px;
+    }
+  }
+
+  &.--drag-below {
+    position: relative;
+
+    &::after {
+      @include d-drag-line-horizontal;
+      bottom: -1px;
+    }
+  }
+
+  /* Kept physical: the class is assigned from the pointer's physical clientX
+     (before = left of the midpoint), so an rtlcss flip would draw the line on
+     the opposite side from where the drop resolves. */
+
+  &.--drag-left {
+    position: relative;
+
+    &::before {
+      @include d-drag-line-vertical;
+
+      /*! rtl:ignore */
+      left: -1px;
+    }
+  }
+
+  &.--drag-right {
+    position: relative;
+
+    &::after {
+      @include d-drag-line-vertical;
+
+      /*! rtl:ignore */
+      right: -1px;
+    }
+  }
+
+  /* The cursor is over a container that accepts the dragged item as a child
+     rather than a sibling, so an outline distinguishes it from the four
+     sibling positions. */
+
+  &.--drag-inside {
+    outline: 2px solid var(--d-drag-indicator-color);
+    outline-offset: -2px;
+  }
+}

--- a/app/assets/stylesheets/common/ui-kit/d-drag-handle.scss
+++ b/app/assets/stylesheets/common/ui-kit/d-drag-handle.scss
@@ -1,0 +1,8 @@
+/* The grab affordance on a draggable row. Colour and cursor only: where the
+   handle sits in the row is the consumer's business, since only it knows
+   whether the row is one line or many. */
+
+.d-drag-handle {
+  color: var(--primary-low-mid);
+  cursor: grab;
+}

--- a/app/assets/stylesheets/common/ui-kit/d-reorder-buttons.scss
+++ b/app/assets/stylesheets/common/ui-kit/d-reorder-buttons.scss
@@ -1,0 +1,52 @@
+/* The stacked reorder pair. Deliberately smaller than a normal button: it sits
+   beside a drag handle in a dense list row, and at full button size it drives the
+   row's height instead of fitting inside it. Positioning within the row is left
+   to the consumer, since only it knows whether the row is one line or many. */
+
+.d-reorder-buttons {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.7em;
+
+  /* On a touch screen these ARE the reorder path, and the compact pair
+     collapses well below the 24px WCAG 2.5.8 asks of a pointer target. The
+     rows are taller under coarse pointers anyway, so full-size targets no
+     longer drive the row height the way they would on desktop. */
+  @media (pointer: coarse) {
+    font-size: 1em;
+
+    /* The full-size pair is often taller than the row beside it, so a consumer
+       that stretches this cell would otherwise leave the buttons pinned to its
+       top rather than balanced around the row's middle. */
+    justify-content: center;
+  }
+
+  &__button.btn {
+    padding: 0 var(--space-1);
+    min-height: 0;
+
+    @media (pointer: coarse) {
+      min-width: 24px;
+      min-height: 24px;
+    }
+
+    /* Marked unavailable rather than disabled, so the button keeps its place in
+       the tab order at the ends of the list. Mirrors what core paints for a real
+       disabled button, minus the focus rule: the whole point of staying
+       focusable is that a keyboard user can still see where they are. */
+
+    &[aria-disabled="true"] {
+      opacity: 0.4;
+      cursor: not-allowed;
+
+      &:hover {
+        background: var(--d-button-flat-bg-color);
+        color: var(--d-button-default-text-color);
+
+        .d-icon {
+          color: var(--d-button-flat-icon-color);
+        }
+      }
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -394,6 +394,8 @@ en:
     skip_to_top: "Skip to top"
     skip_user_nav: "Skip to profile content"
 
+    reorder_announcement: "Moved %{label} to position %{position} of %{total}"
+
     emails_are_disabled: "All outgoing email has been globally disabled by an administrator. No email notifications of any kind will be sent."
     emails_are_disabled_no_smtp: "All outgoing email is disabled because no SMTP server has been configured. No emails of any kind can be sent."
     emails_are_disabled_non_staff: "Outgoing email has been disabled for non-staff users."

--- a/frontend/discourse/app/lib/resize-measurements.ts
+++ b/frontend/discourse/app/lib/resize-measurements.ts
@@ -16,8 +16,8 @@ const DEFAULT_MIN_SIZE: Record<ResizeAxis, number> = {
 
 /** Which properties describe a box's extent along each axis. */
 const AXIS_PROPERTIES = {
-  vertical: { offset: "offsetHeight", min: "minHeight", max: "maxHeight" },
-  horizontal: { offset: "offsetWidth", min: "minWidth", max: "maxWidth" },
+  vertical: { computed: "height", min: "minHeight", max: "maxHeight" },
+  horizontal: { computed: "width", min: "minWidth", max: "maxWidth" },
 } as const;
 
 /**
@@ -37,11 +37,16 @@ function pixels(declared: string | undefined): number | null {
 }
 
 /**
- * The box's current extent along the axis being resized, from its border box.
+ * The box's current extent along the axis being resized, read from the same box
+ * that `style.height` and `style.width` write.
  *
- * Null rather than zero when there is nothing to measure, which a resize would
- * read as a real extent and drag on from. A detached box reports zero, so it
- * counts as unmeasured too.
+ * Those properties set the content box under `content-box` and the border box
+ * under `border-box`. `offsetHeight` is right only in the second case, so a
+ * bordered `content-box` element drifts a little on every gesture.
+ *
+ * Null when there is nothing to measure, which a resize would otherwise drag on
+ * from. `pixels` enforces that. An element with no box keeps whatever was
+ * declared, and a percentage would parse into a plausible-looking number.
  */
 export function measuredSize(
   element: HTMLElement | null | undefined,
@@ -51,7 +56,7 @@ export function measuredSize(
     return null;
   }
 
-  return element[AXIS_PROPERTIES[axis].offset];
+  return pixels(getComputedStyle(element)[AXIS_PROPERTIES[axis].computed]);
 }
 
 /**
@@ -74,8 +79,11 @@ export function measuredMin(
 }
 
 /**
- * What is left of the viewport, leaving the header its space, which is as far as
- * a box can grow.
+ * What is left of the viewport, leaving the header its space.
+ *
+ * This suits a box pinned in the viewport, which would otherwise grow out of
+ * view. A box in a scrolling page only lengthens the page, so this caps it for
+ * no reason. Such a consumer should pass its own maximum.
  *
  * Asymmetric on purpose: `clientWidth` drops the scrollbar gutter while
  * `innerHeight` keeps it, and matching them would move behaviour that shipped.
@@ -87,8 +95,12 @@ export function viewportCap(axis: ResizeAxis): number {
 }
 
 /**
- * The largest the box may be dragged to, never above `cap`. A declared maximum
- * binds too, so dragging past it would report a size never rendered.
+ * The largest the box may be dragged to. A declared maximum binds, so dragging
+ * past it would report a size never rendered, and `cap` binds above that.
+ *
+ * Never below {@link measuredMin}. A short viewport can put the cap under the
+ * declared minimum, and CSS lets the minimum win. Announcing a maximum beneath
+ * it would promise a range the box cannot take.
  */
 export function measuredMax(
   element: HTMLElement | null | undefined,
@@ -100,5 +112,6 @@ export function measuredMax(
   }
 
   const declared = pixels(getComputedStyle(element)[AXIS_PROPERTIES[axis].max]);
-  return declared === null ? cap : Math.min(declared, cap);
+  const capped = declared === null ? cap : Math.min(declared, cap);
+  return Math.max(capped, measuredMin(element, axis));
 }

--- a/frontend/discourse/app/services/drag-and-drop.ts
+++ b/frontend/discourse/app/services/drag-and-drop.ts
@@ -1,0 +1,229 @@
+import { tracked } from "@glimmer/tracking";
+import { registerDestructor } from "@ember/destroyable";
+import Service from "@ember/service";
+import {
+  type ElementDragPayload,
+  monitorForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+/** The in-flight element drag, as the source described it. */
+export interface DragPayload {
+  /** Discriminator string set by the source. */
+  type: string;
+
+  /** Arbitrary payload the source attached to the drag. */
+  data: Record<string, unknown>;
+
+  /**
+   * The element that originated the drag. The service's own monitor always
+   * supplies one; `setCurrentDrag` is public and validates nothing, so a caller
+   * driving the service by hand may not.
+   */
+  element: HTMLElement | null;
+}
+
+/**
+ * Where the dragged body travels when a source registered a drag handle.
+ *
+ * The handle is what the underlying library registers, so that the row keeps
+ * neither `draggable="true"` nor the unselectable text that attribute brings.
+ * The body is the row the handle stands for, and it is what a target reports as
+ * `source.element` and compares for `acceptsSelf`.
+ *
+ * Lives here with the rest of the shared vocabulary because both the source and
+ * the target need it, and importing one modifier from the other would close a
+ * cycle.
+ */
+export const DRAG_BODY = "discourse:dragBody";
+
+/**
+ * The type a drag answers to in an `accepts` / `types` filter.
+ *
+ * @param data - A drag payload's `data`, as the underlying library carries it.
+ */
+export function dragTypeOf(data?: Record<string, unknown>) {
+  return data?.type as string | undefined;
+}
+
+/**
+ * A drag source as consumers read it: routing keys lifted out and the dragged
+ * body in place of the grip that carried it.
+ */
+export interface NormalizedDragSource {
+  /** The source's discriminator, or `null` when the drag carries none. */
+  type: string | null;
+
+  /** The payload the source attached to the drag. */
+  data: Record<string, unknown>;
+
+  /** The dragged element, or `null` when the drag has none. */
+  element: Element | null;
+}
+
+/**
+ * Resolves a raw payload into the shape every reader reports.
+ *
+ * This is the single place the routing vocabulary above is interpreted. The
+ * drop target, the monitor modifier, and this service all consume it, so a
+ * payload reads identically wherever a consumer meets it — a shape one of them
+ * derived by hand drifted once already.
+ *
+ * @param source - The payload as the underlying library carries it.
+ * @param fallbackElement - Reported as `element` when the drag itself has none;
+ *   a drop target passes itself here.
+ */
+export function normalizeDragSource(
+  source: ElementDragPayload,
+  fallbackElement?: Element
+): NormalizedDragSource {
+  // Lifted out first: the body is routing, not payload, so no consumer should
+  // ever iterate onto it.
+  const { [DRAG_BODY]: body, ...data } = source.data ?? {};
+
+  return {
+    // The underlying library types every payload value as `unknown`, because
+    // anything registering a draggable with it can put anything there.
+    // `dDragAndDropSource` always stamps its discriminator as a string.
+    type: (data.type ?? null) as string | null,
+    data,
+    // A source that registered a handle publishes the body it stands for, so a
+    // consumer receives the element the user is moving rather than the grip
+    // they happened to press.
+    element: (body as Element) ?? source.element ?? fallbackElement ?? null,
+  };
+}
+
+/**
+ * Tracks the in-flight `dDragAndDropSource` / `dDragAndDropTarget` element
+ * drag pair.
+ *
+ * Element drag state is populated first-hand by the singleton monitor this
+ * service registers on construction. Per-element modifiers do not each carry
+ * their own monitor; this is the observer.
+ *
+ * Lives as a service rather than a module slot so test setup
+ * (`setupTest` / `setupRenderingTest`) gets a fresh instance per test.
+ *
+ * Use this to READ drag state for rendering. Use `dDragAndDropMonitor` to
+ * RESPOND to a drag imperatively — rendering from its callbacks means
+ * hand-maintaining state this service already keeps.
+ *
+ * Guide to choosing between the gesture primitives:
+ * `docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md`
+ */
+export default class DragAndDropService extends Service {
+  @tracked currentDrag: DragPayload | null = null;
+
+  constructor(...args: ConstructorParameters<typeof Service>) {
+    super(...args);
+    // Registering a monitor subscribes to the library's drag stream. It does
+    // NOT mount the element adapter: only registering a draggable does that, so
+    // a page with targets and monitors but no draggable has no element drag
+    // listener bound at all.
+    //
+    // The monitor is the sole observer of in-flight element drags — the source
+    // modifier does not push state here, the service derives it first-hand.
+    // Only drags carrying a `type` are tracked, so a foreign draggable with
+    // none of its own stays invisible here.
+    const cleanup = monitorForElements({
+      canMonitor: ({ source }) =>
+        !this.isDestroying &&
+        !this.isDestroyed &&
+        dragTypeOf(source.data) != null,
+      onDragStart: ({ source }) => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+        const normalized = normalizeDragSource(source);
+        this.setCurrentDrag({
+          // `canMonitor` above only admits sources whose `type` is set, so the
+          // `null` a typeless drag would normalize to cannot reach here.
+          type: normalized.type as string,
+          data: normalized.data,
+          element: normalized.element as HTMLElement,
+        });
+      },
+      onDrop: () => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+        this.clearCurrentDrag();
+      },
+    });
+    registerDestructor(this, cleanup);
+  }
+
+  /** Whether an element drag is in flight. */
+  get isDragging() {
+    return !!this.currentDrag;
+  }
+
+  /**
+   * Stores the in-flight drag's payload. Called by the service's own
+   * `monitorForElements` on drag start.
+   */
+  setCurrentDrag(payload: DragPayload) {
+    this.currentDrag = payload;
+  }
+
+  /**
+   * Clears the in-flight drag. Called by the service's own
+   * `monitorForElements` on drop — fires regardless of whether the drop
+   * landed on a target or was cancelled.
+   */
+  clearCurrentDrag() {
+    this.currentDrag = null;
+  }
+
+  /**
+   * Does the in-flight drag's `type` match the supplied `accepts` filter?
+   *
+   * @param accepts - Single type string or array. A nullish filter matches
+   *   nothing, so a target can pass its unset arg straight through.
+   */
+  accepts(accepts?: string | string[] | null) {
+    if (!this.currentDrag || !accepts) {
+      return false;
+    }
+    if (Array.isArray(accepts)) {
+      return accepts.includes(this.currentDrag.type);
+    }
+    return this.currentDrag.type === accepts;
+  }
+}
+
+/**
+ * Test-only: end any drag the underlying library still considers in flight.
+ *
+ * If a test starts a drag (`dragstart`) but the matching `dragend` / `drop`
+ * never reaches the library — e.g. the source element is torn down first, or an
+ * assertion throws mid-drag — its global drag state stays active and the next
+ * test's `dragstart` is silently ignored. Dispatching a `dragend` lets the
+ * lifecycle listener tear the drag down. A no-op when nothing is in flight.
+ * Call from the global test teardown.
+ */
+export function resetDragAndDropForTesting() {
+  // The library binds its drag-phase listeners on `window` (capture) only
+  // while a drag is active, and both dispatches are no-ops when nothing is in
+  // flight.
+  //
+  // The order is load-bearing. `dragend` clears the target stack before
+  // dispatching its cancellation, so no target `onDrop` runs; a bare `drop`
+  // takes the cancel path only when no drop target is under the cursor, and with
+  // one it dispatches a real drop, running target callbacks during teardown.
+  // Sending `dragend` first leaves the following `drop` a no-op, because the
+  // listeners are unbound by then.
+  //
+  // This does not silence everything: the library still dispatches its own
+  // `onDrop` to the source and to monitors. A source wrapper deferring its
+  // consumer callbacks is what would then schedule them during teardown, and
+  // guarding that is its job rather than this function's —
+  // `registerDragAndDropSource` cancels the pending task from its own cleanup.
+  const make = (type: string) =>
+    typeof DragEvent === "function"
+      ? new DragEvent(type, { bubbles: true })
+      : new Event(type, { bubbles: true });
+  for (const type of ["dragend", "drop"]) {
+    window.dispatchEvent(make(type));
+  }
+}

--- a/frontend/discourse/app/ui-kit/d-drag-handle.gts
+++ b/frontend/discourse/app/ui-kit/d-drag-handle.gts
@@ -1,0 +1,45 @@
+import type { TemplateOnlyComponent } from "@ember/component/template-only";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+
+interface DDragHandleSignature {
+  Args: {
+    /**
+     * Translated name of what the handle drags, shown as its tooltip. Required
+     * because a bare grip icon says nothing about which row it belongs to.
+     */
+    label: string;
+  };
+  Element: HTMLSpanElement;
+}
+
+/**
+ * The grab affordance on a draggable row.
+ *
+ * Deliberately decorative: `aria-hidden` with no tab stop, because a drag is
+ * unreachable by keyboard and exposing the handle would offer assistive
+ * technology a control it cannot operate. The keyboard path is a separate pair
+ * of buttons beside it, which is what `DReorderButtons` is for. Pair the two.
+ *
+ * This is NOT the right component for a handle that is itself an operable
+ * control — one that takes focus and can be driven by keyboard. Use a real
+ * button there and give it its own accessible name.
+ *
+ * Attributes pass through, so a consumer keeps its own class and can attach the
+ * modifier that registers the handle with a drag source.
+ *
+ * @example
+ * ```hbs
+ * <DDragHandle @label={{this.dragLabel}} class="my-block__handle" />
+ * ```
+ */
+const DDragHandle: TemplateOnlyComponent<DDragHandleSignature> = <template>
+  <span
+    class="d-drag-handle"
+    aria-hidden="true"
+    tabindex="-1"
+    title={{@label}}
+    ...attributes
+  >{{dIcon "grip-vertical"}}</span>
+</template>;
+
+export default DDragHandle;

--- a/frontend/discourse/app/ui-kit/d-reorder-buttons.gts
+++ b/frontend/discourse/app/ui-kit/d-reorder-buttons.gts
@@ -1,0 +1,180 @@
+import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
+import { isDestroyed, isDestroying } from "@ember/destroyable";
+import { action } from "@ember/object";
+import { schedule } from "@ember/runloop";
+import { modifier } from "ember-modifier";
+import DButton from "discourse/ui-kit/d-button";
+
+/**
+ * Invoked when a direction is pressed. Variadic because a consumer normally
+ * binds its item with `fn`; the press event itself is not forwarded.
+ *
+ * Focus is taken back onto the pressed button once the list has re-rendered, so
+ * a consumer that moves focus of its own in response to a reorder will find this
+ * one wins.
+ */
+type ReorderCallback = (...args: unknown[]) => void;
+
+/** Which of the pair was pressed. */
+type Direction = "up" | "down";
+
+interface DReorderButtonsSignature {
+  Args: {
+    /** Moves the item one place earlier in the list. */
+    onMoveUp: ReorderCallback;
+
+    /** Moves the item one place later in the list. */
+    onMoveDown: ReorderCallback;
+
+    /**
+     * Whether moving earlier is unavailable, which is the case for the first
+     * item in the list.
+     */
+    disableUp?: boolean;
+
+    /**
+     * Whether moving later is unavailable, which is the case for the last item
+     * in the list.
+     */
+    disableDown?: boolean;
+
+    /**
+     * Translated name for the upward direction. Required because these are
+     * icon-only buttons, so this is their only accessible name; it should name
+     * the item too, so the buttons stay distinguishable when read out of
+     * context.
+     */
+    upLabel: string;
+
+    /** Translated name for the downward direction. See `upLabel`. */
+    downLabel: string;
+  };
+  Element: HTMLSpanElement;
+}
+
+/**
+ * The keyboard path for a reorderable list: a stacked pair of buttons that move
+ * one item up or down.
+ *
+ * A drag is unreachable by keyboard, so any list whose only way to reorder is a
+ * drag has no keyboard path at all. This is what a reorder surface pairs with
+ * its drag handle to close that gap, and it exists as one component so the
+ * surfaces do not each invent their own icons and sizing.
+ *
+ * Compact by design: it sits beside a drag handle in a dense list row and must
+ * not drive the row's height. Layout within the row stays the consumer's, so
+ * pass a class for anything positional such as `align-self`.
+ *
+ * Owns focus across a move: the pressed button is refocused once the list has
+ * re-rendered, because reordering moves the row in the DOM and that blurs
+ * whatever it contains. Without it a keyboard user lands on the body after one
+ * press. There is deliberately no way to switch this off — a reorder pair that
+ * cannot be pressed twice is not a keyboard path.
+ *
+ * @example
+ * ```hbs
+ * <DReorderButtons
+ *   @onMoveUp={{fn this.moveUp item}}
+ *   @onMoveDown={{fn this.moveDown item}}
+ *   @disableUp={{item.isFirst}}
+ *   @disableDown={{item.isLast}}
+ *   @upLabel={{this.moveUpLabel}}
+ *   @downLabel={{this.moveDownLabel}}
+ *   class="my-block__arrows"
+ * />
+ * ```
+ *
+ * Attributes pass through, so a consumer keeps its own class alongside this one.
+ *
+ * @see The `dDragAndDropSource` / `dDragAndDropTarget` pair for the drag half of
+ *   the same surface.
+ */
+export default class DReorderButtons extends Component<DReorderButtonsSignature> {
+  /**
+   * Holds each button so focus can be taken back after a move.
+   *
+   * A ref rather than a query, because several of these render in one list and
+   * the row this pair belongs to moves out from under any selector.
+   */
+  captureButton = modifier((element: HTMLElement, [direction]: [Direction]) => {
+    this.#buttons.set(direction, element);
+    return () => this.#buttons.delete(direction);
+  });
+  #buttons = new Map<Direction, HTMLElement>();
+
+  @action
+  moveDown(...args: unknown[]) {
+    this.#move("down", this.args.disableDown, this.args.onMoveDown, args);
+  }
+
+  @action
+  moveUp(...args: unknown[]) {
+    this.#move("up", this.args.disableUp, this.args.onMoveUp, args);
+  }
+
+  /**
+   * Runs a direction unless it is unavailable, then takes focus back.
+   *
+   * The disabled args are honoured here rather than by the `disabled` attribute
+   * so the button stays focusable: it is announced as disabled, but a keyboard
+   * user who reaches the end of the list keeps their place in the tab order
+   * instead of being dropped to the top of the document.
+   *
+   * @param direction - Which button was pressed.
+   * @param disabled - Whether that direction is unavailable.
+   * @param callback - The consumer's handler for it.
+   * @param args - Whatever the consumer bound with `fn`.
+   */
+  #move(
+    direction: Direction,
+    disabled: boolean | undefined,
+    callback: ReorderCallback | undefined,
+    args: unknown[]
+  ) {
+    if (disabled) {
+      return;
+    }
+
+    callback?.(...args);
+
+    // Reordering moves this row within its list, and moving a focused element
+    // in the DOM blurs it, so a keyboard user would otherwise land on the body
+    // after one press and be unable to make a second.
+    schedule("afterRender", () => {
+      if (isDestroying(this) || isDestroyed(this)) {
+        return;
+      }
+
+      const button = this.#buttons.get(direction);
+      // The pair renders both directions unconditionally — the unavailable one
+      // is marked, not removed — so a missing button means focus is about to be
+      // dropped on the floor without anything saying so.
+      assert(`d-reorder-buttons: no ${direction} button to focus`, button);
+      button.focus();
+    });
+  }
+
+  <template>
+    <span class="d-reorder-buttons" ...attributes>
+      <DButton
+        {{this.captureButton "up"}}
+        @icon="chevron-up"
+        @action={{this.moveUp}}
+        @translatedAriaLabel={{@upLabel}}
+        @translatedTitle={{@upLabel}}
+        aria-disabled={{if @disableUp "true"}}
+        class="btn-flat d-reorder-buttons__button"
+      />
+      <DButton
+        {{this.captureButton "down"}}
+        @icon="chevron-down"
+        @action={{this.moveDown}}
+        @translatedAriaLabel={{@downLabel}}
+        @translatedTitle={{@downLabel}}
+        aria-disabled={{if @disableDown "true"}}
+        class="btn-flat d-reorder-buttons__button"
+      />
+    </span>
+  </template>
+}

--- a/frontend/discourse/app/ui-kit/d-resize-separator.gts
+++ b/frontend/discourse/app/ui-kit/d-resize-separator.gts
@@ -23,13 +23,12 @@ import dResizeEdge, {
 type Measurement = number | null | (() => number | null);
 
 /**
- * A bound, which unlike a size is never unmeasured: there is nothing to clamp
- * against until it is known, so an unmeasured bound would silently become `0`
- * in the gesture's arithmetic rather than mean "no limit".
+ * A bound, which unlike a size is expected to be known. There is nothing to clamp
+ * against until it is, so a consumer with no limit should leave the arg off.
  *
- * Documentation rather than enforcement. `strictNullChecks` is off repo-wide, so
- * `number | null` collapses to `number` and a nullable measurement still
- * type-checks here. What actually refuses one is the gesture's own guard.
+ * `strictNullChecks` is off repo-wide, so a nullable measurement still type-checks
+ * here. The gesture holds the line instead. It skips a bound that does not
+ * resolve, rather than reading it as zero.
  */
 type Bound = number | (() => number);
 
@@ -210,6 +209,10 @@ interface DResizeSeparatorSignature {
  * only when the number is NOT that measurement — an offset from a resting size,
  * or a count in the consumer's own units — and each one given overrides what
  * would have been measured.
+ *
+ * Supply `@max` for a second reason too, about layout rather than units. The
+ * measured maximum leaves the header its space, which suits a box pinned in the
+ * viewport. A box in a scrolling page should pass its own.
  *
  * @example
  * The ordinary case, where the separator resizes a box on the page:

--- a/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-monitor.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-monitor.ts
@@ -1,0 +1,133 @@
+import {
+  type ElementDragPayload,
+  type ElementEventBasePayload,
+  monitorForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { modifier } from "ember-modifier";
+import {
+  dragTypeOf,
+  type NormalizedDragSource,
+  normalizeDragSource,
+} from "discourse/services/drag-and-drop";
+
+/**
+ * Whether a drag's type is one the consumer asked for.
+ *
+ * Centralized so every monitor applies the same filter semantics.
+ *
+ * @param types - One type, several, or nothing at all to match every drag.
+ * @param source - The dragged source, compared through {@link dragTypeOf}.
+ */
+export function matchesDragType(
+  types: string | string[] | undefined,
+  source: ElementDragPayload
+) {
+  const list = Array.isArray(types) ? types : types ? [types] : [];
+  if (list.length === 0) {
+    return true;
+  }
+  return list.includes(dragTypeOf(source.data) as string);
+}
+
+/**
+ * What a monitor callback is told: the dragged source and where it has been.
+ * The source arrives normalized ({@link normalizeDragSource}), so a monitor
+ * reads the same shape a drop target reports and never meets a routing key.
+ */
+export type DragMonitorEvent = Omit<ElementEventBasePayload, "source"> & {
+  source: NormalizedDragSource;
+};
+
+interface DDragAndDropMonitorSignature {
+  /**
+   * Irrelevant — a monitor is global. Attach to any always-present sentinel for
+   * the lifecycle.
+   */
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      /**
+       * Only drags whose `type` matches are observed. Omit to observe any drag.
+       */
+      types?: string | string[];
+
+      /** The drag was confirmed. */
+      onDragStart?: (event: DragMonitorEvent) => void;
+
+      /** The drag progressed. */
+      onDrag?: (event: DragMonitorEvent) => void;
+
+      /** The drag ended, whether or not it landed on a target. */
+      onDrop?: (event: DragMonitorEvent) => void;
+    };
+    Positional: [];
+  };
+}
+
+/**
+ * The monitor's named args, for a consumer driving
+ * {@link registerDragAndDropMonitor} imperatively rather than through the
+ * modifier.
+ */
+export type DragAndDropMonitorArgs =
+  DDragAndDropMonitorSignature["Args"]["Named"];
+
+/**
+ * Wraps the element-drag monitor behind one shape. Used by the
+ * default-exported modifier below, and exported so consumers can register a
+ * monitor imperatively (when a template modifier doesn't fit) without importing
+ * the underlying library.
+ *
+ * Library-agnostic by design: the dependency is imported only here.
+ *
+ * @param getArgsRef - Closure returning the latest args. Library callbacks read
+ *   this on every invocation.
+ * @returns Cleanup function. Caller invokes it once on teardown.
+ */
+export function registerDragAndDropMonitor(
+  getArgsRef: () => DragAndDropMonitorArgs
+) {
+  const normalized = (event: ElementEventBasePayload): DragMonitorEvent => ({
+    ...event,
+    source: normalizeDragSource(event.source),
+  });
+  return monitorForElements({
+    canMonitor: ({ source }) => matchesDragType(getArgsRef().types, source),
+    onDragStart: (event) => getArgsRef().onDragStart?.(normalized(event)),
+    onDrag: (event) => getArgsRef().onDrag?.(normalized(event)),
+    onDrop: (event) => getArgsRef().onDrop?.(normalized(event)),
+  });
+}
+
+/**
+ * Observes the in-flight element drag, regardless of drop targets. Use it to
+ * react to a drag's progress without making
+ * an element droppable (e.g. paging a scroll container when the cursor hovers
+ * a navigation control mid-drag). Every arg is documented on
+ * {@link DragAndDropMonitorArgs}.
+ *
+ * A monitor is global, so the host element is irrelevant — attach it to any
+ * always-present sentinel for the lifecycle:
+ *
+ * ```hbs
+ * <div {{dDragAndDropMonitor types=this.dragTypes onDrag=this.onDrag}}></div>
+ * ```
+ *
+ * Guide to choosing between the gesture primitives:
+ * `docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md`
+ *
+ * @see The `dragAndDrop` service to *read* drag state reactively. This modifier is
+ *   for *responding* imperatively; rendering from it duplicates what the service keeps.
+ */
+export default modifier<DDragAndDropMonitorSignature>(
+  (_element, _positional, args) =>
+    // Read args INSIDE the closure, not via destructure in the body — a
+    // destructure here would mark the args' tags consumed and force the
+    // modifier to re-run (re-registering the monitor) on every change.
+    registerDragAndDropMonitor(() => ({
+      types: args.types,
+      onDragStart: args.onDragStart,
+      onDrag: args.onDrag,
+      onDrop: args.onDrop,
+    }))
+);

--- a/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-source.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-source.ts
@@ -1,0 +1,771 @@
+import { registerDestructor } from "@ember/destroyable";
+import type Owner from "@ember/owner";
+import { cancel, next } from "@ember/runloop";
+import {
+  draggable,
+  type ElementDropTargetEventBasePayload,
+  type ElementGetFeedbackArgs,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { pointerOutsideOfPreview } from "@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview";
+import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
+import Modifier, { type ArgsFor } from "ember-modifier";
+import { DRAG_BODY } from "discourse/services/drag-and-drop";
+
+/** The pointer position as the underlying library reports it. */
+type DragInput = ElementGetFeedbackArgs["input"];
+
+/** The drag's initial, previous and current locations. */
+type DragLocation = ElementDropTargetEventBasePayload["location"];
+
+/**
+ * Renders a drag preview into an isolated, offscreen container the browser
+ * photographs. Return a cleanup function that tears the preview down.
+ */
+export type DragPreviewRenderer = (args: {
+  /** The offscreen container to render into. */
+  container: HTMLElement;
+
+  /** The source element the drag began on. */
+  element: HTMLElement;
+}) => (() => void) | void;
+
+/** The dragged source, as the lifecycle callbacks receive it. */
+export interface DragSource {
+  /** The discriminator this source stamps, so targets can filter on it. */
+  type?: string;
+
+  /** The payload the drag carries, with `type` merged in. */
+  data: Record<string, unknown>;
+
+  /** The element the drag began on. */
+  element: HTMLElement;
+}
+
+interface DDragAndDropSourceSignature {
+  /** The element to mark draggable. */
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      /**
+       * Discriminator string. Targets filter on this via their `accepts` arg.
+       * Stamped onto `source.data.type` so callbacks receive it with the rest of
+       * the payload.
+       *
+       * Required, and reserved: it is stamped over any `type` the payload
+       * carries. The `dragAndDrop` service also identifies its own drags by it,
+       * so a source without one would be invisible there.
+       */
+      type: string;
+
+      /**
+       * Static payload the source attaches to the drag, exposed as `source.data`
+       * in target callbacks. A `type` key on it is overwritten — see `type`.
+       */
+      data?: object;
+
+      /**
+       * Alternative to `data` for dynamic payloads. Called once just before
+       * `dragstart`. Its `type` key is overwritten the same way.
+       */
+      getInitialData?: () => object;
+
+      /**
+       * A custom native drag preview, in one of two forms. An `Element` is
+       * photographed in place and the browser controls the hotspot. A render
+       * function mounts a fresh preview into an isolated, offscreen container,
+       * so nothing around the source element bleeds into the drag image.
+       * Defaults to the source element when omitted.
+       */
+      dragPreview?: Element | DragPreviewRenderer;
+
+      /**
+       * CSS length values (e.g. `{x: "1rem", y: "0.5rem"}`) that push the preview
+       * clear of the pointer for better drop accuracy. Applies only to the
+       * render-function `dragPreview` form; ignored for an `Element` preview,
+       * whose hotspot the browser clamps to within the image.
+       */
+      dragPreviewOffset?: { x: string; y: string };
+
+      /**
+       * Which drop operations this drag permits, written onto the native
+       * `dataTransfer` at `dragstart`. Defaults to `"move"`, which is what a
+       * drag between places in the same page almost always is, and which stops
+       * the browser badging the pointer with its standing offer to copy.
+       *
+       * A source whose drop genuinely duplicates rather than relocates wants
+       * `"copyMove"` — a target's `getDropEffect` may only return an effect
+       * this permits, and asking for one it does not shows the pointer as
+       * refused.
+       */
+      effectAllowed?: DataTransfer["effectAllowed"];
+
+      /** Returning `false` blocks the drag from starting. */
+      canDrag?: (feedback: {
+        /**
+         * The source as it stands before the drag begins. `data` is the arg
+         * exactly as passed, before it is merged into the drag payload.
+         */
+        source: { type?: string; data?: object; element: HTMLElement };
+
+        /** Where the pointer is. */
+        input: DragInput;
+      }) => boolean | void;
+
+      /** Fires once the drag is confirmed. */
+      onDragStart?: (event: {
+        /** The dragged source. */
+        source: DragSource;
+
+        /** Where the pointer is. */
+        input: DragInput;
+      }) => void;
+
+      /**
+       * Fires once at the end of EVERY drag, whether it landed on a target or the
+       * user abandoned it. This is where drag-time state gets undone.
+       *
+       * Fires AFTER the full drop dispatch (target callbacks, monitor callbacks,
+       * native bubble listeners), so it is safe to clear shared dispatch state
+       * from here. Inspect `location.current.dropTargets` to branch on the
+       * outcome.
+       */
+      onDragEnd?: (event: {
+        /** The dragged source. */
+        source: DragSource;
+
+        /** The drag's location history. */
+        location: DragLocation;
+      }) => void;
+
+      /**
+       * Fires only when the drag ended on at least one drop target, so it is
+       * where the operation gets performed: an abandoned drag never reaches it.
+       * For a drag that lands, both this and `onDragEnd` fire — `onDragEnd`
+       * first — with the same `source` and `location`.
+       */
+      onDrop?: (event: {
+        /** The dragged source. */
+        source: DragSource;
+
+        /** The drag's location history. */
+        location: DragLocation;
+      }) => void;
+
+      /**
+       * An element inside this one that a drag must start from, so the rest stays
+       * free for selecting text and operating controls. Pass the element itself,
+       * not a selector; capture its ref with a modifier on the handle rather than
+       * querying the DOM. Changing it re-registers, so a ref that only arrives on
+       * a later render still takes effect. Omit it and the whole element
+       * initiates a drag.
+       *
+       * The handle becomes what carries `draggable="true"`, because that
+       * attribute is what makes a browser read a press-drag as a drag instead of
+       * a selection — leaving it on the row would cost exactly the text and
+       * controls a handle exists to keep usable. This element stays the body
+       * regardless: it is what the state markers land on, what a target receives
+       * as `source.element`, and what the drag preview photographs.
+       */
+      dragHandle?: Element;
+
+      /**
+       * When `true`, the underlying draggable registration is detached. Used by
+       * consumers that conditionally suppress dragging (e.g. read-only modes).
+       * This, not `dragHandle`, is how to stop an element being dragged:
+       * `dragHandle` only moves where a drag may begin, and something is always
+       * draggable while a registration stands.
+       *
+       * Style and assert on `data-drag-source`, never on `draggable`: the
+       * attribute sits on whichever element was registered, which a handle
+       * changes.
+       */
+      disabled?: boolean;
+    };
+    Positional: [];
+  };
+}
+
+/**
+ * What a registration still owes after being detached without cancelling, and
+ * the two different reasons for letting go of it.
+ *
+ * They are not interchangeable, and picking the wrong one is silent: a dispatch
+ * belongs to a drag that already finished, so cancelling it robs a consumer that
+ * is still there of the `onDragEnd` it was promised, while leaving a waiting
+ * teardown in place lets a second registration land on the same element.
+ */
+export interface DetachedSourceWork {
+  /**
+   * The element the registration was created on — the drag handle when one was
+   * given, the source element otherwise. A replacement registering on the SAME
+   * element must supersede this work first (two registrations on one element is
+   * not a state the library supports); one registering elsewhere must leave it
+   * waiting, because the library dispatches an in-flight drag's end by looking
+   * this element up.
+   */
+  registeredElement: HTMLElement;
+
+  /**
+   * Something has taken this registration's place. Runs a teardown that was
+   * waiting on a drag, and leaves a scheduled dispatch to fire.
+   */
+  supersede: () => void;
+
+  /** The consumer is going away. Drops everything, dispatch included. */
+  abandon: () => void;
+
+  /**
+   * Whether anything is still owed. Goes false once the dispatch has fired and
+   * no teardown is waiting, which a caller holding these has no other way to
+   * find out — so without it they accumulate for as long as it lives.
+   */
+  outstanding: () => boolean;
+}
+
+/**
+ * The drag source's named args, for a consumer driving
+ * {@link registerDragAndDropSource} imperatively rather than through the
+ * modifier.
+ */
+export type DragAndDropSourceArgs =
+  DDragAndDropSourceSignature["Args"]["Named"];
+
+/**
+ * Where to read a registered source element's current args. Weak because it
+ * outlives no registration it should: a module-level strong reference to an
+ * element keeps a removed subtree alive for the life of the tab, and a
+ * registration this never hears the end of would be exactly that.
+ */
+const effectDeclarers = new WeakMap<Element, () => DragAndDropSourceArgs>();
+
+/**
+ * How many sources are registered, which a weak map cannot report and the
+ * listener below is bound and unbound on.
+ */
+let liveSourceCount = 0;
+
+/** Unbinds the shared listener below. Null while no source is registered. */
+let stopDeclaringEffects: (() => void) | null = null;
+
+/**
+ * Says what the drag that is starting permits, which nothing else does — left
+ * unwritten, `effectAllowed` means "anything", which the browser renders as its
+ * standing offer to copy.
+ *
+ * A native listener because the drag callbacks are never handed the event. It
+ * runs during the `dragstart` dispatch, which is all the browser asks: it reads
+ * the value once that dispatch has finished.
+ */
+function declareEffectAllowed(event: DragEvent) {
+  const target = event.target as HTMLElement | null;
+  // The innermost registered source, so a drag begun inside a nested one is
+  // answered by that source rather than by whichever ancestor also registered.
+  const source = target?.closest?.("[data-drag-source]");
+  const getArgsRef = source && effectDeclarers.get(source);
+  if (getArgsRef && event.dataTransfer) {
+    event.dataTransfer.effectAllowed = getArgsRef().effectAllowed ?? "move";
+  }
+}
+
+/**
+ * Puts a source on the shared listener rather than giving it one of its own: a
+ * long list registers a row per item, and the event it needs is one the whole
+ * page dispatches anyway.
+ *
+ * @returns Cleanup, which unbinds the listener once the last source has gone.
+ */
+function declareEffectFor(
+  element: Element,
+  getArgsRef: () => DragAndDropSourceArgs
+) {
+  effectDeclarers.set(element, getArgsRef);
+  liveSourceCount += 1;
+  if (!stopDeclaringEffects) {
+    window.addEventListener("dragstart", declareEffectAllowed, {
+      capture: true,
+    });
+    stopDeclaringEffects = () =>
+      window.removeEventListener("dragstart", declareEffectAllowed, {
+        capture: true,
+      });
+  }
+
+  return () => {
+    // Only the release that finds the entry still there counts. A teardown is
+    // expected to be idempotent, and a second one decrementing again would take
+    // the listener out from under a source that is still registered.
+    if (!effectDeclarers.delete(element)) {
+      return;
+    }
+    // Clamped because a reset zeroes the count while live registrations are
+    // still holding a release, and a negative count would never reach zero.
+    liveSourceCount = Math.max(0, liveSourceCount - 1);
+    if (liveSourceCount === 0) {
+      stopDeclaringEffects?.();
+      stopDeclaringEffects = null;
+    }
+  };
+}
+
+/** Test-only: forget every source and unbind the listener between tests. */
+export function resetDragSourcesForTesting() {
+  liveSourceCount = 0;
+  stopDeclaringEffects?.();
+  stopDeclaringEffects = null;
+}
+
+/**
+ * The payload as a consumer should see it: the body a handled source publishes
+ * for the target and the service to read is routing, not data anyone wrote.
+ */
+function consumerData(data: Record<string, unknown> | null | undefined) {
+  const rest = { ...(data ?? {}) };
+  delete rest[DRAG_BODY];
+  return rest;
+}
+
+/**
+ * Wraps the underlying draggable registration with source-payload
+ * normalisation, the `--dragging` class on the source element, and the
+ * end-of-drag deferral that hides its source-before-target dispatch ordering.
+ * Used by the default-exported modifier below, and exported so a consumer can
+ * register a drag source imperatively (when a template modifier doesn't fit —
+ * e.g. marking elements rendered inside another component as sources) without
+ * importing the underlying library — parallel to
+ * `registerDragAndDropTarget` / `registerDragAndDropMonitor`.
+ *
+ * Library-agnostic by design: the dependency is imported only by the ui-kit
+ * modifier files.
+ *
+ * The consumer's end-of-drag callbacks are deferred to the next task so they
+ * fire after the drop event has finished propagating: `onDragEnd` for every
+ * drag, then `onDrop` only for one that ended on a drop target.
+ *
+ * @param element - The element to mark draggable.
+ * @param getArgsRef - Closure returning the latest args. Library callbacks read
+ *   this on every invocation, so arg changes take effect without re-registering.
+ *   `dragHandle` is the exception: it is read once, when this registers, so a
+ *   caller driving this imperatively must re-register to change it.
+ * @returns Cleanup function. Caller invokes it once on teardown.
+ */
+export function registerDragAndDropSource(
+  element: HTMLElement,
+  getArgsRef: () => DragAndDropSourceArgs
+) {
+  // Marks the element as owned by this primitive for the lifetime of the
+  // registration. The stylesheet gates the state modifiers below on it, so a
+  // generic state name cannot reach an element this never touched. An attribute
+  // rather than a class because consumers frequently bind `class` themselves,
+  // and a dynamic binding would drop anything written here.
+  element.setAttribute("data-drag-source", "");
+
+  // The end-of-drag consumer callbacks are deferred, so teardown has to be able
+  // to take them back: without this a route transition, or a re-render dropping
+  // the row, runs them against a destroyed component one task later.
+  let pendingConsumers: Parameters<typeof cancel>[0] | null = null;
+
+  /** Whether a drag from this element is in flight. */
+  let dragging = false;
+
+  /** A teardown waiting for the drag in flight to finish, if there is one. */
+  let teardownWhenIdle: (() => void) | null = null;
+
+  const stopDeclaringEffect = declareEffectFor(element, getArgsRef);
+
+  // A handle takes the registration, and this element stays the body. The
+  // registration is what receives `draggable="true"`, and that attribute is what
+  // makes a browser read a press-drag as a drag rather than a selection — so
+  // leaving it on the body would cost the row the selectable text and operable
+  // controls a handle exists to preserve. It also makes the library's own
+  // `dragHandle` unnecessary: a press outside the registration cannot begin a
+  // drag at all, rather than beginning one the library then hit-tests and vetoes.
+  //
+  // Read once, here: the underlying library keeps this in the config captured at
+  // registration, so it does not see a later change the way the callbacks below
+  // see one through `getArgsRef`. Replacing the registration when the handle
+  // changes is the modifier's job. Cast because `dragHandle` is the broader
+  // `Element` for consumers, while the library needs an `HTMLElement`.
+  const registered = (getArgsRef().dragHandle ?? element) as HTMLElement;
+
+  const cleanup = draggable({
+    element: registered,
+    canDrag: ({ input }) => {
+      const args = getArgsRef();
+      if (!args.canDrag) {
+        return true;
+      }
+      return (
+        args.canDrag({
+          source: { type: args.type, data: args.data, element },
+          input,
+        }) !== false
+      );
+    },
+    onGenerateDragPreview: ({ nativeSetDragImage }) => {
+      const args = getArgsRef();
+
+      // Answers for the drag everywhere no target accepts it, so releasing over
+      // dead space ends the drag where the pointer is instead of playing the
+      // browser's snap-back animation. Started here rather than from
+      // `onDragStart`, which the library defers by a frame: bound a frame late,
+      // the first moments of every drag would go unanswered.
+      //
+      // Deliberately never stopped. The utility binds its own drop, dragend and
+      // broken-drag cleanup, so it releases itself however the drag ends —
+      // including one whose source was destroyed mid-flight, where our own
+      // teardown callbacks are cancelled and would never run.
+      //
+      // Only drags this primitive starts reach this callback. Native drags the
+      // browser starts from page content carry their own payload, so what the
+      // rest of the page does with them stays the browser's business.
+      preventUnhandled.start();
+
+      if (!nativeSetDragImage) {
+        return;
+      }
+      // A function `dragPreview` renders a fresh preview into an isolated,
+      // offscreen container the browser photographs — nothing around the source
+      // element can bleed into the drag image — and can be pushed clear of the
+      // pointer via `dragPreviewOffset`.
+      if (typeof args.dragPreview === "function") {
+        setCustomNativeDragPreview({
+          nativeSetDragImage,
+          getOffset: args.dragPreviewOffset
+            ? pointerOutsideOfPreview(args.dragPreviewOffset)
+            : undefined,
+          // The narrowing above does not survive into this nested callback,
+          // where TypeScript sees the whole `Element | DragPreviewRenderer`
+          // union again.
+          render: ({ container }) =>
+            (args.dragPreview as DragPreviewRenderer)({ container, element }),
+        });
+        return;
+      }
+      // An `Element` is photographed in place. The browser clamps the hotspot
+      // to within the element, so `dragPreviewOffset` cannot push it off the
+      // pointer here — it applies only to the render-function form above.
+      //
+      // With a handle, the body stands in when the consumer named no preview:
+      // what the user is moving is the row, and the browser's own default would
+      // photograph the registration — a picture of the grip alone. Without one
+      // the two are the same element, so the browser's default already is the
+      // body and asking for it explicitly would only cost a call.
+      const preview =
+        args.dragPreview ?? (registered === element ? null : element);
+      if (preview) {
+        nativeSetDragImage(preview, 0, 0);
+      }
+    },
+    getInitialData: () => {
+      const args = getArgsRef();
+      const resolved = args.getInitialData?.() ?? args.data ?? {};
+      // Stamped last: the discriminator is the primitive's, and a payload
+      // carrying its own `type` — which domain objects routinely do — would
+      // otherwise decide which targets accept the drag.
+      //
+      // The body rides along so a target can name the element the user is
+      // moving rather than the handle the library registered. It is read back
+      // out in `d-drag-and-drop-target.ts` and never surfaces to consumers.
+      return { ...resolved, type: args.type, [DRAG_BODY]: element };
+    },
+    onDragStart: (event) => {
+      const args = getArgsRef();
+      dragging = true;
+      element.classList.add("--dragging");
+      const sourcePayload = {
+        type: args.type,
+        data: consumerData(event.source.data),
+        element,
+      };
+      args.onDragStart?.({
+        source: sourcePayload,
+        input: event.location?.current?.input,
+      });
+    },
+    onDrop: (event) => {
+      const args = getArgsRef();
+      dragging = false;
+      // Source-private cleanup runs synchronously. These touch only
+      // state owned by the source element / source modifier; nothing
+      // downstream (target callbacks, native bubble-phase listeners)
+      // depends on them.
+      element.classList.remove("--dragging");
+
+      // Snapshot the consumer callbacks + payload BEFORE deferring.
+      // The modifier's argsRef can change across re-renders, and by
+      // the time the microtask fires a new drag could already have
+      // started — we want the consumers for THIS drag, with the
+      // payload the library captured at THIS drag's start.
+      const consumerOnDragEnd = args.onDragEnd;
+      const consumerOnDrop = args.onDrop;
+      const sourcePayload = {
+        // Read from the captured payload rather than from the current args, so
+        // it agrees with `data` beside it. `type` is stamped into that payload
+        // when the drag starts, and a consumer that changed `@type` mid-drag
+        // would otherwise be handed a `type` its own `data.type` contradicts.
+        // The library types every payload value as `unknown`; this key is
+        // written by `getInitialData` above and is always the string `type`.
+        type: event.source.data?.type as string,
+        data: consumerData(event.source.data),
+        element,
+      };
+      const location = event.location;
+      // An abandoned drag — cancelled, or released outside every drop target —
+      // arrives here too, and is what separates the two callbacks below.
+      const landed = location.current.dropTargets.length > 0;
+
+      // `next` defers the consumers to the next task, so they fire
+      // after the current drop event finishes propagating —
+      // including bubble-phase listeners that may still need to
+      // read shared dispatch state. One task for both, so their
+      // order is fixed and a drag schedules exactly one.
+      pendingConsumers = next(() => {
+        pendingConsumers = null;
+        try {
+          // Lifecycle before dispatch: a consumer that only needs to undo its
+          // drag-time state hears about every drag, while one that performs an
+          // operation is not asked to perform it for a drag the user gave up on.
+          consumerOnDragEnd?.({ source: sourcePayload, location });
+          if (landed) {
+            consumerOnDrop?.({ source: sourcePayload, location });
+          }
+        } finally {
+          // A teardown that was held back for this drag. Run last, so the
+          // unregistration cannot land in the middle of the library's own
+          // dispatch, and in a `finally`, because a consumer that throws would
+          // otherwise leave the element registered for good.
+          const deferred = teardownWhenIdle;
+          teardownWhenIdle = null;
+          deferred?.();
+        }
+      });
+    },
+  });
+
+  const teardown = () => {
+    cleanup();
+    stopDeclaringEffect();
+    element.classList.remove("--dragging");
+    element.removeAttribute("data-drag-source");
+  };
+
+  /**
+   * Runs a teardown that was waiting on a drag, because something has taken this
+   * registration's place and the drag it was waiting for will never report.
+   *
+   * Deliberately leaves a scheduled dispatch alone: that belongs to a drag which
+   * already finished, and the consumer it belongs to is still there.
+   */
+  const supersede = () => {
+    if (teardownWhenIdle) {
+      teardownWhenIdle = null;
+      teardown();
+    }
+  };
+
+  /**
+   * Drops everything this registration is still owed, for a consumer that is
+   * going away: the scheduled dispatch as well as any waiting teardown.
+   */
+  const abandon = () => {
+    if (pendingConsumers) {
+      cancel(pendingConsumers);
+      pendingConsumers = null;
+    }
+    supersede();
+  };
+
+  const outstanding = () => Boolean(pendingConsumers || teardownWhenIdle);
+
+  /**
+   * Tears the registration down.
+   *
+   * @param options - Cleanup options. `cancelPending` determines whether to
+   *   drop a drop dispatch already scheduled for the next task. True when the
+   *   consumer itself is going away, because running its callbacks against a
+   *   destroyed component is the hazard this defers around. False when the
+   *   registration is merely being replaced — a `disabled` arg flipping, or a
+   *   new handle — because the consumer is still there and still expects to
+   *   hear how its own drag ended.
+   * @returns `null` once nothing is outstanding, or the work still owed. A
+   *   caller that kept it has to hold onto this: it is the only remaining way to
+   *   reach it, and the two ways of letting go are not interchangeable.
+   */
+  return ({
+    cancelPending = true,
+  }: { cancelPending?: boolean } = {}): DetachedSourceWork | null => {
+    if (cancelPending) {
+      abandon();
+      teardown();
+      return null;
+    }
+
+    if (dragging) {
+      // Unregistering now would take the element out of the library's dispatch
+      // mid-drag, so the drop it is about to report — and with it the
+      // `onDragEnd` every drag is promised — would never arrive. The consumer
+      // is still here to receive it, so the teardown waits for the drag.
+      teardownWhenIdle = teardown;
+      return { registeredElement: registered, supersede, abandon, outstanding };
+    }
+
+    teardown();
+    return pendingConsumers
+      ? { registeredElement: registered, supersede, abandon, outstanding }
+      : null;
+  };
+}
+
+/**
+ * Marks an element as a drag source for the Discourse drag-and-drop
+ * vocabulary, paired with `dDragAndDropTarget` on the receiving side.
+ * Thin Ember-modifier wrapper around {@link registerDragAndDropSource}. Every
+ * arg is documented on {@link DragAndDropSourceArgs}.
+ *
+ * ```hbs
+ * <li {{dDragAndDropSource
+ *   type="sidebar-link"
+ *   data=this.link
+ *   dragPreview=this.previewEl
+ *   canDrag=this.canDrag
+ *   onDragStart=this.handleDragStart
+ *   onDragEnd=this.clearDragState
+ *   onDrop=this.applyDrop
+ * }}>...</li>
+ * ```
+ *
+ * Stamps `data-drag-source` on the element for the lifetime of the
+ * registration and adds the `--dragging` class while a drag is active. Both are
+ * styled by `app/assets/stylesheets/common/ui-kit/d-drag-and-drop.scss`, whose
+ * selectors are gated on the attribute.
+ *
+ * Testing: in JS integration tests use `simulateDrag` from
+ * `discourse/tests/helpers/ui-kit/drag-and-drop-helper`; in Ruby system
+ * tests use `SystemHelpers#drag_and_drop` (a real native drag via
+ * Playwright) rather than Capybara's `drag_to`, whose synthetic mouse
+ * events can silently stall mid-drag.
+ *
+ * Guide to choosing between the gesture primitives:
+ * `docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md`
+ *
+ * @see The `dPointerDrag` modifier when there is no drop target and no payload — a
+ *   press that changes a value continuously is a different gesture.
+ */
+export default class DDragAndDropSourceModifier extends Modifier<DDragAndDropSourceSignature> {
+  #cleanup: ReturnType<typeof registerDragAndDropSource> | null = null;
+  #element: HTMLElement | null = null;
+  // Replaced by `modify` before any callback can read it; the empty bag only
+  // covers the window before the first run.
+  #args = {} as DragAndDropSourceArgs;
+
+  /** The handle the live registration was created with, to detect a change. */
+  #dragHandle: Element | undefined = undefined;
+
+  /**
+   * Registrations that were replaced while still owing the consumer something.
+   * Held here rather than left in their own closures, which went away with the
+   * cleanup functions that reached them: a consumer can be destroyed after its
+   * registration was replaced but before the drag it kept has reported.
+   *
+   * A set rather than one, because a replaced registration keeps owing a
+   * dispatch until it fires, and there is no way to observe that it has.
+   */
+  #detached = new Set<DetachedSourceWork>();
+
+  constructor(owner: Owner, args: ArgsFor<DDragAndDropSourceSignature>) {
+    super(owner, args);
+    registerDestructor(this, (instance) => {
+      instance.#detach();
+      instance.#detached.forEach((work) => work.abandon());
+      instance.#detached.clear();
+    });
+  }
+
+  modify(
+    element: HTMLElement,
+    _positional: [],
+    args: DragAndDropSourceArgs = {} as DragAndDropSourceArgs
+  ) {
+    if (this.#element && this.#element !== element) {
+      this.#detach({ cancelPending: false });
+    }
+    this.#element = element;
+
+    if (args?.disabled) {
+      this.#detach({ cancelPending: false });
+      return;
+    }
+
+    // Consumer callbacks pass straight through. The `dragAndDrop` service
+    // observes element drags first-hand via its own `monitorForElements`, so
+    // this modifier owns no shared drag state and stays service-free.
+    this.#args = args;
+
+    // A handle is captured when the registration is created, so a new one has to
+    // replace it. This is the ordinary case rather than an edge case: a handle is
+    // often rendered conditionally and its ref only reaches these args on a later
+    // run, and without this the element would keep dragging from anywhere.
+    if (this.#cleanup && args.dragHandle !== this.#dragHandle) {
+      this.#detach({ cancelPending: false });
+      this.#element = element;
+    }
+    this.#dragHandle = args.dragHandle;
+
+    if (!this.#cleanup) {
+      // Anything still holding the element about to be registered is let go of
+      // first: two registrations on one element is not a state the library
+      // supports. Only that element's work though — a registration waiting on a
+      // DIFFERENT element (the ordinary shape of a handle change) is how an
+      // in-flight drag's end still reaches the consumer, since the library
+      // dispatches it by looking the original element up. And only the
+      // teardowns — a dispatch already scheduled belongs to a drag that
+      // finished, and this consumer is still here to be told how.
+      const registering = (args.dragHandle ?? element) as HTMLElement;
+      this.#detached.forEach((work) => {
+        if (work.registeredElement === registering) {
+          work.supersede();
+        }
+      });
+      this.#pruneDetached();
+      this.#cleanup = registerDragAndDropSource(element, () => this.#args);
+    }
+  }
+
+  /**
+   * Unregisters the source.
+   *
+   * @param options - Cleanup options. `cancelPending` is passed through to the
+   *   registration's own cleanup. Defaults to true, which is the destructor's
+   *   case: only a caller that is replacing the registration while the consumer
+   *   lives on asks for the pending drop dispatch to be kept.
+   */
+  #detach({ cancelPending = true }: { cancelPending?: boolean } = {}) {
+    const work = this.#cleanup?.({ cancelPending }) ?? null;
+    if (work) {
+      // The drag this work is waiting on is still in flight, so the element
+      // keeps its mark; the deferred teardown removes it when the drag ends.
+      this.#detached.add(work);
+    } else {
+      this.#element?.classList.remove("--dragging");
+    }
+    this.#pruneDetached();
+    this.#cleanup = null;
+    this.#element = null;
+  }
+
+  /**
+   * Forgets detached registrations that have finished what they were kept for.
+   *
+   * They cannot report this themselves, so without a sweep on each detach and
+   * re-registration one is retained per drag for as long as this modifier lives,
+   * each holding its element and the library's cleanup.
+   */
+  #pruneDetached() {
+    this.#detached.forEach((work) => {
+      if (!work.outstanding()) {
+        this.#detached.delete(work);
+      }
+    });
+  }
+}

--- a/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-target.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-drag-and-drop-target.ts
@@ -1,0 +1,596 @@
+import {
+  dropTargetForElements,
+  type ElementDragPayload,
+  type ElementDropTargetEventBasePayload,
+  type ElementDropTargetGetFeedbackArgs,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { modifier } from "ember-modifier";
+import {
+  DRAG_BODY,
+  normalizeDragSource,
+} from "discourse/services/drag-and-drop";
+
+/** The pointer position as the underlying library reports it. */
+type DragInput = ElementDropTargetGetFeedbackArgs["input"];
+
+/** The drag's initial, previous and current locations. */
+type DragLocation = ElementDropTargetEventBasePayload["location"];
+
+/** Where a drop would land relative to this target. */
+export type DropPosition = "before" | "after" | "inside";
+
+/** The axis the target's position math and indicator classes work along. */
+export type DropAxis = "x" | "y";
+
+/** The cursor feedback the browser shows for a drop. */
+export type DropEffect = "copy" | "link" | "move";
+
+/** The dragged source, normalised to the shape `dDragAndDropSource` publishes. */
+export interface DropTargetSource {
+  /** The source's discriminator, or `null` when the drag carries none. */
+  type: string | null;
+
+  /** The payload the source attached to the drag. */
+  data: Record<string, unknown>;
+
+  /** The dragged element, falling back to this target when the drag has none. */
+  element: Element | null;
+}
+
+/** What a synchronous gate (`canDrop`, `getDropEffect`) is asked about. */
+export interface DropTargetFeedback {
+  /** The dragged source. */
+  source: DropTargetSource;
+
+  /** Where the pointer is. */
+  input: DragInput;
+
+  /** This target's element. */
+  element: Element;
+}
+
+/** What a lifecycle callback is told. */
+export interface DropTargetEvent {
+  /** The dragged source. */
+  source: DropTargetSource;
+
+  /** Where the drop would land, or `null` when the drag has left. */
+  position: DropPosition | null;
+
+  /** The drag's location history. */
+  location: DragLocation;
+
+  /** This target's element. */
+  element: Element;
+}
+
+/**
+ * Per-axis state modifier classes toggled while the cursor is hovering with a
+ * compatible drag in flight. Paired with the `data-drop-target` attribute the
+ * registrar stamps, and styled by
+ * `app/assets/stylesheets/common/ui-kit/d-drag-and-drop.scss`, which draws a 2px
+ * accent line above/below the row by default; consumers can override with their
+ * own treatment when a different look is needed.
+ */
+const POSITION_CLASSES = Object.freeze({
+  before: { y: "--drag-above", x: "--drag-left" },
+  after: { y: "--drag-below", x: "--drag-right" },
+  inside: { y: "--drag-inside", x: "--drag-inside" },
+});
+
+/** How a target decides where a drop would land. */
+export interface DropPositionOptions {
+  /** A fixed position, which wins over the midpoint math entirely. */
+  position?: DropPosition;
+
+  /** The axis the midpoint is measured along. Defaults to `"y"`. */
+  axis?: DropAxis;
+}
+
+/**
+ * Where a drop would land relative to an element: the `position` arg when one is
+ * fixed, otherwise which side of the element's midpoint the pointer is on.
+ *
+ * Centralized so every consumer uses the same midpoint comparison.
+ *
+ * @param element - The target element to measure against.
+ * @param input - The pointer position, as the underlying library reports it.
+ * @param options - The consumer's `position` / `axis` args.
+ */
+export function resolveDropPosition(
+  element: Element,
+  input: DragInput,
+  { position, axis = "y" }: DropPositionOptions
+): DropPosition {
+  if (position) {
+    return position;
+  }
+  const rect = element.getBoundingClientRect();
+  if (axis === "x") {
+    return input.clientX < rect.left + rect.width / 2 ? "before" : "after";
+  }
+  return input.clientY < rect.top + rect.height / 2 ? "before" : "after";
+}
+
+/**
+ * Keeps at most one positional indicator class on an element, so moving from one
+ * position to another swaps rather than accumulates.
+ *
+ * Centralized with {@link resolveDropPosition} so the position vocabulary and
+ * its class lifecycle cannot drift apart.
+ *
+ * @param element - The element to carry the class.
+ * @returns `apply`, which swaps in the class for a position/axis pair, and
+ *   `clear`, which removes whichever one is currently on.
+ */
+export function createPositionIndicator(element: Element) {
+  let activeClass: string | null = null;
+
+  return {
+    apply(position: DropPosition, axis: DropAxis) {
+      const className = POSITION_CLASSES[position]?.[axis];
+      if (!className || activeClass === className) {
+        return;
+      }
+      if (activeClass) {
+        element.classList.remove(activeClass);
+      }
+      element.classList.add(className);
+      activeClass = className;
+    },
+    clear() {
+      if (activeClass) {
+        element.classList.remove(activeClass);
+        activeClass = null;
+      }
+    },
+  };
+}
+
+/**
+ * One value, several, or nothing, as a list.
+ *
+ * @param value - The `accepts` filter as the consumer supplied it.
+ */
+export function toAcceptList<T>(value?: T | T[]): T[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [value];
+}
+
+/**
+ * Whether this element is the innermost accepted target under the pointer.
+ *
+ * The underlying library fires every lifecycle event on every target in the
+ * hierarchy; the contract here is that only the deepest one acts on it.
+ *
+ * @param location - The drag's location history.
+ * @param element - The element being asked about.
+ */
+export function isDeepestTarget(location: DragLocation, element: Element) {
+  return location.current.dropTargets[0]?.element === element;
+}
+
+/**
+ * Keeps one registration's `onDragEnter` and `onDragLeave` in step.
+ *
+ * The underlying library fires both on every target in the hierarchy, while the
+ * contract here is that only the deepest one tells its consumer. That makes the
+ * two halves easy to get out of step in either direction: an ancestor whose
+ * enter was swallowed would otherwise still be sent a leave, and one that takes
+ * over as deepest without a fresh enter would be sent a leave it was never
+ * given an enter for. Shared because both target modifiers need exactly this and
+ * the pair drifted between them once already.
+ *
+ * @returns `enter` and `leave`, which each run the callback only when doing so
+ *   keeps the pair balanced, and `reset` for a drop, which ends the drag without
+ *   a leave.
+ */
+export function createEnterLeavePairing() {
+  let entered = false;
+
+  return {
+    enter(fire: () => void) {
+      if (entered) {
+        return;
+      }
+      entered = true;
+      fire();
+    },
+    leave(fire: () => void) {
+      if (!entered) {
+        return;
+      }
+      entered = false;
+      fire();
+    },
+    reset() {
+      entered = false;
+    },
+  };
+}
+
+function normalizeSource(
+  pdndSource: ElementDragPayload,
+  element: Element
+): DropTargetSource {
+  // The routing interpretation lives with the vocabulary it reads. The target
+  // supplies itself as the fallback because `acceptsSelf` compares against the
+  // reported element, which is why a handled row still recognises a drop of
+  // itself.
+  return normalizeDragSource(pdndSource, element);
+}
+
+interface DDragAndDropTargetSignature {
+  /** The element to register as a drop target. */
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      /**
+       * The dragged source's `type` must be in this list for the target to
+       * engage. Omit to accept any source.
+       */
+      accepts?: string | string[];
+
+      /**
+       * `false` to refuse a drop whose dragged element is this element. Where
+       * `accepts` filters by type, this filters by identity. Defaults to `true`,
+       * because an element carrying both this modifier and `dDragAndDropSource`
+       * is a supported arrangement with a meaningful drop, so excluding it is
+       * opt-in rather than automatic.
+       */
+      acceptsSelf?: boolean;
+
+      /**
+       * A fixed drop position. When set, `axis` and the midpoint logic are
+       * ignored.
+       */
+      position?: DropPosition;
+
+      /**
+       * Drives the indicator class selection and the smart-row position math.
+       * Defaults to `"y"`.
+       */
+      axis?: DropAxis;
+
+      /**
+       * Synchronous gate. Returning `false` refuses the drop. `source` is
+       * `{type, data, element}` — the shape the matching `dDragAndDropSource`
+       * published.
+       */
+      canDrop?: (feedback: DropTargetFeedback) => boolean | void;
+
+      /**
+       * Optional target-side metadata attached to the drag's record of this
+       * target; consumers reading `source.dropTargets` see it under `.data`.
+       */
+      getData?: () => object;
+
+      /** Determines the cursor feedback browsers show. */
+      getDropEffect?: (feedback: DropTargetFeedback) => DropEffect;
+
+      /**
+       * Enables sticky-target semantics: the target stays "current" briefly
+       * after the cursor leaves, which suits hover-to-expand patterns.
+       */
+      getIsSticky?: () => boolean;
+
+      /** `false` to suppress the `--drag-*` indicator classes. Defaults to `true`. */
+      indicator?: boolean;
+
+      /**
+       * This target became the one a drop would land on, with a compatible drag
+       * in flight. Usually the cursor entering it, but also a nested target that
+       * was covering it going away, so it can fire without the cursor moving.
+       */
+      onDragEnter?: (event: DropTargetEvent) => void;
+
+      /**
+       * The drag progressed. Throttled; fires when the input or the drop-target
+       * hierarchy updates while this target is active.
+       */
+      onDrag?: (event: DropTargetEvent) => void;
+
+      /**
+       * This target stopped being the one a drop would land on. The cursor
+       * leaving it, or a nested target taking over while the cursor is still
+       * inside it. `position` is `null`.
+       *
+       * Tracks the role rather than the callbacks: fires only for a target that
+       * had taken the role, and only once each time it gives it up, whether or
+       * not an `onDragEnter` was supplied to observe it being taken.
+       *
+       * Not every taking is given up here, though. A drop ends the drag without
+       * a leave, and so does the target being torn down mid-drag, so drag-time
+       * state has to be released on the consumer's own destruction too.
+       */
+      onDragLeave?: (event: DropTargetEvent) => void;
+
+      /** The drag was released on this target. */
+      onDrop?: (event: DropTargetEvent) => void;
+    };
+    Positional: [];
+  };
+}
+
+/**
+ * The drop target's named args, for a consumer driving
+ * {@link registerDragAndDropTarget} imperatively rather than through the
+ * modifier.
+ */
+export type DragAndDropTargetArgs =
+  DDragAndDropTargetSignature["Args"]["Named"];
+
+/**
+ * Imperative drop-target registration. Wraps `dropTargetForElements` with the
+ * deepest-target filter,
+ * `--drag-above` / `--drag-below` indicator classes, and the
+ * source-payload normalisation the modifier exposes.
+ *
+ * Use this directly when you've captured an element ref outside your
+ * own template (e.g. via `didInsert` on a sibling marker, or after
+ * walking the DOM) and can't attach the `{{dDragAndDropTarget}}`
+ * modifier. The modifier itself is a thin wrapper around this
+ * function for the template-based common case.
+ *
+ * Library-agnostic by design: the dependency is imported only by the ui-kit
+ * modifier files. Consumers talk to this helper rather than the dependency
+ * directly.
+ *
+ * @param element - The element to register as a drop target.
+ * @param getArgsRef - Closure returning the latest args. Library callbacks read
+ *   this on every invocation, so arg changes take effect without re-registering.
+ * @returns Cleanup function. Caller invokes it once on teardown (modifier
+ *   destroy, component willDestroy, etc.).
+ */
+export function registerDragAndDropTarget(
+  element: Element,
+  getArgsRef: () => DragAndDropTargetArgs
+) {
+  const indicator = createPositionIndicator(element);
+  // Whether this wrapper has forwarded an enter the consumer is still owed a
+  // leave for. The underlying library sends both to every target in the
+  // hierarchy, but only the deepest one is forwarded, so an ancestor would
+  // otherwise be handed a leave it never had an enter for.
+  const pairing = createEnterLeavePairing();
+
+  const acceptsType = (type: unknown) => {
+    const list = toAcceptList(getArgsRef().accepts);
+    return list.length === 0 || list.includes(type as string);
+  };
+
+  /**
+   * Whether this target will take the drag, by whichever branch applies.
+   *
+   * Shared between the synchronous gate and the drop, because the library
+   * decides the target list on the last `dragover` and reuses it when the
+   * pointer is released — so a target that stopped qualifying in between would
+   * otherwise still be handed the drop. Consumers put authorization here, which
+   * makes re-asking the difference between refusing and acting on stale
+   * permission.
+   */
+  const passesGate = (source: ElementDragPayload, input: DragInput) => {
+    const args = getArgsRef();
+
+    if (!acceptsType(source.data?.type)) {
+      return false;
+    }
+
+    // The body a handled source stands for, or the raw source element when
+    // there is none. Deliberately not the normalised payload, whose `element`
+    // falls back to this one and would therefore read as self whenever the
+    // source element is absent — and deliberately not the registered element
+    // alone, which for a handled source is a grip nested inside the row and so
+    // never equal to the target that is the row.
+    const moving = (source.data?.[DRAG_BODY] as Element) ?? source.element;
+    if (args.acceptsSelf === false && moving === element) {
+      return false;
+    }
+
+    if (!args.canDrop) {
+      return true;
+    }
+
+    return (
+      args.canDrop({
+        source: normalizeSource(source, element),
+        input,
+        element,
+      }) !== false
+    );
+  };
+
+  const resolvePosition = (input: DragInput): DropPosition => {
+    const { position, axis } = getArgsRef();
+    return resolveDropPosition(element, input, { position, axis });
+  };
+
+  const isDeepest = (location: DragLocation) =>
+    isDeepestTarget(location, element);
+
+  /**
+   * Closes an open enter, if there is one.
+   *
+   * Called both when the library reports a leave and when this element merely
+   * stops being the deepest target, which the library reports as nothing at all
+   * because the element never left the hierarchy. Without the second case an
+   * ancestor superseded by one of its own children would keep an enter open for
+   * the rest of the drag.
+   */
+  const reportLeave = (source: ElementDragPayload, location: DragLocation) =>
+    pairing.leave(() =>
+      getArgsRef().onDragLeave?.({
+        source: normalizeSource(source, element),
+        position: null,
+        location,
+        element,
+      })
+    );
+
+  // See the note in `registerDragAndDropSource`: the stylesheet gates the state
+  // modifiers on this attribute, and an attribute survives a consumer rebinding
+  // `class`.
+  element.setAttribute("data-drop-target", "");
+
+  const cleanup = dropTargetForElements({
+    element,
+    canDrop: ({ source, input }) => passesGate(source, input),
+    // The consumer's metadata is deliberately typed as a plain object, which the
+    // underlying library's index-signature shape does not accept as-is.
+    getData: () =>
+      (getArgsRef().getData?.() ?? {}) as Record<string | symbol, unknown>,
+    getDropEffect: ({ source, input }) => {
+      const args = getArgsRef();
+      return args.getDropEffect?.({
+        source: normalizeSource(source, element),
+        input,
+        element,
+      });
+    },
+    getIsSticky: () => getArgsRef().getIsSticky?.() === true,
+    onDragEnter: ({ source, location }) => {
+      // Ceasing to be the deepest target makes any indicator this element is
+      // showing stale, and the library keeps an ancestor in the hierarchy rather
+      // than sending it a leave, so clearing here is the only chance to drop it.
+      if (!isDeepest(location)) {
+        indicator.clear();
+        reportLeave(source, location);
+        return;
+      }
+      const args = getArgsRef();
+      const pos = resolvePosition(location.current.input);
+      if (args.indicator !== false) {
+        indicator.apply(pos, args.axis ?? "y");
+      }
+      pairing.enter(() =>
+        args.onDragEnter?.({
+          source: normalizeSource(source, element),
+          position: pos,
+          location,
+          element,
+        })
+      );
+    },
+    onDrag: ({ source, location }) => {
+      if (!isDeepest(location)) {
+        indicator.clear();
+        reportLeave(source, location);
+        return;
+      }
+      const args = getArgsRef();
+      const pos = resolvePosition(location.current.input);
+      if (args.indicator !== false) {
+        indicator.apply(pos, args.axis ?? "y");
+      }
+      // Taking over as the deepest target without a fresh enter, because an
+      // ancestor never left the hierarchy for the child to be entered. The
+      // consumer is told it entered here instead: this is the target a drop
+      // would land on now, and without it the leave would be unmatched.
+      pairing.enter(() =>
+        args.onDragEnter?.({
+          source: normalizeSource(source, element),
+          position: pos,
+          location,
+          element,
+        })
+      );
+      args.onDrag?.({
+        source: normalizeSource(source, element),
+        position: pos,
+        location,
+        element,
+      });
+    },
+    onDragLeave: ({ source, location }) => {
+      indicator.clear();
+      reportLeave(source, location);
+    },
+    onDrop: ({ source, location }) => {
+      // Unconditionally, and before the deepest check: an ancestor that stopped
+      // being deepest still needs its indicator dropped.
+      indicator.clear();
+      // A drop ends the drag, so the enter it closes is not also reported as a
+      // leave.
+      pairing.reset();
+      if (!isDeepest(location)) {
+        return;
+      }
+      // Asked again rather than trusted: the target list was settled on the last
+      // `dragover`, so anything that changed since — a panel switched, a
+      // permission withdrawn, the arg turned off — would otherwise land a drop
+      // this target would now refuse.
+      if (!passesGate(source, location.current.input)) {
+        return;
+      }
+      const pos = resolvePosition(location.current.input);
+      getArgsRef().onDrop?.({
+        source: normalizeSource(source, element),
+        position: pos,
+        location,
+        element,
+      });
+    },
+  });
+
+  return () => {
+    cleanup();
+    indicator.clear();
+    element.removeAttribute("data-drop-target");
+  };
+}
+
+/**
+ * Marks an element as a drop target compatible with the
+ * `dDragAndDropSource` vocabulary. Thin Ember-modifier wrapper around
+ * {@link registerDragAndDropTarget}. Every arg is documented on
+ * {@link DragAndDropTargetArgs}.
+ *
+ * Smart row mode — position is computed from the cursor against the
+ * element's midpoint:
+ *
+ * ```hbs
+ * <li {{dDragAndDropTarget
+ *   accepts="sidebar-link"
+ *   onDrop=this.reorder
+ * }}>...</li>
+ * ```
+ *
+ * Fixed-position mode — for explicit `"before"` / `"after"` / `"inside"`
+ * zones where the slot is decided by geometry, not the cursor:
+ *
+ * ```hbs
+ * <div {{dDragAndDropTarget
+ *   accepts="block"
+ *   position="inside"
+ *   onDrop=this.applyMove
+ * }}></div>
+ * ```
+ *
+ * Nested targets: only the deepest accepted target receives the
+ * lifecycle callbacks, so an ancestor decorated with this modifier
+ * doesn't double-handle a drop the child already claimed.
+ *
+ * Testing: in JS integration tests use `simulateDrag` from
+ * `discourse/tests/helpers/ui-kit/drag-and-drop-helper`; in Ruby system
+ * tests use `SystemHelpers#drag_and_drop` (a real native drag via
+ * Playwright) rather than Capybara's `drag_to`, whose synthetic mouse
+ * events can silently stall mid-drag.
+ *
+ * Guide to choosing between the gesture primitives:
+ * `docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md`
+ *
+ * This modifier only receives registered element sources. File uploads continue
+ * to use the existing upload target.
+ */
+export default modifier<DDragAndDropTargetSignature>(
+  (element, _positional, args) =>
+    // Pass `args` through to the closure WITHOUT reading any property of
+    // it here. Reading args.X inside the body would mark its tag consumed
+    // and force the modifier to re-run (re-registering the target) on every
+    // change. The closure reads fresh values inside the library's callbacks.
+    registerDragAndDropTarget(element, () => args)
+);

--- a/frontend/discourse/app/ui-kit/modifiers/d-draggable.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-draggable.js
@@ -9,20 +9,14 @@ import ElementClassLease from "discourse/lib/element-class-lease";
  * native drag events, with document-level listeners for the gesture's duration.
  *
  * @deprecated since 2026.8.0. Use `dPointerDrag`
- *   (`discourse/ui-kit/modifiers/d-pointer-drag`), which covers mouse, touch and
- *   pen through unified Pointer Events and `setPointerCapture` rather than
- *   parallel event pairs. Map `didStartDrag` to `onDragStart`, `dragMove` to
- *   `onDrag`, and `didEndDrag` to `onDragEnd` — usually to `onDragCancel` too, so
- *   an interrupted gesture still finishes. Where this marked the body, pass
- *   `bodyClass="dragging"`.
+ *   (`discourse/ui-kit/modifiers/d-pointer-drag`). Rename `didStartDrag`,
+ *   `dragMove` and `didEndDrag` to `onDragStart`, `onDrag` and `onDragEnd`, and
+ *   add `onDragCancel` so an interrupted gesture still finishes.
  *
- *   Three behaviour differences matter when migrating. This treats `dragenter` and
- *   `dragover` as gesture input, so a file dragged over the element starts a
- *   gesture, where `dPointerDrag` answers pointer input only. Handlers here can
- *   receive a `TouchEvent` and so tend to read `event.touches[0].pageY`, which a
- *   `PointerEvent` does not have — read `event.pageY` directly. And a gesture here
- *   is driven by whichever pointer moves, while `dPointerDrag` matches the
- *   `pointerId` that began it, so a second finger cannot take one over.
+ *   Three differences bite beyond the renames:
+ *   - the second callback argument is gesture info, not the element;
+ *   - the body class is automatic here, but needs `bodyClass` there;
+ *   - a touch handler reading `event.touches[0]` should read the event itself.
  */
 export default class DDraggableModifier extends Modifier {
   hasStarted = false;
@@ -32,7 +26,7 @@ export default class DDraggableModifier extends Modifier {
   constructor(owner, args) {
     super(owner, args);
     deprecated(
-      "`dDraggable` is deprecated. Use `dPointerDrag` (`discourse/ui-kit/modifiers/d-pointer-drag`) instead.",
+      "`dDraggable` is deprecated. Use `dPointerDrag` (`discourse/ui-kit/modifiers/d-pointer-drag`); it is not a drop-in, see its JSDoc.",
       { id: "discourse.ui-kit.d-draggable", since: "2026.8.0" }
     );
     registerDestructor(this, (instance) => instance.cleanup());

--- a/frontend/discourse/app/ui-kit/modifiers/d-draggable.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-draggable.js
@@ -1,8 +1,29 @@
 import { registerDestructor } from "@ember/destroyable";
 import Modifier from "ember-modifier";
 import { bind } from "discourse/lib/decorators";
+import deprecated from "discourse/lib/deprecated";
 import ElementClassLease from "discourse/lib/element-class-lease";
 
+/**
+ * Binds a press-drag lifecycle using legacy mouse and touch event pairs, plus
+ * native drag events, with document-level listeners for the gesture's duration.
+ *
+ * @deprecated since 2026.8.0. Use `dPointerDrag`
+ *   (`discourse/ui-kit/modifiers/d-pointer-drag`), which covers mouse, touch and
+ *   pen through unified Pointer Events and `setPointerCapture` rather than
+ *   parallel event pairs. Map `didStartDrag` to `onDragStart`, `dragMove` to
+ *   `onDrag`, and `didEndDrag` to `onDragEnd` — usually to `onDragCancel` too, so
+ *   an interrupted gesture still finishes. Where this marked the body, pass
+ *   `bodyClass="dragging"`.
+ *
+ *   Three behaviour differences matter when migrating. This treats `dragenter` and
+ *   `dragover` as gesture input, so a file dragged over the element starts a
+ *   gesture, where `dPointerDrag` answers pointer input only. Handlers here can
+ *   receive a `TouchEvent` and so tend to read `event.touches[0].pageY`, which a
+ *   `PointerEvent` does not have — read `event.pageY` directly. And a gesture here
+ *   is driven by whichever pointer moves, while `dPointerDrag` matches the
+ *   `pointerId` that began it, so a second finger cannot take one over.
+ */
 export default class DDraggableModifier extends Modifier {
   hasStarted = false;
   element;
@@ -10,6 +31,10 @@ export default class DDraggableModifier extends Modifier {
 
   constructor(owner, args) {
     super(owner, args);
+    deprecated(
+      "`dDraggable` is deprecated. Use `dPointerDrag` (`discourse/ui-kit/modifiers/d-pointer-drag`) instead.",
+      { id: "discourse.ui-kit.d-draggable", since: "2026.8.0" }
+    );
     registerDestructor(this, (instance) => instance.cleanup());
   }
 

--- a/frontend/discourse/app/ui-kit/modifiers/d-resize-edge.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-resize-edge.ts
@@ -268,6 +268,18 @@ export default class DResizeEdgeModifier extends Modifier<DResizeEdgeSignature> 
       return;
     }
 
+    // A jump with no bound has nowhere to land. Leave the key to whatever else
+    // would act on it, as the size check below does.
+    let jumpTarget;
+    if (event.key === "Home" || event.key === "End") {
+      jumpTarget = this.#read(
+        event.key === "Home" ? this.#named.min : this.#named.max
+      );
+      if (!Number.isFinite(jumpTarget)) {
+        return;
+      }
+    }
+
     if (this.#keyboardValue === null) {
       const startValue = this.#read(this.#named.value);
       // Checked before the key is claimed: with no size to step from there is
@@ -294,11 +306,8 @@ export default class DResizeEdgeModifier extends Modifier<DResizeEdgeSignature> 
       case growKey:
         next = this.#keyboardValue + KEYBOARD_STEP * this.#growthDirection;
         break;
-      case "Home":
-        next = this.#read(this.#named.min);
-        break;
       default:
-        next = this.#read(this.#named.max);
+        next = jumpTarget;
         break;
     }
 
@@ -515,14 +524,17 @@ export default class DResizeEdgeModifier extends Modifier<DResizeEdgeSignature> 
   }
 
   #clamp(size: number) {
+    // An absent bound reads as zero in arithmetic, which would collapse the size
+    // onto the other one. Skip it instead.
+    const max = this.#read(this.#named.max);
+    const min = this.#read(this.#named.min);
+
     // The minimum is applied last, so it wins when the two bounds conflict — a
     // short viewport can put `max` below `min`, and the stylesheet's own min-height
     // would still hold the box open. Letting `max` win would report a size the
     // element never takes.
-    return Math.max(
-      Math.min(size, this.#read(this.#named.max)),
-      this.#read(this.#named.min)
-    );
+    const capped = Number.isFinite(max) ? Math.min(size, max) : size;
+    return Number.isFinite(min) ? Math.max(capped, min) : capped;
   }
 
   #cancelFrame() {

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -24,6 +24,7 @@
     "start": "./rolldown.mjs"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-javascript": "^6.2.5",

--- a/frontend/discourse/tests/helpers/qunit-helpers.js
+++ b/frontend/discourse/tests/helpers/qunit-helpers.js
@@ -96,6 +96,7 @@ import { clearAddedTrackedTopicProperties } from "discourse/models/topic";
 import User from "discourse/models/user";
 import { clearResolverOptions } from "discourse/resolver";
 import { enableClearA11yAnnouncementsInTests } from "discourse/services/a11y";
+import { resetDragAndDropForTesting } from "discourse/services/drag-and-drop";
 import {
   clearDisabledDefaultKeyboardBindings,
   clearExtraKeyboardShortcutHelp,
@@ -114,6 +115,7 @@ import {
 } from "discourse/tests/helpers/site-settings";
 import { resetHtmlDecorators } from "discourse/ui-kit/d-decorated-html";
 import { clearToolbarCallbacks } from "discourse/ui-kit/d-editor";
+import { resetDragSourcesForTesting } from "discourse/ui-kit/modifiers/d-drag-and-drop-source";
 import { resetPointerDragForTesting } from "discourse/ui-kit/modifiers/d-pointer-drag";
 import I18n from "discourse-i18n";
 import { setupDSelectAssertions } from "./d-select-assertions";
@@ -290,6 +292,8 @@ export function testCleanup(container, app) {
   _resetOutletLayoutsForTesting();
   resetBlockRegistryForTesting();
   resetDebugCallbacks();
+  resetDragAndDropForTesting();
+  resetDragSourcesForTesting();
   resetPointerDragForTesting();
   resetElementClassLeasesForTesting();
   clearBacklog();

--- a/frontend/discourse/tests/helpers/ui-kit/drag-and-drop-helper.ts
+++ b/frontend/discourse/tests/helpers/ui-kit/drag-and-drop-helper.ts
@@ -1,0 +1,157 @@
+import { triggerEvent } from "@ember/test-helpers";
+
+/** A point on the viewport, in the shape every drag event has to carry. */
+interface ClientPoint {
+  clientX: number;
+  clientY: number;
+}
+
+/**
+ * Returns the center-point client coordinates of an element, for realistic
+ * synthetic drag events.
+ *
+ * Every drag event dispatched in a test must carry finite `clientX` /
+ * `clientY`: the drag monitor resolves the pointer via `elementsFromPoint`,
+ * which throws on non-finite values. A real drag always has coordinates, so the
+ * test must supply them too.
+ *
+ * @param selector - CSS selector for the element to measure.
+ * @returns The element's center point.
+ */
+export function centerOf(selector: string): ClientPoint {
+  // A selector matching nothing is a test bug; failing on the next line names it
+  // directly, where a guard here would report a missing coordinate instead.
+  const rect = (
+    document.querySelector(selector) as Element
+  ).getBoundingClientRect();
+  return {
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+  };
+}
+
+/**
+ * Throws unless both ends of a drag are really registered with the primitives.
+ *
+ * Dispatching a drag at an element that is not a source, or at one that is not a
+ * target, does nothing at all. A test whose assertion is that nothing happened
+ * then passes for the wrong reason, and keeps passing after the registration is
+ * removed outright. Failing loudly here names which end was unwired instead.
+ *
+ * @param sourceSelector - CSS selector for the element the drag starts on.
+ * @param targetSelector - CSS selector for the element it is dropped on.
+ */
+export function assertDragRegistered(
+  sourceSelector: string,
+  targetSelector: string
+) {
+  const source = document.querySelector(sourceSelector);
+  const target = document.querySelector(targetSelector);
+
+  if (!source?.hasAttribute("data-drag-source")) {
+    throw new Error(
+      `${sourceSelector} is not a registered drag source, so this drag would do nothing`
+    );
+  }
+  if (!target?.hasAttribute("data-drop-target")) {
+    throw new Error(
+      `${targetSelector} is not a registered drop target, so this drag would do nothing`
+    );
+  }
+}
+
+/**
+ * Dispatches one synthetic drag event and then waits a single animation frame
+ * before resolving.
+ *
+ * The frame wait is the whole point of this wrapper. The underlying drag
+ * library batches its `onDragStart` / `onDrag` consumer callbacks through
+ * `requestAnimationFrame` (via `raf-schd`), and Ember's `settled()` does not
+ * pump animation frames. So immediately after a synthetic `dragstart` /
+ * `dragover` those callbacks have not fired yet. Awaiting a real frame lets the
+ * batched callback run before the caller's next step or assertion — our frame
+ * resolves after the library's already-queued one, so the queued callback is
+ * guaranteed to have fired. Bundling the wait here keeps it out of the test
+ * bodies.
+ *
+ * @param target - CSS selector for the event target, or the element itself when
+ *   the caller has already resolved it.
+ * @param type - The drag event type (e.g. `"dragstart"`, `"drop"`).
+ * @param options - Forwarded to `triggerEvent`; must include the shared
+ *   `dataTransfer` and finite client coordinates (see {@link centerOf}).
+ */
+export async function dragEvent(
+  target: string | Element,
+  type: string,
+  options?: Record<string, unknown>
+) {
+  await triggerEvent(target as Element, type, options);
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+/**
+ * Drives a complete HTML5 drag/drop cycle from a source element to a target
+ * element through the test runner.
+ *
+ * The drag library wraps the native DnD events, so its callbacks fire when the
+ * matching DOM events are dispatched. Each event is sent via {@link dragEvent},
+ * so a frame is flushed after every step. That single rule covers both timing
+ * traps at once: the rAF-batched `onDragStart` fires before the move, and the
+ * rAF-batched `onDrag` fires before the `drop` (which would otherwise cancel a
+ * still-pending `onDrag` and never let it be observed). The source and target
+ * center coordinates are computed via {@link centerOf}, then independently
+ * overridden when a test needs a more precise pointer location. A bare center
+ * only exercises the `after` branch of strict midpoint comparisons.
+ *
+ * `sourceSelector` names the row, the way a consumer and a reader both think of
+ * it. A row that scopes its drag to a handle registers the handle rather than
+ * itself, so the browser would dispatch `dragstart` there — this resolves that
+ * and dispatches on whichever element the registration actually sits on, so a
+ * caller never has to know which shape a surface used.
+ *
+ * @param sourceSelector - CSS selector for the source element.
+ * @param targetSelector - CSS selector for the target element.
+ */
+export async function simulateDrag(
+  sourceSelector: string,
+  targetSelector: string,
+  {
+    dataTransfer,
+    sourceCoordinates,
+    targetCoordinates,
+  }: {
+    /**
+     * Shared payload that must travel across every event so the drag library can
+     * correlate them.
+     */
+    dataTransfer: DataTransfer;
+
+    /** Coordinates merged over the source element's center. */
+    sourceCoordinates?: Partial<ClientPoint>;
+
+    /** Coordinates merged over the target element's center. */
+    targetCoordinates?: Partial<ClientPoint>;
+  }
+) {
+  const source = { ...centerOf(sourceSelector), ...sourceCoordinates };
+  const target = { ...centerOf(targetSelector), ...targetCoordinates };
+  const registered = registeredElementFor(sourceSelector);
+  await dragEvent(registered, "dragstart", { dataTransfer, ...source });
+  await dragEvent(targetSelector, "dragenter", { dataTransfer, ...target });
+  await dragEvent(targetSelector, "dragover", { dataTransfer, ...target });
+  await dragEvent(targetSelector, "drop", { dataTransfer, ...target });
+  await dragEvent(registered, "dragend", { dataTransfer, ...source });
+}
+
+/**
+ * The element a row's drag registration sits on: its handle when the row scopes
+ * the drag to one, and the row itself otherwise.
+ *
+ * The browser dispatches `dragstart` at the element carrying `draggable`, and
+ * the drag library looks the registration up by exactly that element, so a
+ * synthetic drag aimed anywhere else routes nowhere and silently does nothing.
+ */
+function registeredElementFor(rowSelector: string) {
+  const row = document.querySelector(rowSelector);
+  return (row?.querySelector("[draggable]") ?? row) as Element;
+}

--- a/frontend/discourse/tests/integration/modifiers/d-resize-edge-test.gjs
+++ b/frontend/discourse/tests/integration/modifiers/d-resize-edge-test.gjs
@@ -1161,6 +1161,97 @@ module("Integration | Modifier | d-resize-edge", function (hooks) {
       );
     });
 
+    test("an absent maximum leaves a pointer drag unclamped", async function (assert) {
+      const state = new Harness();
+      const noMax = () => null;
+
+      await render(
+        <template>
+          <div
+            class="resize-edge"
+            {{dResizeEdge
+              value=state.value
+              min=240
+              max=noMax
+              onResize=state.onResize
+              onResizeEnd=state.onResizeEnd
+            }}
+          ></div>
+        </template>
+      );
+
+      const edge = find(EDGE);
+      stubPointerCapture(edge);
+      await triggerEvent(edge, "pointerdown", {
+        button: 0,
+        clientX: 300,
+        pointerId: 1,
+      });
+      await triggerEvent(edge, "pointerup", {
+        button: 0,
+        clientX: 420,
+        pointerId: 1,
+      });
+
+      assert.deepEqual(
+        state.resizeEnds,
+        [420],
+        "the size the pointer reached is reported, not a coerced bound"
+      );
+    });
+
+    test("End is left alone when no maximum resolves", async function (assert) {
+      const state = new Harness();
+      const noMax = () => null;
+
+      await render(
+        <template>
+          <div
+            class="resize-edge"
+            {{dResizeEdge
+              value=state.value
+              min=240
+              max=noMax
+              onResize=state.onResize
+              onResizeEnd=state.onResizeEnd
+            }}
+          ></div>
+        </template>
+      );
+
+      await triggerKeyEvent(EDGE, "keydown", "End");
+      await triggerKeyEvent(EDGE, "keyup", "End");
+
+      assert.deepEqual(state.resizes, [], "no size is reported");
+      assert.deepEqual(state.resizeEnds, [], "no gesture is opened or closed");
+    });
+
+    test("Home is left alone when no minimum resolves", async function (assert) {
+      const state = new Harness();
+      const noMin = () => null;
+
+      await render(
+        <template>
+          <div
+            class="resize-edge"
+            {{dResizeEdge
+              value=state.value
+              min=noMin
+              max=360
+              onResize=state.onResize
+              onResizeEnd=state.onResizeEnd
+            }}
+          ></div>
+        </template>
+      );
+
+      await triggerKeyEvent(EDGE, "keydown", "Home");
+      await triggerKeyEvent(EDGE, "keyup", "Home");
+
+      assert.deepEqual(state.resizes, [], "no size is reported");
+      assert.deepEqual(state.resizeEnds, [], "no gesture is opened or closed");
+    });
+
     test("an interrupted resize keeps the size it was dragged to", async function (assert) {
       const state = new Harness();
 

--- a/frontend/discourse/tests/integration/ui-kit/d-drag-handle-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-drag-handle-test.gjs
@@ -1,0 +1,49 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DDragHandle from "discourse/ui-kit/d-drag-handle";
+
+module("Integration | ui-kit | DDragHandle", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("is hidden from assistive technology and out of the tab order", async function (assert) {
+    await render(<template><DDragHandle @label="Reorder Topics" /></template>);
+
+    // The point of the component: a drag cannot be performed by keyboard, so
+    // exposing the handle would offer a control that cannot be operated. The
+    // keyboard path is DReorderButtons beside it.
+    assert
+      .dom(".d-drag-handle")
+      .hasAttribute("aria-hidden", "true", "it is hidden from the a11y tree")
+      .hasAttribute("tabindex", "-1", "and it is not a tab stop")
+      .hasAttribute(
+        "title",
+        "Reorder Topics",
+        "the label names what it drags for a sighted pointer user"
+      );
+  });
+
+  test("passes attributes through so a consumer can register it with a source", async function (assert) {
+    await render(
+      <template>
+        <DDragHandle
+          @label="Reorder Topics"
+          class="my-row__handle"
+          data-link-name="Topics"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".d-drag-handle")
+      .hasClass(
+        "my-row__handle",
+        "a consumer class lands alongside the component's own"
+      )
+      .hasAttribute(
+        "data-link-name",
+        "Topics",
+        "and arbitrary attributes reach the element"
+      );
+  });
+});

--- a/frontend/discourse/tests/integration/ui-kit/d-reorder-buttons-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-reorder-buttons-test.gjs
@@ -1,0 +1,186 @@
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DReorderButtons from "discourse/ui-kit/d-reorder-buttons";
+
+module("Integration | ui-kit | DReorderButtons", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("each button moves in its own direction", async function (assert) {
+    const calls = [];
+    const up = () => calls.push("up");
+    const down = () => calls.push("down");
+
+    await render(
+      <template>
+        <DReorderButtons
+          @onMoveUp={{up}}
+          @onMoveDown={{down}}
+          @upLabel="Move up"
+          @downLabel="Move down"
+        />
+      </template>
+    );
+
+    await click(".d-reorder-buttons__button:first-child");
+    await click(".d-reorder-buttons__button:last-child");
+
+    assert.deepEqual(calls, ["up", "down"], "up is first, down is second");
+  });
+
+  test("the labels name the item for both pointer and screen reader", async function (assert) {
+    const noop = () => {};
+
+    await render(
+      <template>
+        <DReorderButtons
+          @onMoveUp={{noop}}
+          @onMoveDown={{noop}}
+          @upLabel="Move Reports up"
+          @downLabel="Move Reports down"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".d-reorder-buttons__button:first-child")
+      .hasAria("label", "Move Reports up")
+      .hasAttribute(
+        "title",
+        "Move Reports up",
+        "the tooltip repeats the accessible name, so both audiences are told the same thing"
+      );
+    assert
+      .dom(".d-reorder-buttons__button:last-child")
+      .hasAria("label", "Move Reports down");
+  });
+
+  test("each end of the list disables only its own direction", async function (assert) {
+    const calls = [];
+    const onMoveUp = () => calls.push("up");
+    const onMoveDown = () => calls.push("down");
+
+    await render(
+      <template>
+        <DReorderButtons
+          @onMoveUp={{onMoveUp}}
+          @onMoveDown={{onMoveDown}}
+          @disableUp={{true}}
+          @disableDown={{false}}
+          @upLabel="Move up"
+          @downLabel="Move down"
+        />
+      </template>
+    );
+
+    // Marked unavailable rather than carrying the `disabled` attribute, so the
+    // button keeps its place in the tab order at the ends of the list. The
+    // component is what refuses the press, which is why that is asserted too.
+    assert
+      .dom(".d-reorder-buttons__button:first-child")
+      .hasAttribute("aria-disabled", "true")
+      .isNotDisabled();
+    assert
+      .dom(".d-reorder-buttons__button:last-child")
+      .doesNotHaveAttribute("aria-disabled")
+      .isNotDisabled();
+
+    await click(".d-reorder-buttons__button:first-child");
+    assert.deepEqual(
+      calls,
+      [],
+      "pressing the unavailable direction does nothing"
+    );
+
+    await click(".d-reorder-buttons__button:last-child");
+    assert.deepEqual(
+      calls,
+      ["down"],
+      "while the available one still runs its callback"
+    );
+  });
+
+  test("a press keeps its button focused across the re-render it causes", async function (assert) {
+    // The real consumers move the pressed row inside a keyed list, and moving a
+    // DOM node drops focus to the body. A bare component would pass this from
+    // the click's own native focus alone, so the list is part of the fixture —
+    // it is what makes the component's refocus observable.
+    const state = new (class {
+      @tracked items = ["a", "b"];
+      move = () => (this.items = [...this.items].reverse());
+    })();
+
+    await render(
+      <template>
+        {{#each state.items key="@identity" as |item|}}
+          <div data-item={{item}}>
+            <DReorderButtons
+              @onMoveUp={{fn state.move item}}
+              @onMoveDown={{fn state.move item}}
+              @upLabel="Move up"
+              @downLabel="Move down"
+            />
+          </div>
+        {{/each}}
+      </template>
+    );
+
+    await click("[data-item='a'] .d-reorder-buttons__button:last-child");
+
+    assert.strictEqual(state.items[1], "a", "the move happened");
+    assert
+      .dom("[data-item='a'] .d-reorder-buttons__button:last-child")
+      .isFocused(
+        "the pressed button is focused again after its row moved, so a keyboard user can keep going"
+      );
+  });
+
+  test("keeps the tab order, so the pair is the keyboard path", async function (assert) {
+    const noop = () => {};
+
+    await render(
+      <template>
+        <DReorderButtons
+          @onMoveUp={{noop}}
+          @onMoveDown={{noop}}
+          @upLabel="Move up"
+          @downLabel="Move down"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".d-reorder-buttons__button:first-child")
+      .doesNotHaveAttribute(
+        "tabindex",
+        "the buttons keep their native tab stop"
+      );
+  });
+
+  test("attributes pass through so a consumer keeps its own class", async function (assert) {
+    const noop = () => {};
+
+    await render(
+      <template>
+        <DReorderButtons
+          @onMoveUp={{noop}}
+          @onMoveDown={{noop}}
+          @upLabel="Move up"
+          @downLabel="Move down"
+          class="my-block__arrows"
+          data-test-marker="present"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".d-reorder-buttons")
+      .hasClass(
+        "my-block__arrows",
+        "the consumer's class lands alongside the block's own"
+      )
+      .hasAttribute("data-test-marker", "present");
+  });
+});

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-monitor-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-monitor-test.gjs
@@ -1,0 +1,156 @@
+import { hash } from "@ember/helper";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { simulateDrag } from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+import dDragAndDropMonitor, {
+  matchesDragType,
+} from "discourse/ui-kit/modifiers/d-drag-and-drop-monitor";
+import dDragAndDropSource from "discourse/ui-kit/modifiers/d-drag-and-drop-source";
+import dDragAndDropTarget from "discourse/ui-kit/modifiers/d-drag-and-drop-target";
+
+module(
+  "Integration | ui-kit | Modifier | dragAndDropMonitor",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("observes a matching drag — start, drag, drop", async function (assert) {
+      const events = [];
+
+      const onDragStart = () => events.push("start");
+      const onDrag = () => events.push("drag");
+      const onDrop = () => events.push("drop");
+
+      await render(
+        <template>
+          {{! The monitor is global; attach it to any sentinel for lifecycle. }}
+          <div
+            {{dDragAndDropMonitor
+              types="row"
+              onDragStart=onDragStart
+              onDrag=onDrag
+              onDrop=onDrop
+            }}
+          ></div>
+          <div id="src" {{dDragAndDropSource type="row" data=(hash id=1)}}>
+            src
+          </div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      await simulateDrag("#src", "#tgt", { dataTransfer: new DataTransfer() });
+
+      assert.true(events.includes("start"), "onDragStart fired");
+      assert.true(events.includes("drag"), "onDrag fired on move");
+      assert.true(events.includes("drop"), "onDrop fired when the drag ended");
+    });
+
+    test("is type-gated — ignores a non-matching drag", async function (assert) {
+      let fired = false;
+
+      const onDragStart = () => {
+        fired = true;
+      };
+
+      await render(
+        <template>
+          <div
+            {{dDragAndDropMonitor types="card" onDragStart=onDragStart}}
+          ></div>
+          <div id="src" {{dDragAndDropSource type="row" data=(hash id=1)}}>
+            src
+          </div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      await simulateDrag("#src", "#tgt", { dataTransfer: new DataTransfer() });
+
+      assert.false(fired, "a `row` drag does not engage a `card` monitor");
+    });
+
+    test("observes any drag when no types are given", async function (assert) {
+      let started = false;
+
+      const onDragStart = () => {
+        started = true;
+      };
+
+      await render(
+        <template>
+          <div {{dDragAndDropMonitor onDragStart=onDragStart}}></div>
+          <div id="src" {{dDragAndDropSource type="row" data=(hash id=1)}}>
+            src
+          </div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      await simulateDrag("#src", "#tgt", { dataTransfer: new DataTransfer() });
+
+      assert.true(started, "untyped monitor engages on any drag");
+    });
+
+    test("passes the source payload to the callbacks", async function (assert) {
+      let seen = null;
+
+      const onDragStart = ({ source }) => {
+        seen = source.data;
+      };
+
+      await render(
+        <template>
+          <div
+            {{dDragAndDropMonitor types="row" onDragStart=onDragStart}}
+          ></div>
+          <div id="src" {{dDragAndDropSource type="row" data=(hash id=2)}}>
+            src
+          </div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      await simulateDrag("#src", "#tgt", { dataTransfer: new DataTransfer() });
+
+      assert.deepEqual(
+        seen,
+        { type: "row", id: 2 },
+        "the monitor callback receives the source's data"
+      );
+    });
+
+    test("the shared type gate engages only for the requested types", function (assert) {
+      const source = (type) => ({ data: { type } });
+
+      assert.true(
+        matchesDragType(undefined, source("row")),
+        "no filter engages on any drag"
+      );
+      assert.true(
+        matchesDragType([], source("row")),
+        "an empty list is the same as no filter"
+      );
+      assert.true(
+        matchesDragType("row", source("row")),
+        "a single matching type engages"
+      );
+      assert.false(
+        matchesDragType("row", source("card")),
+        "a single non-matching type does not"
+      );
+      assert.true(
+        matchesDragType(["row", "card"], source("card")),
+        "a list containing the type engages"
+      );
+      assert.false(
+        matchesDragType(["row", "card"], source("other")),
+        "a list without it does not"
+      );
+      assert.false(
+        matchesDragType("row", { data: {} }),
+        "a typeless source matches no filter"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-test.gjs
@@ -1,0 +1,2230 @@
+import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { find, render, settled, setupOnerror } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  centerOf,
+  dragEvent,
+  simulateDrag,
+} from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+import { registerDragAndDropMonitor } from "discourse/ui-kit/modifiers/d-drag-and-drop-monitor";
+import dDragAndDropSource, {
+  registerDragAndDropSource,
+} from "discourse/ui-kit/modifiers/d-drag-and-drop-source";
+import dDragAndDropTarget from "discourse/ui-kit/modifiers/d-drag-and-drop-target";
+
+module("Integration | ui-kit | Modifier | dragAndDrop", function (hooks) {
+  setupRenderingTest(hooks);
+
+  module("marker attribute lifecycle", function () {
+    test("marks every registered element after render", async function (assert) {
+      await render(
+        <template>
+          <div id="source" {{dDragAndDropSource type="row"}}>source</div>
+          <div id="target" {{dDragAndDropTarget accepts="row"}}>target</div>
+        </template>
+      );
+
+      assert
+        .dom("#source")
+        .hasAttribute(
+          "data-drag-source",
+          "",
+          "the source has its registration marker"
+        );
+      assert
+        .dom("#target")
+        .hasAttribute(
+          "data-drop-target",
+          "",
+          "the element target has its registration marker"
+        );
+    });
+
+    test("removes every marker when its element is destroyed", async function (assert) {
+      const state = new (class {
+        @tracked show = true;
+      })();
+
+      await render(
+        <template>
+          {{#if state.show}}
+            <div id="source" {{dDragAndDropSource type="row"}}>source</div>
+            <div id="target" {{dDragAndDropTarget accepts="row"}}>target</div>
+          {{/if}}
+        </template>
+      );
+
+      const source = find("#source");
+      const target = find("#target");
+
+      assert.true(
+        source.hasAttribute("data-drag-source"),
+        "the source starts registered"
+      );
+      assert.true(
+        target.hasAttribute("data-drop-target"),
+        "the element target starts registered"
+      );
+      state.show = false;
+      await settled();
+
+      assert.false(
+        source.hasAttribute("data-drag-source"),
+        "destroying the source removes its marker"
+      );
+      assert.false(
+        target.hasAttribute("data-drop-target"),
+        "destroying the element target removes its marker"
+      );
+    });
+
+    test("source marker follows the disabled registration cycle", async function (assert) {
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+
+      await render(
+        <template>
+          <div
+            id="source"
+            {{dDragAndDropSource type="row" disabled=state.disabled}}
+          >source</div>
+        </template>
+      );
+
+      const source = find("#source");
+      assert.true(
+        source.hasAttribute("data-drag-source"),
+        "the enabled source is marked"
+      );
+
+      state.disabled = true;
+      await settled();
+      assert.false(
+        source.hasAttribute("data-drag-source"),
+        "disabling removes the marker from the live element"
+      );
+
+      state.disabled = false;
+      await settled();
+      assert.true(
+        source.hasAttribute("data-drag-source"),
+        "re-enabling restores the marker on the same element"
+      );
+    });
+  });
+
+  test("source + target handshake fires onDrop with source data", async function (assert) {
+    const drops = [];
+    const onDrop = (payload) => drops.push(payload);
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource type="row" data=(hash id=1)}}
+        >src</div>
+        <div
+          id="tgt"
+          {{dDragAndDropTarget accepts="row" position="before" onDrop=onDrop}}
+        >tgt</div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    await simulateDrag("#src", "#tgt", { dataTransfer });
+
+    assert.strictEqual(drops.length, 1, "onDrop fires once");
+    assert.strictEqual(drops[0].position, "before");
+    assert.deepEqual(drops[0].source.data, { type: "row", id: 1 });
+    assert.strictEqual(drops[0].source.type, "row");
+  });
+
+  test("type discriminator gates compatibility", async function (assert) {
+    let dropped = false;
+    const onDrop = () => {
+      dropped = true;
+    };
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource type="row" data=(hash id=1)}}
+        >src</div>
+        <div
+          id="tgt"
+          {{dDragAndDropTarget accepts="card" onDrop=onDrop}}
+        >tgt</div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    await simulateDrag("#src", "#tgt", { dataTransfer });
+
+    assert.false(dropped, "onDrop is not called for foreign types");
+  });
+
+  test("simulateDrag merges independent partial coordinate overrides", async function (assert) {
+    const events = {};
+
+    await render(
+      <template>
+        <div id="src">source</div>
+        <div id="tgt">target</div>
+      </template>
+    );
+
+    for (const type of ["dragstart", "dragend"]) {
+      find("#src").addEventListener(type, (event) => {
+        events[type] = { clientX: event.clientX, clientY: event.clientY };
+      });
+    }
+    for (const type of ["dragenter", "dragover", "drop"]) {
+      find("#tgt").addEventListener(type, (event) => {
+        events[type] = { clientX: event.clientX, clientY: event.clientY };
+      });
+    }
+
+    const sourceCenter = centerOf("#src");
+    const targetCenter = centerOf("#tgt");
+    const sourceCoordinates = { clientY: sourceCenter.clientY - 1 };
+    const targetCoordinates = { clientX: targetCenter.clientX + 1 };
+
+    await simulateDrag("#src", "#tgt", {
+      dataTransfer: new DataTransfer(),
+      sourceCoordinates,
+      targetCoordinates,
+    });
+
+    assert.strictEqual(
+      events.dragstart.clientY,
+      sourceCoordinates.clientY,
+      "dragstart uses the source clientY override"
+    );
+    assert.strictEqual(
+      events.dragstart.clientX,
+      sourceCenter.clientX,
+      "dragstart keeps the computed source clientX"
+    );
+    assert.strictEqual(
+      events.dragend.clientY,
+      sourceCoordinates.clientY,
+      "dragend uses the source clientY override"
+    );
+    assert.strictEqual(
+      events.dragend.clientX,
+      sourceCenter.clientX,
+      "dragend keeps the computed source clientX"
+    );
+    for (const type of ["dragenter", "dragover", "drop"]) {
+      assert.strictEqual(
+        events[type].clientX,
+        targetCoordinates.clientX,
+        `${type} uses the target clientX override`
+      );
+      assert.strictEqual(
+        events[type].clientY,
+        targetCenter.clientY,
+        `${type} keeps the computed target clientY`
+      );
+    }
+  });
+
+  test("source without dragHandle starts from the whole element", async function (assert) {
+    let starts = 0;
+    const onDragStart = () => starts++;
+
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row" onDragStart=onDragStart}}>
+          <span id="body">body</span>
+        </div>
+        <div id="tgt" {{dDragAndDropTarget accepts="row"}}>target</div>
+      </template>
+    );
+
+    await simulateDrag("#src", "#tgt", {
+      dataTransfer: new DataTransfer(),
+      sourceCoordinates: centerOf("#body"),
+    });
+
+    assert.strictEqual(starts, 1, "pressing the row body starts the drag");
+  });
+
+  test("source re-registers when dragHandle arrives after initial registration", async function (assert) {
+    const state = new (class {
+      @tracked showHandle = false;
+      @tracked dragHandle;
+      starts = 0;
+      captureHandle = (element) => (this.dragHandle = element);
+      onDragStart = () => this.starts++;
+    })();
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource
+            type="row"
+            dragHandle=state.dragHandle
+            onDragStart=state.onDragStart
+          }}
+        >
+          <span id="body">body</span>
+          {{#if state.showHandle}}
+            <button id="handle" type="button" {{didInsert state.captureHandle}}>
+              handle
+            </button>
+          {{/if}}
+        </div>
+        <div id="tgt" {{dDragAndDropTarget accepts="row"}}>target</div>
+      </template>
+    );
+
+    state.showHandle = true;
+    await settled();
+
+    // The handle takes over the registration, which is what the browser reads
+    // to decide a press can begin a drag at all. Asserting the attribute rather
+    // than a coordinate is the honest form: a press on the row body cannot
+    // produce a `dragstart` once the row is no longer draggable, so a synthetic
+    // one dispatched there would be testing a state the browser never reaches.
+    assert.dom("#src").doesNotHaveAttribute("draggable");
+    assert.dom("#handle").hasAttribute("draggable", "true");
+
+    await simulateDrag("#src", "#tgt", {
+      dataTransfer: new DataTransfer(),
+    });
+    assert.strictEqual(
+      state.starts,
+      1,
+      "after the handle arrives, a drag from it still reaches the source"
+    );
+  });
+
+  test("source re-registers when dragHandle changes identity", async function (assert) {
+    const state = new (class {
+      @tracked showSecondHandle = false;
+      @tracked dragHandle;
+      starts = 0;
+      captureHandle = (element) => (this.dragHandle = element);
+      onDragStart = () => this.starts++;
+    })();
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource
+            type="row"
+            dragHandle=state.dragHandle
+            onDragStart=state.onDragStart
+          }}
+        >
+          <button
+            id="first-handle"
+            type="button"
+            {{didInsert state.captureHandle}}
+          >
+            first
+          </button>
+          {{#if state.showSecondHandle}}
+            <button
+              id="second-handle"
+              type="button"
+              {{didInsert state.captureHandle}}
+            >
+              second
+            </button>
+          {{/if}}
+        </div>
+        <div id="tgt" {{dDragAndDropTarget accepts="row"}}>target</div>
+      </template>
+    );
+
+    state.showSecondHandle = true;
+    await settled();
+
+    // The registration moves with the handle, so the superseded one stops being
+    // draggable and the replacement starts. Without the first assertion a stale
+    // registration would leave two draggable elements and the row would drag
+    // from a handle it no longer recognises.
+    assert.dom("#first-handle").doesNotHaveAttribute("draggable");
+    assert.dom("#second-handle").hasAttribute("draggable", "true");
+
+    await simulateDrag("#src", "#tgt", {
+      dataTransfer: new DataTransfer(),
+    });
+    assert.strictEqual(
+      state.starts,
+      1,
+      "a drag from the replacement handle reaches the source"
+    );
+  });
+
+  test("source re-registers when dragHandle is removed", async function (assert) {
+    const state = new (class {
+      @tracked dragHandle;
+      @tracked useHandle = true;
+      starts = 0;
+      captureHandle = (element) => (this.dragHandle = element);
+      onDragStart = () => this.starts++;
+    })();
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource
+            type="row"
+            dragHandle=(if state.useHandle state.dragHandle)
+            onDragStart=state.onDragStart
+          }}
+        >
+          <span id="body">body</span>
+          <button id="handle" type="button" {{didInsert state.captureHandle}}>
+            handle
+          </button>
+        </div>
+        <div id="tgt" {{dDragAndDropTarget accepts="row"}}>target</div>
+      </template>
+    );
+
+    // While a handle is configured the row itself is not draggable, so a press
+    // on its body is an ordinary press — which is what leaves the text there
+    // selectable.
+    assert.dom("#src").doesNotHaveAttribute("draggable");
+    assert.dom("#handle").hasAttribute("draggable", "true");
+
+    state.useHandle = false;
+    await settled();
+
+    assert.dom("#handle").doesNotHaveAttribute("draggable");
+    assert.dom("#src").hasAttribute("draggable", "true");
+
+    await simulateDrag("#src", "#tgt", {
+      dataTransfer: new DataTransfer(),
+      sourceCoordinates: centerOf("#body"),
+    });
+    assert.strictEqual(
+      state.starts,
+      1,
+      "after removing the handle, pressing the row body starts a drag"
+    );
+  });
+
+  test("target accepts a self drop by default", async function (assert) {
+    let drops = 0;
+    const onDrop = () => drops++;
+
+    await render(
+      <template>
+        <div
+          id="row"
+          {{dDragAndDropSource type="row"}}
+          {{dDragAndDropTarget accepts="row" onDrop=onDrop}}
+        >row</div>
+      </template>
+    );
+
+    await simulateDrag("#row", "#row", {
+      dataTransfer: new DataTransfer(),
+    });
+
+    assert.strictEqual(drops, 1, "self drops remain enabled when omitted");
+  });
+
+  test("target with acceptsSelf=false rejects its own source element", async function (assert) {
+    let drops = 0;
+    const onDrop = () => drops++;
+
+    await render(
+      <template>
+        <div
+          id="row"
+          {{dDragAndDropSource type="row"}}
+          {{dDragAndDropTarget accepts="row" acceptsSelf=false onDrop=onDrop}}
+        >row</div>
+      </template>
+    );
+
+    await simulateDrag("#row", "#row", {
+      dataTransfer: new DataTransfer(),
+    });
+
+    assert.strictEqual(drops, 0, "the target refuses its own source element");
+  });
+
+  test("acceptsSelf checks the raw source element without target fallback", async function (assert) {
+    let drops = 0;
+    let rawElement = "monitor never ran";
+    let normalisedElement = "canDrop never ran";
+    const onDrop = () => drops++;
+    const canDrop = ({ source }) => {
+      normalisedElement = source.element;
+      return true;
+    };
+    const cleanupMonitor = registerDragAndDropMonitor(() => ({
+      onDragStart: ({ source }) => {
+        delete source.element;
+        rawElement = source.element;
+      },
+    }));
+
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row"}}>source</div>
+        <div
+          id="tgt"
+          {{dDragAndDropTarget
+            accepts="row"
+            acceptsSelf=false
+            canDrop=canDrop
+            onDrop=onDrop
+          }}
+        >target</div>
+      </template>
+    );
+
+    await simulateDrag("#src", "#tgt", {
+      dataTransfer: new DataTransfer(),
+    });
+    cleanupMonitor();
+
+    // Read back, because the whole fixture rests on this mutation landing: if the
+    // delete silently did nothing, the drop below would succeed for the ordinary
+    // reason and prove nothing about the fallback.
+    assert.strictEqual(
+      rawElement,
+      undefined,
+      "the raw source element really was removed"
+    );
+    // The source publishes the element it stands for in the payload, so the
+    // normalisation has something to name even once the raw one is gone and
+    // never reaches the fallback that would read as self. That is what makes a
+    // deleted raw element harmless rather than a refused drop.
+    assert.strictEqual(
+      normalisedElement,
+      find("#src"),
+      "the normalised payload still names the source, not the target it fell through to"
+    );
+    assert.strictEqual(
+      drops,
+      1,
+      "a missing raw source element is not treated as the target element"
+    );
+  });
+
+  test("source toggles --dragging during the drag", async function (assert) {
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource type="row" data=(hash id=1)}}
+        >src</div>
+      </template>
+    );
+
+    assert
+      .dom("#src")
+      .hasAttribute(
+        "data-drag-source",
+        "",
+        "the style hook is present for the whole registration, not only mid-drag"
+      );
+
+    const dataTransfer = new DataTransfer();
+    await dragEvent("#src", "dragstart", { dataTransfer, ...centerOf("#src") });
+    assert.dom("#src").hasClass("--dragging");
+    await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+    assert.dom("#src").doesNotHaveClass("--dragging");
+  });
+
+  test("cancelled source drag cleans up without firing consumer onDrop", async function (assert) {
+    let drops = 0;
+    const onDrop = () => drops++;
+
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row" onDrop=onDrop}}>
+          src
+        </div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    await dragEvent("#src", "dragstart", {
+      dataTransfer,
+      ...centerOf("#src"),
+    });
+    await dragEvent("#src", "dragend", {
+      dataTransfer,
+      ...centerOf("#src"),
+    });
+
+    assert
+      .dom("#src")
+      .doesNotHaveClass(
+        "--dragging",
+        "a cancelled drag still removes the source-private dragging class"
+      );
+    assert.strictEqual(
+      drops,
+      0,
+      "a cancelled drag does not fire the consumer's onDrop"
+    );
+  });
+
+  module("source end callbacks", function () {
+    test("abandoned drag defers onDragEnd without onDrop", async function (assert) {
+      const calls = [];
+      let dragEndPayload;
+      const onDragEnd = (payload) => {
+        dragEndPayload = payload;
+        calls.push("onDragEnd");
+      };
+      const onDrop = () => calls.push("onDrop");
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              data=(hash id=1)
+              onDragEnd=onDragEnd
+              onDrop=onDrop
+            }}
+          >src</div>
+        </template>
+      );
+
+      find("#src").addEventListener("dragend", () =>
+        calls.push("native dragend")
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#src", "dragend", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+
+      assert.deepEqual(
+        {
+          calls,
+          sourceData: dragEndPayload?.source.data ?? null,
+          hasSourceElement: dragEndPayload?.source.element === find("#src"),
+          dropTargetCount:
+            dragEndPayload?.location.current.dropTargets.length ?? null,
+        },
+        {
+          calls: ["native dragend", "onDragEnd"],
+          sourceData: { type: "row", id: 1 },
+          hasSourceElement: true,
+          dropTargetCount: 0,
+        },
+        "an abandoned drag defers onDragEnd with its snapshot and does not fire onDrop"
+      );
+    });
+
+    test("landed drag defers onDragEnd before onDrop with the same payload", async function (assert) {
+      const calls = [];
+      const onDragEnd = (payload) => calls.push({ name: "onDragEnd", payload });
+      const onDrop = (payload) => calls.push({ name: "onDrop", payload });
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              data=(hash id=1)
+              onDragEnd=onDragEnd
+              onDrop=onDrop
+            }}
+          >src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>target</div>
+        </template>
+      );
+
+      find("#tgt").addEventListener("drop", () =>
+        calls.push({ name: "native drop" })
+      );
+
+      await simulateDrag("#src", "#tgt", {
+        dataTransfer: new DataTransfer(),
+      });
+
+      const dragEndPayload = calls.find(
+        ({ name }) => name === "onDragEnd"
+      )?.payload;
+      const dropPayload = calls.find(({ name }) => name === "onDrop")?.payload;
+
+      assert.deepEqual(
+        {
+          calls: calls.map(({ name }) => name),
+          sharesSource: dragEndPayload?.source === dropPayload?.source,
+          sharesLocation: dragEndPayload?.location === dropPayload?.location,
+          sourceData: dragEndPayload?.source.data ?? null,
+        },
+        {
+          calls: ["native drop", "onDragEnd", "onDrop"],
+          sharesSource: true,
+          sharesLocation: true,
+          sourceData: { type: "row", id: 1 },
+        },
+        "a landed drag defers onDragEnd before onDrop with the same snapshot"
+      );
+    });
+
+    test("landed drag fires onDragEnd once across multiple drop targets", async function (assert) {
+      const dragEnds = [];
+      const onDragEnd = (payload) => dragEnds.push(payload);
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource type="row" onDragEnd=onDragEnd}}
+          >src</div>
+          <div id="outer" {{dDragAndDropTarget accepts="row"}}>
+            outer
+            <div id="inner" {{dDragAndDropTarget accepts="row"}}>inner</div>
+          </div>
+        </template>
+      );
+
+      await simulateDrag("#src", "#inner", {
+        dataTransfer: new DataTransfer(),
+      });
+
+      assert.deepEqual(
+        {
+          callbackCount: dragEnds.length,
+          dropTargetCount:
+            dragEnds[0]?.location.current.dropTargets.length ?? 0,
+        },
+        { callbackCount: 1, dropTargetCount: 2 },
+        "onDragEnd fires once for a drag that lands on two nested targets"
+      );
+    });
+  });
+
+  test("smart row mode resolves position from cursor midpoint", async function (assert) {
+    const drops = [];
+    const onDrop = (payload) => drops.push(payload);
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource type="row" data=(hash id=1)}}
+        >src</div>
+        <div
+          id="tgt"
+          style="height: 100px"
+          {{dDragAndDropTarget accepts="row" onDrop=onDrop}}
+        >tgt</div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    const target = document.querySelector("#tgt");
+    const rect = target.getBoundingClientRect();
+
+    await dragEvent("#src", "dragstart", { dataTransfer, ...centerOf("#src") });
+    await dragEvent("#tgt", "dragenter", { dataTransfer, ...centerOf("#tgt") });
+    await dragEvent("#tgt", "dragover", {
+      dataTransfer,
+      clientY: rect.top + 5,
+      clientX: rect.left + 5,
+    });
+    await dragEvent("#tgt", "drop", {
+      dataTransfer,
+      clientY: rect.top + 5,
+      clientX: rect.left + 5,
+    });
+    await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+
+    assert.strictEqual(drops.at(-1).position, "before");
+
+    drops.length = 0;
+    const dataTransfer2 = new DataTransfer();
+    await dragEvent("#src", "dragstart", {
+      dataTransfer: dataTransfer2,
+      ...centerOf("#src"),
+    });
+    await dragEvent("#tgt", "dragenter", {
+      dataTransfer: dataTransfer2,
+      ...centerOf("#tgt"),
+    });
+    await dragEvent("#tgt", "dragover", {
+      dataTransfer: dataTransfer2,
+      clientY: rect.top + rect.height - 5,
+      clientX: rect.left + 5,
+    });
+    await dragEvent("#tgt", "drop", {
+      dataTransfer: dataTransfer2,
+      clientY: rect.top + rect.height - 5,
+      clientX: rect.left + 5,
+    });
+    await dragEvent("#src", "dragend", {
+      dataTransfer: dataTransfer2,
+      ...centerOf("#src"),
+    });
+
+    assert.strictEqual(drops.at(-1).position, "after");
+  });
+
+  test("nested targets — innermost accepting target wins drop", async function (assert) {
+    const events = [];
+    const onOuterDrop = () => events.push("outer");
+    const onInnerDrop = () => events.push("inner");
+
+    await render(
+      <template>
+        <div
+          id="src"
+          {{dDragAndDropSource type="row" data=(hash id=1)}}
+        >src</div>
+        <div
+          id="outer"
+          {{dDragAndDropTarget
+            accepts="row"
+            position="inside"
+            onDrop=onOuterDrop
+          }}
+        >
+          outer
+          <div
+            id="inner"
+            {{dDragAndDropTarget
+              accepts="row"
+              position="before"
+              onDrop=onInnerDrop
+            }}
+          >inner</div>
+        </div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    await simulateDrag("#src", "#inner", { dataTransfer });
+
+    assert.deepEqual(
+      events,
+      ["inner"],
+      "only the deepest accepted target receives the drop"
+    );
+  });
+
+  test("dropping on a nested target clears the ancestor indicator", async function (assert) {
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+        <div
+          id="outer"
+          style="height: 100px"
+          {{dDragAndDropTarget accepts="row" position="inside"}}
+        >
+          outer
+          <div
+            id="inner"
+            {{dDragAndDropTarget accepts="row" position="inside"}}
+          >inner</div>
+        </div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    const outerRect = find("#outer").getBoundingClientRect();
+
+    await dragEvent("#src", "dragstart", {
+      dataTransfer,
+      ...centerOf("#src"),
+    });
+    await dragEvent("#outer", "dragenter", {
+      dataTransfer,
+      clientX: outerRect.left + 5,
+      clientY: outerRect.top + 5,
+    });
+    await dragEvent("#outer", "dragover", {
+      dataTransfer,
+      clientX: outerRect.left + 5,
+      clientY: outerRect.top + 5,
+    });
+
+    assert
+      .dom("#outer")
+      .hasClass("--drag-inside", "the parent paints its indicator first");
+
+    await dragEvent("#inner", "dragenter", {
+      dataTransfer,
+      ...centerOf("#inner"),
+    });
+    await dragEvent("#inner", "dragover", {
+      dataTransfer,
+      ...centerOf("#inner"),
+    });
+
+    // Asserted before the drop, so this pins down that the ancestor clears as
+    // soon as it stops being deepest rather than only once the drop lands.
+    assert
+      .dom("#outer")
+      .doesNotHaveClass(
+        "--drag-inside",
+        "moving onto the child clears the parent indicator immediately"
+      );
+
+    await dragEvent("#inner", "drop", {
+      dataTransfer,
+      ...centerOf("#inner"),
+    });
+    await dragEvent("#src", "dragend", {
+      dataTransfer,
+      ...centerOf("#src"),
+    });
+
+    assert
+      .dom("#outer")
+      .doesNotHaveClass(
+        "--drag-inside",
+        "dropping on the child clears the parent indicator"
+      );
+  });
+
+  test("a drop clears an ancestor indicator that never saw another drag event", async function (assert) {
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+        <div
+          id="outer"
+          style="height: 100px"
+          {{dDragAndDropTarget accepts="row" position="inside"}}
+        >
+          outer
+          <div
+            id="inner"
+            {{dDragAndDropTarget accepts="row" position="inside"}}
+          >inner</div>
+        </div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    const outerRect = find("#outer").getBoundingClientRect();
+
+    await dragEvent("#src", "dragstart", {
+      dataTransfer,
+      ...centerOf("#src"),
+    });
+    await dragEvent("#outer", "dragenter", {
+      dataTransfer,
+      clientX: outerRect.left + 5,
+      clientY: outerRect.top + 5,
+    });
+    await dragEvent("#outer", "dragover", {
+      dataTransfer,
+      clientX: outerRect.left + 5,
+      clientY: outerRect.top + 5,
+    });
+
+    assert
+      .dom("#outer")
+      .hasClass("--drag-inside", "the ancestor is showing an indicator");
+
+    // Straight from the ancestor to a drop on the child, with no drag event in
+    // between: the ancestor's own enter/drag clears never run again, so the
+    // unconditional clear in `onDrop` is the only thing left to drop it.
+    await dragEvent("#inner", "drop", {
+      dataTransfer,
+      ...centerOf("#inner"),
+    });
+    await dragEvent("#src", "dragend", {
+      dataTransfer,
+      ...centerOf("#src"),
+    });
+
+    assert
+      .dom("#outer")
+      .doesNotHaveClass(
+        "--drag-inside",
+        "a drop clears the ancestor even though it is no longer the deepest target"
+      );
+  });
+
+  test("target modifier picks up arg changes without re-registering", async function (assert) {
+    // The modifier runs `modify()` only once (its body reads no tracked
+    // arg properties), so the underlying target is registered just once. The closure
+    // around `args` must still see updated values when tracked args
+    // change. This guards against the modifier going stale after an
+    // arg update.
+    const state = new (class {
+      @tracked accepted = "row";
+      @tracked dropped = null;
+      handleDrop = (payload) => (this.dropped = payload.source.type);
+    })();
+
+    await render(
+      <template>
+        <div
+          id="src-row"
+          {{dDragAndDropSource type="row" data=(hash id=1)}}
+        >src-row</div>
+        <div
+          id="src-card"
+          {{dDragAndDropSource type="card" data=(hash id=2)}}
+        >src-card</div>
+        <div
+          id="tgt"
+          {{dDragAndDropTarget accepts=state.accepted onDrop=state.handleDrop}}
+        >tgt</div>
+      </template>
+    );
+
+    let dataTransfer = new DataTransfer();
+    await simulateDrag("#src-row", "#tgt", { dataTransfer });
+    assert.strictEqual(
+      state.dropped,
+      "row",
+      "drops the type currently in `accepts`"
+    );
+
+    state.accepted = "card";
+    state.dropped = null;
+    await settled();
+
+    dataTransfer = new DataTransfer();
+    await simulateDrag("#src-row", "#tgt", { dataTransfer });
+    assert.strictEqual(
+      state.dropped,
+      null,
+      "after arg update, the old accepted type is rejected"
+    );
+
+    dataTransfer = new DataTransfer();
+    await simulateDrag("#src-card", "#tgt", { dataTransfer });
+    assert.strictEqual(
+      state.dropped,
+      "card",
+      "after arg update, the new accepted type fires onDrop"
+    );
+  });
+
+  test("the service tracks the element drag first-hand", async function (assert) {
+    // The source modifier no longer pushes drag state; the service derives it
+    // via its own `monitorForElements`. Looking the service up registers that
+    // monitor before the drag begins.
+    const dnd = this.owner.lookup("service:drag-and-drop");
+
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row" data=(hash id=1)}}>
+          src
+        </div>
+      </template>
+    );
+
+    assert.false(dnd.isDragging, "no drag in flight before dragstart");
+
+    const dataTransfer = new DataTransfer();
+    await dragEvent("#src", "dragstart", { dataTransfer, ...centerOf("#src") });
+
+    assert.true(dnd.isDragging, "isDragging is true during the drag");
+    assert.true(dnd.accepts("row"), "accepts the in-flight type");
+    assert.false(dnd.accepts("card"), "rejects a foreign type");
+    assert.strictEqual(dnd.currentDrag.type, "row", "currentDrag carries type");
+    assert.deepEqual(
+      dnd.currentDrag.data,
+      { type: "row", id: 1 },
+      "currentDrag.data carries the source payload"
+    );
+    assert.strictEqual(
+      dnd.currentDrag.element,
+      document.querySelector("#src"),
+      "currentDrag.element is the source element"
+    );
+
+    await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+
+    assert.strictEqual(dnd.currentDrag, null, "cleared once the drag ends");
+    assert.false(dnd.isDragging, "isDragging is false after the drag");
+  });
+
+  test("currentDrag identity is stable within a drag (one object per drag)", async function (assert) {
+    // grid-overlay keys its drag cache on the `currentDrag` reference, so the
+    // service must set it once per drag, not rebuild it per move.
+    const dnd = this.owner.lookup("service:drag-and-drop");
+
+    await render(
+      <template>
+        <div id="src" {{dDragAndDropSource type="row" data=(hash id=1)}}>
+          src
+        </div>
+      </template>
+    );
+
+    const dataTransfer = new DataTransfer();
+    await dragEvent("#src", "dragstart", { dataTransfer, ...centerOf("#src") });
+    const first = dnd.currentDrag;
+    await dragEvent("#src", "dragover", { dataTransfer, ...centerOf("#src") });
+    assert.strictEqual(
+      dnd.currentDrag,
+      first,
+      "the reference is unchanged across drag moves"
+    );
+    await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+  });
+
+  module(
+    "the discriminator is the primitive's, not the payload's",
+    function () {
+      test("a `type` key on the payload does not change what a target accepts", async function (assert) {
+        const drops = [];
+        const onDrop = ({ source }) => drops.push(source.type);
+        // A domain object carrying its own `type` is the ordinary case: models
+        // routinely have one, and the modifier's own docs pass `data=this.link`.
+        const payload = { id: 1, type: "something-else" };
+
+        await render(
+          <template>
+            <div
+              id="src"
+              {{dDragAndDropSource type="row" data=payload}}
+            >src</div>
+            <div id="tgt" {{dDragAndDropTarget accepts="row" onDrop=onDrop}}>
+              tgt
+            </div>
+          </template>
+        );
+
+        await simulateDrag("#src", "#tgt", {
+          dataTransfer: new DataTransfer(),
+        });
+
+        assert.deepEqual(
+          drops,
+          ["row"],
+          "the declared type wins, so the target still matches and reports it"
+        );
+      });
+    }
+  );
+
+  module("a torn-down source drops its deferred callbacks", function () {
+    test("destroying the modifier before the runloop flushes cancels them", async function (assert) {
+      const calls = [];
+      const state = new (class {
+        @tracked rendered = true;
+      })();
+      const onDragEnd = () => calls.push("dragEnd");
+      const onDrop = () => calls.push("drop");
+
+      await render(
+        <template>
+          {{#if state.rendered}}
+            <div
+              id="src"
+              {{dDragAndDropSource
+                type="row"
+                onDragEnd=onDragEnd
+                onDrop=onDrop
+              }}
+            >src</div>
+          {{/if}}
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      // The source defers its consumer callbacks to the next task, so tearing
+      // it down in between is what a route transition or a re-render dropping
+      // the row does.
+      find("#tgt").dispatchEvent(
+        new DragEvent("drop", { bubbles: true, dataTransfer })
+      );
+      state.rendered = false;
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        [],
+        "a destroyed source runs no consumer callback against it"
+      );
+    });
+
+    test("re-registering the modifier before the runloop flushes keeps them", async function (assert) {
+      const calls = [];
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+      const onDragEnd = () => calls.push("dragEnd");
+      const onDrop = () => calls.push("drop");
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              disabled=state.disabled
+              onDragEnd=onDragEnd
+              onDrop=onDrop
+            }}
+          >src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      find("#tgt").dispatchEvent(
+        new DragEvent("drop", { bubbles: true, dataTransfer })
+      );
+      // The consumer is still here — only the registration is being replaced,
+      // which is what an arg bound to drag state does the moment the drag ends.
+      // It still expects to be told how its own drag finished.
+      state.disabled = true;
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        ["dragEnd", "drop"],
+        "a source that merely re-registered still reports the drop it was in the middle of"
+      );
+    });
+
+    test("a source disabled mid-drag still reports how that drag ended", async function (assert) {
+      const calls = [];
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+      const onDragEnd = () => calls.push("dragEnd");
+      const onDrop = () => calls.push("drop");
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              disabled=state.disabled
+              onDragEnd=onDragEnd
+              onDrop=onDrop
+            }}
+          >src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      // Disabled while the drag is still in flight, which a consumer binding
+      // the arg to anything that changes mid-drag will do. The drag itself
+      // carries on — the browser is holding it, not the page.
+      state.disabled = true;
+      await settled();
+
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "drop", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      assert.deepEqual(
+        calls,
+        ["dragEnd", "drop"],
+        "the consumer is still told how its drag finished, as it is promised for every drag"
+      );
+    });
+
+    test("a source re-enabled mid-drag leaves only one registration behind", async function (assert) {
+      const warn = sinon.stub(console, "warn");
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource type="row" disabled=state.disabled}}
+          >src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+
+      // Disabled while the drag is live, which keeps the registration alive to
+      // report the drop, then enabled again before that drop arrives. The one
+      // being kept has to be let go of before a replacement is made.
+      state.disabled = true;
+      await settled();
+      state.disabled = false;
+      await settled();
+
+      const duplicate = warn
+        .getCalls()
+        .some((call) =>
+          String(call.args[0]).includes("already registered a `draggable`")
+        );
+
+      assert.false(
+        duplicate,
+        "the element carries one registration, not two competing for the same drag"
+      );
+    });
+
+    test("superseding a detached source keeps the callbacks it still owes", async function (assert) {
+      const calls = [];
+      const args = {
+        type: "row",
+        onDragEnd: () => calls.push("dragEnd"),
+        onDrop: () => calls.push("drop"),
+      };
+
+      await render(
+        <template>
+          <div id="src">src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const release = registerDragAndDropSource(find("#src"), () => args);
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      find("#tgt").dispatchEvent(
+        new DragEvent("drop", { bubbles: true, dataTransfer })
+      );
+
+      const work = release({ cancelPending: false });
+
+      // Something has taken this registration's place, which says nothing about
+      // the drag that already finished. The consumer is still there and is still
+      // owed the end of it.
+      work.supersede();
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        ["dragEnd", "drop"],
+        "being replaced does not cost the consumer the drag it had already completed"
+      );
+      assert.false(
+        work.outstanding(),
+        "and once it has fired the work reports itself finished, so a holder can let go"
+      );
+    });
+
+    test("detached work reports itself outstanding until its dispatch fires", async function (assert) {
+      const args = { type: "row", onDragEnd: () => {}, onDrop: () => {} };
+
+      await render(
+        <template>
+          <div id="src">src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const release = registerDragAndDropSource(find("#src"), () => args);
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      find("#tgt").dispatchEvent(
+        new DragEvent("drop", { bubbles: true, dataTransfer })
+      );
+
+      const work = release({ cancelPending: false });
+
+      assert.true(
+        work.outstanding(),
+        "a dispatch is still scheduled, so a holder has to keep it"
+      );
+
+      await settled();
+
+      assert.false(
+        work.outstanding(),
+        "and stops being owed once that dispatch has run"
+      );
+    });
+
+    test("abandoning a detached source drops the callbacks it still owes", async function (assert) {
+      const calls = [];
+      const args = {
+        type: "row",
+        onDragEnd: () => calls.push("dragEnd"),
+        onDrop: () => calls.push("drop"),
+      };
+
+      await render(
+        <template>
+          <div id="src">src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const release = registerDragAndDropSource(find("#src"), () => args);
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      find("#tgt").dispatchEvent(
+        new DragEvent("drop", { bubbles: true, dataTransfer })
+      );
+
+      // Detaching without cancelling hands the outstanding work back, because
+      // this closure was the only thing that could still reach it.
+      const work = release({ cancelPending: false });
+      assert.strictEqual(
+        typeof work?.abandon,
+        "function",
+        "keeping the dispatch hands back a way to reach it"
+      );
+
+      // The consumer itself is going away, which is the one reason to take the
+      // dispatch back.
+      work.abandon();
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        [],
+        "a consumer that is gone is not called for the drag it completed"
+      );
+    });
+
+    test("a source disabled and re-enabled mid-drag still reports how that drag ended", async function (assert) {
+      const calls = [];
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+      const onDragEnd = () => calls.push("dragEnd");
+      const onDrop = () => calls.push("drop");
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              disabled=state.disabled
+              onDragEnd=onDragEnd
+              onDrop=onDrop
+            }}
+          >src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      // Detached mid-drag, then replaced before the drop. Whichever registration
+      // ends up holding the element has to be the one that reports, because the
+      // consumer is promised the end of every drag it started.
+      state.disabled = true;
+      await settled();
+      state.disabled = false;
+      await settled();
+
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "drop", { dataTransfer, ...centerOf("#tgt") });
+
+      assert.deepEqual(
+        calls,
+        ["dragEnd", "drop"],
+        "replacing the registration mid-drag does not cost the consumer the end of it"
+      );
+    });
+
+    test("a source whose handle changes identity mid-drag still reports how that drag ended", async function (assert) {
+      const calls = [];
+      const state = new (class {
+        @tracked useSecondHandle = false;
+        @tracked dragHandle;
+        captureHandle = (element) => (this.dragHandle = element);
+        onDragEnd = () => calls.push("dragEnd");
+        onDrop = () => calls.push("drop");
+      })();
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              dragHandle=state.dragHandle
+              onDragEnd=state.onDragEnd
+              onDrop=state.onDrop
+            }}
+          >
+            {{#if state.useSecondHandle}}
+              <button
+                id="second-handle"
+                type="button"
+                {{didInsert state.captureHandle}}
+              >second</button>
+            {{else}}
+              <button
+                id="first-handle"
+                type="button"
+                {{didInsert state.captureHandle}}
+              >first</button>
+            {{/if}}
+          </div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      // The drag begins on the handle the live registration sits on.
+      await dragEvent("#first-handle", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      // The handle is re-rendered mid-drag, replacing the registration while
+      // the drag it started is still in flight. The library dispatches the
+      // drag's end by looking the ORIGINAL handle up, so the replaced
+      // registration must stay reachable until then.
+      state.useSecondHandle = true;
+      await settled();
+
+      assert
+        .dom("#src")
+        .hasClass("--dragging", "the drag in flight keeps its mark");
+
+      await dragEvent("#tgt", "drop", { dataTransfer, ...centerOf("#tgt") });
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        ["dragEnd", "drop"],
+        "the swap does not cost the consumer the end of its drag"
+      );
+    });
+
+    test("a source disabled mid-drag and then destroyed drops its callbacks", async function (assert) {
+      const calls = [];
+      const state = new (class {
+        @tracked disabled = false;
+        @tracked rendered = true;
+      })();
+      const onDragEnd = () => calls.push("dragEnd");
+      const onDrop = () => calls.push("drop");
+
+      await render(
+        <template>
+          {{#if state.rendered}}
+            <div
+              id="src"
+              {{dDragAndDropSource
+                type="row"
+                disabled=state.disabled
+                onDragEnd=onDragEnd
+                onDrop=onDrop
+              }}
+            >src</div>
+          {{/if}}
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      // Detached, but kept alive to report the drag it is in the middle of.
+      state.disabled = true;
+      await settled();
+
+      // The drop schedules the consumer callbacks, and the row goes away before
+      // the runloop flushes them. Whatever is still holding that dispatch has to
+      // be reachable from here, or nothing can call it off.
+      find("#tgt").dispatchEvent(
+        new DragEvent("drop", { bubbles: true, dataTransfer })
+      );
+      state.rendered = false;
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        [],
+        "a destroyed consumer runs no callback for the drag its registration was keeping"
+      );
+    });
+
+    test("a consumer that throws does not strand the registration", async function (assert) {
+      let thrown = 0;
+      setupOnerror(() => thrown++);
+
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+      const onDragEnd = () => {
+        throw new Error("consumer blew up");
+      };
+
+      await render(
+        <template>
+          <div
+            id="src"
+            {{dDragAndDropSource
+              type="row"
+              disabled=state.disabled
+              onDragEnd=onDragEnd
+            }}
+          >src</div>
+          <div id="tgt" {{dDragAndDropTarget accepts="row"}}>tgt</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#tgt", "dragenter", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+
+      // Detached mid-drag, so the teardown is waiting on the drop that is about
+      // to dispatch into a consumer that throws.
+      state.disabled = true;
+      await settled();
+
+      await dragEvent("#tgt", "dragover", {
+        dataTransfer,
+        ...centerOf("#tgt"),
+      });
+      await dragEvent("#tgt", "drop", { dataTransfer, ...centerOf("#tgt") });
+
+      assert.strictEqual(thrown, 1, "the consumer's error is not swallowed");
+      assert
+        .dom("#src")
+        .doesNotHaveAttribute(
+          "data-drag-source",
+          "and the registration is still torn down, rather than left on the element for good"
+        );
+    });
+  });
+
+  module("a drag held over nothing", function () {
+    /**
+     * Dispatches a drag event and hands the event back, which `triggerEvent`
+     * cannot: what is being asserted is whether something claimed the event.
+     *
+     * `dataTransfer.dropEffect` would be the more direct reading, and it is not
+     * available — a synthetic drag leaves it at `"none"` however it is set, even
+     * over a target that asked for `"copy"`. `defaultPrevented` is the half that
+     * carries the meaning anyway: it is what tells the browser the drag was
+     * handled here, and the cursor follows from it.
+     */
+    async function dragOverAndReturnEvent(selector, dataTransfer) {
+      const event = new DragEvent("dragover", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        ...centerOf(selector),
+      });
+      find(selector).dispatchEvent(event);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      return event;
+    }
+
+    test("a sourced drag claims the space no target wants", async function (assert) {
+      await render(
+        <template>
+          <div id="row" {{dDragAndDropSource type="row"}}>row</div>
+          <div id="nowhere">not a drop target</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#row", "dragstart", {
+        dataTransfer,
+        ...centerOf("#row"),
+      });
+
+      const event = await dragOverAndReturnEvent("#nowhere", dataTransfer);
+
+      assert.true(
+        event.defaultPrevented,
+        "the drag answers for itself over dead space, so the browser stops offering to copy something it has no way to take"
+      );
+    });
+  });
+
+  module("what a drag permits", function () {
+    /**
+     * A real `DataTransfer` whose `effectAllowed` keeps what is written to it.
+     *
+     * The native property is a no-op here — its setter requires a drag data
+     * store in a mode only a browser-driven drag puts it in, so a synthetic
+     * event silently discards every write, the test's own included. An own
+     * property shadows the accessor and leaves the rest of the object real,
+     * which makes what the source declares readable at all.
+     */
+    function recordingTransfer(effectAllowed = "none") {
+      const dataTransfer = new DataTransfer();
+      Object.defineProperty(dataTransfer, "effectAllowed", {
+        value: effectAllowed,
+        writable: true,
+        configurable: true,
+      });
+      return dataTransfer;
+    }
+
+    test("a sourced drag permits a move, and nothing else", async function (assert) {
+      await render(
+        <template>
+          <div id="row" {{dDragAndDropSource type="row"}}>row</div>
+        </template>
+      );
+
+      const dataTransfer = recordingTransfer();
+      await dragEvent("#row", "dragstart", {
+        dataTransfer,
+        ...centerOf("#row"),
+      });
+
+      assert.strictEqual(
+        dataTransfer.effectAllowed,
+        "move",
+        "the drag says what it permits, so the pointer stops carrying the browser's standing offer to copy"
+      );
+    });
+
+    test("a source can permit a copy as well", async function (assert) {
+      await render(
+        <template>
+          <div
+            id="row"
+            {{dDragAndDropSource type="row" effectAllowed="copyMove"}}
+          >row</div>
+        </template>
+      );
+
+      const dataTransfer = recordingTransfer();
+      await dragEvent("#row", "dragstart", {
+        dataTransfer,
+        ...centerOf("#row"),
+      });
+
+      assert.strictEqual(
+        dataTransfer.effectAllowed,
+        "copyMove",
+        "a source whose drop duplicates rather than relocates keeps the copy available to its targets"
+      );
+    });
+
+    test("the innermost source is the one that answers", async function (assert) {
+      await render(
+        <template>
+          <div id="outer" {{dDragAndDropSource type="outer"}}>
+            <div
+              id="inner"
+              {{dDragAndDropSource type="inner" effectAllowed="copyMove"}}
+            >inner</div>
+          </div>
+        </template>
+      );
+
+      const dataTransfer = recordingTransfer();
+      await dragEvent("#inner", "dragstart", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+
+      assert.strictEqual(
+        dataTransfer.effectAllowed,
+        "copyMove",
+        "a drag begun on a nested source passes through its ancestor on the way out, which must not answer over it"
+      );
+    });
+
+    test("a source still registered keeps answering after a sibling detaches", async function (assert) {
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+
+      await render(
+        <template>
+          <div
+            id="going"
+            {{dDragAndDropSource type="going" disabled=state.disabled}}
+          >going</div>
+          <div id="staying" {{dDragAndDropSource type="staying"}}>staying</div>
+        </template>
+      );
+
+      state.disabled = true;
+      await settled();
+
+      const dataTransfer = recordingTransfer();
+      await dragEvent("#staying", "dragstart", {
+        dataTransfer,
+        ...centerOf("#staying"),
+      });
+
+      assert.strictEqual(
+        dataTransfer.effectAllowed,
+        "move",
+        "one source going away takes only its own share of the shared listener"
+      );
+    });
+
+    test("the last source to go takes the shared listener with it", async function (assert) {
+      // White-box, because the only thing a leak costs is an idle listener and
+      // a map entry per registration — nothing a drag can observe.
+      const state = new (class {
+        @tracked disabled = false;
+      })();
+
+      await render(
+        <template>
+          <div
+            id="row"
+            {{dDragAndDropSource type="row" disabled=state.disabled}}
+          >row</div>
+        </template>
+      );
+
+      const released = sinon.spy(window, "removeEventListener");
+      state.disabled = true;
+      await settled();
+
+      assert.true(
+        released.calledWith("dragstart", sinon.match.func, { capture: true }),
+        "nothing stays bound to a page with no drag sources left on it"
+      );
+    });
+  });
+
+  module("lifecycle callbacks stay paired", function () {
+    test("an ancestor that never received an enter receives no leave", async function (assert) {
+      const events = [];
+      const onOuterEnter = () => events.push("outer:enter");
+      const onOuterLeave = () => events.push("outer:leave");
+      // The deepest target is instrumented too, as this test's positive control:
+      // without it, an implementation that dispatched no lifecycle callback at
+      // all would satisfy the assertion below just as well as a correct one.
+      const onInnerEnter = () => events.push("inner:enter");
+      const onInnerLeave = () => events.push("inner:leave");
+
+      await render(
+        <template>
+          <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+          <div
+            id="outer"
+            style="height: 100px"
+            {{dDragAndDropTarget
+              accepts="row"
+              position="inside"
+              onDragEnter=onOuterEnter
+              onDragLeave=onOuterLeave
+            }}
+          >
+            outer
+            <div
+              id="inner"
+              {{dDragAndDropTarget
+                accepts="row"
+                position="inside"
+                onDragEnter=onInnerEnter
+                onDragLeave=onInnerLeave
+              }}
+            >inner</div>
+          </div>
+          <div id="away" {{dDragAndDropTarget accepts="row"}}>away</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+      // Straight onto the child, so the ancestor is in the stack but never the
+      // deepest and so never forwards an enter.
+      await dragEvent("#inner", "dragenter", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+      await dragEvent("#inner", "dragover", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+      await dragEvent("#away", "dragenter", {
+        dataTransfer,
+        ...centerOf("#away"),
+      });
+      await dragEvent("#away", "dragover", {
+        dataTransfer,
+        ...centerOf("#away"),
+      });
+      await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+
+      assert.deepEqual(
+        events,
+        ["inner:enter", "inner:leave"],
+        "the deepest target is entered and left as a pair, and the ancestor that was never entered is never left"
+      );
+    });
+
+    test("a target that becomes deepest without a fresh enter is entered and left", async function (assert) {
+      const events = [];
+      let drags = 0;
+
+      const onOuterEnter = () => events.push("outer:enter");
+      const onOuterDrag = () => drags++;
+      const onOuterLeave = () => events.push("outer:leave");
+
+      await render(
+        <template>
+          <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+          <div
+            id="outer"
+            style="height: 100px"
+            {{dDragAndDropTarget
+              accepts="row"
+              position="inside"
+              onDragEnter=onOuterEnter
+              onDrag=onOuterDrag
+              onDragLeave=onOuterLeave
+            }}
+          >
+            outer
+            <div
+              id="inner"
+              {{dDragAndDropTarget accepts="row" position="inside"}}
+            >inner</div>
+          </div>
+          <div id="away" {{dDragAndDropTarget accepts="row"}}>away</div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      const outerRect = find("#outer").getBoundingClientRect();
+
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+
+      // Onto the child first, so the ancestor joins the hierarchy while the
+      // child is deepest and its own enter is swallowed.
+      await dragEvent("#inner", "dragenter", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+      await dragEvent("#inner", "dragover", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+
+      // Back onto the ancestor's own area. It becomes deepest without a fresh
+      // enter, because it never left the hierarchy.
+      await dragEvent("#outer", "dragover", {
+        dataTransfer,
+        clientX: outerRect.left + 5,
+        clientY: outerRect.top + 5,
+      });
+
+      await dragEvent("#away", "dragenter", {
+        dataTransfer,
+        ...centerOf("#away"),
+      });
+      await dragEvent("#away", "dragover", {
+        dataTransfer,
+        ...centerOf("#away"),
+      });
+      await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+
+      assert.true(
+        drags > 0,
+        "the ancestor was told about the drag once it was the deepest target"
+      );
+      assert.deepEqual(
+        events,
+        ["outer:enter", "outer:leave"],
+        "so it is entered when it takes over and left when it gives up, rather than being told only about the middle"
+      );
+    });
+
+    test("an ancestor superseded by a child is left before the drop lands", async function (assert) {
+      const events = [];
+      const onOuterEnter = () => events.push("outer:enter");
+      const onOuterLeave = () => events.push("outer:leave");
+      // Recording the drop pins the ordering as well as the pairing: the
+      // ancestor has to be left when the child takes over, not once the drag is
+      // already over.
+      const onInnerDrop = () => events.push("inner:drop");
+
+      await render(
+        <template>
+          <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+          <div
+            id="outer"
+            style="height: 100px"
+            {{dDragAndDropTarget
+              accepts="row"
+              position="inside"
+              onDragEnter=onOuterEnter
+              onDragLeave=onOuterLeave
+            }}
+          >
+            outer
+            <div
+              id="inner"
+              {{dDragAndDropTarget
+                accepts="row"
+                position="inside"
+                onDrop=onInnerDrop
+              }}
+            >inner</div>
+          </div>
+        </template>
+      );
+
+      const dataTransfer = new DataTransfer();
+      const outerRect = find("#outer").getBoundingClientRect();
+
+      await dragEvent("#src", "dragstart", {
+        dataTransfer,
+        ...centerOf("#src"),
+      });
+
+      // The ancestor's own area first, so it is genuinely entered.
+      await dragEvent("#outer", "dragenter", {
+        dataTransfer,
+        clientX: outerRect.left + 5,
+        clientY: outerRect.top + 5,
+      });
+      await dragEvent("#outer", "dragover", {
+        dataTransfer,
+        clientX: outerRect.left + 5,
+        clientY: outerRect.top + 5,
+      });
+
+      // Then onto the child. The ancestor stays in the hierarchy, so no leave
+      // arrives from the library and the target has to synthesise one.
+      await dragEvent("#inner", "dragenter", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+      await dragEvent("#inner", "dragover", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+
+      await dragEvent("#inner", "drop", {
+        dataTransfer,
+        ...centerOf("#inner"),
+      });
+      await dragEvent("#src", "dragend", { dataTransfer, ...centerOf("#src") });
+
+      assert.deepEqual(
+        events,
+        ["outer:enter", "outer:leave", "inner:drop"],
+        "the ancestor is left as soon as the child takes over, so a drop never lands with its enter still open"
+      );
+    });
+
+    test("a second drag over the same target is entered again", async function (assert) {
+      const events = [];
+      const onEnter = () => events.push("enter");
+      const onLeave = () => events.push("leave");
+      const onDrop = () => events.push("drop");
+
+      await render(
+        <template>
+          <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+          <div
+            id="target"
+            {{dDragAndDropTarget
+              accepts="row"
+              position="inside"
+              onDragEnter=onEnter
+              onDragLeave=onLeave
+              onDrop=onDrop
+            }}
+          >target</div>
+          <div id="away" {{dDragAndDropTarget accepts="row"}}>away</div>
+        </template>
+      );
+
+      const firstTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer: firstTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#target", "dragenter", {
+        dataTransfer: firstTransfer,
+        ...centerOf("#target"),
+      });
+      await dragEvent("#target", "dragover", {
+        dataTransfer: firstTransfer,
+        ...centerOf("#target"),
+      });
+      // A drop closes the enter without reporting a leave, so the target has to
+      // forget it was entered or the next drag's enter is swallowed.
+      await dragEvent("#target", "drop", {
+        dataTransfer: firstTransfer,
+        ...centerOf("#target"),
+      });
+      await dragEvent("#src", "dragend", {
+        dataTransfer: firstTransfer,
+        ...centerOf("#src"),
+      });
+
+      const secondTransfer = new DataTransfer();
+      await dragEvent("#src", "dragstart", {
+        dataTransfer: secondTransfer,
+        ...centerOf("#src"),
+      });
+      await dragEvent("#target", "dragenter", {
+        dataTransfer: secondTransfer,
+        ...centerOf("#target"),
+      });
+      await dragEvent("#target", "dragover", {
+        dataTransfer: secondTransfer,
+        ...centerOf("#target"),
+      });
+      await dragEvent("#away", "dragenter", {
+        dataTransfer: secondTransfer,
+        ...centerOf("#away"),
+      });
+      await dragEvent("#away", "dragover", {
+        dataTransfer: secondTransfer,
+        ...centerOf("#away"),
+      });
+      await dragEvent("#src", "dragend", {
+        dataTransfer: secondTransfer,
+        ...centerOf("#src"),
+      });
+
+      assert.deepEqual(
+        events,
+        ["enter", "drop", "enter", "leave"],
+        "each drag gets its own enter, and the second one is still paired with a leave"
+      );
+    });
+  });
+});

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-draggable-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-draggable-test.gjs
@@ -1,0 +1,57 @@
+import { render, resetOnerror, setupOnerror } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DeprecationWorkflow from "discourse/deprecation-workflow";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  restoreCountingDeprecation,
+  skipCountingDeprecation,
+} from "discourse/tests/helpers/deprecation-counter";
+import {
+  disableRaiseOnDeprecationQUnitResult,
+  enableRaiseOnDeprecationQUnitResult,
+} from "discourse/tests/helpers/raise-on-deprecation";
+import dDraggable from "discourse/ui-kit/modifiers/d-draggable";
+
+const DEPRECATION_ID = "discourse.ui-kit.d-draggable";
+
+module("Integration | ui-kit | modifiers | dDraggable", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    // Reaching the modifier both pushes a failed assertion and throws. Only the
+    // assertion is suppressed here; the throw is what these tests are about.
+    disableRaiseOnDeprecationQUnitResult();
+    skipCountingDeprecation(DEPRECATION_ID);
+  });
+
+  hooks.afterEach(function () {
+    resetOnerror();
+    enableRaiseOnDeprecationQUnitResult();
+    restoreCountingDeprecation(DEPRECATION_ID);
+  });
+
+  test("using it raises, naming the id that tracks remaining usage", async function (assert) {
+    let raised = null;
+    setupOnerror((error) => (raised = error));
+
+    await render(
+      <template>
+        <div {{dDraggable}}></div>
+      </template>
+    );
+
+    // Asserted after the render rather than inside the handler, so a render that
+    // raises nothing fails here instead of silently making no assertion.
+    assert.true(
+      raised?.message.includes(DEPRECATION_ID),
+      "the raised error names the deprecation id"
+    );
+  });
+
+  test("nothing silences the deprecation, so a usage in core or a preinstalled plugin fails CI", function (assert) {
+    assert.true(
+      DeprecationWorkflow.shouldThrow(DEPRECATION_ID, true),
+      "an id with no workflow entry raises under RAISE_ON_DEPRECATION"
+    );
+  });
+});

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -7,6 +7,7 @@ import {
   triggerEvent,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { withSilencedDeprecationsAsync } from "discourse/lib/deprecated";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import {
   stubPointerCapture,
@@ -14,6 +15,8 @@ import {
 } from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
 import dDraggable from "discourse/ui-kit/modifiers/d-draggable";
 import dPointerDrag, * as dPointerDragModule from "discourse/ui-kit/modifiers/d-pointer-drag";
+
+const LEGACY_DEPRECATION_ID = "discourse.ui-kit.d-draggable";
 
 function installEventListenerSpy(element) {
   const added = [];
@@ -1608,11 +1611,15 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
 
     test("a legacy drag keeps the body class after a pointer drag ends", async function (assert) {
       const noop = () => {};
-      await render(
-        <template>
-          <div class="dpd-target" {{dPointerDrag bodyClass="dragging"}}></div>
-          <div class="legacy-target" {{dDraggable didEndDrag=noop}}></div>
-        </template>
+      // The deprecation throws from the constructor, so the modifier would
+      // never reach the listeners these tests need.
+      await withSilencedDeprecationsAsync(LEGACY_DEPRECATION_ID, () =>
+        render(
+          <template>
+            <div class="dpd-target" {{dPointerDrag bodyClass="dragging"}}></div>
+            <div class="legacy-target" {{dDraggable didEndDrag=noop}}></div>
+          </template>
+        )
       );
 
       const pointerTarget = find(".dpd-target");
@@ -1640,11 +1647,15 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
 
     test("a pointer drag keeps the body class after a legacy drag ends", async function (assert) {
       const noop = () => {};
-      await render(
-        <template>
-          <div class="dpd-target" {{dPointerDrag bodyClass="dragging"}}></div>
-          <div class="legacy-target" {{dDraggable didEndDrag=noop}}></div>
-        </template>
+      // The deprecation throws from the constructor, so the modifier would
+      // never reach the listeners these tests need.
+      await withSilencedDeprecationsAsync(LEGACY_DEPRECATION_ID, () =>
+        render(
+          <template>
+            <div class="dpd-target" {{dPointerDrag bodyClass="dragging"}}></div>
+            <div class="legacy-target" {{dDraggable didEndDrag=noop}}></div>
+          </template>
+        )
       );
 
       const pointerTarget = find(".dpd-target");

--- a/frontend/discourse/tests/unit/lib/resize-measurements-test.js
+++ b/frontend/discourse/tests/unit/lib/resize-measurements-test.js
@@ -1,0 +1,141 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  measuredMax,
+  measuredMin,
+  measuredSize,
+} from "discourse/lib/resize-measurements";
+
+/**
+ * Appends a styled box and removes it when the test ends.
+ *
+ * @param {object} hooks - The QUnit hooks the cleanup registers against.
+ * @returns {(css: string) => HTMLElement} A factory taking inline styles.
+ */
+function boxFactory(hooks) {
+  const created = [];
+  hooks.afterEach(function () {
+    created.splice(0).forEach((element) => element.remove());
+  });
+
+  return (css) => {
+    const element = document.createElement("div");
+    element.style.cssText = `position:absolute;top:-9999px;${css}`;
+    document.body.appendChild(element);
+    created.push(element);
+    return element;
+  };
+}
+
+module("Unit | Lib | resize-measurements", function (hooks) {
+  setupTest(hooks);
+  const box = boxFactory(hooks);
+
+  module("measuredSize round-trips what consumers write", function () {
+    const CASES = [
+      { boxSizing: "content-box", padding: "0" },
+      { boxSizing: "content-box", padding: "10px" },
+      { boxSizing: "border-box", padding: "0" },
+      { boxSizing: "border-box", padding: "10px" },
+    ];
+
+    for (const { boxSizing, padding } of CASES) {
+      for (const axis of ["vertical", "horizontal"]) {
+        const property = axis === "vertical" ? "height" : "width";
+
+        test(`${axis}, ${boxSizing}, padding ${padding}`, function (assert) {
+          const element = box(
+            `box-sizing:${boxSizing};border:1px solid;padding:${padding};` +
+              `height:400px;width:400px;`
+          );
+
+          element.style[property] = "440px";
+
+          assert.strictEqual(
+            measuredSize(element, axis),
+            440,
+            "reads back the number that was written"
+          );
+        });
+      }
+    }
+
+    test("a written fraction is preserved rather than rounded", function (assert) {
+      const element = box("box-sizing:border-box;height:100px;width:100px;");
+      element.style.height = "440.5px";
+
+      assert.strictEqual(measuredSize(element, "vertical"), 440.5);
+    });
+
+    test("a flex item reports the height it was given", function (assert) {
+      const parent = box("display:flex;flex-direction:column;height:600px;");
+      const child = document.createElement("div");
+      child.style.cssText = "box-sizing:content-box;border:1px solid;";
+      parent.appendChild(child);
+
+      child.style.height = "440px";
+
+      assert.strictEqual(measuredSize(child, "vertical"), 440);
+    });
+  });
+
+  module("measuredSize refuses a box that is not laid out", function () {
+    test("a detached element is unmeasured", function (assert) {
+      const element = document.createElement("div");
+      element.style.height = "440px";
+
+      assert.strictEqual(measuredSize(element, "vertical"), null);
+    });
+
+    test("a display:none element is unmeasured, percentage height and all", function (assert) {
+      // With no box, CSSOM returns the computed value, so a percentage
+      // survives as a plausible-looking number.
+      const parent = box("height:800px;");
+      const child = document.createElement("div");
+      child.style.cssText = "display:none;height:50%;";
+      parent.appendChild(child);
+
+      assert.strictEqual(measuredSize(child, "vertical"), null);
+    });
+
+    test("an auto height is unmeasured", function (assert) {
+      const parent = box("display:none;");
+      const child = document.createElement("div");
+      child.style.cssText = "height:auto;";
+      parent.appendChild(child);
+
+      assert.strictEqual(measuredSize(child, "vertical"), null);
+    });
+  });
+
+  module("measuredMax never lands below measuredMin", function () {
+    test("a declared minimum above the cap wins", function (assert) {
+      const element = box("min-height:400px;height:400px;");
+
+      assert.strictEqual(measuredMin(element, "vertical"), 400);
+      assert.strictEqual(
+        measuredMax(element, "vertical", 300),
+        400,
+        "the floor beats a cap that would announce an impossible range"
+      );
+    });
+
+    test("a declared maximum below the minimum still loses to it", function (assert) {
+      const element = box("min-height:400px;max-height:300px;height:400px;");
+
+      assert.strictEqual(measuredMax(element, "vertical", 1000), 400);
+    });
+
+    test("the cap still wins when it sits above the minimum", function (assert) {
+      const element = box("min-height:200px;height:200px;");
+
+      assert.strictEqual(measuredMax(element, "vertical", 500), 500);
+    });
+
+    test("a detached element is capped, with no minimum to floor against", function (assert) {
+      const element = document.createElement("div");
+
+      assert.strictEqual(measuredMax(element, "vertical", 300), 300);
+    });
+  });
+});

--- a/frontend/discourse/tests/unit/services/drag-and-drop-test.js
+++ b/frontend/discourse/tests/unit/services/drag-and-drop-test.js
@@ -1,0 +1,94 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Service | drag-and-drop", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.dragAndDrop = getOwner(this).lookup("service:drag-and-drop");
+  });
+
+  test("setCurrentDrag / clearCurrentDrag round-trip", function (assert) {
+    assert.strictEqual(
+      this.dragAndDrop.currentDrag,
+      null,
+      "nothing is in flight before a drag starts"
+    );
+    this.dragAndDrop.setCurrentDrag({
+      type: "row",
+      data: { id: 1 },
+      element: document.body,
+    });
+    assert.deepEqual(
+      this.dragAndDrop.currentDrag.data,
+      { id: 1 },
+      "the payload is readable while the drag is in flight"
+    );
+    this.dragAndDrop.clearCurrentDrag();
+    assert.strictEqual(
+      this.dragAndDrop.currentDrag,
+      null,
+      "clearing returns the service to its resting state"
+    );
+  });
+
+  test("accepts matches a single type", function (assert) {
+    this.dragAndDrop.setCurrentDrag({
+      type: "row",
+      data: {},
+      element: null,
+    });
+    assert.true(
+      this.dragAndDrop.accepts("row"),
+      "the in-flight type is accepted"
+    );
+    assert.false(
+      this.dragAndDrop.accepts("card"),
+      "a different type is rejected"
+    );
+  });
+
+  test("accepts matches against an array of types", function (assert) {
+    this.dragAndDrop.setCurrentDrag({
+      type: "card",
+      data: {},
+      element: null,
+    });
+    assert.true(
+      this.dragAndDrop.accepts(["row", "card"]),
+      "a list containing the in-flight type is accepted"
+    );
+    assert.false(
+      this.dragAndDrop.accepts(["other"]),
+      "a list without it is rejected"
+    );
+  });
+
+  test("accepts is false when nothing is in flight", function (assert) {
+    assert.false(
+      this.dragAndDrop.accepts("row"),
+      "no drag in flight accepts no single type"
+    );
+    assert.false(
+      this.dragAndDrop.accepts(["a", "b"]),
+      "and accepts no list either"
+    );
+  });
+
+  test("accepts is false when no filter is supplied", function (assert) {
+    this.dragAndDrop.setCurrentDrag({
+      type: "row",
+      data: {},
+      element: null,
+    });
+    assert.false(
+      this.dragAndDrop.accepts(null),
+      "a null filter accepts nothing rather than everything"
+    );
+    assert.false(
+      this.dragAndDrop.accepts(undefined),
+      "an omitted filter accepts nothing either"
+    );
+  });
+});

--- a/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-errors-test.gts
+++ b/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-errors-test.gts
@@ -1,0 +1,28 @@
+// Negative type assertions for the element drag-and-drop primitives: every
+// invocation below MUST fail to compile. They are quarantined here because a
+// `@glint-expect-error` suppresses reporting elsewhere in its file, which
+// would let a positive assertion pass against a broken declaration. Positives
+// live in d-drag-and-drop-test.gts.
+import dDragAndDropSource from "discourse/ui-kit/modifiers/d-drag-and-drop-source";
+import dDragAndDropTarget from "discourse/ui-kit/modifiers/d-drag-and-drop-target";
+
+declare const payload: object;
+
+const Negatives = <template>
+  {{! @glint-expect-error - a selector is not an element; the handle ref must be }}
+  <li {{dDragAndDropSource type="link" dragHandle="#handle"}}></li>
+
+  {{! @glint-expect-error - the discriminator is required, since targets filter on it and the service identifies its own drags by it }}
+  <li {{dDragAndDropSource data=payload}}></li>
+
+  {{! @glint-expect-error - a drag permits a fixed set of operations, and move-copy is not one of their spellings }}
+  <li {{dDragAndDropSource type="link" effectAllowed="moveCopy"}}></li>
+
+  {{! @glint-expect-error - the axis vocabulary is x and y }}
+  <li {{dDragAndDropTarget accepts="link" axis="z"}}></li>
+
+  {{! @glint-expect-error - a drop lands before, after or inside, nowhere else }}
+  <li {{dDragAndDropTarget accepts="link" position="middle"}}></li>
+</template>;
+
+export default Negatives;

--- a/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-test.gts
+++ b/frontend/discourse/type-tests/ui-kit/d-drag-and-drop-test.gts
@@ -1,0 +1,58 @@
+// Positive template invocations of the element drag-and-drop primitives,
+// asserting each Signature resolves in template position. Keep this file free
+// of Glint directives: a single `@glint-expect-error` anywhere makes Glint stop
+// reporting every other error in the file, so a broken declaration would pass
+// unnoticed. Negatives live in d-drag-and-drop-errors-test.gts.
+import { hash } from "@ember/helper";
+import dDragAndDropMonitor from "discourse/ui-kit/modifiers/d-drag-and-drop-monitor";
+import dDragAndDropSource from "discourse/ui-kit/modifiers/d-drag-and-drop-source";
+import dDragAndDropTarget, {
+  DropTargetEvent,
+} from "discourse/ui-kit/modifiers/d-drag-and-drop-target";
+
+declare const noop: () => void;
+declare const handle: HTMLElement;
+declare const payload: object;
+declare const acceptedTypes: string[];
+
+declare function onDropTargetEvent(event: DropTargetEvent): void;
+
+const Positives = <template>
+  {{! A source takes a single type, an arbitrary payload object, and a handle }}
+  <li
+    {{dDragAndDropSource
+      type="sidebar-link"
+      data=payload
+      dragHandle=handle
+      dragPreviewOffset=(hash x="1rem" y="0.5rem")
+      effectAllowed="copyMove"
+      disabled=false
+      onDragStart=noop
+      onDragEnd=noop
+      onDrop=noop
+    }}
+  ></li>
+
+  {{! A target accepts one type or several, and reports a normalised source }}
+  <li
+    {{dDragAndDropTarget accepts="sidebar-link" onDrop=onDropTargetEvent}}
+  ></li>
+  <li
+    {{dDragAndDropTarget
+      accepts=acceptedTypes
+      acceptsSelf=false
+      position="inside"
+      axis="x"
+      indicator=false
+      onDragEnter=onDropTargetEvent
+      onDrag=onDropTargetEvent
+      onDragLeave=onDropTargetEvent
+      onDrop=onDropTargetEvent
+    }}
+  ></li>
+
+  {{! A monitor is global, so any sentinel element carries it }}
+  <div {{dDragAndDropMonitor types=acceptedTypes onDrag=noop}}></div>
+</template>;
+
+export default Positives;

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -9,10 +9,10 @@ import MultiSelect from "discourse/select-kit/components/multi-select";
 import { and, eq, notEq, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
+import DResizeSeparator from "discourse/ui-kit/d-resize-separator";
 import DTextField from "discourse/ui-kit/d-text-field";
 import DTextarea from "discourse/ui-kit/d-textarea";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
-import dDraggable from "discourse/ui-kit/modifiers/d-draggable";
 import { i18n } from "discourse-i18n";
 import CodeView from "discourse/plugins/discourse-data-explorer/discourse/components/code-view";
 import ExplorerSchema from "discourse/plugins/discourse-data-explorer/discourse/components/explorer-schema";
@@ -143,15 +143,17 @@ export default class QueriesEdit extends Component {
                   </div>
                 </div>
 
-                <div
+                <DResizeSeparator
                   class="grippie"
-                  {{dDraggable
-                    didStartDrag=@controller.didStartDrag
-                    didEndDrag=@controller.didEndDrag
-                    dragMove=@controller.dragMove
-                  }}
-                >
-                </div>
+                  @axis="vertical"
+                  @side="start"
+                  @value={{@controller.paneHeight}}
+                  @min={{@controller.minPaneHeight}}
+                  @max={{@controller.maxPaneHeight}}
+                  @label={{i18n "explorer.resize_editor"}}
+                  @measure={{@controller.panesFor}}
+                  @onResize={{@controller.onPaneResize}}
+                />
 
                 <div class="clear"></div>
               {{else}}
@@ -276,16 +278,17 @@ export default class QueriesEdit extends Component {
                 </div>
               </div>
 
-              <div
+              <DResizeSeparator
                 class="grippie"
-                {{dDraggable
-                  didStartDrag=@controller.didStartDrag
-                  didEndDrag=@controller.didEndDrag
-                  dragMove=@controller.dragMove
-                }}
-              >
-                {{dIcon "discourse-expand"}}
-              </div>
+                @axis="vertical"
+                @side="start"
+                @value={{@controller.paneHeight}}
+                @min={{@controller.minPaneHeight}}
+                @max={{@controller.maxPaneHeight}}
+                @label={{i18n "explorer.resize_editor"}}
+                @measure={{@controller.panesFor}}
+                @onResize={{@controller.onPaneResize}}
+              >{{dIcon "discourse-expand"}}</DResizeSeparator>
 
               <div class="clear"></div>
             {{else}}

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -12,7 +12,6 @@ import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-s
 import DResizeSeparator from "discourse/ui-kit/d-resize-separator";
 import DTextField from "discourse/ui-kit/d-text-field";
 import DTextarea from "discourse/ui-kit/d-textarea";
-import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import CodeView from "discourse/plugins/discourse-data-explorer/discourse/components/code-view";
 import ExplorerSchema from "discourse/plugins/discourse-data-explorer/discourse/components/explorer-schema";
@@ -22,6 +21,18 @@ import QueryModeSwitch from "discourse/plugins/discourse-data-explorer/discourse
 import QueryResultDownloadButtons from "discourse/plugins/discourse-data-explorer/discourse/components/query-result-download-buttons";
 import QueryResultsWrapper from "discourse/plugins/discourse-data-explorer/discourse/components/query-results-wrapper";
 import QueryRunSplitButton from "discourse/plugins/discourse-data-explorer/discourse/components/query-run-split-button";
+
+const PaneSeparator = <template>
+  <DResizeSeparator
+    class="grippie"
+    @axis="vertical"
+    @side="start"
+    @max={{@controller.maxPaneHeight}}
+    @label={{i18n "explorer.resize_editor"}}
+    @measure={{@controller.panesFor}}
+    @onResize={{@controller.onPaneResize}}
+  />
+</template>;
 
 export default class QueriesEdit extends Component {
   get showDestroyQuery() {
@@ -122,7 +133,7 @@ export default class QueriesEdit extends Component {
               </div>
 
               {{#if @controller.editingQuery}}
-                <div class="panels-flex">
+                <div class="panels-flex query-editor__panes">
                   <div class="editor-panel">
                     <AceEditor
                       @content={{@controller.model.sql}}
@@ -143,17 +154,7 @@ export default class QueriesEdit extends Component {
                   </div>
                 </div>
 
-                <DResizeSeparator
-                  class="grippie"
-                  @axis="vertical"
-                  @side="start"
-                  @value={{@controller.paneHeight}}
-                  @min={{@controller.minPaneHeight}}
-                  @max={{@controller.maxPaneHeight}}
-                  @label={{i18n "explorer.resize_editor"}}
-                  @measure={{@controller.panesFor}}
-                  @onResize={{@controller.onPaneResize}}
-                />
+                <PaneSeparator @controller={{@controller}} />
 
                 <div class="clear"></div>
               {{else}}
@@ -257,7 +258,7 @@ export default class QueriesEdit extends Component {
             </div>
 
             {{#if @controller.editingQuery}}
-              <div class="panels-flex">
+              <div class="panels-flex query-editor__panes">
                 <div class="editor-panel">
                   <AceEditor
                     @content={{@controller.model.sql}}
@@ -278,17 +279,7 @@ export default class QueriesEdit extends Component {
                 </div>
               </div>
 
-              <DResizeSeparator
-                class="grippie"
-                @axis="vertical"
-                @side="start"
-                @value={{@controller.paneHeight}}
-                @min={{@controller.minPaneHeight}}
-                @max={{@controller.maxPaneHeight}}
-                @label={{i18n "explorer.resize_editor"}}
-                @measure={{@controller.panesFor}}
-                @onResize={{@controller.onPaneResize}}
-              >{{dIcon "discourse-expand"}}</DResizeSeparator>
+              <PaneSeparator @controller={{@controller}} />
 
               <div class="clear"></div>
             {{else}}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
@@ -7,6 +7,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import { bind } from "discourse/lib/decorators";
+import { measuredMin } from "discourse/lib/resize-measurements";
 import { i18n } from "discourse-i18n";
 import QueryHelp from "discourse/plugins/discourse-data-explorer/discourse/components/modal/query-help";
 import { ParamValidationError } from "discourse/plugins/discourse-data-explorer/discourse/components/param-input-form";
@@ -47,13 +48,13 @@ export default class PluginsExplorerController extends Controller {
   form = null;
   shouldAutoRun = false;
 
-  #originalPaneHeight = null;
-
   /**
-   * The panes the live separator resolved, so the reader and the writer cannot
-   * disagree with the observer about which editor they belong to. A global
-   * first-match query would pick whichever editor happens to be first in the
-   * document.
+   * A weak handle on the panes the live separator resolved, rather than a global
+   * query that would find whichever editor comes first in the document.
+   *
+   * Weak because this controller is an app-lifetime singleton and the separator
+   * can go without telling it, so a strong reference would hold a detached
+   * subtree until something else replaced it.
    */
   #resolvedPanes = null;
   _pristine = null;
@@ -177,8 +178,9 @@ export default class PluginsExplorerController extends Controller {
     return items;
   }
 
+  /** The one place the weak handle is dereferenced. */
   get #panes() {
-    return this.#resolvedPanes;
+    return this.#resolvedPanes?.deref() ?? null;
   }
 
   initView() {
@@ -196,71 +198,31 @@ export default class PluginsExplorerController extends Controller {
   }
 
   /**
-   * The panes the separator resizes, found from the separator's own position so the
-   * two cannot disagree about which editor they belong to.
+   * The panes the separator resizes, found from the separator's own position.
    *
    * @param {HTMLElement} separator - The separator element.
    * @returns {HTMLElement|null} The panes, or null before they render.
    */
   @bind
   panesFor(separator) {
-    this.#resolvedPanes =
+    const panes =
       separator.closest(".query-editor")?.querySelector(".panels-flex") ?? null;
-    // A fresh separator means a fresh minimum. This runs once per separator
-    // install (the modifier's args never change), so a same-route transition
-    // that reuses the element keeps the previous bound — the ordinary path
-    // through the index tears the template down and re-lands here.
-    this.#originalPaneHeight = null;
-    return this.#resolvedPanes;
-  }
-
-  /**
-   * The panes' current height.
-   *
-   * A function rather than a number because it is a live measurement: an arg whose
-   * compute reads no tracked state is cached for the modifier's lifetime, so every
-   * drag after the first would start from the first one's height.
-   *
-   * @returns {number} The height in pixels.
-   */
-  @bind
-  paneHeight() {
-    return this.#panes?.clientHeight ?? 0;
-  }
-
-  /**
-   * The smallest the panes may be dragged to, which is the height they were first
-   * seen at. Captured once, so shrinking is bounded by the layout's own idea of a
-   * reasonable editor rather than by an arbitrary constant.
-   *
-   * @returns {number} The minimum height in pixels.
-   */
-  @bind
-  minPaneHeight() {
-    const measured = this.paneHeight();
-    // Zero means the panes have not been laid out yet — the narrow layout makes
-    // their height content-driven and the editor loads asynchronously. Capturing
-    // that would pin the minimum at zero and let the editor be dragged shut.
-    if (measured > 0) {
-      this.#originalPaneHeight ??= measured;
-    }
-    return this.#originalPaneHeight ?? measured;
+    this.#resolvedPanes = panes ? new WeakRef(panes) : null;
+    // The element, not the handle. It goes straight to a ResizeObserver.
+    return panes;
   }
 
   /**
    * The largest the panes may be dragged to.
    *
-   * A screenful, not the space below the header: these panes sit in a page that
-   * scrolls, so growing them lengthens the page rather than pushing anything out of
-   * view, and subtracting a header offset here would cap them below their own
-   * resting height on a short window. Past one screen the results are off-screen
-   * anyway, which is what makes a screenful the useful limit.
+   * A screenful, not the space below the header. This page scrolls, so growing
+   * the panes lengthens it rather than pushing anything out of view.
    *
    * @returns {number} The maximum height in pixels.
    */
   @bind
   maxPaneHeight() {
-    return Math.max(window.innerHeight, this.minPaneHeight());
+    return Math.max(window.innerHeight, measuredMin(this.#panes, "vertical"));
   }
 
   @bind
@@ -274,15 +236,9 @@ export default class PluginsExplorerController extends Controller {
     this.appEvents.trigger("ace:resize");
   }
 
-  /**
-   * Lets go of the resolved panes and the height bound derived from them.
-   * Called from the route on exit: this controller is an app-lifetime
-   * singleton, so a reference kept here would hold the detached editor subtree
-   * alive until the next visit resolved a fresh one.
-   */
+  /** Lets go of the panes. Called by the route on exit. */
   releasePanes() {
     this.#resolvedPanes = null;
-    this.#originalPaneHeight = null;
   }
 
   @action

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
@@ -46,6 +46,16 @@ export default class PluginsExplorerController extends Controller {
   order = null;
   form = null;
   shouldAutoRun = false;
+
+  #originalPaneHeight = null;
+
+  /**
+   * The panes the live separator resolved, so the reader and the writer cannot
+   * disagree with the observer about which editor they belong to. A global
+   * first-match query would pick whichever editor happens to be first in the
+   * document.
+   */
+  #resolvedPanes = null;
   _pristine = null;
   _teardownAiGeneration = null;
   _aiGenerationToken = 0;
@@ -167,6 +177,10 @@ export default class PluginsExplorerController extends Controller {
     return items;
   }
 
+  get #panes() {
+    return this.#resolvedPanes;
+  }
+
   initView() {
     const queryId = this.model?.id;
     const stored = queryId ? dataExplorerStore.get(`view_${queryId}`) : null;
@@ -179,6 +193,96 @@ export default class PluginsExplorerController extends Controller {
     } else {
       this.view = defaultView(this.results);
     }
+  }
+
+  /**
+   * The panes the separator resizes, found from the separator's own position so the
+   * two cannot disagree about which editor they belong to.
+   *
+   * @param {HTMLElement} separator - The separator element.
+   * @returns {HTMLElement|null} The panes, or null before they render.
+   */
+  @bind
+  panesFor(separator) {
+    this.#resolvedPanes =
+      separator.closest(".query-editor")?.querySelector(".panels-flex") ?? null;
+    // A fresh separator means a fresh minimum. This runs once per separator
+    // install (the modifier's args never change), so a same-route transition
+    // that reuses the element keeps the previous bound — the ordinary path
+    // through the index tears the template down and re-lands here.
+    this.#originalPaneHeight = null;
+    return this.#resolvedPanes;
+  }
+
+  /**
+   * The panes' current height.
+   *
+   * A function rather than a number because it is a live measurement: an arg whose
+   * compute reads no tracked state is cached for the modifier's lifetime, so every
+   * drag after the first would start from the first one's height.
+   *
+   * @returns {number} The height in pixels.
+   */
+  @bind
+  paneHeight() {
+    return this.#panes?.clientHeight ?? 0;
+  }
+
+  /**
+   * The smallest the panes may be dragged to, which is the height they were first
+   * seen at. Captured once, so shrinking is bounded by the layout's own idea of a
+   * reasonable editor rather than by an arbitrary constant.
+   *
+   * @returns {number} The minimum height in pixels.
+   */
+  @bind
+  minPaneHeight() {
+    const measured = this.paneHeight();
+    // Zero means the panes have not been laid out yet — the narrow layout makes
+    // their height content-driven and the editor loads asynchronously. Capturing
+    // that would pin the minimum at zero and let the editor be dragged shut.
+    if (measured > 0) {
+      this.#originalPaneHeight ??= measured;
+    }
+    return this.#originalPaneHeight ?? measured;
+  }
+
+  /**
+   * The largest the panes may be dragged to.
+   *
+   * A screenful, not the space below the header: these panes sit in a page that
+   * scrolls, so growing them lengthens the page rather than pushing anything out of
+   * view, and subtracting a header offset here would cap them below their own
+   * resting height on a short window. Past one screen the results are off-screen
+   * anyway, which is what makes a screenful the useful limit.
+   *
+   * @returns {number} The maximum height in pixels.
+   */
+  @bind
+  maxPaneHeight() {
+    return Math.max(window.innerHeight, this.minPaneHeight());
+  }
+
+  @bind
+  onPaneResize(size) {
+    const panes = this.#panes;
+    if (!panes) {
+      return;
+    }
+
+    panes.style.height = `${size}px`;
+    this.appEvents.trigger("ace:resize");
+  }
+
+  /**
+   * Lets go of the resolved panes and the height bound derived from them.
+   * Called from the route on exit: this controller is an app-lifetime
+   * singleton, so a reference kept here would hold the detached editor subtree
+   * alive until the next visit resolved a fresh one.
+   */
+  releasePanes() {
+    this.#resolvedPanes = null;
+    this.#originalPaneHeight = null;
   }
 
   @action
@@ -337,37 +441,6 @@ export default class PluginsExplorerController extends Controller {
       reader.readAsText(file);
     });
   }
-
-  @bind
-  dragMove(e) {
-    if (!e.movementX) {
-      return;
-    }
-
-    const editPane = document.querySelector(".query-editor");
-    const target = editPane.querySelector(".panels-flex");
-
-    // we need to get the initial height / width of edit pane
-    // before we manipulate the size
-    if (!this.initialPaneWidth && !this.originalPaneHeight) {
-      this.originalPaneHeight = target.clientHeight;
-    }
-
-    const newHeight = Math.max(
-      this.originalPaneHeight,
-      target.clientHeight + e.movementY
-    );
-
-    target.style.height = newHeight + "px";
-
-    this.appEvents.trigger("ace:resize");
-  }
-
-  @bind
-  didStartDrag() {}
-
-  @bind
-  didEndDrag() {}
 
   @action
   updateGroupIds(value) {

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/index.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/index.js
@@ -12,7 +12,6 @@ import { i18n } from "discourse-i18n";
 
 export default class PluginsExplorerController extends Controller {
   @service dialog;
-  @service appEvents;
   @service router;
   @service store;
 
@@ -66,38 +65,6 @@ export default class PluginsExplorerController extends Controller {
 
       reader.readAsText(file);
     });
-  }
-
-  @bind
-  dragMove(e) {
-    if (!e.movementY && !e.movementX) {
-      return;
-    }
-
-    const editPane = document.querySelector(".query-editor");
-    const target = editPane.querySelector(".panels-flex");
-    const grippie = editPane.querySelector(".grippie");
-
-    // we need to get the initial height / width of edit pane
-    // before we manipulate the size
-    if (!this.initialPaneWidth && !this.originalPaneHeight) {
-      this.originalPaneWidth = target.clientWidth;
-      this.originalPaneHeight = target.clientHeight;
-    }
-
-    const newHeight = Math.max(
-      this.originalPaneHeight,
-      target.clientHeight + e.movementY
-    );
-    const newWidth = Math.max(
-      this.originalPaneWidth,
-      target.clientWidth + e.movementX
-    );
-
-    target.style.height = newHeight + "px";
-    target.style.width = newWidth + "px";
-    grippie.style.width = newWidth + "px";
-    this.appEvents.trigger("ace:resize");
   }
 
   @bind

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
@@ -86,6 +86,7 @@ export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller._teardownAi();
+      controller.releasePanes();
     }
   }
 }

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -315,7 +315,6 @@ table.group-reports {
   }
 
   .grippie {
-    cursor: nwse-resize;
     padding-bottom: var(--space-2);
     user-select: none;
     color: var(--primary);

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -115,6 +115,25 @@ table.group-reports {
     }
   }
 
+  /* The floor a resize may not cross, read from here by the separator. Declared
+     rather than measured once, so it follows the layout rather than whichever
+     state the editor opened in. Carried by a class, so panes without a separator
+     keep their own sizing. */
+
+  .query-editor__panes {
+    min-height: 400px;
+
+    @include viewport.until(sm) {
+      min-height: 548px;
+    }
+  }
+
+  &.no-schema .query-editor__panes {
+    @include viewport.until(sm) {
+      min-height: 300px;
+    }
+  }
+
   .editor-panel {
     flex: 1 0 50%;
 
@@ -317,8 +336,6 @@ table.group-reports {
   .grippie {
     padding-bottom: var(--space-2);
     user-select: none;
-    color: var(--primary);
-    text-align: right;
   }
 }
 

--- a/plugins/discourse-data-explorer/config/locales/client.en.yml
+++ b/plugins/discourse-data-explorer/config/locales/client.en.yml
@@ -22,6 +22,7 @@ en:
         title: "Create a Data Explorer query"
         description: "Write a custom SQL query to surface anything specific to your community."
     explorer:
+      resize_editor: "Resize the query editor"
       default_query: "Default"
       default_query_notice: "This is a default query, the SQL cannot be edited. To edit the SQL, create a new query."
       queries: "Queries"

--- a/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_query_runner.rb
+++ b/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_query_runner.rb
@@ -131,6 +131,40 @@ module PageObjects
       def has_chart?
         page.has_css?(".query-results .chart-canvas-container")
       end
+
+      def collapse_schema
+        page.find(".schema__toggle.--collapse").click
+        self
+      end
+
+      # Clicked through the DOM. Stacked, this affordance sits past the left edge
+      # of the viewport, where a real click cannot land on it.
+      def expand_schema
+        page.execute_script("document.querySelector('.schema__toggle.--expand').click()")
+        self
+      end
+
+      # Drags the editor separator, negative to shrink.
+      def resize_panes_by(y)
+        drag_with_pointer(from: ".query-editor .grippie", by: { y: y })
+        self
+      end
+
+      # The floor the separator announces for the layout as it stands.
+      def pane_floor
+        page.find(".query-editor .grippie")["aria-valuemin"].to_f
+      end
+
+      # How much taller the panes' content is than the box clipping it. One pixel
+      # is not overflow; the two readings round independently.
+      def pane_overflow
+        page.evaluate_script(<<~JS)
+          (() => {
+            const panes = document.querySelector(".query-editor .panels-flex");
+            return Math.max(0, panes.scrollHeight - panes.clientHeight - 1);
+          })()
+        JS
+      end
     end
   end
 end

--- a/plugins/discourse-data-explorer/spec/system/query_editor_resize_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/query_editor_resize_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe "Data explorer query editor resizing" do
+  fab!(:admin)
+  fab!(:query) { Fabricate(:query, name: "Resize", sql: "SELECT 1", user: admin) }
+
+  let(:query_runner) { PageObjects::Pages::DataExplorerQueryRunner.new }
+
+  before do
+    SiteSetting.data_explorer_enabled = true
+    sign_in admin
+  end
+
+  # Narrow enough for the stacked layout, where the panes are content-sized and a
+  # short floor clips them. Wide, they have a fixed height and cannot overflow.
+  def in_the_stacked_layout(&block)
+    resize_window(width: 500, height: 900, &block)
+  end
+
+  def shrink_hard
+    query_runner.resize_panes_by(-400)
+    # Asserted through a retry: the drag bypasses Capybara's settle wait.
+    try_until_success { expect(query_runner.pane_overflow).to eq(0) }
+  end
+
+  it "will not shrink the panes past the content they clip" do
+    in_the_stacked_layout do
+      query_runner.visit_admin_query(query.id)
+      expect(page).to have_css(".query-editor .panels-flex")
+
+      shrink_hard
+    end
+  end
+
+  it "will not shrink past the shorter content left when the schema is hidden" do
+    in_the_stacked_layout do
+      query_runner.visit_admin_query(query.id)
+      expect(page).to have_css(".query-editor .panels-flex")
+      query_runner.collapse_schema
+      expect(page).to have_css(".query-editor.no-schema")
+
+      shrink_hard
+    end
+  end
+
+  it "asks less of the layout once the schema is out of it" do
+    in_the_stacked_layout do
+      query_runner.visit_admin_query(query.id)
+      expect(page).to have_css(".query-editor .panels-flex")
+      with_schema = query_runner.pane_floor
+
+      query_runner.collapse_schema
+      expect(page).to have_css(".query-editor.no-schema")
+
+      # Stacked, the floor is what the panes rest at, not just a drag limit. The
+      # taller figure would leave the editor standing in space it cannot fill.
+      expect(query_runner.pane_floor).to be < with_schema
+    end
+  end
+
+  it "follows the schema appearing after the panes were first measured without it" do
+    in_the_stacked_layout do
+      query_runner.visit_admin_query(query.id)
+      query_runner.collapse_schema
+      expect(page).to have_css(".query-editor.no-schema")
+
+      # Revisited so the editor is built with the schema already hidden. Only
+      # this order leaves a captured floor too low for the content that follows.
+      query_runner.visit_admin_query(query.id)
+      expect(page).to have_css(".query-editor.no-schema")
+      query_runner.expand_schema
+      expect(page).to have_no_css(".query-editor.no-schema")
+
+      shrink_hard
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/run-query-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/run-query-test.js
@@ -452,8 +452,7 @@ acceptance("Run Query", function (needs) {
       pointerId: 1,
       clientY: 200,
     });
-    // Straight down, with no sideways movement at all. The handle used to gate on
-    // horizontal travel while resizing on vertical, so this did nothing.
+    // No sideways movement: a vertical resize must not need any.
     await triggerEvent(grippie, "pointermove", { pointerId: 1, clientY: 240 });
     await settleGestureFrame();
 
@@ -482,14 +481,20 @@ acceptance("Run Query", function (needs) {
 
     const grippie = find(".query-editor .grippie");
 
-    // It had no role, no tab stop and no keyboard path before this; an admin-only
-    // surface is still a surface.
     assert
       .dom(grippie)
       .hasAttribute("role", "separator")
       .hasAttribute("aria-orientation", "horizontal")
       .hasAttribute("tabindex", "0")
       .hasAttribute("data-resize-axis", "vertical");
+    assert
+      .dom(grippie)
+      .hasAttribute(
+        "aria-label",
+        i18n("explorer.resize_editor"),
+        "the separator says what it resizes rather than announcing a bare splitter"
+      );
+
     const panes = find(".query-editor .panels-flex");
     const startingHeight = panes.clientHeight;
     await triggerKeyEvent(grippie, "keydown", "ArrowDown");
@@ -497,6 +502,85 @@ acceptance("Run Query", function (needs) {
     assert.true(
       parseInt(panes.style.height, 10) > startingHeight,
       "arrow keys resize it without a pointer"
+    );
+  });
+
+  test("the separator announces a size inside the bounds it announces", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/2");
+
+    const grippie = find(".query-editor .grippie");
+    const read = (name) => parseFloat(grippie.getAttribute(name));
+
+    // Asserted against each other, not against pixels. The numbers depend on the
+    // stylesheet and the window; a size outside its own range is wrong regardless.
+    assert.true(
+      Number.isFinite(read("aria-valuenow")),
+      "a size is announced once the panes are measured"
+    );
+    assert.true(
+      read("aria-valuemin") <= read("aria-valuenow"),
+      "the announced size is not below the announced minimum"
+    );
+    assert.true(
+      read("aria-valuenow") <= read("aria-valuemax"),
+      "the announced size is not above the announced maximum"
+    );
+  });
+
+  test("dragging far past the maximum stops at it", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/2");
+
+    const grippie = find(".query-editor .grippie");
+    const panes = find(".query-editor .panels-flex");
+    stubPointerCapture(grippie);
+    const ceiling = parseFloat(grippie.getAttribute("aria-valuemax"));
+
+    await triggerEvent(grippie, "pointerdown", {
+      button: 0,
+      pointerId: 1,
+      clientY: 200,
+    });
+    await triggerEvent(grippie, "pointermove", {
+      pointerId: 1,
+      clientY: 200 + ceiling * 3,
+    });
+    await settleGestureFrame();
+    await triggerEvent(grippie, "pointerup", {
+      pointerId: 1,
+      clientY: 200 + ceiling * 3,
+    });
+
+    assert.true(
+      parseFloat(panes.style.height) <= ceiling,
+      "the panes stop at the maximum rather than following the pointer"
+    );
+  });
+
+  test("a separator torn down mid-gesture writes nothing afterwards", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/2");
+
+    const grippie = find(".query-editor .grippie");
+    const panes = find(".query-editor .panels-flex");
+    stubPointerCapture(grippie);
+
+    await triggerEvent(grippie, "pointerdown", {
+      button: 0,
+      pointerId: 1,
+      clientY: 200,
+    });
+    await triggerEvent(grippie, "pointermove", { pointerId: 1, clientY: 260 });
+    await settleGestureFrame();
+    const heightWhenTornDown = panes.style.height;
+
+    // Leaving the route with the gesture still held: the separator goes, and the
+    // controller is a singleton that outlives it.
+    await visit("/admin/plugins/discourse-data-explorer");
+    await triggerEvent(document, "pointerup", { pointerId: 1, clientY: 900 });
+
+    assert.strictEqual(
+      panes.style.height,
+      heightWhenTornDown,
+      "the detached panes keep the size they had when the separator went"
     );
   });
 });

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/run-query-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/run-query-test.js
@@ -1,7 +1,17 @@
-import { click, visit } from "@ember/test-helpers";
+import {
+  click,
+  find,
+  triggerEvent,
+  triggerKeyEvent,
+  visit,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import sinon from "sinon";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import {
+  settleGestureFrame,
+  stubPointerCapture,
+} from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
 import { i18n } from "discourse-i18n";
 
 acceptance("Run Query", function (needs) {
@@ -427,5 +437,66 @@ acceptance("Run Query", function (needs) {
     await visit("/g/testgroup/reports/2?run=1");
 
     assert.dom("div.query-results").exists("query results should be displayed");
+  });
+
+  test("dragging the grippie resizes the editor panes", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/2");
+
+    const grippie = find(".query-editor .grippie");
+    const panes = find(".query-editor .panels-flex");
+    stubPointerCapture(grippie);
+    const startingHeight = panes.clientHeight;
+
+    await triggerEvent(grippie, "pointerdown", {
+      button: 0,
+      pointerId: 1,
+      clientY: 200,
+    });
+    // Straight down, with no sideways movement at all. The handle used to gate on
+    // horizontal travel while resizing on vertical, so this did nothing.
+    await triggerEvent(grippie, "pointermove", { pointerId: 1, clientY: 240 });
+    await settleGestureFrame();
+
+    assert.strictEqual(
+      panes.style.height,
+      `${startingHeight + 40}px`,
+      "the panes grow by the pointer's vertical travel"
+    );
+    // Asserted mid-gesture as well as after: absence on release alone would
+    // pass against a resize that never held the cursor at all.
+    assert
+      .dom(document.body)
+      .hasClass("d-resizing-ns", "the cursor is held while the drag runs");
+
+    await triggerEvent(grippie, "pointerup", { pointerId: 1, clientY: 240 });
+    assert
+      .dom(document.body)
+      .doesNotHaveClass(
+        "d-resizing-ns",
+        "the held cursor is given back on release"
+      );
+  });
+
+  test("the grippie is an operable separator", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/2");
+
+    const grippie = find(".query-editor .grippie");
+
+    // It had no role, no tab stop and no keyboard path before this; an admin-only
+    // surface is still a surface.
+    assert
+      .dom(grippie)
+      .hasAttribute("role", "separator")
+      .hasAttribute("aria-orientation", "horizontal")
+      .hasAttribute("tabindex", "0")
+      .hasAttribute("data-resize-axis", "vertical");
+    const panes = find(".query-editor .panels-flex");
+    const startingHeight = panes.clientHeight;
+    await triggerKeyEvent(grippie, "keydown", "ArrowDown");
+
+    assert.true(
+      parseInt(panes.style.height, 10) > startingHeight,
+      "arrow keys resize it without a pointer"
+    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
 
   frontend/discourse:
     dependencies:
+      '@atlaskit/pragmatic-drag-and-drop':
+        specifier: ^1.7.4
+        version: 1.8.1
       '@codemirror/autocomplete':
         specifier: ^6.20.3
         version: 6.20.3
@@ -973,6 +976,9 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@atlaskit/pragmatic-drag-and-drop@1.8.1':
+    resolution: {integrity: sha512-uXWNPpL8n4OmTVbduH7nq8pk8htqGo/prR5cYEE8sVCPJGAUMWn6lzvWTfI+4VCeQvHiDRODVz4YzH06OVAxhw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -3530,6 +3536,9 @@ packages:
 
   bind-decorator@1.0.11:
     resolution: {integrity: sha512-yzkH0uog6Vv/vQ9+rhSKxecnqGUZHYncg7qS7voz3Q76+TAi1SGiOKk2mlOvusQnFz9Dc4BC/NMkeXu11YgjJg==}
+
+  bind-event-listener@3.0.0:
+    resolution: {integrity: sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -6988,6 +6997,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  raf-schd@4.0.3:
+    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -8453,6 +8465,12 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@atlaskit/pragmatic-drag-and-drop@1.8.1':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      bind-event-listener: 3.0.0
+      raf-schd: 4.0.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -11564,6 +11582,8 @@ snapshots:
   binaryextensions@2.3.0: {}
 
   bind-decorator@1.0.11: {}
+
+  bind-event-listener@3.0.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -15709,6 +15729,8 @@ snapshots:
       commander: 7.2.0
       node-watch: 0.7.3
       tiny-glob: 0.2.9
+
+  raf-schd@4.0.3: {}
 
   range-parser@1.2.1: {}
 

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -422,8 +422,50 @@ module SystemHelpers
     page.driver.with_playwright_page { |pw_page| pw_page.touchscreen.tap_point(x, y) }
   end
 
+  # Drives a real native drag through Playwright's CDP drag interception.
+  #
+  # Capybara's own `drag_to` synthesises mouse events (mousedown/move/up), which
+  # works for simple drags but is unreliable here: some drags fire `dragstart` and
+  # then stall with no `dragover`/`drop`/`dragend`, so the drop silently no-ops.
+  # That is what a drag into a multi-layer region tends to do.
+  #
+  # `source:` and `target:` are CSS selectors, and BOTH ends may need a position.
+  # `source_position:` matters whenever the press point decides whether a drag is
+  # an element drag at all: pressing the centre of a row that contains a text
+  # input starts a text-selection drag, which fires `dragstart` and then stalls
+  # with no further events. Point it at the row's grip instead. It is also how a
+  # drag handle is satisfied, since the press must land inside the handle while
+  # the drag itself originates from the registered element.
+  #
+  # `target_position:` (`{ x:, y: }`,
+  # relative to the target's top-left) picks where inside the target the drop
+  # lands, which is what a before/after drop zone needs: the target's centre is
+  # the ambiguous midpoint and resolves the same way every time. `steps:` smooths
+  # the pointer movement when a drag needs more intermediate moves to register.
+  #
+  # Note this does NOT wait for the client to settle. Capybara's patched node
+  # methods, `drag_to` among them, get that wait for free; driving Playwright
+  # directly bypasses it, and the wait is only reachable from the driver's own
+  # patch. So assert through a retrying matcher after calling this, not a bare
+  # equality on a value read once.
+  def drag_and_drop(source:, target:, source_position: nil, target_position: nil, steps: nil)
+    page.driver.with_playwright_page do |pw_page|
+      options = {}
+      options[:sourcePosition] = source_position if source_position
+      options[:targetPosition] = target_position if target_position
+      options[:steps] = steps if steps
+      pw_page.drag_and_drop(source, target, **options)
+    end
+  end
+
   # Drives a press-drag-release with the real mouse, for the surfaces built on
   # pointer events rather than native drag-and-drop.
+  #
+  # `drag_and_drop` above is NOT interchangeable with this: it goes through
+  # Playwright's CDP drag interception, which is what makes a native HTML5 drag
+  # work and which suppresses the ordinary mouse moves a pointer gesture needs. A
+  # pointer-driven surface therefore sees the press and then nothing, and looks
+  # exactly like a dead drag. Pick the helper that matches the mechanism.
   #
   # `from:` is a CSS selector for the element to press. `to:` is an absolute
   # viewport point; `by:` is an offset from the press point, for when the distance
@@ -431,12 +473,14 @@ module SystemHelpers
   # gesture with a movement threshold actually crosses it, and so anything driven
   # by intermediate moves sees more than one.
   #
-  # This bypasses Capybara's client-settle wait, so assert through a retrying
-  # matcher rather than a value read once.
+  # Like `drag_and_drop`, this bypasses Capybara's client-settle wait, so assert
+  # through a retrying matcher rather than a value read once.
   #
-  # The mouse moves through absolute viewport coordinates. An element below the
-  # fold would otherwise be measured where it cannot be pressed, so it is scrolled
-  # into view first and measured after.
+  # Unlike `drag_and_drop`, which scrolls its source into view itself, this drives
+  # the mouse at absolute viewport coordinates. An element below the fold would
+  # otherwise be measured where it cannot be pressed, and the gesture would land on
+  # whatever is at that point instead — doing nothing while reporting success. So
+  # it is scrolled into view first, and measured after.
   #
   # Pass a block to assert on the page while the gesture is still open: it runs
   # after the pointer has moved and before the release, so anything a drag holds


### PR DESCRIPTION
Previously, reorder consumers had to provide their own drag grips, keyboard controls, focus restoration, and announcements.

This change adds shared `DDragHandle` and `DReorderButtons` components with keyboard-operable movement, persistent focus, coarse-pointer targets, and a common announcement string.
