### PR TITLE
DEV: Move report reordering onto `DReorderableList`

### DIFF
--- a/app/assets/stylesheets/common/modal/manage-reports-modal.scss
+++ b/app/assets/stylesheets/common/modal/manage-reports-modal.scss
@@ -8,6 +8,11 @@
 
   &__search-wrapper {
     padding: var(--space-2) 1.5rem;
+
+    /* Not decoration: rows draw their separator on their own bottom edge, so this
+       is what supplies the first row's top one. Removing it is why the first row
+       needs its own `--drag-above` rule below rather than borrowing a
+       predecessor's edge like every other row. */
     border-bottom: 1px solid var(--primary-low);
     background: var(--secondary);
   }
@@ -34,33 +39,34 @@
       inset 0 2px 0 0 transparent,
       inset 0 -2px 0 0 transparent;
 
-    .manage-reports__list.--dragging & {
-      transition: box-shadow 0.1s ease;
-    }
-
     &:not(:last-child) {
       border-bottom: 1px solid var(--primary-low);
     }
 
-    &[draggable="true"] {
-      cursor: grab;
+    /* The grip is what the row is grabbed by, and it carries its own cursor. A
+       row-wide `grab` would promise that the text beside it drags too, when
+       pressing there selects instead. */
+
+    /* Rows carry their own separator, so "above row N" is drawn on row N-1's bottom
+       edge instead, and nothing doubles up. The shared primitive's inserted lines are
+       dropped in favour of these insets. */
+
+    &.--drag-above::before,
+    &.--drag-below::after {
+      content: none;
     }
 
-    &.dragging {
-      opacity: 0.5;
-    }
-
-    &.drag-below,
-    &:not(.dragging):has(+ .manage-reports__row.drag-above) {
+    &.--drag-below,
+    &:not(.--dragging):has(+ .manage-reports__row.--drag-above) {
       box-shadow:
         inset 0 2px 0 0 transparent,
-        inset 0 -2px 0 0 var(--tertiary);
+        inset 0 -2px 0 0 var(--d-drag-indicator-color);
     }
 
-    &:first-child.drag-above,
-    .manage-reports__row.dragging + &.drag-above {
+    &:first-child.--drag-above,
+    .manage-reports__row.--dragging + &.--drag-above {
       box-shadow:
-        inset 0 2px 0 0 var(--tertiary),
+        inset 0 2px 0 0 var(--d-drag-indicator-color),
         inset 0 -2px 0 0 transparent;
     }
 
@@ -69,8 +75,7 @@
     }
   }
 
-  &__grip {
-    align-self: flex-start;
+  .d-reorderable-list__handle {
     color: var(--primary-low-mid);
     visibility: hidden;
 
@@ -79,10 +84,7 @@
     }
   }
 
-  &__order-mobile {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
+  .d-reorderable-list__arrows {
     visibility: hidden;
 
     .manage-reports__list.--reorderable .manage-reports__row.--enabled & {
@@ -118,10 +120,6 @@
     color: var(--primary-medium);
     font-size: var(--font-down-1);
     text-transform: capitalize;
-  }
-
-  &__arrow {
-    flex: 0 0 auto;
   }
 
   .d-modal__footer {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7625,8 +7625,6 @@ en:
             apply: "Apply"
             enable: "Enable %{title}"
             disable: "Disable %{title}"
-            move_up: "Move %{title} up"
-            move_down: "Move %{title} down"
             footer_note: "These changes will apply for all users."
 
         configure:

--- a/frontend/discourse/admin/components/modal/manage-reports.gjs
+++ b/frontend/discourse/admin/components/modal/manage-reports.gjs
@@ -3,171 +3,57 @@ import { tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
-import { and, eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DModal from "discourse/ui-kit/d-modal";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
-import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 const VISIBLE_CAP = 10;
 const SEARCH_DEBOUNCE_MS = 200;
 
-class ManageReportsRow extends Component {
-  @service site;
-
-  @tracked dragCssClass;
-  dragCount = 0;
-
-  isAboveElement(event) {
-    const domRect = event.currentTarget.getBoundingClientRect();
-    return event.offsetY < domRect.height / 2;
-  }
-
-  @action
-  dragStart(event) {
-    event.dataTransfer.effectAllowed = "move";
-    this.args.onDragStart(this.args.row.key);
-    this.dragCssClass = "dragging";
-  }
-
-  @action
-  dragOver(event) {
-    if (!this.args.row.enabled) {
-      return;
-    }
-    event.preventDefault();
-    if (this.dragCssClass === "dragging") {
-      return;
-    }
-    this.dragCssClass = this.isAboveElement(event)
-      ? "drag-above"
-      : "drag-below";
-  }
-
-  @action
-  dragEnter() {
-    this.dragCount++;
-  }
-
-  @action
-  dragLeave() {
-    this.dragCount--;
-    if (
-      this.dragCount === 0 &&
-      (this.dragCssClass === "drag-above" || this.dragCssClass === "drag-below")
-    ) {
-      this.dragCssClass = null;
-    }
-  }
-
-  @action
-  drop(event) {
-    if (!this.args.row.enabled) {
-      return;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-    this.dragCount = 0;
-    const dropAbove = this.isAboveElement(event);
-    this.dragCssClass = null;
-    this.args.onDrop(this.args.row.key, dropAbove);
-  }
-
-  @action
-  dragEnd() {
-    this.dragCount = 0;
-    this.dragCssClass = null;
-    this.args.onDragEnd();
-  }
-
-  <template>
-    <li
-      class={{dConcatClass
-        "manage-reports__row"
-        (if @row.enabled "--enabled")
-        this.dragCssClass
-      }}
-      data-identifier={{@row.key}}
-      draggable={{and @row.enabled @reorderable}}
-      {{on "dragstart" this.dragStart}}
-      {{on "dragover" this.dragOver}}
-      {{on "dragenter" this.dragEnter}}
-      {{on "dragleave" this.dragLeave}}
-      {{on "drop" this.drop}}
-      {{on "dragend" this.dragEnd}}
-    >
-
-      {{#unless this.site.mobileView}}
-        <span class="manage-reports__grip">
-          {{dIcon "grip-vertical"}}
+/**
+ * One report's text and enable toggle, shared between the reorderable rows and
+ * the disabled rows below them — the two populations share a look while only
+ * one of them carries reorder controls.
+ */
+const ReportRowContent = <template>
+  <div class="manage-reports__row-text">
+    <div class="manage-reports__row-heading">
+      <span class="manage-reports__title">{{@row.title}}</span>
+      {{#if @row.label}}
+        <span class="db-report__label">
+          {{@row.label}}
         </span>
-      {{/unless}}
-
-      {{#if this.site.mobileView}}
-        <div class="manage-reports__order-mobile">
-          <DButton
-            @icon="arrow-up"
-            @action={{fn @onMoveUp @row}}
-            @disabled={{eq @index 0}}
-            @translatedAriaLabel={{i18n
-              "admin.dashboard.reports_section.modal.move_up"
-              title=@row.title
-            }}
-            class="manage-reports__arrow btn-transparent"
-          />
-          <DButton
-            @icon="arrow-down"
-            @action={{fn @onMoveDown @row}}
-            @disabled={{eq @index @lastEnabledIndex}}
-            @translatedAriaLabel={{i18n
-              "admin.dashboard.reports_section.modal.move_down"
-              title=@row.title
-            }}
-            class="manage-reports__arrow btn-transparent"
-          />
-        </div>
       {{/if}}
+    </div>
+    {{#if @row.description}}
+      <p class="manage-reports__description">{{@row.description}}</p>
+    {{/if}}
+  </div>
 
-      <div class="manage-reports__row-text">
-        <div class="manage-reports__row-heading">
-          <span class="manage-reports__title">{{@row.title}}</span>
-          {{#if @row.label}}
-            <span class="db-report__label">
-              {{@row.label}}
-            </span>
-          {{/if}}
-        </div>
-        {{#if @row.description}}
-          <p class="manage-reports__description">{{@row.description}}</p>
-        {{/if}}
-      </div>
-
-      <DToggleSwitch
-        @state={{@row.enabled}}
-        disabled={{@toggleDisabled}}
-        aria-label={{i18n
-          (if
-            @row.enabled
-            "admin.dashboard.reports_section.modal.disable"
-            "admin.dashboard.reports_section.modal.enable"
-          )
-          title=@row.title
-        }}
-        {{on "click" (fn @onToggle @row)}}
-      />
-    </li>
-  </template>
-}
+  <DToggleSwitch
+    @state={{@enabled}}
+    disabled={{@toggleDisabled}}
+    aria-label={{i18n
+      (if
+        @enabled
+        "admin.dashboard.reports_section.modal.disable"
+        "admin.dashboard.reports_section.modal.enable"
+      )
+      title=@row.title
+    }}
+    {{on "click" (fn @onToggle @row)}}
+  />
+</template>;
 
 export default class ManageReports extends Component {
   @tracked allKeys = [];
@@ -179,11 +65,11 @@ export default class ManageReports extends Component {
   @tracked loading = true;
   @tracked loadingMore = false;
   @tracked applying = false;
-  @tracked draggedId = null;
   itemsByKey = new Map();
 
   isEnabled = (row) => this.enabledKeys.has(row.key);
   toggleDisabled = (row) => this.atCap && !this.isEnabled(row);
+  rowTitle = (row) => row.title;
 
   constructor() {
     super(...arguments);
@@ -220,13 +106,6 @@ export default class ManageReports extends Component {
     );
   }
 
-  get visibleRows() {
-    return [
-      ...this.filteredEnabledRows.map((row) => ({ ...row, enabled: true })),
-      ...this.disabledRows.map((row) => ({ ...row, enabled: false })),
-    ];
-  }
-
   get atCap() {
     return this.enabledOrder.length >= VISIBLE_CAP;
   }
@@ -235,8 +114,8 @@ export default class ManageReports extends Component {
     return this.enabledOrder.length > 1;
   }
 
-  get lastEnabledIndex() {
-    return this.filteredEnabledRows.length - 1;
+  get visibleRowCount() {
+    return this.filteredEnabledRows.length + this.disabledRows.length;
   }
 
   cacheItems(items) {
@@ -330,63 +209,19 @@ export default class ManageReports extends Component {
     }
   }
 
+  /**
+   * Projects a committed move back onto the stored order. The list works in
+   * the displayed rows only, so a row a search filter is hiding keeps the
+   * slot it already held — letting a move carry rows across hidden ones would
+   * persist a change nothing on screen accounts for.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
   @action
-  moveUp(row) {
-    const index = this.enabledOrder.indexOf(row.key);
-    if (index <= 0) {
-      return;
-    }
-    const next = [...this.enabledOrder];
-    [next[index - 1], next[index]] = [next[index], next[index - 1]];
-    this.enabledOrder = next;
-  }
-
-  @action
-  moveDown(row) {
-    const index = this.enabledOrder.indexOf(row.key);
-    if (index < 0 || index === this.enabledOrder.length - 1) {
-      return;
-    }
-    const next = [...this.enabledOrder];
-    [next[index], next[index + 1]] = [next[index + 1], next[index]];
-    this.enabledOrder = next;
-  }
-
-  @action
-  onDragStart(key) {
-    this.draggedId = key;
-  }
-
-  @action
-  onDrop(targetKey, dropAbove) {
-    const fromIndex = this.enabledOrder.indexOf(this.draggedId);
-    this.draggedId = null;
-    if (fromIndex < 0) {
-      return;
-    }
-
-    const targetIndex = this.enabledOrder.indexOf(targetKey);
-    if (targetIndex < 0) {
-      return;
-    }
-
-    let toIndex = dropAbove ? targetIndex : targetIndex + 1;
-    if (fromIndex < toIndex) {
-      toIndex -= 1;
-    }
-    if (fromIndex === toIndex) {
-      return;
-    }
-
-    const next = [...this.enabledOrder];
-    const [moved] = next.splice(fromIndex, 1);
-    next.splice(toIndex, 0, moved);
-    this.enabledOrder = next;
-  }
-
-  @action
-  onDragEnd() {
-    this.draggedId = null;
+  handleMove(move) {
+    this.enabledOrder = this.#storedOrderFrom(
+      move.proposedToItems.map((row) => row.key)
+    );
   }
 
   @action
@@ -410,6 +245,23 @@ export default class ManageReports extends Component {
     } finally {
       this.applying = false;
     }
+  }
+
+  /**
+   * Rebuilds the stored order from a reordered displayed list.
+   *
+   * A reorder permutes the rows the user can see among the slots they occupy,
+   * so a row a search filter is hiding keeps the slot it already held.
+   *
+   * @param {string[]} nextVisible - The displayed keys in their new order.
+   * @returns {string[]} The full stored order.
+   */
+  #storedOrderFrom(nextVisible) {
+    const remaining = [...nextVisible];
+    const visible = new Set(nextVisible);
+    return this.enabledOrder.map((key) =>
+      visible.has(key) ? remaining.shift() : key
+    );
   }
 
   <template>
@@ -444,30 +296,42 @@ export default class ManageReports extends Component {
 
       <:body>
 
-        {{#if this.visibleRows.length}}
-          <ul
+        {{#if this.visibleRowCount}}
+          <DReorderableList
+            @items={{this.filteredEnabledRows}}
+            @key="key"
+            @label={{this.rowTitle}}
+            @onMove={{this.handleMove}}
+            @rowClass="manage-reports__row --enabled"
             class={{dConcatClass
               "manage-reports__list"
-              (if this.draggedId "--dragging")
               (if this.reorderable "--reorderable")
             }}
           >
-            {{#each this.visibleRows key="key" as |row index|}}
-              <ManageReportsRow
+            <:default as |row|>
+              <ReportRowContent
                 @row={{row}}
-                @index={{index}}
-                @lastEnabledIndex={{this.lastEnabledIndex}}
-                @reorderable={{this.reorderable}}
+                @enabled={{true}}
                 @toggleDisabled={{this.toggleDisabled row}}
                 @onToggle={{this.toggle}}
-                @onMoveUp={{this.moveUp}}
-                @onMoveDown={{this.moveDown}}
-                @onDragStart={{this.onDragStart}}
-                @onDrop={{this.onDrop}}
-                @onDragEnd={{this.onDragEnd}}
               />
-            {{/each}}
-          </ul>
+            </:default>
+            <:static>
+              {{#each this.disabledRows key="key" as |row|}}
+                <li
+                  class="manage-reports__row"
+                  data-reorderable-key={{row.key}}
+                >
+                  <ReportRowContent
+                    @row={{row}}
+                    @enabled={{false}}
+                    @toggleDisabled={{this.toggleDisabled row}}
+                    @onToggle={{this.toggle}}
+                  />
+                </li>
+              {{/each}}
+            </:static>
+          </DReorderableList>
           <DLoadMore
             @action={{this.loadMore}}
             @enabled={{this.hasMore}}

--- a/frontend/discourse/tests/acceptance/manage-reports-drag-and-drop-test.gjs
+++ b/frontend/discourse/tests/acceptance/manage-reports-drag-and-drop-test.gjs
@@ -1,0 +1,493 @@
+import { getOwner } from "@ember/owner";
+import {
+  click,
+  fillIn,
+  find,
+  findAll,
+  settled,
+  visit,
+} from "@ember/test-helpers";
+import { test } from "qunit";
+import ManageReports from "discourse/admin/components/modal/manage-reports";
+import {
+  disableClearA11yAnnouncementsInTests,
+  enableClearA11yAnnouncementsInTests,
+} from "discourse/services/a11y";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import {
+  assertDragRegistered,
+  centerOf,
+  dragEvent,
+  simulateDrag,
+} from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+
+const REORDER_TEST_PREFIX = "Manage reports reordering";
+
+const REPORTS = [
+  {
+    source: "core_report",
+    identifier: "signups",
+    key: "core_report:signups",
+    title: "Matching signups",
+    description: "New account signups",
+  },
+  {
+    source: "core_report",
+    identifier: "topics",
+    key: "core_report:topics",
+    title: "Matching topics",
+    description: "New topics",
+  },
+  {
+    source: "core_report",
+    identifier: "posts",
+    key: "core_report:posts",
+    title: "Other posts",
+    description: "New posts",
+  },
+];
+
+function rowSelector(key) {
+  return `.manage-reports__row[data-reorderable-key="${key}"]`;
+}
+
+// A drag starts on the grip rather than anywhere on the row, so a press meant to
+// scroll still scrolls. The row owns the source data, while the shared helper
+// dispatches the browser events on the grip carrying the draggable registration.
+function gripSelector(key) {
+  return `${rowSelector(key)} .d-reorderable-list__handle`;
+}
+
+function enabledKeys() {
+  return findAll(".manage-reports__row.--enabled").map(
+    (row) => row.dataset.reorderableKey
+  );
+}
+
+async function openModal(context) {
+  await visit("/");
+  getOwner(context).lookup("service:modal").show(ManageReports);
+  await settled();
+}
+
+async function dragReport(sourceKey, targetKey, position) {
+  const source = rowSelector(sourceKey);
+  const target = rowSelector(targetKey);
+
+  assertDragRegistered(gripSelector(sourceKey), target);
+
+  const targetRect = find(target).getBoundingClientRect();
+  await simulateDrag(source, target, {
+    dataTransfer: new DataTransfer(),
+    sourceCoordinates: centerOf(gripSelector(sourceKey)),
+    targetCoordinates: {
+      clientY:
+        position === "above" ? targetRect.top + 1 : targetRect.bottom - 1,
+    },
+  });
+}
+
+acceptance("Manage reports drag and drop", function (needs) {
+  needs.user({ admin: true });
+  needs.pretender((server, helper) => {
+    server.get("/admin/dashboard/reports/available.json", () =>
+      helper.response({
+        enabled: REPORTS.slice(0, 2),
+        available: REPORTS,
+        providers: [],
+        cursor: null,
+        has_more: false,
+      })
+    );
+  });
+
+  // `settled()` waits out pending timers, and an announcement schedules its own
+  // clear, so a message read after an awaited interaction would always be gone.
+  needs.hooks.beforeEach(disableClearA11yAnnouncementsInTests);
+  needs.hooks.afterEach(enableClearA11yAnnouncementsInTests);
+
+  test(`${REORDER_TEST_PREFIX} adjacent rows leave no dead space between drop zones`, async function (assert) {
+    await openModal(this);
+
+    // Container spacing (a flex `gap`) belongs to the list, not to either row,
+    // so a pointer inside it reaches no drop target and the above/below zones
+    // stop meeting.
+    const rows = findAll(".manage-reports__row");
+    for (let i = 1; i < rows.length; i++) {
+      const previous = rows[i - 1].getBoundingClientRect();
+      const current = rows[i].getBoundingClientRect();
+
+      assert.strictEqual(
+        Math.round(current.top),
+        Math.round(previous.bottom),
+        `row ${i} starts exactly where row ${i - 1} ends, so no pointer position between them falls outside both`
+      );
+    }
+  });
+
+  test(`${REORDER_TEST_PREFIX} renders the grip alongside the arrows on desktop`, async function (assert) {
+    await openModal(this);
+
+    assert.dom(".d-reorderable-list__handle").exists({ count: 2 });
+    assert
+      .dom(".d-reorder-buttons__button")
+      .exists(
+        { count: 4 },
+        "desktop keeps a keyboard path to reorder, not only the pointer drag"
+      );
+  });
+
+  test(`${REORDER_TEST_PREFIX} desktop arrow buttons reorder the enabled list`, async function (assert) {
+    await openModal(this);
+
+    await click(
+      `${rowSelector("core_report:topics")} .d-reorder-buttons__button:first-child`
+    );
+
+    assert.deepEqual(
+      enabledKeys(),
+      ["core_report:topics", "core_report:signups"],
+      "the up arrow moves the report earlier on desktop, with no pointer involved"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} the arrow path announces through the same call as the drag`, async function (assert) {
+    const a11y = getOwner(this).lookup("service:a11y");
+    await openModal(this);
+
+    await click(
+      `${rowSelector("core_report:topics")} .d-reorder-buttons__button:first-child`
+    );
+
+    assert.strictEqual(
+      a11y.politeMessage,
+      "Moved Matching topics to position 1 of 2",
+      "an arrow press announces exactly like the equivalent drag"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} announces where a dragged report landed`, async function (assert) {
+    const a11y = getOwner(this).lookup("service:a11y");
+    await openModal(this);
+
+    await dragReport("core_report:topics", "core_report:signups", "above");
+
+    assert.strictEqual(
+      a11y.politeMessage,
+      "Moved Matching topics to position 1 of 2",
+      "a completed drag announces the report and its resulting position"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} announces nothing when a drop changes no order`, async function (assert) {
+    const a11y = getOwner(this).lookup("service:a11y");
+    await openModal(this);
+
+    const before = a11y.politeMessage;
+
+    await dragReport("core_report:signups", "core_report:signups", "above");
+    assert.strictEqual(
+      a11y.politeMessage,
+      before,
+      "dropping a report onto itself is not a reorder, so nothing is announced"
+    );
+
+    // Below the report directly above it resolves to the index it already holds.
+    await dragReport("core_report:topics", "core_report:signups", "below");
+    assert.strictEqual(
+      a11y.politeMessage,
+      before,
+      "a drop that resolves to the report's current index announces nothing"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} reorders by stable key with a search filter applied`, async function (assert) {
+    await openModal(this);
+    await fillIn(".manage-reports__search-wrapper .filter-input", "Matching");
+
+    await dragReport("core_report:topics", "core_report:signups", "above");
+
+    assert.deepEqual(
+      enabledKeys(),
+      ["core_report:topics", "core_report:signups"],
+      "a filtered reorder resolves fresh visible-row copies through their stable keys"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} conditionally registers rows and puts the grab cursor on the grip`, async function (assert) {
+    await openModal(this);
+
+    const disabledRow = rowSelector("core_report:posts");
+    assert
+      .dom(disabledRow)
+      .doesNotHaveAttribute(
+        "data-drag-source",
+        "a disabled row has no active drag-source registration"
+      )
+      .doesNotHaveAttribute(
+        "draggable",
+        "a disabled row is not stamped as draggable"
+      );
+    // The grip is what a drag begins on, so it is what advertises the grab. The
+    // row must not: its text is selectable, and a `grab` cursor over text would
+    // promise a gesture pressing there does not perform.
+    assert.strictEqual(
+      getComputedStyle(find(rowSelector("core_report:signups"))).cursor,
+      "auto",
+      "an enabled row does not claim the grab cursor across its whole width"
+    );
+    // Paired with the row above, because `auto` is what an unstyled element
+    // reports anyway: on its own that assertion passes even if no rule is
+    // reached at all.
+    assert.strictEqual(
+      getComputedStyle(find(gripSelector("core_report:signups"))).cursor,
+      "grab",
+      "the grip does, so the rule is reached"
+    );
+
+    assert
+      .dom(".manage-reports__row.--enabled[data-drop-target]")
+      .exists({ count: 2 }, "every enabled reorderable row is a drop target");
+    assert
+      .dom(
+        ".manage-reports__row.--enabled .d-reorderable-list__handle[data-drag-source]"
+      )
+      .exists(
+        { count: 2 },
+        "every enabled row's grip carries the drag registration"
+      );
+  });
+
+  test(`${REORDER_TEST_PREFIX} uses the shared drag state classes`, async function (assert) {
+    await openModal(this);
+
+    const source = rowSelector("core_report:signups");
+    const target = rowSelector("core_report:topics");
+    const dataTransfer = new DataTransfer();
+    const sourceGrip = gripSelector("core_report:signups");
+    const sourceCoordinates = centerOf(sourceGrip);
+    const targetRect = find(target).getBoundingClientRect();
+    const targetCoordinates = {
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + 1,
+    };
+
+    await dragEvent(sourceGrip, "dragstart", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+    await dragEvent(target, "dragenter", {
+      dataTransfer,
+      ...targetCoordinates,
+    });
+    await dragEvent(target, "dragover", {
+      dataTransfer,
+      offsetY: 1,
+      ...targetCoordinates,
+    });
+
+    assert
+      .dom(source)
+      .hasClass("--dragging", "the source uses the shared dragging class");
+    assert
+      .dom(target)
+      .hasClass("--drag-above", "the target uses the shared above indicator");
+
+    await dragEvent(sourceGrip, "dragend", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+  });
+
+  test(`${REORDER_TEST_PREFIX} leaves no indicator after an abandoned drag`, async function (assert) {
+    await openModal(this);
+
+    const source = rowSelector("core_report:signups");
+    const target = rowSelector("core_report:topics");
+    const dataTransfer = new DataTransfer();
+    const sourceGrip = gripSelector("core_report:signups");
+    const sourceCoordinates = centerOf(sourceGrip);
+    const targetRect = find(target).getBoundingClientRect();
+    const targetCoordinates = {
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + 1,
+    };
+
+    await dragEvent(sourceGrip, "dragstart", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+    await dragEvent(target, "dragenter", {
+      dataTransfer,
+      ...targetCoordinates,
+    });
+    await dragEvent(target, "dragover", {
+      dataTransfer,
+      offsetY: 1,
+      ...targetCoordinates,
+    });
+    await dragEvent(sourceGrip, "dragend", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+
+    assert
+      .dom(source)
+      .doesNotHaveClass(
+        "--dragging",
+        "an abandoned drag clears the source indicator"
+      )
+      .doesNotHaveClass(
+        "dragging",
+        "an abandoned drag leaves no legacy source indicator"
+      );
+    assert
+      .dom(target)
+      .doesNotHaveClass(
+        "drag-above",
+        "an abandoned drag leaves no legacy above indicator"
+      )
+      .doesNotHaveClass(
+        "drag-below",
+        "an abandoned drag leaves no legacy below indicator"
+      )
+      .doesNotHaveClass(
+        "--drag-above",
+        "an abandoned drag clears the target's above indicator"
+      )
+      .doesNotHaveClass(
+        "--drag-below",
+        "an abandoned drag clears the target's below indicator"
+      );
+  });
+});
+
+acceptance(
+  "Manage reports arrow reorder with a hidden row between matches",
+  function (needs) {
+    needs.user({ admin: true });
+    needs.pretender((server, helper) =>
+      server.get("/admin/dashboard/reports/available.json", () =>
+        helper.response({
+          // Order matters: the row the filter hides sits BETWEEN the two it
+          // shows, which is the arrangement that separates moving by displayed
+          // position from moving by stored position.
+          enabled: [REPORTS[0], REPORTS[2], REPORTS[1]],
+          available: REPORTS,
+          providers: [],
+          cursor: null,
+          has_more: false,
+        })
+      )
+    );
+
+    needs.hooks.beforeEach(disableClearA11yAnnouncementsInTests);
+    needs.hooks.afterEach(enableClearA11yAnnouncementsInTests);
+
+    test(`${REORDER_TEST_PREFIX} moves a row past its visible neighbour with an arrow`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await openModal(this);
+      await fillIn(".manage-reports__search-wrapper .filter-input", "Matching");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:signups", "core_report:topics"],
+        "the filter shows the two matching rows, with one hidden between them"
+      );
+
+      await click(
+        `${rowSelector("core_report:signups")} .d-reorder-buttons__button:last-child`
+      );
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:signups"],
+        "the row moves past its visible neighbour, so the list the user sees actually changes"
+      );
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Matching signups to position 2 of 2",
+        "and the announced position counts the rows on screen, not the stored order"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} drag announces the same displayed position as an arrow`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await openModal(this);
+      await fillIn(".manage-reports__search-wrapper .filter-input", "Matching");
+
+      await dragReport("core_report:signups", "core_report:topics", "below");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:signups"],
+        "the drag reaches the same order the arrow did"
+      );
+      // The stored order is three long and the row lands third in it, so an
+      // announcement counted there would say "3 of 3" for a list showing two.
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Matching signups to position 2 of 2",
+        "so it announces the same position, counted on screen rather than in the stored order"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} filtered drag leaves the hidden row in its slot`, async function (assert) {
+      await openModal(this);
+      await fillIn(".manage-reports__search-wrapper .filter-input", "Matching");
+
+      await dragReport("core_report:signups", "core_report:topics", "below");
+
+      await fillIn(".manage-reports__search-wrapper .filter-input", "");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:posts", "core_report:signups"],
+        "the two rows on screen swap the slots they held, and the row between them keeps its own"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} arrow leaves the hidden row in the same slot as drag`, async function (assert) {
+      await openModal(this);
+      await fillIn(".manage-reports__search-wrapper .filter-input", "Matching");
+
+      await click(
+        `${rowSelector("core_report:signups")} .d-reorder-buttons__button:last-child`
+      );
+
+      await fillIn(".manage-reports__search-wrapper .filter-input", "");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:posts", "core_report:signups"],
+        "so the two ways of reordering persist the same order rather than disagreeing about the hidden row"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} no-op filtered drag changes nothing`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await openModal(this);
+      await fillIn(".manage-reports__search-wrapper .filter-input", "Matching");
+
+      const before = a11y.politeMessage;
+
+      // Below the row shown above it, which is the position it already holds.
+      // In the stored order it is a move, because of the row hidden between.
+      await dragReport("core_report:topics", "core_report:signups", "below");
+
+      assert.strictEqual(
+        a11y.politeMessage,
+        before,
+        "a drop onto the position the row already occupies announces nothing"
+      );
+
+      await fillIn(".manage-reports__search-wrapper .filter-input", "");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:signups", "core_report:posts", "core_report:topics"],
+        "and stores nothing, rather than quietly moving the row the user cannot see"
+      );
+    });
+  }
+);

--- a/spec/system/admin_dashboard_redesign/reports_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/reports_section_spec.rb
@@ -47,6 +47,42 @@ describe "Admin Dashboard Redesign | Reports section" do
     expect(modal).to have_disabled_move_down("core_report:topics")
   end
 
+  it "lets the admin select a report's text" do
+    # A row is a drag source, and a `draggable` element turns a press-drag into a
+    # drag rather than a selection. The grip is what should be draggable, so the
+    # title and description stay selectable like any other text.
+    #
+    # `drag_with_pointer`, not `drag_and_drop`: the latter goes through CDP drag
+    # interception, which suppresses the ordinary mouse moves a selection is made
+    # of. And a real pointer is the only thing that can select at all — a
+    # synthetic drag never touches the browser's selection.
+    AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+    AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+    page.visit("/admin")
+    dashboard.open_manage_reports_via_cog
+    expect(modal).to have_open
+
+    drag_with_pointer(from: ".manage-reports__row.--enabled .manage-reports__title", by: { x: 60 })
+
+    expect(page.evaluate_script("window.getSelection().toString()")).to be_present
+  end
+
+  it "lets an admin reorder reports with a real browser drag" do
+    AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+    AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+    page.visit("/admin")
+    dashboard.open_manage_reports_via_cog
+    expect(modal).to have_open
+
+    modal.drag_report("core_report:topics", "core_report:signups")
+
+    try_until_success do
+      expect(modal.enabled_identifiers).to eq(%w[core_report:topics core_report:signups])
+    end
+  end
+
   it "lets admins customize the reports section via the manage-reports modal" do
     AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
     AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)

--- a/spec/system/page_objects/components/manage_reports_modal.rb
+++ b/spec/system/page_objects/components/manage_reports_modal.rb
@@ -21,15 +21,15 @@ module PageObjects
       end
 
       def enabled_identifiers
-        all("#{MODAL} #{ENABLED_ROW}").map { |el| el["data-identifier"] }
+        all("#{MODAL} #{ENABLED_ROW}").map { |el| el["data-reorderable-key"] }
       end
 
       def has_all_row?(identifier)
-        has_css?("#{MODAL} #{ROW}[data-identifier='#{identifier}']")
+        has_css?("#{MODAL} #{ROW}[data-reorderable-key='#{identifier}']")
       end
 
       def has_no_all_row?(identifier)
-        has_no_css?("#{MODAL} #{ROW}[data-identifier='#{identifier}']")
+        has_no_css?("#{MODAL} #{ROW}[data-reorderable-key='#{identifier}']")
       end
 
       def toggle(identifier)
@@ -38,17 +38,17 @@ module PageObjects
       end
 
       def has_toggle_on?(identifier)
-        has_css?("#{MODAL} #{ENABLED_ROW}[data-identifier='#{identifier}']")
+        has_css?("#{MODAL} #{ENABLED_ROW}[data-reorderable-key='#{identifier}']")
       end
 
       def has_toggle_off?(identifier)
-        has_css?("#{MODAL} #{ROW}[data-identifier='#{identifier}']") &&
-          has_no_css?("#{MODAL} #{ENABLED_ROW}[data-identifier='#{identifier}']")
+        has_css?("#{MODAL} #{ROW}[data-reorderable-key='#{identifier}']") &&
+          has_no_css?("#{MODAL} #{ENABLED_ROW}[data-reorderable-key='#{identifier}']")
       end
 
       def toggle_for(identifier)
         PageObjects::Components::DToggleSwitch.new(
-          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] .d-toggle-switch__checkbox",
+          "#{MODAL} #{ROW}[data-reorderable-key='#{identifier}'] .d-toggle-switch__checkbox",
         )
       end
 
@@ -63,27 +63,19 @@ module PageObjects
       end
 
       def has_disabled_move_up?(identifier)
-        has_css?(
-          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow[disabled] .d-icon-arrow-up",
-        )
+        has_css?(arrow_selector(identifier, "up", disabled: true))
       end
 
       def has_disabled_move_down?(identifier)
-        has_css?(
-          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow[disabled] .d-icon-arrow-down",
-        )
+        has_css?(arrow_selector(identifier, "down", disabled: true))
       end
 
       def has_enabled_move_up?(identifier)
-        has_css?(
-          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow:not([disabled]) .d-icon-arrow-up",
-        )
+        has_css?(arrow_selector(identifier, "up", disabled: false))
       end
 
       def has_enabled_move_down?(identifier)
-        has_css?(
-          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow:not([disabled]) .d-icon-arrow-down",
-        )
+        has_css?(arrow_selector(identifier, "down", disabled: false))
       end
 
       def has_drag_controls?
@@ -100,6 +92,34 @@ module PageObjects
           "#{MODAL} .manage-reports__counter",
           text: I18n.t("admin_js.admin.dashboard.reports_section.modal.counter", count:, max:),
         )
+      end
+
+      def drag_report(source_identifier, target_identifier)
+        drag_and_drop(
+          source: "#{row_selector(source_identifier)} .d-reorderable-list__handle",
+          target: row_selector(target_identifier),
+          target_position: {
+            x: 100,
+            y: 1,
+          },
+        )
+        self
+      end
+
+      private
+
+      def arrow_selector(identifier, direction, disabled:)
+        # `aria-disabled`, not the real attribute: an arrow at the end of the
+        # list stays focusable so a keyboard user keeps their place in the tab
+        # order.
+        state = disabled ? "[aria-disabled='true']" : ":not([aria-disabled])"
+
+        "#{row_selector(identifier)} .d-reorder-buttons " \
+          "button#{state} .d-icon-chevron-#{direction}"
+      end
+
+      def row_selector(identifier)
+        "#{MODAL} #{ROW}[data-reorderable-key='#{identifier}']"
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -182,9 +182,7 @@ module PageObjects
       end
 
       def toggle_section(id)
-        within(".db-configure__row[data-section-id='#{id}']") do
-          find(".d-toggle-switch__label").click
-        end
+        within(configure_row_selector(id)) { find(".d-toggle-switch__label").click }
         self
       end
 
@@ -200,7 +198,7 @@ module PageObjects
 
       def drag_section(source_id, target_id)
         drag_and_drop(
-          source: "#{configure_row_selector(source_id)} .db-configure__drag-handle",
+          source: "#{configure_row_selector(source_id)} .d-reorderable-list__handle",
           target: configure_row_selector(target_id),
           target_position: {
             x: 100,
@@ -217,7 +215,7 @@ module PageObjects
       end
 
       def configure_row_selector(id)
-        ".db-configure__row[data-section-id='#{id}']"
+        ".db-configure__row[data-reorderable-key='#{id}']"
       end
 
       def custom_range_params(from:, to:)


### PR DESCRIPTION
Manage Reports carried both a drag implementation and its own arrow controls, each maintained separately, and had to keep filtered-list positions straight by itself. Both paths now come from `DReorderableList`, leaving the modal only what is specific to reports.

Filtering and report selection are unchanged. A new acceptance test covers the drag, keyboard and button paths together, including reordering across a hidden row.