### PR TITLE
UX: Keep site traffic counts visible in site traffic explorer card

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -240,10 +240,10 @@
     color: var(--primary);
     font: inherit;
     text-align: start;
+  }
 
-    > span:not(.site-traffic-explorer__row-count) {
-      @include ellipsis;
-    }
+  &__row-label {
+    @include ellipsis;
   }
 
   &__row-count {

--- a/frontend/discourse/admin/components/site-traffic-explorer-breakdown-card.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer-breakdown-card.gjs
@@ -212,7 +212,7 @@ export default class SiteTrafficExplorerBreakdownCard extends Component {
                     data-test-site-traffic-row
                     {{on "click" (fn this.filter row)}}
                   >
-                    <span>
+                    <span class="site-traffic-explorer__row-label">
                       <SiteTrafficExplorerDimensionLabel
                         @dimension={{this.activeTab.dimension}}
                         @row={{row}}


### PR DESCRIPTION
## Before

<img width="341" height="193" alt="before" src="https://github.com/user-attachments/assets/64c66ecb-94d4-4fb3-aab2-8b9a51954b6b" />


## After

<img width="341" height="193" alt="after" src="https://github.com/user-attachments/assets/6445a918-f26f-4143-b3f5-9c629f7502ed" />
