### PR TITLE
UX: Add btn-default class to two buttons

### DIFF
--- a/frontend/discourse/admin/components/modal/site-setting-default-categories.gjs
+++ b/frontend/discourse/admin/components/modal/site-setting-default-categories.gjs
@@ -38,6 +38,7 @@ export default class SiteSettingDefaultCategories extends Component {
         />
         <DButton
           @action={{this.cancel}}
+          class="btn-default"
           @label="admin.site_settings.default_categories.modal_no"
         />
       </:footer>

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -54,7 +54,7 @@ export default class QueriesEdit extends Component {
               <DButton
                 @action={{@controller.exitEdit}}
                 @icon="xmark"
-                class="previous"
+                class="btn-default previous"
               />
               <div class="name-text-field">
                 <DTextField


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="609" height="211" alt="image" src="https://github.com/user-attachments/assets/32222027-f464-49eb-89aa-4583bd8a72cc" />|<img width="609" height="212" alt="image" src="https://github.com/user-attachments/assets/1cc8357f-5c36-439a-8855-02b071ee9f04" />|
|<img width="394" height="311" alt="image" src="https://github.com/user-attachments/assets/3d067fe6-4ffa-4c75-bcc0-ab54fa0efae8" />|<img width="385" height="308" alt="image" src="https://github.com/user-attachments/assets/b7c2fac3-9585-49e3-a06a-da786cdef474" />|<img width="394" height="311" alt="image" src="https://github.com/user-attachments/assets/3d067fe6-4ffa-4c75-bcc0-ab54fa0efae8" />|
