### PR TITLE
FIX: Handle new pseudogroups in message bus group IDs

### DIFF
--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -53,17 +53,27 @@ def setup_message_bus_env(env)
       Discourse.warn_exception(e, message: "Unexpected error in Message Bus", env: env)
     end
 
-    user_id = user && user.id
+    user_id = user&.id
 
     raise Discourse::InvalidAccess if !user_id && SiteSetting.login_required
 
-    is_admin = !!(user && user.admin?)
+    is_admin = user&.admin || false
+
+    logged_in_pseudogroups =
+      if SiteSetting.granular_anonymous_and_logged_in_groups_permissions
+        [Group::AUTO_GROUPS[:logged_in_users]]
+      else
+        [Group::AUTO_GROUPS[:logged_in_users], Group::AUTO_GROUPS[:everyone]]
+      end
+
     group_ids =
       if is_admin
-        # special rule, admin is allowed access to all groups
-        Group.pluck(:id)
+        # Special rule, admin is allowed access to all groups
+        Group.pluck(:id) + logged_in_pseudogroups
       elsif user
-        user.groups.pluck("groups.id")
+        user.belonging_to_group_ids + logged_in_pseudogroups
+      else
+        [Group::AUTO_GROUPS[:anonymous_users]]
       end
 
     extra_headers["Discourse-Logged-Out"] = "1" if env[Auth::DefaultCurrentUserProvider::BAD_TOKEN]

--- a/spec/integration/message_bus_spec.rb
+++ b/spec/integration/message_bus_spec.rb
@@ -40,4 +40,131 @@ RSpec.describe "message bus integration" do
       expect(response.status).to eq(200)
     end
   end
+
+  describe "limiting messages to group_ids" do
+    fab!(:group_1, :group)
+    fab!(:group_2, :group)
+
+    # dlp=t disables long polling so the response comes back immediately,
+    # SecureRandom.hex is the client ID which doesn't matter here
+    let(:message_bus_url) { "/message-bus/#{SecureRandom.hex}/poll?dlp=t" }
+    let(:test_channel) { "/test-channel" }
+
+    # Publishes to the channel, then polls as the current client from just before
+    # that message, so the response contains only the message we published.
+    def publish_and_poll(group_ids)
+      message_id = MessageBus.publish(test_channel, "hello", group_ids: group_ids)
+
+      post(message_bus_url, params: { test_channel => message_id - 1 })
+      expect(response.status).to eq(200)
+
+      message_id
+    end
+
+    def allowed_response(message_id)
+      [hash_including("channel" => test_channel, "message_id" => message_id, "data" => "hello")]
+    end
+
+    # A message the client may not see is filtered out, and MessageBus returns a
+    # /__status message instead, fast-forwarding the client past that message.
+    def disallowed_response(message_id)
+      [
+        {
+          "global_id" => -1,
+          "message_id" => -1,
+          "channel" => "/__status",
+          "data" => {
+            test_channel => message_id,
+          },
+        },
+      ]
+    end
+
+    context "when the user is logged in" do
+      fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+
+      before { sign_in(user) }
+
+      it "receives messages for the logged_in_users pseudogroup" do
+        message_id = publish_and_poll([Group::AUTO_GROUPS[:logged_in_users]])
+
+        expect(response.parsed_body).to match(allowed_response(message_id))
+      end
+
+      it "receives messages for a specific group that the user is a member of" do
+        group_1.add(user)
+
+        message_id = publish_and_poll([group_1.id])
+
+        expect(response.parsed_body).to match(allowed_response(message_id))
+      end
+
+      it "does not receive messages for a specific group that the user is not a member of" do
+        message_id = publish_and_poll([group_1.id])
+
+        expect(response.parsed_body).to match(disallowed_response(message_id))
+      end
+
+      it "does not receive messages for the anonymous_users pseudogroup" do
+        message_id = publish_and_poll([Group::AUTO_GROUPS[:anonymous_users]])
+
+        expect(response.parsed_body).to match(disallowed_response(message_id))
+      end
+
+      context "when granular_anonymous_and_logged_in_groups_permissions is enabled" do
+        before { SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true }
+
+        it "does not receive messages for the everyone pseudogroup" do
+          message_id = publish_and_poll([Group::AUTO_GROUPS[:everyone]])
+
+          expect(response.parsed_body).to match(disallowed_response(message_id))
+        end
+      end
+
+      context "when granular_anonymous_and_logged_in_groups_permissions is disabled" do
+        before { SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false }
+
+        it "receives messages for the everyone pseudogroup" do
+          message_id = publish_and_poll([Group::AUTO_GROUPS[:everyone]])
+
+          expect(response.parsed_body).to match(allowed_response(message_id))
+        end
+      end
+
+      context "when the user is admin" do
+        fab!(:user) { Fabricate(:admin, refresh_auto_groups: true) }
+
+        it "receives all messages regardless of group" do
+          message_id = publish_and_poll([group_1.id])
+          expect(response.parsed_body).to match(allowed_response(message_id))
+
+          message_id = publish_and_poll([group_2.id])
+          expect(response.parsed_body).to match(allowed_response(message_id))
+
+          message_id = publish_and_poll([Group::AUTO_GROUPS[:logged_in_users]])
+          expect(response.parsed_body).to match(allowed_response(message_id))
+        end
+      end
+    end
+
+    context "when the user is anonymous" do
+      it "receives messages for the anonymous_users pseudogroup" do
+        message_id = publish_and_poll([Group::AUTO_GROUPS[:anonymous_users]])
+
+        expect(response.parsed_body).to match(allowed_response(message_id))
+      end
+
+      it "does not receive messages for the everyone pseudogroup" do
+        message_id = publish_and_poll([Group::AUTO_GROUPS[:everyone]])
+
+        expect(response.parsed_body).to match(disallowed_response(message_id))
+      end
+
+      it "does not receive messages for a specific group" do
+        message_id = publish_and_poll([group_1.id])
+
+        expect(response.parsed_body).to match(disallowed_response(message_id))
+      end
+    end
+  end
 end


### PR DESCRIPTION
For logged in users, MessageBus needs to be able to handle
publish directives with group_ids including the new
anonymous_users and logged_in_users pseudogroups. This commit updates the
message bus configuration to recognize these pseudogroups and ensures that
they are correctly processed when publishing messages to the bus.

If granular_anonymous_and_logged_in_groups_permissions is disabled,
then the everyone pseudogroup will also be used for logged in users.

The use case for this was Kanban boards publishing card updates,
some board permissions have logged_in_users (group ID 5) in the board
permissions which we use for MessageBus group_ids.
