### PR TITLE
FIX: Hide git signature output when reading commit date

### DIFF
--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -22,7 +22,7 @@ class GitUtils
   end
 
   def self.last_commit_date
-    git_cmd = 'git -c log.showSignature=false log -1 --format="%ct"'
+    git_cmd = "git rev-list -1 --no-commit-header --format=%ct HEAD"
     seconds = try_git(git_cmd, nil)
     seconds.nil? ? nil : DateTime.strptime(seconds, "%s")
   end

--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -22,7 +22,7 @@ class GitUtils
   end
 
   def self.last_commit_date
-    git_cmd = 'git log -1 --format="%ct"'
+    git_cmd = 'git -c log.showSignature=false log -1 --format="%ct"'
     seconds = try_git(git_cmd, nil)
     seconds.nil? ? nil : DateTime.strptime(seconds, "%s")
   end

--- a/spec/lib/git_utils_spec.rb
+++ b/spec/lib/git_utils_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe GitUtils do
     end
   end
 
+  describe ".last_commit_date" do
+    it "disables signature output" do
+      timestamp = "1786671289"
+      GitUtils
+        .expects(:try_git)
+        .with('git -c log.showSignature=false log -1 --format="%ct"', nil)
+        .returns(timestamp)
+      expect(GitUtils.last_commit_date).to eq(DateTime.strptime(timestamp, "%s"))
+    end
+  end
+
   describe ".has_commit?" do
     it "validates commit existence and format" do
       within_temp_git_repo do

--- a/spec/lib/git_utils_spec.rb
+++ b/spec/lib/git_utils_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe GitUtils do
   end
 
   describe ".last_commit_date" do
-    it "disables signature output" do
+    it "reads the commit timestamp without commit headers" do
       timestamp = "1786671289"
       GitUtils
         .expects(:try_git)
-        .with('git -c log.showSignature=false log -1 --format="%ct"', nil)
+        .with("git rev-list -1 --no-commit-header --format=%ct HEAD", nil)
         .returns(timestamp)
       expect(GitUtils.last_commit_date).to eq(DateTime.strptime(timestamp, "%s"))
     end


### PR DESCRIPTION
## What does this change?

Disables `log.showSignature` when `GitUtils.last_commit_date` reads the latest commit timestamp.

When `log.showSignature=true` is configured, `git log -1 --format="%ct"` may include GPG signature verification output in addition to the Unix timestamp. This causes `DateTime.strptime` to raise `Date::Error`, which can make `/admin/dashboard/general.json` return a 500 error.

Using `git -c log.showSignature=false` ensures the command returns only the timestamp expected by `GitUtils`.

## Tests

Added a regression test for `.last_commit_date`.

Tested with:

`RAILS_ENV=test bundle exec rspec spec/lib/git_utils_spec.rb`

8 examples, 0 failures.