### PR TITLE
DEV: Refactor test descriptions around observable behavior

### DIFF
--- a/.skills/discourse-writing-js-tests/SKILL.md
+++ b/.skills/discourse-writing-js-tests/SKILL.md
@@ -13,6 +13,10 @@ Discourse uses [QUnit](https://qunitjs.com/) with `ember-qunit` and
 
 - **Test behavior, not implementation** — assert on rendered output, DOM state, and public
   return values, not internal component state or private methods.
+- **Describe behavior, not implementation** — `module` names the public subject or scenario,
+  `test` states the observable outcome, and assertion messages explain the behavior being
+  proved. Avoid implementation details unless they are part of the public contract.
+  Descriptions should survive internal refactoring.
 - **One concept per `test`** — each `test()` verifies one behavior for clear failure diagnosis.
 - **Prefer `assert.dom(...)`** over manual DOM querying. It produces better failure messages
   and waits-free, synchronous DOM reads. See the [qunit-dom API](https://github.com/mainmatter/qunit-dom/blob/master/API.md).

--- a/.skills/discourse-writing-js-tests/SKILL.md
+++ b/.skills/discourse-writing-js-tests/SKILL.md
@@ -13,8 +13,12 @@ Discourse uses [QUnit](https://qunitjs.com/) with `ember-qunit` and
 
 - **Test behavior, not implementation** — assert on rendered output, DOM state, and public
   return values, not internal component state or private methods.
-- **Describe behavior, not implementation** — `module` names the public subject or scenario,
-  `test` states the observable outcome, and assertion messages explain the behavior being
+- **Describe behavior at the test layer** — Unit modules identify the public object under
+  the existing module-naming convention. Component integration modules identify the public
+  component. Other integration modules name the public capability or boundary spanning the
+  participating parts. Acceptance suites name the user task or product feature. Nested
+  modules name a condition or scenario, not an internal mechanism. Each `test` states the
+  observable outcome at that layer, and assertion messages explain the behavior being
   proved. Avoid implementation details unless they are part of the public contract.
   Descriptions should survive internal refactoring.
 - **One concept per `test`** — each `test()` verifies one behavior for clear failure diagnosis.

--- a/.skills/discourse-writing-rspec-tests/SKILL.md
+++ b/.skills/discourse-writing-rspec-tests/SKILL.md
@@ -10,6 +10,7 @@ Discourse uses RSpec for testing. Follow these patterns for all test types.
 ## Testing Principles
 
 - **Test behavior, not implementation** — test public interfaces; don't assert on internal state or private methods. Refactoring internals shouldn't break tests.
+- **Describe behavior, not implementation** — `describe` names the public subject or entry point, `context` names the condition, and `it` states the observable outcome at that test layer. Avoid implementation details unless they are part of the public contract. Descriptions should survive internal refactoring.
 - **Choose assertions at the public boundary** — for a query, assert its return value. For a command, drive its public entry point and assert the direct side effect it owns: persisted state, an enqueued job, an emitted event, a response body, or rendered output. Group class, service, job, and model specs by that entry point (`describe ".call"`, `describe "#execute"`, or `describe "#expire!"`).
 - **One concept per test** — each `it` block verifies one behavior for clear failure diagnosis.
 - **Don't over-mock** — mock external boundaries (HTTP, third-party services), not internal collaborators. Too many mocks signals a design problem.

--- a/.skills/discourse-writing-rspec-tests/SKILL.md
+++ b/.skills/discourse-writing-rspec-tests/SKILL.md
@@ -10,7 +10,13 @@ Discourse uses RSpec for testing. Follow these patterns for all test types.
 ## Testing Principles
 
 - **Test behavior, not implementation** — test public interfaces; don't assert on internal state or private methods. Refactoring internals shouldn't break tests.
-- **Describe behavior, not implementation** — `describe` names the public subject or entry point, `context` names the condition, and `it` states the observable outcome at that test layer. Avoid implementation details unless they are part of the public contract. Descriptions should survive internal refactoring.
+- **Describe behavior at the test layer** — For class, model, service, and job specs,
+  group examples under the public `#instance_method` or `.class_method`. Request specs
+  group examples under the controller action. Integration specs name the public capability
+  or entry point spanning the participating components. System specs name the user task or
+  product feature. At every layer, `context` names the condition and `it` states the
+  observable outcome. Avoid implementation details unless they are part of the public
+  contract. Descriptions should survive internal refactoring.
 - **Choose assertions at the public boundary** — for a query, assert its return value. For a command, drive its public entry point and assert the direct side effect it owns: persisted state, an enqueued job, an emitted event, a response body, or rendered output. Group class, service, job, and model specs by that entry point (`describe ".call"`, `describe "#execute"`, or `describe "#expire!"`).
 - **One concept per test** — each `it` block verifies one behavior for clear failure diagnosis.
 - **Don't over-mock** — mock external boundaries (HTTP, third-party services), not internal collaborators. Too many mocks signals a design problem.

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
@@ -133,7 +133,7 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
       );
   });
 
-  test("renders setting links in the description and rewrites their href via the modifier", async function (assert) {
+  test("links setting names in the description to their config pages", async function (assert) {
     const rewrittenURL = "/admin/config/category/settings?filter=other_setting";
     const dataSource = this.owner.lookup("service:admin-search-data-source");
     dataSource.urlForSetting = ({ setting }) =>
@@ -159,7 +159,7 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
       .hasAttribute(
         "href",
         rewrittenURL,
-        "rewrites the href to the setting's config page via the modifier"
+        "links the setting name to its config page"
       );
 
     assert

--- a/frontend/discourse/tests/integration/components/admin-notice-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-notice-test.gjs
@@ -16,7 +16,7 @@ module("Integration | Component | AdminNotice", function (hooks) {
     updateCurrentUser({ admin: true });
   });
 
-  test("rewrites setting links in the problem message via the modifier", async function (assert) {
+  test("links settings in the problem message to their config pages", async function (assert) {
     const rewrittenURL =
       "/admin/config/onebox?filter=github_onebox_access_tokens";
     const dataSource = this.owner.lookup("service:admin-search-data-source");

--- a/frontend/discourse/tests/integration/components/dashboard/site-advice-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/site-advice-test.gjs
@@ -16,7 +16,7 @@ module("Integration | Component | DashboardSiteAdvice", function (hooks) {
     updateCurrentUser({ admin: true });
   });
 
-  test("rewrites setting links in problem messages via the modifier", async function (assert) {
+  test("links settings in problem messages to their config pages", async function (assert) {
     const rewrittenURL =
       "/admin/config/onebox?filter=github_onebox_access_tokens";
     const dataSource = this.owner.lookup("service:admin-search-data-source");

--- a/frontend/discourse/tests/integration/components/language-switcher-test.gjs
+++ b/frontend/discourse/tests/integration/components/language-switcher-test.gjs
@@ -42,7 +42,7 @@ module("Integration | Component | <LanguageSwitcher />", function (hooks) {
     assert.dom("[data-menu-option-id='de']").exists();
   });
 
-  test("displays locale names from language lookup service", async function (assert) {
+  test("shows localized names for available languages", async function (assert) {
     await render(<template><LanguageSwitcher /></template>);
     await open();
 

--- a/frontend/discourse/tests/unit/lib/keyboard-shortcuts-test.js
+++ b/frontend/discourse/tests/unit/lib/keyboard-shortcuts-test.js
@@ -24,20 +24,20 @@ module("Unit | Utility | keyboard-shortcuts", function (hooks) {
     assert.true(called, "history.back is called");
   });
 
-  test("nextSection calls _changeSection with 1", function (assert) {
+  test("nextSection moves selection to the next section", function (assert) {
     const keyboardShortcuts = this.owner.lookup("service:keyboard-shortcuts");
     let spy = sinon.spy(keyboardShortcuts, "_changeSection");
 
     keyboardShortcuts.nextSection();
-    assert.true(spy.calledWith(1), "_changeSection is called with 1");
+    assert.true(spy.calledWith(1), "moves selection forward");
   });
 
-  test("prevSection calls _changeSection with -1", function (assert) {
+  test("prevSection moves selection to the previous section", function (assert) {
     const keyboardShortcuts = this.owner.lookup("service:keyboard-shortcuts");
     let spy = sinon.spy(keyboardShortcuts, "_changeSection");
 
     keyboardShortcuts.prevSection();
-    assert.true(spy.calledWith(-1), "_changeSection is called with -1");
+    assert.true(spy.calledWith(-1), "moves selection backward");
   });
 
   module("addShortcut context option", function () {
@@ -371,7 +371,7 @@ module("Unit | Utility | keyboard-shortcuts", function (hooks) {
       );
     });
 
-    test("selectDown outside the nested view delegates to _moveSelection", function (assert) {
+    test("selectDown moves selection down in the flat topic stream", function (assert) {
       const ks = this.owner.lookup("service:keyboard-shortcuts");
       const stub = sinon.stub(ks, "_moveSelection");
       try {

--- a/frontend/discourse/tests/unit/lib/uppy-media-optimization-plugin-test.js
+++ b/frontend/discourse/tests/unit/lib/uppy-media-optimization-plugin-test.js
@@ -51,7 +51,7 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function (hooks) {
     assert.strictEqual(plugin.optimizeFn(), "wow such optimized");
   });
 
-  test("installation uses the correct function", function (assert) {
+  test("installation registers the selected optimization mode", function (assert) {
     const fakeUppy = new FakeUppy();
     const plugin = new UppyMediaOptimization(fakeUppy, {
       runParallel: true,

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Chat::DirectMessageChannel do
     let(:user) { stub }
     let(:direct_message) { channel.direct_message }
 
-    it "delegates to direct_message" do
+    it "returns the direct message title for the user" do
       direct_message.expects(:chat_channel_title_for_user).with(channel, user).returns("something")
       expect(title).to eq("something")
     end

--- a/plugins/discourse-ai/spec/lib/translation/translation_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/translation_spec.rb
@@ -10,7 +10,7 @@ describe DiscourseAi::Translation do
   end
 
   describe ".locales" do
-    it "delegates to SiteSetting.content_localization_locales" do
+    it "returns the configured content localization locales" do
       SiteSetting.content_localization_supported_locales = "es|fr"
       SiteSetting.default_locale = "en"
 

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/pin-data-editor-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/pin-data-editor-test.gjs
@@ -130,7 +130,7 @@ module(
         .containsText("Pinned data must be an array of items");
     });
 
-    test("Save calls pinNodeData and exits edit mode", async function (assert) {
+    test("Save persists pinned data and closes the editor", async function (assert) {
       let requestBody = null;
       pretender.put(
         "/admin/plugins/discourse-workflows/workflows/7/pin-data.json",

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -37,43 +37,43 @@ RSpec.describe Jobs::UserEmail do
     fab!(:user) { Fabricate(:user, last_seen_at: 8.days.ago, last_emailed_at: 8.days.ago) }
     fab!(:popular_topic) { Fabricate(:topic, user: Fabricate(:admin), created_at: 1.hour.ago) }
 
-    it "doesn't call the mailer when the user is missing" do
+    it "does not send a digest when the user is missing" do
       Jobs::UserEmail.new.execute(type: :digest, user_id: User.last.id + 10_000)
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
-    it "doesn't call the mailer when the user is staged" do
+    it "does not send a digest when the user is staged" do
       staged.update!(last_seen_at: 8.days.ago, last_emailed_at: 8.days.ago)
       Jobs::UserEmail.new.execute(type: :digest, user_id: staged.id)
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
-    it "doesn't call the mailer when the user is suspended" do
+    it "does not send a digest when the user is suspended" do
       suspended.update!(last_seen_at: 8.days.ago, last_emailed_at: 8.days.ago)
       Jobs::UserEmail.new.execute(type: :digest, user_id: suspended.id)
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
-    it "doesn't call the mailer when the user is not active" do
+    it "does not send a digest when the user is not active" do
       user.update!(active: false)
       Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
-    it "doesn't call the mailer when the user has disabled email digests" do
+    it "does not send a digest when the user has disabled email digests" do
       user.user_option.update!(email_digests: false)
       Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
-    it "doesn't call the mailer when the user has enabled mailing list mode" do
+    it "does not send a digest when the user has enabled mailing list mode" do
       SiteSetting.disable_mailing_list_mode = false
       user.user_option.update!(mailing_list_mode: true)
       Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
-    it "doesn't call the mailer when the user's digest_after_minute is 0" do
+    it "does not send a digest when the user's digest interval is disabled" do
       user.user_option.update!(digest_after_minutes: 0)
       Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
       expect(ActionMailer::Base.deliveries).to eq([])
@@ -85,7 +85,7 @@ RSpec.describe Jobs::UserEmail do
         user.update!(last_emailed_at: 8.days.ago)
       end
 
-      it "calls the mailer when the user exists" do
+      it "sends a digest and records the delivery attempt" do
         Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
         expect(ActionMailer::Base.deliveries).to_not be_empty
         expect(user.user_stat.reload.digest_attempted_at).to eq_time(Time.zone.now)

--- a/spec/services/site_setting/update_spec.rb
+++ b/spec/services/site_setting/update_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe SiteSetting::Update do
         ]
       end
 
-      it "calls the relevant class for backfill" do
+      it "backfills users for settings that request it" do
         SiteSettingUpdateExistingUsers.expects(:call).once.with("default_hide_profile", true, false)
 
         result

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe UserAnonymizer do
       expect(user.ip_address).to eq(old_ip)
     end
 
-    it "is called if you pass an option" do
+    it "anonymizes IP addresses when anonymize_ip is provided" do
       UserAnonymizer.make_anonymous(user, admin, anonymize_ip: anon_ip)
       user.reload
       expect(user.ip_address).to eq(anon_ip)

--- a/themes/horizon/test/acceptance/topic-activity-column-test.gjs
+++ b/themes/horizon/test/acceptance/topic-activity-column-test.gjs
@@ -9,7 +9,7 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test("formats the bumpedAt date", async function (assert) {
+    test("shows the topic activity month and year", async function (assert) {
       const topic = Topic.create({
         id: 1,
         bumped_at: "2024-06-01T12:00:00Z",
@@ -20,7 +20,7 @@ module(
       assert.dom(".topic-activity__time").hasText("Jun 2024");
     });
 
-    test("has the correct user details and class when there is only one post", async function (assert) {
+    test("shows the topic creator for a topic with one post", async function (assert) {
       const topic = Topic.create({
         id: 1,
         bumped_at: "2024-06-01T12:00:00Z",
@@ -34,7 +34,7 @@ module(
       assert.dom(".topic-activity__username").hasText("bob");
     });
 
-    test("has the correct user details and class when there are multiple posts", async function (assert) {
+    test("shows the latest replier for a topic with multiple posts", async function (assert) {
       const topic = Topic.create({
         id: 1,
         bumped_at: "2024-06-01T12:00:00Z",
@@ -48,7 +48,7 @@ module(
       assert.dom(".topic-activity__username").hasText("alice");
     });
 
-    test("shows no user and the updated class when the topic was bumped long after the last post", async function (assert) {
+    test("omits the user when topic activity is not tied to a post", async function (assert) {
       const topic = Topic.create({
         id: 1,
         bumped_at: "2024-06-10T12:00:00Z",


### PR DESCRIPTION
This PR makes test descriptions name behavior at the public boundary appropriate to each test layer.

The RSpec skill now says:

- class, model, service, and job specs group examples under the public instance or class method
- request specs group examples under the controller action
- integration specs name the public capability or entry point spanning participating components
- system specs name the user task or product feature
- contexts name conditions and examples state observable outcomes

The QUnit skill applies the same principle to JavaScript:

- unit modules identify the public object
- component integration modules identify the public component
- other integration modules name the public capability or boundary
- acceptance suites name the user task or product feature
- nested modules name conditions or scenarios, tests state observable outcomes, and assertion messages explain the behavior proved

The existing stricter user-perspective guidance remains in place for system and acceptance tests.

## Sweep coverage

Parallel read-only sweeps covered core, bundled plugins, themes, and migrations without overlapping ownership:

- 3,424 RSpec files and 65,519 declaration lines
- 1,155 QUnit files and 9,936 module/test declaration lines
- separate mechanism-keyword searches for contexts, examples, tests, and assertion messages

Every reported candidate was inspected in context. This PR changes 25 test/example descriptions and 3 assertion messages where the public outcome was clear. It does not change test behavior or production code.

Some implementation-oriented descriptions were deliberately retained because the mechanism is itself the public contract. Examples include protocol and wire formats, public component callback arguments, cache APIs whose contract is hit/miss/TTL/invalidation behavior, MessageBus channel and payload contracts, and DOM classes in low-level rendering tests where the class is the rendered API.

## Validation

- 12 focused RSpec examples
- 44 core QUnit tests
- 450 discourse-workflows QUnit tests
- 11 Horizon QUnit tests
- `bin/lint --fix` for the updated skill files immediately before the latest push
