### PR TITLE
FIX: Stop the event builder from clearing typed custom fields

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -55,7 +55,7 @@ export default class PostEventBuilder extends Component {
   // mirror-write and reinitialize the form (losing focus mid-keystroke).
   // Snapshot once at construction; refresh only when toggleAdvanced enters
   // the advanced screen.
-  formData = this.#snapshotFormData();
+  @tracked formData = this.#snapshotFormData();
 
   #initAttendanceMode() {
     if (this.event.status === "standalone") {
@@ -561,8 +561,12 @@ export default class PostEventBuilder extends Component {
   }
 
   @action
-  setCustomField(field, value) {
-    this.event.customFields[field] = value;
+  setCustomField(field, value, { set, name }) {
+    set(name, value);
+    this.event.customFields = EmberObject.create({
+      ...this.event.customFields,
+      [field]: value,
+    });
   }
 
   @action

--- a/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
@@ -1,5 +1,5 @@
 import { getOwner } from "@ember/owner";
-import { fillIn, render } from "@ember/test-helpers";
+import { click, fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import PostEventBuilder from "../../discourse/components/modal/post-event-builder";
@@ -151,6 +151,110 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
     assert.false(
       event.livestream,
       "livestream is reset so it is not submitted for a non-URL location"
+    );
+  });
+
+  test("typed custom field keeps its value when the location is edited", async function (assert) {
+    this.siteSettings.discourse_post_event_allowed_custom_fields = "test1";
+
+    const event = DiscoursePostEventEvent.create({
+      name: "My event",
+      starts_at: "2022-07-01T10:00:00Z",
+      ends_at: "2022-07-01T11:00:00Z",
+      timezone: "UTC",
+      status: "public",
+      reminders: [],
+      raw_invitees: [],
+      custom_fields: {},
+    });
+
+    let updatedEvent = null;
+    const model = {
+      event,
+      initialScreen: "advanced",
+      onUpdate: (startsAt, endsAt, savedEvent) => {
+        updatedEvent = savedEvent;
+      },
+      toolbarEvent: {},
+    };
+    const closeModal = () => {};
+
+    await render(
+      <template>
+        <PostEventBuilder
+          @inline={{true}}
+          @model={{model}}
+          @closeModal={{closeModal}}
+        />
+      </template>
+    );
+
+    await fillIn(`[data-name="customFields.test1"] input`, "hello");
+    await fillIn(`[data-name="location"] input`, "Sydney");
+
+    assert
+      .dom(`[data-name="customFields.test1"] input`)
+      .hasValue("hello", "the custom field is not visually cleared");
+
+    await click(".btn-primary");
+    assert.strictEqual(
+      updatedEvent.customFields.test1,
+      "hello",
+      "the custom field value is part of the saved event"
+    );
+  });
+
+  test("typed custom field survives a compact-screen edit in between", async function (assert) {
+    this.siteSettings.discourse_post_event_allowed_custom_fields = "test1";
+
+    const event = DiscoursePostEventEvent.create({
+      name: "My event",
+      starts_at: "2022-07-01T10:00:00Z",
+      ends_at: "2022-07-01T11:00:00Z",
+      timezone: "UTC",
+      status: "public",
+      reminders: [],
+      raw_invitees: [],
+      custom_fields: { test1: "seeded" },
+    });
+
+    let updatedEvent = null;
+    const model = {
+      event,
+      initialScreen: "compact",
+      onUpdate: (startsAt, endsAt, savedEvent) => {
+        updatedEvent = savedEvent;
+      },
+      toolbarEvent: {},
+    };
+    const closeModal = () => {};
+
+    await render(
+      <template>
+        <PostEventBuilder
+          @inline={{true}}
+          @model={{model}}
+          @closeModal={{closeModal}}
+        />
+      </template>
+    );
+
+    await click(".advanced-mode-btn");
+    await fillIn(`[data-name="customFields.test1"] input`, "typed");
+
+    await click(".advanced-mode-btn");
+    await fillIn(".composer-event__location-input", "Sydney");
+
+    await click(".advanced-mode-btn");
+    assert
+      .dom(`[data-name="customFields.test1"] input`)
+      .hasValue("typed", "the advanced screen shows the latest value");
+
+    await click(".btn-primary");
+    assert.strictEqual(
+      updatedEvent.customFields.test1,
+      "typed",
+      "the compact edit does not revive the stale value"
     );
   });
 });


### PR DESCRIPTION
Previously, values typed into the event builder's custom fields were cleared as soon as another field changed (location, image, name, …), and toggling between the compact and advanced screens could permanently revert them to stale values.

This change commits custom field values through the form's `set` (a field's `@onSet` replaces FormKit's default write, so skipping it left the typed value out of the form data), replaces the `customFields` reference on every write (mutating inside the object never invalidated `compactInitialState`, so the compact screen served stale values back), and tracks `formData` (untracked, the advanced screen always reinitialized from the modal's construction-time snapshot).

Reported in https://meta.discourse.org/t/potential-bug-where-data-in-custom-fields-is-cleared-if-certain-fields-change/410050