### PR TITLE
FEATURE: Name the linked topic in linked notifications

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -224,7 +224,7 @@ class PostAlerter
           user,
           :linked,
           post,
-          custom_data: linked_topics_notification_data(linked_topics_by_user[user]),
+          custom_data: linked_topics_notification_data(user, linked_topics_by_user[user]),
         )
     end
 
@@ -851,9 +851,11 @@ class PostAlerter
         next if !user
 
         linked_topic ||= linked_post.topic
-        next if !linked_topic
 
-        (by_user[user] ||= []) << linked_topic
+        # A user with no visible linked topic still gets notified, exactly as
+        # before; they just have no topic named for them.
+        by_user[user] ||= []
+        by_user[user] << linked_topic if linked_topic
       end
 
     by_user
@@ -861,10 +863,17 @@ class PostAlerter
 
   # The `linked_topics` payload for one recipient, capped so a post linking
   # many of their topics cannot bloat the notification.
-  def linked_topics_notification_data(topics)
+  #
+  # Titles are stored on the notification and sent to the client, so a topic
+  # the recipient cannot see is left out entirely: moving a post leaves a
+  # moderator post linking the destination, which may be restricted. They are
+  # still notified, just without a topic named.
+  def linked_topics_notification_data(user, topics)
     return {} if topics.blank?
 
-    named = topics.uniq(&:id)
+    guardian = Guardian.new(user)
+    named = topics.uniq(&:id).select { |topic| guardian.can_see?(topic) }
+    return {} if named.empty?
 
     {
       linked_topics:

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -211,8 +211,22 @@ class PostAlerter
     DiscourseEvent.trigger(:post_alerter_before_linked, post, new_record, notified)
 
     # linked
-    linked_users = extract_linked_users(post)
-    notified += notify_non_pm_users(linked_users - notified, :linked, post)
+    #
+    # Notified one at a time rather than as a batch: each recipient's
+    # notification names the topics of *theirs* that were linked, so the
+    # custom data differs per user.
+    linked_topics_by_user = extract_linked_topics_by_user(post)
+    linked_users = extract_linked_users(post, linked_topics_by_user)
+
+    (linked_users - notified).uniq.each do |user|
+      notified +=
+        notify_non_pm_users(
+          user,
+          :linked,
+          post,
+          custom_data: linked_topics_notification_data(linked_topics_by_user[user]),
+        )
+    end
 
     DiscourseEvent.trigger(:post_alerter_before_post, post, new_record, notified)
 
@@ -800,23 +814,65 @@ class PostAlerter
     User.where.not(id: post.user_id).where(username_lower: usernames)
   end
 
-  def extract_linked_users(post)
-    users =
-      post
-        .topic_links
-        .where(reflection: false)
-        .map do |link|
-          linked_post = link.link_post
-          if !linked_post && topic = link.link_topic
-            linked_post = topic.posts.find_by(post_number: 1)
-          end
-          (linked_post && post.user_id != linked_post.user_id && linked_post.user) || nil
-        end
-        .compact
+  # The most topics we name individually in a linked notification. Anything
+  # past this is reported as a count so the stored data stays bounded.
+  MAX_LINKED_TOPICS_IN_NOTIFICATION = 5
+
+  # `linked_topics_by_user` is accepted so the notify path can reuse a map it
+  # has already built rather than querying the links twice.
+  def extract_linked_users(post, linked_topics_by_user = nil)
+    linked_topics_by_user ||= extract_linked_topics_by_user(post)
+    users = linked_topics_by_user.flat_map { |user, links| [user] * links.size }
 
     DiscourseEvent.trigger(:after_extract_linked_users, users, post)
 
     users
+  end
+
+  # Maps each notifiable user to the topics of theirs that `post` links to.
+  #
+  # A single post can link several of one author's topics, but they only get
+  # one notification for it, so the notification has to name every topic
+  # rather than an arbitrary one of them.
+  def extract_linked_topics_by_user(post)
+    by_user = {}
+
+    post
+      .topic_links
+      .where(reflection: false)
+      .each do |link|
+        linked_post = link.link_post
+        linked_topic = link.link_topic
+        linked_post = linked_topic.posts.find_by(post_number: 1) if !linked_post && linked_topic
+        next if !linked_post
+        next if post.user_id == linked_post.user_id
+
+        user = linked_post.user
+        next if !user
+
+        linked_topic ||= linked_post.topic
+        next if !linked_topic
+
+        (by_user[user] ||= []) << linked_topic
+      end
+
+    by_user
+  end
+
+  # The `linked_topics` payload for one recipient, capped so a post linking
+  # many of their topics cannot bloat the notification.
+  def linked_topics_notification_data(topics)
+    return {} if topics.blank?
+
+    named = topics.uniq(&:id)
+
+    {
+      linked_topics:
+        named
+          .first(MAX_LINKED_TOPICS_IN_NOTIFICATION)
+          .map { |topic| { topic_id: topic.id, title: topic.title, slug: topic.slug } },
+      linked_topics_count: named.size,
+    }
   end
 
   # Notify a bunch of users

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3785,6 +3785,9 @@ en:
         one: "linked %{count} of your posts"
         other: "linked %{count} of your posts"
       linked_consolidated: "<span>%{username}</span> %{description}"
+      linked_topics_with_others:
+        one: "%{topic} and %{count} other topic of yours"
+        other: "%{topic} and %{count} other topics of yours"
       private_message: "<span>%{username}</span> %{description}"
       invited_to_private_message: "<p><span>%{username}</span> %{description}"
       invited_to_topic: "<span>%{username}</span> %{description}"

--- a/frontend/discourse/app/lib/notification-types-manager.js
+++ b/frontend/discourse/app/lib/notification-types-manager.js
@@ -9,6 +9,7 @@ import GroupMessageSummary from "discourse/lib/notification-types/group-message-
 import InviteeAccepted from "discourse/lib/notification-types/invitee-accepted";
 import Liked from "discourse/lib/notification-types/liked";
 import LikedConsolidated from "discourse/lib/notification-types/liked-consolidated";
+import Linked from "discourse/lib/notification-types/linked";
 import LinkedConsolidated from "discourse/lib/notification-types/linked-consolidated";
 import MembershipRequestAccepted from "discourse/lib/notification-types/membership-request-accepted";
 import MembershipRequestConsolidated from "discourse/lib/notification-types/membership-request-consolidated";
@@ -29,6 +30,7 @@ const CLASS_FOR_TYPE = {
   invitee_accepted: InviteeAccepted,
   liked: Liked,
   liked_consolidated: LikedConsolidated,
+  linked: Linked,
   linked_consolidated: LinkedConsolidated,
   membership_request_accepted: MembershipRequestAccepted,
   membership_request_consolidated: MembershipRequestConsolidated,

--- a/frontend/discourse/app/lib/notification-types/linked.js
+++ b/frontend/discourse/app/lib/notification-types/linked.js
@@ -1,0 +1,32 @@
+import NotificationTypeBase from "discourse/lib/notification-types/base";
+import { i18n } from "discourse-i18n";
+
+export default class extends NotificationTypeBase {
+  /**
+   * Names the recipient's topic that was linked, rather than the topic doing
+   * the linking, so they can tell which of their own topics this is about.
+   *
+   * One post can link several of their topics but only produces a single
+   * notification. The description is a single clamped line, so listing every
+   * title runs past the end and cuts mid-word; the first title plus a count
+   * of the rest stays readable and still says how many there were.
+   */
+  get description() {
+    const topics = this.notification.data.linked_topics;
+    if (!topics?.length) {
+      return super.description;
+    }
+
+    const total = this.notification.data.linked_topics_count ?? topics.length;
+    const remaining = total - 1;
+
+    if (remaining > 0) {
+      return i18n("notifications.linked_topics_with_others", {
+        topic: topics[0].title,
+        count: remaining,
+      });
+    }
+
+    return topics[0].title;
+  }
+}

--- a/frontend/discourse/tests/unit/lib/notification-types/linked-test.js
+++ b/frontend/discourse/tests/unit/lib/notification-types/linked-test.js
@@ -1,0 +1,140 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { deepMerge } from "discourse/lib/object";
+import Notification from "discourse/models/notification";
+import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
+import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
+import { i18n } from "discourse-i18n";
+
+function getNotification(overrides = {}) {
+  return Notification.create(
+    deepMerge(
+      {
+        id: 11,
+        user_id: 1,
+        notification_type: NOTIFICATION_TYPES.linked,
+        read: false,
+        high_priority: false,
+        created_at: "2022-07-01T06:00:32.173Z",
+        fancy_title: "The topic that did the linking",
+        slug: "the-topic-that-did-the-linking",
+        topic_id: 22,
+        data: {
+          topic_title: "The topic that did the linking",
+          original_post_id: 3294,
+          original_post_type: 1,
+          original_username: "linkerman",
+          display_username: "linkerman",
+          linked_topics: [{ topic_id: 5, title: "My first topic" }],
+          linked_topics_count: 1,
+        },
+      },
+      overrides
+    )
+  );
+}
+
+function directorFor(notification, siteSettings) {
+  return createRenderDirector(notification, "linked", siteSettings);
+}
+
+module("Unit | Notification Types | linked", function (hooks) {
+  setupTest(hooks);
+
+  test("names the linked topic rather than the linking one", function (assert) {
+    const director = directorFor(getNotification(), this.siteSettings);
+    assert.strictEqual(
+      director.description,
+      "My first topic",
+      "shows the recipient's own topic"
+    );
+  });
+
+  test("names the first topic and counts the rest", function (assert) {
+    // One post linking several of the recipient's topics still produces a
+    // single notification, and the description is one clamped line, so the
+    // remainder is reported as a count.
+    const notification = getNotification({
+      data: {
+        linked_topics: [
+          { topic_id: 5, title: "My first topic" },
+          { topic_id: 6, title: "My second topic" },
+        ],
+        linked_topics_count: 3,
+      },
+    });
+    const director = directorFor(notification, this.siteSettings);
+
+    assert.strictEqual(
+      director.description,
+      i18n("notifications.linked_topics_with_others", {
+        topic: "My first topic",
+        count: 2,
+      }),
+      "names one topic and counts the others"
+    );
+  });
+
+  test("uses the singular form for exactly one other topic", function (assert) {
+    const notification = getNotification({
+      data: {
+        linked_topics: [
+          { topic_id: 5, title: "My first topic" },
+          { topic_id: 6, title: "My second topic" },
+        ],
+        linked_topics_count: 2,
+      },
+    });
+    const director = directorFor(notification, this.siteSettings);
+
+    assert.strictEqual(
+      director.description,
+      i18n("notifications.linked_topics_with_others", {
+        topic: "My first topic",
+        count: 1,
+      }),
+      "counts a single remaining topic"
+    );
+  });
+
+  test("counts topics beyond the stored ones", function (assert) {
+    // The backend caps how many titles it stores but keeps the true total,
+    // so the count comes from linked_topics_count, not the array length.
+    const notification = getNotification({
+      data: {
+        linked_topics: [
+          { topic_id: 5, title: "My first topic" },
+          { topic_id: 6, title: "My second topic" },
+        ],
+        linked_topics_count: 9,
+      },
+    });
+    const director = directorFor(notification, this.siteSettings);
+
+    assert.strictEqual(
+      director.description,
+      i18n("notifications.linked_topics_with_others", {
+        topic: "My first topic",
+        count: 8,
+      }),
+      "reports every uncounted topic, not just the stored ones"
+    );
+  });
+
+  test("falls back to the linking topic when no linked topics were recorded", function (assert) {
+    // Notifications created before this data was stored have to keep
+    // rendering.
+    const notification = getNotification({
+      data: { linked_topics: null, linked_topics_count: null },
+    });
+    const director = directorFor(notification, this.siteSettings);
+
+    // The base class returns the linking topic's fancy_title wrapped for safe
+    // HTML rendering, so compare the rendered text rather than the wrapper.
+    assert.strictEqual(
+      director.description.toString(),
+      "The topic that did the linking",
+      "uses the previous behaviour"
+    );
+  });
+});

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -707,6 +707,84 @@ RSpec.describe PostAlerter do
       expect(PostAlerter.new.extract_linked_users(post1).length).to eq(0)
     end
 
+    it "records the linked topic on the notification" do
+      linking_post
+
+      notification = user.notifications.find_by(notification_type: Notification.types[:linked])
+      data = notification.data_hash
+
+      expect(data[:linked_topics].map { |t| t[:topic_id] }).to eq([post1.topic_id])
+      expect(data[:linked_topics].first[:title]).to eq(post1.topic.title)
+      expect(data[:linked_topics_count]).to eq(1)
+    end
+
+    it "records every linked topic when one post links several of them" do
+      # A post linking three of someone's topics still produces a single
+      # notification, so that notification has to name all three rather than
+      # an arbitrary one.
+      other1 = create_post(user: user, raw: "another topic of mine")
+      other2 = create_post(user: user, raw: "a third topic of mine")
+
+      create_post(
+        raw:
+          "see #{Discourse.base_url}#{post1.url} " \
+            "and #{Discourse.base_url}#{other1.url} " \
+            "and #{Discourse.base_url}#{other2.url}",
+      )
+
+      notifications = user.notifications.where(notification_type: Notification.types[:linked])
+      expect(notifications.count).to eq(1)
+
+      data = notifications.first.data_hash
+      expect(data[:linked_topics].map { |t| t[:topic_id] }).to contain_exactly(
+        post1.topic_id,
+        other1.topic_id,
+        other2.topic_id,
+      )
+      expect(data[:linked_topics_count]).to eq(3)
+    end
+
+    it "caps the named topics but keeps the full count" do
+      posts =
+        (1..PostAlerter::MAX_LINKED_TOPICS_IN_NOTIFICATION + 2).map do |i|
+          create_post(user: user, raw: "a topic of mine number #{i}")
+        end
+
+      # Kept on one line so the links stay inline: a post that is nothing but
+      # bare URLs gets oneboxed, and rendering those previews reaches for
+      # avatar images that WebMock blocks.
+      create_post(raw: "see " + posts.map { |p| "#{Discourse.base_url}#{p.url}" }.join(" and "))
+
+      data =
+        user.notifications.where(notification_type: Notification.types[:linked]).first.data_hash
+
+      expect(data[:linked_topics].size).to eq(PostAlerter::MAX_LINKED_TOPICS_IN_NOTIFICATION)
+      expect(data[:linked_topics_count]).to eq(posts.size)
+    end
+
+    it "gives each recipient only their own linked topics" do
+      other_user_post = create_post
+
+      create_post(
+        raw:
+          "see #{Discourse.base_url}#{post1.url}\n" \
+            "and #{Discourse.base_url}#{other_user_post.url}",
+      )
+
+      mine =
+        user.notifications.where(notification_type: Notification.types[:linked]).first.data_hash
+      theirs =
+        other_user_post
+          .user
+          .notifications
+          .where(notification_type: Notification.types[:linked])
+          .first
+          .data_hash
+
+      expect(mine[:linked_topics].map { |t| t[:topic_id] }).to eq([post1.topic_id])
+      expect(theirs[:linked_topics].map { |t| t[:topic_id] }).to eq([other_user_post.topic_id])
+    end
+
     it "triggers :before_create_notifications_for_users" do
       events = DiscourseEvent.track_events { linking_post }
       expect(events).to include(

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -785,6 +785,35 @@ RSpec.describe PostAlerter do
       expect(theirs[:linked_topics].map { |t| t[:topic_id] }).to eq([other_user_post.topic_id])
     end
 
+    it "does not name a linked topic the recipient cannot see" do
+      # Moving a post leaves a moderator post linking the destination topic,
+      # which may be in a category the post's author has no access to. The
+      # title is stored on the notification and sent to the client, so it must
+      # not name that topic - they are still notified, just without it named.
+      # The recipient authored the post in the restricted topic - that is what
+      # a moved post looks like - so the link resolves to them and would be
+      # named on their notification without the visibility check.
+      restricted_category = Fabricate(:private_category, group: Group[:staff])
+      restricted_topic =
+        Fabricate(:topic, category: restricted_category, title: "Secret destination")
+      restricted_post = Fabricate(:post, topic: restricted_topic, user: user)
+
+      expect(user.guardian.can_see?(restricted_topic)).to eq(false)
+
+      create_post(
+        raw:
+          "see #{Discourse.base_url}#{post1.url} " \
+            "and #{Discourse.base_url}#{restricted_post.url}",
+      )
+
+      notification = user.notifications.find_by(notification_type: Notification.types[:linked])
+      expect(notification).to be_present
+
+      titles = notification.data_hash[:linked_topics].map { |t| t[:title] }
+      expect(titles).to eq([post1.topic.title])
+      expect(notification.data).not_to include("Secret destination")
+    end
+
     it "triggers :before_create_notifications_for_users" do
       events = DiscourseEvent.track_events { linking_post }
       expect(events).to include(


### PR DESCRIPTION
A "linked" notification told you someone had linked one of your topics but not which one, so with several of your own topics in play you had to open the post and hunt for the link.

The notification now names the topic of yours that was linked. A post linking several of your topics still produces a single notification