### PR TITLE
FEATURE: `type: icon` support for theme settings

### DIFF
--- a/app/models/theme_setting.rb
+++ b/app/models/theme_setting.rb
@@ -6,7 +6,17 @@ class ThemeSetting < ActiveRecord::Base
   has_many :upload_references, as: :target, dependent: :destroy
 
   TYPES_ENUM =
-    Enum.new(integer: 0, float: 1, string: 2, bool: 3, list: 4, enum: 5, upload: 6, objects: 7)
+    Enum.new(
+      integer: 0,
+      float: 1,
+      string: 2,
+      bool: 3,
+      list: 4,
+      enum: 5,
+      upload: 6,
+      objects: 7,
+      icon: 8,
+    )
 
   MAXIMUM_JSON_VALUE_SIZE_BYTES = 0.5 * 1024 * 1024 # 0.5 MB
 

--- a/docs/developer-guides/docs/05-themes-components/09-theme-settings.md
+++ b/docs/developer-guides/docs/05-themes-components/09-theme-settings.md
@@ -43,7 +43,7 @@ So until this point we've covered the simplest way to define settings. In the ne
 
 ## :symbols: Supported types
 
-There are 8 types of settings:
+There are 9 types of settings:
 
 1. `integer`
 2. `float`
@@ -53,6 +53,7 @@ There are 8 types of settings:
 6. `enum`
 7. `objects` (replacement for `json_schema`)
 8. `upload` (for images)
+9. `icon` (for a single icon from the Discourse icon set)
 
 And you can specify type by adding a `type` attribute to your setting like this:
 
@@ -69,7 +70,7 @@ float_setting:
   default: 3.14
 ```
 
-That said, you _need_ to set a type attribute when working with **`list`** and **`enum`** settings, otherwise Discourse will not recognize them correctly.
+That said, you _need_ to set a type attribute when working with **`list`**, **`enum`** and **`icon`** settings, otherwise Discourse will not recognize them correctly.
 
 **List Setting:**
 
@@ -100,6 +101,16 @@ You can set the default list of values for the setting by joining the values wit
 You can see a real-world use case for list settings here: https://meta.discourse.org/t/linkify-words-in-post-theme-component/82193?u=osama.
 
 > :loudspeaker: **Note**: Pay attention to indentation when working with YAML because YAML is very picky about spaces and will throw a syntax error if your code indentation is incorrect.
+
+**Icon Setting:**
+
+```yaml
+banner_icon:
+  default: bullhorn
+  type: icon
+```
+
+Icon settings give site owners a searchable icon picker, and the value is the icon name. Discourse adds the selected icon to the sprite sheet, so you can render it in your theme without registering it separately.
 
 ### `objects` type
 

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -505,11 +505,16 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
 
   def self.settings_icons
     get_set_cache("settings_icons") do
-      # includes svg_icon_subset and any settings containing _icon (incl. plugin settings)
+      # includes svg_icon_subset, icon type settings, and any settings containing
+      # _icon (incl. plugin settings)
       site_setting_icons = []
 
       SiteSetting.settings_hash.each do |key, value|
-        site_setting_icons |= value.split("|") if key.to_s.include?("_icon") && String === value
+        next unless String === value
+
+        if key.to_s.include?("_icon") || SiteSetting.type_supervisor.get_type(key) == :icon
+          site_setting_icons |= value.split("|")
+        end
       end
 
       site_setting_icons
@@ -538,12 +543,16 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     Theme
       .where(id: theme_ids)
       .each do |theme|
-        _settings =
-          theme.cached_settings.each do |key, value|
-            if key.to_s.include?("_icon") && String === value
-              theme_icon_settings |= value.split("|")
-            end
+        settings = theme.cached_settings
+        type_info = settings["theme_setting_type_info"] || {}
+
+        settings.each do |key, value|
+          next unless String === value
+
+          if key.to_s.include?("_icon") || type_info.dig(key, :type) == "icon"
+            theme_icon_settings |= value.split("|")
           end
+        end
       end
 
     theme_icon_settings |= ThemeModifierHelper.new(theme_ids: theme_ids).svg_icons

--- a/lib/theme_settings_manager/icon.rb
+++ b/lib/theme_settings_manager/icon.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ThemeSettingsManager::Icon < ThemeSettingsManager
+end

--- a/lib/theme_settings_validator.rb
+++ b/lib/theme_settings_validator.rb
@@ -15,7 +15,7 @@ class ThemeSettingsValidator
         value.is_a?(Integer) || value.is_a?(Float)
       when types[:bool]
         value.is_a?(TrueClass) || value.is_a?(FalseClass)
-      when types[:list]
+      when types[:list], types[:icon]
         value.is_a?(String)
       when types[:objects]
         value.is_a?(Array) && value.all? { |v| v.is_a?(Hash) }

--- a/spec/fixtures/site_settings/icon_settings.yml
+++ b/spec/fixtures/site_settings/icon_settings.yml
@@ -1,0 +1,4 @@
+category:
+  reaction_flair:
+    type: icon
+    default: ""

--- a/spec/fixtures/theme_settings/valid_settings.yaml
+++ b/spec/fixtures/theme_settings/valid_settings.yaml
@@ -77,6 +77,10 @@ upload_setting:
   type: upload
   default: "default-upload"
 
+icon_setting:
+  type: icon
+  default: "heart"
+
 invalid_json_schema_setting:
   default: ""
   json_schema: '{ "type": "array", "invalid json"'

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -145,6 +145,30 @@ RSpec.describe SvgSprite do
     expect(SvgSprite.all_icons(parent_theme.id)).to include("dragon")
   end
 
+  it "includes icons defined in icon type theme settings" do
+    theme.set_field(
+      target: :settings,
+      name: :yaml,
+      value: "flair:\n  type: icon\n  default: dragon\n",
+    )
+    theme.save!
+    expect(SvgSprite.all_icons(theme.id)).to include("dragon")
+
+    theme.update_setting(:flair, "gas-pump")
+    theme.save!
+    expect(SvgSprite.all_icons(theme.id)).to include("gas-pump")
+    expect(SvgSprite.all_icons(theme.id)).not_to include("dragon")
+  end
+
+  it "includes icons defined in icon type site settings" do
+    SiteSetting.load_settings(Rails.root.join("spec/fixtures/site_settings/icon_settings.yml").to_s)
+
+    SiteSetting.reaction_flair = "dragon"
+    SvgSprite.expire_cache
+
+    expect(SvgSprite.all_icons).to include("dragon")
+  end
+
   it "includes icons defined in theme modifiers" do
     child_theme = Fabricate(:theme, component: true)
     theme.add_relative_theme!(:child, child_theme)

--- a/spec/lib/theme_settings_manager_spec.rb
+++ b/spec/lib/theme_settings_manager_spec.rb
@@ -205,6 +205,25 @@ RSpec.describe ThemeSettingsManager do
     end
   end
 
+  describe "Icon" do
+    it "stores the icon name" do
+      icon_setting = theme_settings[:icon_setting]
+      expect(icon_setting.value).to eq("heart")
+
+      icon_setting.value = "gamepad"
+      theme.reload
+
+      expect(icon_setting.value).to eq("gamepad")
+      expect(
+        ThemeSetting.exists?(
+          theme_id: theme.id,
+          name: "icon_setting",
+          data_type: ThemeSetting.types[:icon],
+        ),
+      ).to eq(true)
+    end
+  end
+
   describe "Upload" do
     let!(:upload) { Fabricate(:upload) }
 

--- a/spec/lib/theme_settings_parser_spec.rb
+++ b/spec/lib/theme_settings_parser_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe ThemeSettingsParser do
     expect(loader.find_by_name(:float_setting)[:type]).to eq(types[:float])
     expect(loader.find_by_name(:list_setting)[:type]).to eq(types[:list])
     expect(loader.find_by_name(:enum_setting)[:type]).to eq(types[:enum])
+    expect(loader.find_by_name(:icon_setting)[:type]).to eq(types[:icon])
   end
 
   describe "description locale" do

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -345,6 +345,38 @@ describe "Admin Customize Themes" do
     end
   end
 
+  describe "editing an icon type theme setting" do
+    let(:icon_picker) do
+      PageObjects::Components::DIconGridPicker.new(".setting[data-setting='icon_setting']")
+    end
+
+    before do
+      SiteSetting.svg_icon_subset = "gamepad"
+
+      theme.set_field(
+        target: :settings,
+        name: "yaml",
+        value: "icon_setting:\n  type: icon\n  default: heart\n",
+      )
+      theme.save!
+    end
+
+    it "allows admin to pick an icon from the dropdown and save it" do
+      theme_page.visit(theme)
+
+      expect(icon_picker).to have_selected_icon("heart")
+
+      icon_picker.expand
+      icon_picker.filter("gamepad")
+      icon_picker.select_icon("gamepad")
+
+      find(".setting[data-setting='icon_setting'] .setting-controls__ok").click
+
+      expect(page).to have_no_css(".setting[data-setting='icon_setting'] .setting-controls__ok")
+      expect(theme.reload.settings[:icon_setting].value).to eq("gamepad")
+    end
+  end
+
   describe "editing theme site settings" do
     it "shows all themeable site settings and allows editing values" do
       theme_page.visit(theme.id)


### PR DESCRIPTION
Mirrors site-setting support added in 802fa4c3562.

Also updates the sprite-sheet logic so that it includes all site/theme settings with `type: icon`, in addition to the existing logic which looked for setting names ending in `_icon`.