### PR TITLE
UX: Preserve copied node names when pasting workflow nodes

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
@@ -37,7 +37,12 @@ import {
   normalizeNodeConfiguration,
   removeNodesFromGraph,
 } from "./graph-utils";
-import { createNode, generateNodeName } from "./node-factory";
+import {
+  createNode,
+  defaultNodeName,
+  takenNodeNames,
+  uniqueNodeName,
+} from "./node-factory";
 import UndoManager from "./undo-manager";
 
 const MAX_NODES = 50;
@@ -83,12 +88,21 @@ export function buildPastedGraph({
 }) {
   const newNodes = [];
   const remappedClientIds = new Map();
+  const takenNames = takenNodeNames(existingNodes);
 
   for (const copiedNode of copiedNodes) {
+    const copiedName =
+      typeof copiedNode.name === "string" ? copiedNode.name.trim() : "";
+    const name = uniqueNodeName(
+      copiedName || defaultNodeName(copiedNode.type),
+      takenNames
+    );
+    takenNames.add(name);
+
     const newNode = WorkflowNode.create({
       type: copiedNode.type,
       typeVersion: copiedNode.typeVersion,
-      name: generateNodeName(copiedNode.type, [...existingNodes, ...newNodes]),
+      name,
       configuration: structuredClone(copiedNode.configuration || {}),
       position: copiedNode.position
         ? { x: copiedNode.position.x, y: copiedNode.position.y }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/node-factory.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/node-factory.js
@@ -1,5 +1,6 @@
 import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
+import { STICKY_NOTE_NAME } from "../../../models/sticky-note";
 import WorkflowNode from "../../../models/workflow-node";
 
 const NODE_DEFAULTS = {
@@ -14,17 +15,24 @@ const NODE_DEFAULTS = {
   }),
 };
 
-export function generateNodeName(identifier, existingNodes) {
-  const baseName = i18n(`discourse_workflows.nodes.${identifier}`);
-
-  const existingNames = new Set(existingNodes.map((n) => n.name));
+export function uniqueNodeName(baseName, takenNames) {
   let name = baseName;
   let counter = 1;
-  while (existingNames.has(name)) {
+  while (takenNames.has(name)) {
     name = `${baseName} ${counter}`;
     counter++;
   }
   return name;
+}
+
+export function defaultNodeName(identifier) {
+  return i18n(`discourse_workflows.nodes.${identifier}`);
+}
+
+// sticky notes serialize under a fixed name and the server rejects executable
+// nodes colliding with it, so it stays reserved even while a workflow has none
+export function takenNodeNames(existingNodes) {
+  return new Set([STICKY_NOTE_NAME, ...existingNodes.map((n) => n.name)]);
 }
 
 export function createNode(
@@ -42,7 +50,10 @@ export function createNode(
   return WorkflowNode.create({
     type: identifier,
     typeVersion: typeVersion || "1.0",
-    name: generateNodeName(identifier, existingNodes),
+    name: uniqueNodeName(
+      defaultNodeName(identifier),
+      takenNodeNames(existingNodes)
+    ),
     configuration: {
       ...(defaultsFn ? defaultsFn() : {}),
       ...(configOverrides || {}),

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/models/sticky-note.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/models/sticky-note.js
@@ -1,4 +1,5 @@
 export const STICKY_NOTE_TYPE = "flow:sticky_note";
+export const STICKY_NOTE_NAME = "Sticky Note";
 
 const DEFAULT_WIDTH = 200;
 const DEFAULT_HEIGHT = 150;
@@ -14,7 +15,7 @@ export default class StickyNote {
       id: note.id || note.clientId,
       type: STICKY_NOTE_TYPE,
       typeVersion: "1.0",
-      name: "Sticky Note",
+      name: STICKY_NOTE_NAME,
       parameters: {
         content: note.text,
         width: note.size.width,

--- a/plugins/discourse-workflows/test/javascripts/unit/components/workflows/editor-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/components/workflows/editor-test.js
@@ -4,6 +4,7 @@ import WorkflowsEditor, {
   buildPastedGraph,
   isNodeUnavailable,
 } from "discourse/plugins/discourse-workflows/admin/components/workflows/editor";
+import { STICKY_NOTE_NAME } from "discourse/plugins/discourse-workflows/admin/models/sticky-note";
 
 function buildEditor(workflow) {
   const editor = Object.create(WorkflowsEditor.prototype);
@@ -258,6 +259,83 @@ module("Unit | Component | workflows editor", function () {
       updatedConnections[0].targetClientId,
       updatedNodes[2].clientId,
       "connection target is remapped"
+    );
+  });
+
+  test("buildPastedGraph preserves copied node names, suffixing only on collision", function (assert) {
+    const existingNodes = [
+      { clientId: "existing", type: "trigger:manual", name: "Foo step" },
+    ];
+
+    const { updatedNodes } = buildPastedGraph({
+      existingNodes,
+      existingConnections: [],
+      copiedNodes: [
+        {
+          clientId: "copied-1",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "Foo step",
+          position: { x: 10, y: 20 },
+        },
+        {
+          clientId: "copied-2",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "Bar step",
+          position: { x: 100, y: 20 },
+        },
+        {
+          clientId: "copied-3",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "   ",
+          position: { x: 200, y: 20 },
+        },
+        {
+          clientId: "copied-4",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "Foo step",
+          position: { x: 300, y: 20 },
+        },
+      ],
+      copiedConnections: [],
+    });
+
+    assert.deepEqual(
+      updatedNodes.map((node) => node.name),
+      [
+        "Foo step",
+        "Foo step 1",
+        "Bar step",
+        i18n("discourse_workflows.nodes.trigger:manual"),
+        "Foo step 2",
+      ],
+      "copied names are kept, deduped on collision (including against already-pasted nodes), regenerated when blank"
+    );
+  });
+
+  test("buildPastedGraph keeps the sticky note name reserved", function (assert) {
+    const { updatedNodes } = buildPastedGraph({
+      existingNodes: [],
+      existingConnections: [],
+      copiedNodes: [
+        {
+          clientId: "copied-1",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: STICKY_NOTE_NAME,
+          position: { x: 10, y: 20 },
+        },
+      ],
+      copiedConnections: [],
+    });
+
+    assert.deepEqual(
+      updatedNodes.map((node) => node.name),
+      [`${STICKY_NOTE_NAME} 1`],
+      "reserved even though the workflow has no sticky note"
     );
   });
 

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-factory-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-factory-test.js
@@ -1,37 +1,48 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import { i18n } from "discourse-i18n";
 import {
   createNode,
-  generateNodeName,
+  takenNodeNames,
+  uniqueNodeName,
 } from "discourse/plugins/discourse-workflows/admin/components/workflows/editor/node-factory";
 import { FORM_TRIGGER_TYPE } from "discourse/plugins/discourse-workflows/admin/lib/workflows/node-data-shape";
+import { STICKY_NOTE_NAME } from "discourse/plugins/discourse-workflows/admin/models/sticky-note";
 import WorkflowNode from "discourse/plugins/discourse-workflows/admin/models/workflow-node";
 
 module("Unit | lib | discourse-workflows | node-factory", function (hooks) {
   setupTest(hooks);
 
-  test("generateNodeName returns a non-empty string for a valid identifier", function (assert) {
-    const name = generateNodeName("trigger:webhook", []);
-    assert.strictEqual(typeof name, "string");
-    assert.true(name.length > 0);
+  test("createNode names a node after its i18n label, deduping against existing nodes", function (assert) {
+    const baseName = i18n("discourse_workflows.nodes.trigger:webhook");
+
+    assert.strictEqual(createNode("trigger:webhook", []).name, baseName);
+    assert.strictEqual(
+      createNode("trigger:webhook", [
+        { name: baseName },
+        { name: `${baseName} 1` },
+      ]).name,
+      `${baseName} 2`
+    );
   });
 
-  test("generateNodeName appends counter on single name collision", function (assert) {
-    const baseName = generateNodeName("trigger:webhook", []);
-    const existingNodes = [{ name: baseName }];
-    const name = generateNodeName("trigger:webhook", existingNodes);
-    assert.strictEqual(name, `${baseName} 1`);
+  test("takenNodeNames reserves the sticky note name alongside existing names", function (assert) {
+    const taken = takenNodeNames([{ name: "Foo step" }]);
+
+    assert.true(taken.has(STICKY_NOTE_NAME), "sticky note name is reserved");
+    assert.true(taken.has("Foo step"), "existing node names are taken");
   });
 
-  test("generateNodeName increments counter past multiple collisions", function (assert) {
-    const baseName = generateNodeName("trigger:webhook", []);
-    const existingNodes = [
-      { name: baseName },
-      { name: `${baseName} 1` },
-      { name: `${baseName} 2` },
-    ];
-    const name = generateNodeName("trigger:webhook", existingNodes);
-    assert.strictEqual(name, `${baseName} 3`);
+  test("uniqueNodeName keeps the base name when free and suffixes on collision", function (assert) {
+    assert.strictEqual(uniqueNodeName("Foo step", new Set()), "Foo step");
+    assert.strictEqual(
+      uniqueNodeName("Foo step", new Set(["Foo step"])),
+      "Foo step 1"
+    );
+    assert.strictEqual(
+      uniqueNodeName("Foo step", new Set(["Foo step", "Foo step 1"])),
+      "Foo step 2"
+    );
   });
 
   test("createNode returns a node with correct type and default version", function (assert) {


### PR DESCRIPTION
Previously, pasting a node in the workflow editor threw away its name and regenerated one from the node type, so a node named "Fetch topic" came back as "HTTP request 1".

This change keeps the copied name and appends a counter only on collision. Because a pasted name can now be anything the user typed, node naming also reserves the name sticky notes serialize under — the server rejects a graph where an executable node shares it, and that reservation has to hold before the workflow has any sticky note, not just once one exists.

https://meta.discourse.org/t/copy-workflow-step-names/409410