### PR TITLE
FIX: Keep workflow connections from a node named `__proto__`

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/models/workflow-connection.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/models/workflow-connection.js
@@ -32,6 +32,13 @@ export default class WorkflowConnection {
   }
 }
 
+// user-supplied node names index this map directly, so a plain object literal
+// would route a node named `__proto__` to the prototype accessor: the write
+// lands on `Object.prototype` and the connection disappears from the payload
+function emptyConnectionMap() {
+  return Object.create(null);
+}
+
 export function serializeConnections(connections, nodes) {
   const nodesByClientId = new Map(nodes.map((node) => [node.clientId, node]));
 
@@ -61,7 +68,7 @@ export function serializeConnections(connections, nodes) {
     });
 
     return result;
-  }, {});
+  }, emptyConnectionMap());
 }
 
 export function deserializeConnections(connections, nodes) {

--- a/plugins/discourse-workflows/test/javascripts/unit/models/workflows-connection-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/models/workflows-connection-test.js
@@ -1,0 +1,52 @@
+import { module, test } from "qunit";
+import { serializeConnections } from "discourse/plugins/discourse-workflows/admin/models/workflow-connection";
+import WorkflowNode from "discourse/plugins/discourse-workflows/admin/models/workflow-node";
+
+// referenced through a variable so `no-proto` does not flag the member access
+const PROTO_NAME = "__proto__";
+
+module("Unit | Model | discourse-workflows | workflow-connection", function () {
+  test("serializeConnections keeps connections from a node named __proto__", function (assert) {
+    const source = WorkflowNode.create({
+      clientId: "source",
+      type: "trigger:manual",
+      name: PROTO_NAME,
+    });
+    const target = WorkflowNode.create({
+      clientId: "target",
+      type: "action:post",
+      name: "Send post",
+    });
+
+    try {
+      const serialized = serializeConnections(
+        [
+          {
+            sourceClientId: "source",
+            targetClientId: "target",
+            connectionType: "main",
+            sourceOutputIndex: 0,
+            targetInputIndex: 0,
+          },
+        ],
+        [source, target]
+      );
+
+      assert.deepEqual(
+        Object.keys(serialized),
+        [PROTO_NAME],
+        "the connection survives serialization"
+      );
+      assert.deepEqual(serialized[PROTO_NAME], {
+        main: [[{ node: "Send post", type: "main", index: 0 }]],
+      });
+      assert.strictEqual(
+        {}.main,
+        undefined,
+        "Object.prototype is left untouched"
+      );
+    } finally {
+      delete Object.prototype.main;
+    }
+  });
+});


### PR DESCRIPTION
Previously, `serializeConnections` accumulated into a plain object literal keyed by node name, so a node named `__proto__` routed the write to the prototype accessor instead of an own property: the node's connections silently vanished from the save payload and `Object.prototype` gained a stray `main` property for the rest of the session.

This change accumulates into a null-prototype object, so a node name can never resolve to an inherited property. Node names are user supplied — typed in the rename field, or arriving via paste and file import — so nothing upstream constrains them to safe keys.