### PR TITLE
FIX: Keep workflow node names unique when renaming and importing

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/canvas-file-io.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/canvas-file-io.js
@@ -7,6 +7,7 @@ import {
 import WorkflowNode, {
   NODE_DIRECT_SETTING_KEYS,
 } from "../../../models/workflow-node";
+import { defaultNodeName } from "../editor/node-factory";
 
 function sanitizeImportedObject(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -49,6 +50,13 @@ function directSettingsFromImportedNode(node) {
   }
 
   return settings;
+}
+
+// an imported file is arbitrary user input, so a node can arrive with a missing
+// or non-string name that the server would then reject on every later save
+function importedNodeName(node) {
+  const name = typeof node.name === "string" ? node.name.trim() : "";
+  return name || defaultNodeName(node.type);
 }
 
 function hasUnsupportedNodeKey(node) {
@@ -147,7 +155,7 @@ export function parseWorkflowImport(text) {
       clientId: crypto.randomUUID(),
       type: n.type,
       typeVersion: n.typeVersion,
-      name: n.name,
+      name: importedNodeName(n),
       parameters: sanitizeImportedObject(n.parameters),
       credentials: {},
       webhookId: n.webhookId || null,

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
@@ -1117,6 +1117,14 @@ export default class WorkflowsEditor extends Component {
     this.#captureUndo();
     const existingConnections = this.formApi.get("connections");
 
+    // imported connections are already resolved to client ids, so renaming a
+    // node here cannot orphan them
+    const takenNames = takenNodeNames(existingNodes);
+    for (const node of newNodes) {
+      node.name = uniqueNodeName(node.name, takenNames);
+      takenNames.add(node.name);
+    }
+
     this.formApi.set("nodes", [...existingNodes, ...newNodes]);
     this.formApi.set("connections", [
       ...existingConnections,

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
@@ -37,7 +37,12 @@ import {
   normalizeNodeConfiguration,
   removeNodesFromGraph,
 } from "./graph-utils";
-import { createNode, generateNodeName } from "./node-factory";
+import {
+  createNode,
+  defaultNodeName,
+  takenNodeNames,
+  uniqueNodeName,
+} from "./node-factory";
 import UndoManager from "./undo-manager";
 
 const MAX_NODES = 50;
@@ -83,12 +88,21 @@ export function buildPastedGraph({
 }) {
   const newNodes = [];
   const remappedClientIds = new Map();
+  const takenNames = takenNodeNames(existingNodes);
 
   for (const copiedNode of copiedNodes) {
+    const copiedName =
+      typeof copiedNode.name === "string" ? copiedNode.name.trim() : "";
+    const name = uniqueNodeName(
+      copiedName || defaultNodeName(copiedNode.type),
+      takenNames
+    );
+    takenNames.add(name);
+
     const newNode = WorkflowNode.create({
       type: copiedNode.type,
       typeVersion: copiedNode.typeVersion,
-      name: generateNodeName(copiedNode.type, [...existingNodes, ...newNodes]),
+      name,
       configuration: structuredClone(copiedNode.configuration || {}),
       position: copiedNode.position
         ? { x: copiedNode.position.x, y: copiedNode.position.y }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/node-factory.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/node-factory.js
@@ -1,5 +1,6 @@
 import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
+import { STICKY_NOTE_NAME } from "../../../models/sticky-note";
 import WorkflowNode from "../../../models/workflow-node";
 
 const NODE_DEFAULTS = {
@@ -14,17 +15,24 @@ const NODE_DEFAULTS = {
   }),
 };
 
-export function generateNodeName(identifier, existingNodes) {
-  const baseName = i18n(`discourse_workflows.nodes.${identifier}`);
-
-  const existingNames = new Set(existingNodes.map((n) => n.name));
+export function uniqueNodeName(baseName, takenNames) {
   let name = baseName;
   let counter = 1;
-  while (existingNames.has(name)) {
+  while (takenNames.has(name)) {
     name = `${baseName} ${counter}`;
     counter++;
   }
   return name;
+}
+
+export function defaultNodeName(identifier) {
+  return i18n(`discourse_workflows.nodes.${identifier}`);
+}
+
+// sticky notes serialize under a fixed name and the server rejects executable
+// nodes colliding with it, so it stays reserved even while a workflow has none
+export function takenNodeNames(existingNodes) {
+  return new Set([STICKY_NOTE_NAME, ...existingNodes.map((n) => n.name)]);
 }
 
 export function createNode(
@@ -42,7 +50,10 @@ export function createNode(
   return WorkflowNode.create({
     type: identifier,
     typeVersion: typeVersion || "1.0",
-    name: generateNodeName(identifier, existingNodes),
+    name: uniqueNodeName(
+      defaultNodeName(identifier),
+      takenNodeNames(existingNodes)
+    ),
     configuration: {
       ...(defaultsFn ? defaultsFn() : {}),
       ...(configOverrides || {}),

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/node/configurator.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/node/configurator.gjs
@@ -40,6 +40,7 @@ import CredentialControl from "../configurators/credential";
 import PropertyEngineConfigurator from "../configurators/property-engine";
 import InputContext from "../context/input";
 import OutputContext from "../context/output";
+import { takenNodeNames } from "../editor/node-factory";
 import LivePreview from "./live-preview";
 
 function credentialSlotLabel(slot) {
@@ -214,8 +215,22 @@ export default class NodeConfigurator extends Component {
     return this.nodeName.trim();
   }
 
+  get nodeNameError() {
+    if (this.trimmedNodeName.length === 0) {
+      return null;
+    }
+
+    const otherNodes = this.args.model.nodes.filter(
+      (node) => node.clientId !== this.args.model.node.clientId
+    );
+
+    return takenNodeNames(otherNodes).has(this.trimmedNodeName)
+      ? i18n("discourse_workflows.node_name_taken")
+      : null;
+  }
+
   get canSaveNodeName() {
-    return this.trimmedNodeName.length > 0;
+    return this.trimmedNodeName.length > 0 && !this.nodeNameError;
   }
 
   @action
@@ -520,6 +535,12 @@ export default class NodeConfigurator extends Component {
                 class="btn-flat workflows-configurator-modal__cancel-name"
               />
             </div>
+            {{#if this.nodeNameError}}
+              <div
+                class="workflows-configurator-modal__name-error"
+                role="alert"
+              >{{this.nodeNameError}}</div>
+            {{/if}}
           {{else}}
             {{! eslint-disable ember/template-no-invalid-interactive }}
             <div

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/models/sticky-note.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/models/sticky-note.js
@@ -1,4 +1,5 @@
 export const STICKY_NOTE_TYPE = "flow:sticky_note";
+export const STICKY_NOTE_NAME = "Sticky Note";
 
 const DEFAULT_WIDTH = 200;
 const DEFAULT_HEIGHT = 150;
@@ -14,7 +15,7 @@ export default class StickyNote {
       id: note.id || note.clientId,
       type: STICKY_NOTE_TYPE,
       typeVersion: "1.0",
-      name: "Sticky Note",
+      name: STICKY_NOTE_NAME,
       parameters: {
         content: note.text,
         width: note.size.width,

--- a/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator-modal.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator-modal.scss
@@ -59,6 +59,11 @@
     gap: var(--space-1);
   }
 
+  &__name-error {
+    color: var(--danger);
+    font-size: var(--font-down-1);
+  }
+
   &__edit-name,
   &__save-name,
   &__cancel-name {

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -105,6 +105,7 @@ en:
       edit: "Edit"
       save: "Save"
       cancel: "Cancel"
+      node_name_taken: "Another node already uses this name"
       more_options: "More options"
       publish: "Publish"
       discard_changes: "Discard changes"

--- a/plugins/discourse-workflows/spec/system/node_names_spec.rb
+++ b/plugins/discourse-workflows/spec/system/node_names_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe "Discourse Workflows | node names" do
+  fab!(:admin)
+
+  let(:editor_page) { PageObjects::Pages::DiscourseWorkflows::WorkflowEditor.new }
+
+  before { sign_in(admin) }
+
+  def build_two_node_workflow
+    editor_page.visit_new
+    editor_page.click_empty_state_add_node
+    editor_page.select_node_type("trigger:topic_created")
+    editor_page.click_add_node
+    editor_page.select_node_type("action:post", operation: "create")
+  end
+
+  def import_nodes(nodes)
+    file = Tempfile.new(%w[workflow .json])
+    file.write({ nodes: nodes, connections: {} }.to_json)
+    file.flush
+    page.find("input[type='file'][accept='.json']", visible: :all).set(file.path)
+    file
+  end
+
+  it "blocks renaming a node to a name another node already uses" do
+    build_two_node_workflow
+
+    editor_page.double_click_node(1)
+    find(".workflows-configurator-modal__name").click
+    find(".workflows-configurator-modal__name-input").fill_in(with: "Topic created")
+
+    expect(page).to have_css(".workflows-configurator-modal__name-error")
+    expect(find(".workflows-configurator-modal__save-name")).to be_disabled
+    expect(page).to have_no_css(".dialog-body")
+  end
+
+  it "renames imported nodes that collide with existing ones" do
+    build_two_node_workflow
+
+    import_nodes(
+      [{ type: "action:post", typeVersion: "1.0", name: "Topic created", parameters: {} }],
+    )
+
+    expect(editor_page).to have_node_count(3)
+    expect(editor_page).to have_node("Topic created 1")
+    expect(page).to have_no_css(".dialog-body")
+  end
+
+  it "names imported nodes that arrive without one" do
+    build_two_node_workflow
+
+    import_nodes([{ type: "action:http_request", typeVersion: "1.0", parameters: {} }])
+
+    expect(editor_page).to have_node_count(3)
+    expect(page).to have_no_css(".dialog-body")
+  end
+end

--- a/plugins/discourse-workflows/test/javascripts/unit/components/workflows/editor-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/components/workflows/editor-test.js
@@ -4,6 +4,7 @@ import WorkflowsEditor, {
   buildPastedGraph,
   isNodeUnavailable,
 } from "discourse/plugins/discourse-workflows/admin/components/workflows/editor";
+import { STICKY_NOTE_NAME } from "discourse/plugins/discourse-workflows/admin/models/sticky-note";
 
 function buildEditor(workflow) {
   const editor = Object.create(WorkflowsEditor.prototype);
@@ -258,6 +259,83 @@ module("Unit | Component | workflows editor", function () {
       updatedConnections[0].targetClientId,
       updatedNodes[2].clientId,
       "connection target is remapped"
+    );
+  });
+
+  test("buildPastedGraph preserves copied node names, suffixing only on collision", function (assert) {
+    const existingNodes = [
+      { clientId: "existing", type: "trigger:manual", name: "Foo step" },
+    ];
+
+    const { updatedNodes } = buildPastedGraph({
+      existingNodes,
+      existingConnections: [],
+      copiedNodes: [
+        {
+          clientId: "copied-1",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "Foo step",
+          position: { x: 10, y: 20 },
+        },
+        {
+          clientId: "copied-2",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "Bar step",
+          position: { x: 100, y: 20 },
+        },
+        {
+          clientId: "copied-3",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "   ",
+          position: { x: 200, y: 20 },
+        },
+        {
+          clientId: "copied-4",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: "Foo step",
+          position: { x: 300, y: 20 },
+        },
+      ],
+      copiedConnections: [],
+    });
+
+    assert.deepEqual(
+      updatedNodes.map((node) => node.name),
+      [
+        "Foo step",
+        "Foo step 1",
+        "Bar step",
+        i18n("discourse_workflows.nodes.trigger:manual"),
+        "Foo step 2",
+      ],
+      "copied names are kept, deduped on collision (including against already-pasted nodes), regenerated when blank"
+    );
+  });
+
+  test("buildPastedGraph keeps the sticky note name reserved", function (assert) {
+    const { updatedNodes } = buildPastedGraph({
+      existingNodes: [],
+      existingConnections: [],
+      copiedNodes: [
+        {
+          clientId: "copied-1",
+          type: "trigger:manual",
+          typeVersion: "1.0",
+          name: STICKY_NOTE_NAME,
+          position: { x: 10, y: 20 },
+        },
+      ],
+      copiedConnections: [],
+    });
+
+    assert.deepEqual(
+      updatedNodes.map((node) => node.name),
+      [`${STICKY_NOTE_NAME} 1`],
+      "reserved even though the workflow has no sticky note"
     );
   });
 

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-canvas-file-io-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-canvas-file-io-test.js
@@ -1,4 +1,5 @@
 import { module, test } from "qunit";
+import { i18n } from "discourse-i18n";
 import {
   buildWorkflowExportPayload,
   parseWorkflowImport,
@@ -134,6 +135,36 @@ module("Unit | lib | discourse-workflows | canvas-file-io", function () {
     assert.strictEqual(result.nodes[0].notes, "Imported note");
     assert.false(result.nodes[0].notesInFlow);
     assert.true(result.nodes[0].alwaysOutputData);
+  });
+
+  test("parseWorkflowImport falls back to the type label when a node has no usable name", function (assert) {
+    const result = parseWorkflowImport(
+      JSON.stringify({
+        nodes: [
+          { type: "action:http_request", typeVersion: "1.0", parameters: {} },
+          {
+            type: "action:http_request",
+            typeVersion: "1.0",
+            name: "   ",
+            parameters: {},
+          },
+          {
+            type: "action:http_request",
+            typeVersion: "1.0",
+            name: { not: "a string" },
+            parameters: {},
+          },
+        ],
+        connections: {},
+      })
+    );
+
+    const expected = i18n("discourse_workflows.nodes.action:http_request");
+    assert.deepEqual(
+      result.nodes.map((node) => node.name),
+      [expected, expected, expected],
+      "a missing, blank, or non-string name never reaches the server"
+    );
   });
 
   test("parseWorkflowImport preserves imported static data", function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-factory-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-factory-test.js
@@ -1,37 +1,48 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import { i18n } from "discourse-i18n";
 import {
   createNode,
-  generateNodeName,
+  takenNodeNames,
+  uniqueNodeName,
 } from "discourse/plugins/discourse-workflows/admin/components/workflows/editor/node-factory";
 import { FORM_TRIGGER_TYPE } from "discourse/plugins/discourse-workflows/admin/lib/workflows/node-data-shape";
+import { STICKY_NOTE_NAME } from "discourse/plugins/discourse-workflows/admin/models/sticky-note";
 import WorkflowNode from "discourse/plugins/discourse-workflows/admin/models/workflow-node";
 
 module("Unit | lib | discourse-workflows | node-factory", function (hooks) {
   setupTest(hooks);
 
-  test("generateNodeName returns a non-empty string for a valid identifier", function (assert) {
-    const name = generateNodeName("trigger:webhook", []);
-    assert.strictEqual(typeof name, "string");
-    assert.true(name.length > 0);
+  test("createNode names a node after its i18n label, deduping against existing nodes", function (assert) {
+    const baseName = i18n("discourse_workflows.nodes.trigger:webhook");
+
+    assert.strictEqual(createNode("trigger:webhook", []).name, baseName);
+    assert.strictEqual(
+      createNode("trigger:webhook", [
+        { name: baseName },
+        { name: `${baseName} 1` },
+      ]).name,
+      `${baseName} 2`
+    );
   });
 
-  test("generateNodeName appends counter on single name collision", function (assert) {
-    const baseName = generateNodeName("trigger:webhook", []);
-    const existingNodes = [{ name: baseName }];
-    const name = generateNodeName("trigger:webhook", existingNodes);
-    assert.strictEqual(name, `${baseName} 1`);
+  test("takenNodeNames reserves the sticky note name alongside existing names", function (assert) {
+    const taken = takenNodeNames([{ name: "Foo step" }]);
+
+    assert.true(taken.has(STICKY_NOTE_NAME), "sticky note name is reserved");
+    assert.true(taken.has("Foo step"), "existing node names are taken");
   });
 
-  test("generateNodeName increments counter past multiple collisions", function (assert) {
-    const baseName = generateNodeName("trigger:webhook", []);
-    const existingNodes = [
-      { name: baseName },
-      { name: `${baseName} 1` },
-      { name: `${baseName} 2` },
-    ];
-    const name = generateNodeName("trigger:webhook", existingNodes);
-    assert.strictEqual(name, `${baseName} 3`);
+  test("uniqueNodeName keeps the base name when free and suffixes on collision", function (assert) {
+    assert.strictEqual(uniqueNodeName("Foo step", new Set()), "Foo step");
+    assert.strictEqual(
+      uniqueNodeName("Foo step", new Set(["Foo step"])),
+      "Foo step 1"
+    );
+    assert.strictEqual(
+      uniqueNodeName("Foo step", new Set(["Foo step", "Foo step 1"])),
+      "Foo step 2"
+    );
   });
 
   test("createNode returns a node with correct type and default version", function (assert) {


### PR DESCRIPTION
Previously, only *generated* node names were unique. The rename field accepted any non-blank string and file import concatenated names verbatim, so renaming two nodes to the same value — or importing a workflow into one that already shares a node name, or importing a node with no name at all — produced a graph the server rejected on every subsequent save, surfaced as a generic toast with no indication of which node was at fault.

This change validates the name inline while renaming (the save button stays disabled with an explanatory message) and uniques imported names against the existing graph, falling back to the node type's label when an imported node has no usable name.

Stacked on #42627, which adds the `takenNodeNames` helper this uses.