### PR TITLE
A11Y: make like and reaction count menus keyboard accessible

### DIFF
--- a/frontend/discourse/app/components/post/menu/liked-users-list.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-list.gjs
@@ -16,14 +16,17 @@ export default class LikedUsersList extends Component {
     return this.args.post.yours ? "d-liked" : null;
   }
 
+  get elementId() {
+    return `post-liked-users-list-${this.args.post.id}`;
+  }
+
+  get expanded() {
+    return this.menu.getByIdentifier(MENU_IDENTIFIER)?.id === this.elementId;
+  }
+
   @action
   togglePopup(event) {
-    const target = event.currentTarget;
-    const virtualElement = {
-      getBoundingClientRect: () => target.getBoundingClientRect(),
-    };
-
-    this.menu.show(virtualElement, {
+    this.menu.show(event.currentTarget, {
       identifier: MENU_IDENTIFIER,
       component: PostLikedUsersMenu,
       modalForMobile: true,
@@ -37,8 +40,11 @@ export default class LikedUsersList extends Component {
 
   <template>
     <button
+      id={{this.elementId}}
       type="button"
       aria-label={{i18n "post.sr_post_like_count_button" count=@post.likeCount}}
+      aria-haspopup="dialog"
+      aria-expanded={{if this.expanded "true" "false"}}
       class={{dConcatClass
         "btn btn-flat no-text"
         "post-action-menu__like-count"

--- a/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
@@ -50,6 +50,7 @@ export default class PostLikedUsersMenu extends Component {
 
   <template>
     <UsersPopup
+      @autofocus={{true}}
       @fetchUsers={{this.fetchUsers}}
       @titleText={{this.titleText}}
       @totalUsers={{this.post.likeCount}}

--- a/frontend/discourse/app/components/user/users-popup.gjs
+++ b/frontend/discourse/app/components/user/users-popup.gjs
@@ -172,7 +172,6 @@ export default class UsersPopup extends Component {
                   {{this.displayName user}}
                 </DUserLink>
                 {{#unless this.siteSettings.prioritize_username_in_ux}}
-                  {{! the name above links to the same profile, so a second announced link would read every user twice }}
                   <DUserLink
                     @ariaHidden={{true}}
                     @username={{user.username}}

--- a/frontend/discourse/app/components/user/users-popup.gjs
+++ b/frontend/discourse/app/components/user/users-popup.gjs
@@ -81,6 +81,19 @@ export default class UsersPopup extends Component {
     return Array.from({ length: count });
   }
 
+  /**
+   * The list is fetched after render, so at insertion time the popup holds no
+   * focusable element for a float's own focus handling to land on. Focusing the
+   * container instead puts a keyboard user inside the dialog — where the tab
+   * trap and Escape apply, and where closing returns focus to the trigger.
+   */
+  @action
+  autofocus(element) {
+    if (this.args.autofocus) {
+      element.focus({ preventScroll: true });
+    }
+  }
+
   @action
   async loadInitial(element) {
     this.#bodyElement = element;
@@ -119,7 +132,12 @@ export default class UsersPopup extends Component {
   }
 
   <template>
-    <div class="users-popup" ...attributes>
+    <div
+      class="users-popup"
+      tabindex="-1"
+      {{didInsert this.autofocus}}
+      ...attributes
+    >
       <div class="users-popup__sticky-header">
         {{#if this.site.mobileView}}
           <div class="users-popup__title">{{@titleText}}</div>
@@ -154,7 +172,9 @@ export default class UsersPopup extends Component {
                   {{this.displayName user}}
                 </DUserLink>
                 {{#unless this.siteSettings.prioritize_username_in_ux}}
+                  {{! the name above links to the same profile, so a second announced link would read every user twice }}
                   <DUserLink
+                    @ariaHidden={{true}}
                     @username={{user.username}}
                     class="users-popup__username"
                   >

--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -123,7 +123,6 @@ export default class DMenuInstance extends FloatKitInstance {
     await super.close(options);
   }
 
-  /** Whether focus has fallen back to the document, i.e. nothing meaningful holds it. */
   get #focusIsUnowned(): boolean {
     const { activeElement } = document;
     return !activeElement || activeElement === document.body;

--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -84,6 +84,15 @@ export default class DMenuInstance extends FloatKitInstance {
     return this.expanded;
   }
 
+  /**
+   * Whether focus currently sits inside the menu's content. Read before the content is torn
+   * down, because a menu that owns focus has to hand it back on close — otherwise closing
+   * strands focus on a removed element and the browser drops it to the body.
+   */
+  get #ownsFocus(): boolean {
+    return !!this.content?.contains(document.activeElement);
+  }
+
   @action
   async close(options = { focusTrigger: true }) {
     this.resetHoverCloseState();
@@ -93,6 +102,8 @@ export default class DMenuInstance extends FloatKitInstance {
       return;
     }
 
+    const ownedFocus = this.#ownsFocus;
+
     await animateClosing(this.content);
 
     if (this.renderInModal && this.expanded) {
@@ -101,11 +112,21 @@ export default class DMenuInstance extends FloatKitInstance {
 
     await this.menu.close(this);
 
-    if (options.focusTrigger) {
+    // A caller that closes without asking for the trigger to be refocused (a click outside,
+    // say) still must not lose focus altogether. Recheck rather than trusting `ownedFocus`:
+    // closing is animated, so by now the click may have deliberately focused something else,
+    // and only focus left with no owner is ours to restore.
+    if (options.focusTrigger || (ownedFocus && this.#focusIsUnowned)) {
       this.triggerElement?.focus();
     }
 
     await super.close(options);
+  }
+
+  /** Whether focus has fallen back to the document, i.e. nothing meaningful holds it. */
+  get #focusIsUnowned(): boolean {
+    const { activeElement } = document;
+    return !activeElement || activeElement === document.body;
   }
 
   @action

--- a/frontend/discourse/float-kit/services/menu.ts
+++ b/frontend/discourse/float-kit/services/menu.ts
@@ -82,7 +82,7 @@ export default class Menu extends Service {
     }
 
     if (instance.expanded) {
-      await this.close(instance);
+      await instance.close();
       return;
     }
 

--- a/frontend/discourse/tests/acceptance/post-controls-test.js
+++ b/frontend/discourse/tests/acceptance/post-controls-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
@@ -15,6 +15,31 @@ acceptance(`Post controls`, function () {
     assert
       .dom(".users-popup__item")
       .exists("liked users are listed in the popup");
+  });
+
+  test("popup with likes moves focus into the popup and back out again", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    assert
+      .dom("#post_2 .button-count")
+      .hasAria("expanded", "false", "the like count starts collapsed");
+
+    await click("#post_2 .button-count");
+
+    assert
+      .dom("#post_2 .button-count")
+      .hasAria("expanded", "true", "the like count reports the popup is open");
+    assert.true(
+      document.querySelector(".users-popup").contains(document.activeElement),
+      "focus moves into the popup"
+    );
+
+    await triggerKeyEvent(document.activeElement, "keydown", "Escape");
+
+    assert.dom(".users-popup").doesNotExist("escape closes the popup");
+    assert
+      .dom("#post_2 .button-count")
+      .isFocused("focus returns to the like count");
   });
 
   test("accessibility of the embedded replies below the post", async function (assert) {

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -613,6 +613,71 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     assert.dom(document.activeElement).hasClass("my-button");
   });
 
+  test("closing hands focus back to the trigger when the menu holds it", async function (assert) {
+    await render(
+      <template>
+        <span class="test">test</span><DMenu
+          @inline={{true}}
+          @label="label"
+          @autofocus={{true}}
+        >
+          <:content>
+            <DButton class="my-button" />
+          </:content>
+        </DMenu>
+      </template>
+    );
+
+    await open();
+    assert.dom(document.activeElement).hasClass("my-button");
+
+    await triggerEvent(".test", "pointerdown");
+
+    assert
+      .dom(document.activeElement)
+      .hasClass(
+        "fk-d-menu__trigger",
+        "a click outside closes the menu and returns focus to the trigger"
+      );
+
+    await open();
+    await close();
+
+    assert
+      .dom(document.activeElement)
+      .hasClass(
+        "fk-d-menu__trigger",
+        "toggling the menu shut from its trigger also returns focus"
+      );
+  });
+
+  test("closing leaves focus alone when something else has taken it", async function (assert) {
+    await render(
+      <template>
+        <DButton class="outside-button" /><DMenu
+          @inline={{true}}
+          @label="label"
+          @autofocus={{true}}
+        >
+          <:content>
+            <DButton class="my-button" />
+          </:content>
+        </DMenu>
+      </template>
+    );
+
+    await open();
+    await focus(".outside-button");
+    await triggerEvent(".outside-button", "pointerdown");
+
+    assert
+      .dom(document.activeElement)
+      .hasClass(
+        "outside-button",
+        "focus stays where the user put it rather than snapping to the trigger"
+      );
+  });
+
   test("a menu can be closed by identifier", async function (assert) {
     await render(
       <template>
@@ -775,7 +840,7 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     assert.dom(".fk-d-menu__trigger").isFocused();
   });
 
-  test("focusTrigger=false on close", async function (assert) {
+  test("focusTrigger=false still rescues focus the menu was holding", async function (assert) {
     this.api = null;
     this.onRegisterApi = (api) => (this.api = api);
     this.close = async () => await this.api.close({ focusTrigger: false });
@@ -796,7 +861,7 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     await triggerKeyEvent(document.activeElement, "keydown", "Tab");
     await triggerKeyEvent(document.activeElement, "keydown", "Enter");
 
-    assert.dom(document.body).isFocused();
+    assert.dom(".fk-d-menu__trigger").isFocused();
   });
 
   test("traps pointerdown events only when expanded ", async function (assert) {

--- a/frontend/discourse/tests/integration/components/user/users-popup-test.gjs
+++ b/frontend/discourse/tests/integration/components/user/users-popup-test.gjs
@@ -183,6 +183,29 @@ module("Integration | Component | User | UsersPopup", function (hooks) {
     await settled();
   });
 
+  test("announces each user once when the name and username are both shown", async function (assert) {
+    this.siteSettings.prioritize_username_in_ux = false;
+
+    const fetchUsers = () =>
+      Promise.resolve({ users: makeUsers(1), canLoadMore: false });
+
+    await renderMenu({ fetchUsers });
+
+    assert
+      .dom(".users-popup__name")
+      .doesNotHaveAria("hidden", "the name link is announced");
+    assert
+      .dom(".users-popup__username")
+      .hasAria(
+        "hidden",
+        "true",
+        "the username link duplicates it, so it is not announced"
+      );
+    assert
+      .dom(".users-popup__username")
+      .hasAttribute("tabindex", "-1", "and is skipped when tabbing");
+  });
+
   test("can transform the display name via user-list-display-name transformer", async function (assert) {
     this.siteSettings.prioritize_username_in_ux = false;
 

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
@@ -18,6 +18,10 @@ export default class DiscourseReactionsCounter extends Component {
     }`;
   }
 
+  get expanded() {
+    return this.menu.getByIdentifier(MENU_IDENTIFIER)?.id === this.elementId;
+  }
+
   @action
   mouseDown(event) {
     event.stopImmediatePropagation();
@@ -26,14 +30,6 @@ export default class DiscourseReactionsCounter extends Component {
   @action
   mouseUp(event) {
     event.stopImmediatePropagation();
-  }
-
-  @action
-  keyDown(event) {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      this.#toggleMenu(event.currentTarget);
-    }
   }
 
   @action
@@ -52,22 +48,18 @@ export default class DiscourseReactionsCounter extends Component {
   }
 
   get classes() {
-    const classes = [];
+    const classes = ["discourse-reactions-counter"];
     const mainReaction =
       this.siteSettings.discourse_reactions_reaction_for_like;
 
-    const { post } = this.args;
+    const { reactions } = this.args.post;
 
     if (
-      post.reactions &&
-      post.reactions.length === 1 &&
-      post.reactions[0].id === mainReaction
+      reactions &&
+      reactions.length === 1 &&
+      reactions[0].id === mainReaction
     ) {
       classes.push("only-like");
-    }
-
-    if (post.reaction_users_count > 0) {
-      classes.push("discourse-reactions-counter");
     }
 
     return classes.join(" ");
@@ -80,11 +72,7 @@ export default class DiscourseReactionsCounter extends Component {
   }
 
   #toggleMenu(trigger) {
-    const virtualElement = {
-      getBoundingClientRect: () => trigger.getBoundingClientRect(),
-    };
-
-    this.menu.show(virtualElement, {
+    this.menu.show(trigger, {
       identifier: MENU_IDENTIFIER,
       component: DiscourseReactionsUsersMenu,
       modalForMobile: true,
@@ -98,24 +86,24 @@ export default class DiscourseReactionsCounter extends Component {
 
   <template>
     {{! eslint-disable ember/template-no-pointer-down-event-binding }}
-    <div
-      id={{this.elementId}}
-      class={{this.classes}}
-      role="button"
-      tabindex="0"
-      aria-label={{this.counterAriaLabel}}
-      {{on "mousedown" this.mouseDown}}
-      {{on "mouseup" this.mouseUp}}
-      {{on "click" this.click}}
-      {{on "keydown" this.keyDown}}
-    >
-      {{#if @post.reaction_users_count}}
+    {{#if @post.reaction_users_count}}
+      <button
+        id={{this.elementId}}
+        type="button"
+        class={{this.classes}}
+        aria-label={{this.counterAriaLabel}}
+        aria-haspopup="dialog"
+        aria-expanded={{if this.expanded "true" "false"}}
+        {{on "mousedown" this.mouseDown}}
+        {{on "mouseup" this.mouseUp}}
+        {{on "click" this.click}}
+      >
         <DiscourseReactionsList @post={{@post}} />
 
         <span class="reactions-counter" aria-hidden="true">
           {{@post.reaction_users_count}}
         </span>
-      {{/if}}
-    </div>
+      </button>
+    {{/if}}
   </template>
 }

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
@@ -10,7 +10,7 @@ export default class DiscourseReactionsListEmoji extends Component {
   }
 
   <template>
-    <div class="discourse-reactions-list-emoji" id={{this.elementId}}>
+    <span class="discourse-reactions-list-emoji" id={{this.elementId}}>
       {{#if @reaction.count}}
         {{dEmoji
           @reaction.id
@@ -21,6 +21,6 @@ export default class DiscourseReactionsListEmoji extends Component {
           )
         }}
       {{/if}}
-    </div>
+    </span>
   </template>
 }

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list.gjs
@@ -1,15 +1,15 @@
 import DiscourseReactionsListEmoji from "./discourse-reactions-list-emoji";
 
 const DiscourseReactionsList = <template>
-  <div class="discourse-reactions-list" ...attributes>
+  <span class="discourse-reactions-list" ...attributes>
     {{#if @post.reaction_users_count}}
-      <div class="reactions">
+      <span class="reactions">
         {{#each @post.reactions as |reaction|}}
           <DiscourseReactionsListEmoji @reaction={{reaction}} @post={{@post}} />
         {{/each}}
-      </div>
+      </span>
     {{/if}}
-  </div>
+  </span>
 </template>;
 
 export default DiscourseReactionsList;

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -120,6 +120,7 @@ export default class DiscourseReactionsUsersMenu extends Component {
 
   <template>
     <UsersPopup
+      @autofocus={{true}}
       @fetchUsers={{this.fetchUsers}}
       @titleText={{this.titleText}}
       @totalUsers={{this.activeFilterTotalUsers}}

--- a/plugins/discourse-reactions/assets/stylesheets/common/discourse-reactions.scss
+++ b/plugins/discourse-reactions/assets/stylesheets/common/discourse-reactions.scss
@@ -244,6 +244,11 @@ html.discourse-reactions-no-select {
   text-align: center;
   cursor: pointer;
   border-radius: var(--d-button-border-radius);
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
 
   &:focus-visible {
     outline: none;

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import ReactionsTopics from "../fixtures/reactions-topic-fixtures";
@@ -93,6 +93,31 @@ acceptance(
         "does not refetch when returning to all"
       );
       assert.dom(".users-popup__item").exists({ count: 5 });
+    });
+
+    test("moves focus into the users menu and back out again", async function (assert) {
+      await visit("/t/topic_with_reactions_and_likes/374");
+
+      assert
+        .dom("#post_1 .discourse-reactions-counter")
+        .hasAria("expanded", "false", "the counter starts collapsed");
+
+      await click("#post_1 .discourse-reactions-counter");
+
+      assert
+        .dom("#post_1 .discourse-reactions-counter")
+        .hasAria("expanded", "true", "the counter reports the menu is open");
+      assert.true(
+        document.querySelector(".users-popup").contains(document.activeElement),
+        "focus moves into the menu"
+      );
+
+      await triggerKeyEvent(document.activeElement, "keydown", "Escape");
+
+      assert.dom(".users-popup").doesNotExist("escape closes the menu");
+      assert
+        .dom("#post_1 .discourse-reactions-counter")
+        .isFocused("focus returns to the counter");
     });
 
     test("closes the users menu when navigating away", async function (assert) {


### PR DESCRIPTION
Currently it's very difficult to access this content in the "who liked" menu with keyboard navigation, because the menu doesn't auto-focus and it's rendered at the end of the document in a portal (which is absolutely positioned) 

<img width="200" alt="image" src="https://github.com/user-attachments/assets/073aece3-b5e8-4cba-bbd5-2301f2fdae4b" />

The fix is to focus the menu when it's opened, and trap the focus until the menu is closed and re-focus the trigger. I've also excluded a duplicate username link for screenreaders, as the link is the same on both name and username and is redundant when read. 

There are various surrounding changes as well, including making float kit menus return focus to the triggering element and making the like/reaction count a proper button. 