### PR TITLE
A11Y: make chat reactions reachable by keyboard and read by screenreaders

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
@@ -206,8 +206,6 @@ export default class ChatMessageReaction extends Component {
         type="button"
         title={{this.emojiString}}
         data-emoji-name={{@reaction.emoji}}
-        {{! `interactive` is opt-out, as it is on the message itself: only an explicit
-        false makes a reaction display-only. }}
         tabindex={{if (eq @interactive false) "-1" "0"}}
         aria-pressed={{if @reaction.reacted "true" "false"}}
         aria-describedby={{if this.description this.descriptionId}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
@@ -10,10 +10,12 @@ import { modifier } from "ember-modifier";
 import { bind } from "discourse/lib/decorators";
 import discourseLater from "discourse/lib/later";
 import { emojiUnescape, emojiUrlFor } from "discourse/lib/text";
-import { and } from "discourse/truth-helpers";
+import { and, eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import ChatMessageReactionsUsers from "discourse/plugins/chat/discourse/components/chat-message-reactions-users";
 import { getReactionText } from "discourse/plugins/chat/discourse/lib/get-reaction-text";
+
+let descriptionSequence = 0;
 
 export default class ChatMessageReaction extends Component {
   @service currentUser;
@@ -32,7 +34,7 @@ export default class ChatMessageReaction extends Component {
     }
 
     const instance = this.tooltip.register(element, {
-      content: trustHTML(this.popoverContent),
+      content: this.description,
       identifier: "chat-message-reaction-tooltip",
       animated: false,
       placement: "top",
@@ -93,6 +95,12 @@ export default class ChatMessageReaction extends Component {
         this.scheduleCloseReactionsUsersPopup,
         { passive: true }
       );
+      element.addEventListener("focus", this.openReactionsUsersPopup, {
+        passive: true,
+      });
+      element.addEventListener("blur", this.scheduleCloseReactionsUsersPopup, {
+        passive: true,
+      });
     }
 
     return () => {
@@ -105,10 +113,17 @@ export default class ChatMessageReaction extends Component {
         "pointerleave",
         this.scheduleCloseReactionsUsersPopup
       );
+      element.removeEventListener("focus", this.openReactionsUsersPopup);
+      element.removeEventListener(
+        "blur",
+        this.scheduleCloseReactionsUsersPopup
+      );
       instance.destroy();
       this.#reactionsUsersPopupInstance = null;
     };
   });
+
+  descriptionId = `chat-message-reaction-description-${descriptionSequence++}`;
   #reactionsUsersPopupInstance = null;
   #closeReactionsUsersPopupTimer = null;
 
@@ -120,6 +135,12 @@ export default class ChatMessageReaction extends Component {
     this.#closeReactionsUsersPopupTimer = discourseLater(() => {
       this.#reactionsUsersPopupInstance?.close({ focusTrigger: false });
     }, 250);
+  }
+
+  @bind
+  openReactionsUsersPopup() {
+    this.cancelCloseReactionsUsersPopup();
+    this.#reactionsUsersPopupInstance?.show();
   }
 
   @bind
@@ -172,6 +193,10 @@ export default class ChatMessageReaction extends Component {
     return emojiUnescape(getReactionText(this.args.reaction, this.currentUser));
   }
 
+  get description() {
+    return this.popoverContent ? trustHTML(this.popoverContent) : undefined;
+  }
+
   <template>
     {{#if (and @reaction this.emojiUrl)}}
       <button
@@ -181,7 +206,11 @@ export default class ChatMessageReaction extends Component {
         type="button"
         title={{this.emojiString}}
         data-emoji-name={{@reaction.emoji}}
-        tabindex={{if @interactive "0" "-1"}}
+        {{! `interactive` is opt-out, as it is on the message itself: only an explicit
+        false makes a reaction display-only. }}
+        tabindex={{if (eq @interactive false) "-1" "0"}}
+        aria-pressed={{if @reaction.reacted "true" "false"}}
+        aria-describedby={{if this.description this.descriptionId}}
         class={{dConcatClass
           "chat-message-reaction"
           (if @reaction.reacted "reacted")
@@ -200,6 +229,13 @@ export default class ChatMessageReaction extends Component {
           <span class="count">{{@reaction.count}}</span>
         {{/if}}
       </button>
+
+      {{#if this.description}}
+        <span
+          id={{this.descriptionId}}
+          class="sr-only"
+        >{{this.description}}</span>
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/plugins/chat/test/javascripts/components/chat-message-reaction-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-reaction-test.gjs
@@ -1,8 +1,12 @@
 import { hash } from "@ember/helper";
-import { click, render } from "@ember/test-helpers";
+import { getOwner } from "@ember/owner";
+import { blur, click, focus, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import DMenus from "discourse/float-kit/components/d-menus";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import ChatMessageReaction from "discourse/plugins/chat/discourse/components/chat-message-reaction";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
 module("Component | ChatMessageReaction", function (hooks) {
   setupRenderingTest(hooks);
@@ -36,6 +40,125 @@ module("Component | ChatMessageReaction", function (hooks) {
 
     assert.dom(".chat-message-reaction").hasAttribute("title", ":heart:");
     assert.dom(".chat-message-reaction img").hasAttribute("alt", ":heart:");
+  });
+
+  test("is reachable by keyboard unless explicitly non-interactive", async function (assert) {
+    await render(
+      <template>
+        <ChatMessageReaction @reaction={{hash emoji="heart"}} />
+      </template>
+    );
+
+    assert
+      .dom(".chat-message-reaction")
+      .hasAttribute(
+        "tabindex",
+        "0",
+        "an omitted @interactive still means interactive"
+      );
+
+    await render(
+      <template>
+        <ChatMessageReaction
+          @reaction={{hash emoji="heart"}}
+          @interactive={{false}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".chat-message-reaction")
+      .hasAttribute(
+        "tabindex",
+        "-1",
+        "a display-only reaction stays out of the tab order"
+      );
+  });
+
+  test("opens the users popup on focus, not only on hover", async function (assert) {
+    this.siteSettings.enable_new_chat_reactions_popup = true;
+
+    const fabricators = new ChatFabricators(getOwner(this));
+    const message = fabricators.message();
+    const reaction = fabricators.reaction({ emoji: "heart", count: 1 });
+
+    pretender.get(
+      `/chat/${message.channel.id}/${message.id}/reactions-users`,
+      () => response({ users: [], total_rows: 0 })
+    );
+
+    await render(
+      <template>
+        <DMenus />
+        <ChatMessageReaction @reaction={{reaction}} @message={{message}} />
+      </template>
+    );
+
+    await focus(".chat-message-reaction");
+
+    assert
+      .dom("[data-identifier='chat-message-reaction-users']")
+      .exists("focusing the reaction opens the popup");
+
+    await blur(".chat-message-reaction");
+
+    assert
+      .dom("[data-identifier='chat-message-reaction-users']")
+      .doesNotExist("leaving the reaction closes it again");
+  });
+
+  test("reports whether the current user reacted", async function (assert) {
+    await render(
+      <template>
+        <ChatMessageReaction @reaction={{hash emoji="heart" reacted=true}} />
+        <ChatMessageReaction @reaction={{hash emoji="+1" reacted=false}} />
+      </template>
+    );
+
+    assert
+      .dom("[data-emoji-name='heart']")
+      .hasAria("pressed", "true", "a reaction the user added is pressed");
+    assert
+      .dom("[data-emoji-name='+1']")
+      .hasAria("pressed", "false", "one they have not added is not pressed");
+  });
+
+  test("describes who reacted, without folding them into the name", async function (assert) {
+    const reaction = {
+      emoji: "heart",
+      count: 2,
+      users: [
+        { id: 1, username: "bob" },
+        { id: 2, username: "jane" },
+      ],
+    };
+
+    await render(
+      <template><ChatMessageReaction @reaction={{reaction}} /></template>
+    );
+
+    const descriptionId = document
+      .querySelector(".chat-message-reaction")
+      .getAttribute("aria-describedby");
+
+    assert.dom(`#${descriptionId}`).hasClass("sr-only");
+    assert.dom(`#${descriptionId}`).includesText("bob");
+    assert
+      .dom(`.chat-message-reaction #${descriptionId}`)
+      .doesNotExist("the description sits outside the button");
+  });
+
+  test("has no description when nobody has reacted", async function (assert) {
+    await render(
+      <template>
+        <ChatMessageReaction @reaction={{hash emoji="heart" count=0}} />
+      </template>
+    );
+
+    assert
+      .dom(".chat-message-reaction")
+      .doesNotHaveAttribute("aria-describedby");
+    assert.dom(".sr-only").doesNotExist();
   });
 
   test("count of reactions", async function (assert) {


### PR DESCRIPTION
Currently you can't reach the reaction counts in chat via keyboard because it only appears on hover. This change allows the menu containing the "who reacted" info to open on keyboard focus as well. An aria-describedby is also added for screenreader users so they can have the list of who reacted read. 