### PR TITLE
FEATURE: Workflow triggers for event participation and event end

### DIFF
--- a/plugins/chat/lib/discourse_workflows/nodes/chat_message_created/v1.rb
+++ b/plugins/chat/lib/discourse_workflows/nodes/chat_message_created/v1.rb
@@ -15,6 +15,7 @@ if defined?(DiscourseWorkflows)
               color: "teal",
             },
             group: "discourse_triggers",
+            events: [:chat_message_created],
             available: -> { SiteSetting.chat_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_chat",
             output_contracts: [
@@ -91,7 +92,7 @@ if defined?(DiscourseWorkflows)
             },
           )
 
-          def initialize(message, channel, user)
+          def initialize(message, channel, user, *)
             super(parameters: {})
             @message = message
             @channel = channel

--- a/plugins/chat/lib/discourse_workflows/nodes/chat_message_created/v1.rb
+++ b/plugins/chat/lib/discourse_workflows/nodes/chat_message_created/v1.rb
@@ -15,7 +15,7 @@ if defined?(DiscourseWorkflows)
               color: "teal",
             },
             group: "discourse_triggers",
-            events: [:chat_message_created],
+            event: :chat_message_created,
             available: -> { SiteSetting.chat_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_chat",
             output_contracts: [

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -116,27 +116,14 @@ after_initialize do
       require_relative "lib/discourse_workflows/nodes/send_chat_message/v1"
       require_relative "lib/discourse_workflows/nodes/chat_approval/v1"
       require_relative "lib/discourse_workflows/nodes/chat_approval/v2"
+      require_relative "lib/discourse_workflows/nodes/chat_message_created/v1"
 
       [
         DiscourseWorkflows::Nodes::SendChatMessage::V1,
         DiscourseWorkflows::Nodes::ChatApproval::V1,
         DiscourseWorkflows::Nodes::ChatApproval::V2,
-      ]
-    end
-
-    require_relative "lib/discourse_workflows/nodes/chat_message_created/v1"
-    DiscoursePluginRegistry.register_discourse_workflows_node(
-      DiscourseWorkflows::Nodes::ChatMessageCreated::V1,
-      self,
-    )
-
-    on(:chat_message_created) do |message, channel, user|
-      DiscourseWorkflows::EventListener.handle(
         DiscourseWorkflows::Nodes::ChatMessageCreated::V1,
-        message,
-        channel,
-        user,
-      )
+      ]
     end
 
     on(:chat_message_interaction) do |interaction|

--- a/plugins/discourse-assign/lib/discourse_workflows/nodes/assigned/v1.rb
+++ b/plugins/discourse-assign/lib/discourse_workflows/nodes/assigned/v1.rb
@@ -13,7 +13,7 @@ if defined?(DiscourseWorkflows)
               color: "cyan",
             },
             group: "discourse_triggers",
-            events: [:assigned],
+            event: :assigned,
             available: -> { SiteSetting.assign_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_assign",
             output_contracts: [

--- a/plugins/discourse-assign/lib/discourse_workflows/nodes/unassigned/v1.rb
+++ b/plugins/discourse-assign/lib/discourse_workflows/nodes/unassigned/v1.rb
@@ -13,7 +13,7 @@ if defined?(DiscourseWorkflows)
               color: "cyan",
             },
             group: "discourse_triggers",
-            events: [:unassigned],
+            event: :unassigned,
             available: -> { SiteSetting.assign_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_assign",
             output_contracts: [

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -38,17 +38,6 @@ after_initialize do
         DiscourseWorkflows::Nodes::CheckAssignment::V1,
       ]
     end
-
-    on(:assigned) do |assignment|
-      DiscourseWorkflows::EventListener.handle(DiscourseWorkflows::Nodes::Assigned::V1, assignment)
-    end
-
-    on(:unassigned) do |assignment|
-      DiscourseWorkflows::EventListener.handle(
-        DiscourseWorkflows::Nodes::Unassigned::V1,
-        assignment,
-      )
-    end
   end
   UserUpdater::OPTION_ATTR.push(:notification_level_when_assigned)
 

--- a/plugins/discourse-events/app/models/discourse_events/events/invitee.rb
+++ b/plugins/discourse-events/app/models/discourse_events/events/invitee.rb
@@ -71,6 +71,10 @@ module DiscourseEvents
         DiscourseEvent.trigger(:discourse_calendar_post_event_invitee_status_changed, self)
       end
 
+      def publish_attendance_removed!
+        DiscourseEvent.trigger(:discourse_calendar_post_event_invitee_status_changed, self)
+      end
+
       def self.extract_uniq_usernames(groups)
         User.real.where(
           id: GroupUser.where(group_id: Group.where(name: groups).select(:id)).select(:user_id),

--- a/plugins/discourse-events/app/services/discourse_events/events/destroy_invitee.rb
+++ b/plugins/discourse-events/app/services/discourse_events/events/destroy_invitee.rb
@@ -46,6 +46,7 @@ module DiscourseEvents
 
       def destroy(invitee:)
         invitee.destroy!
+        invitee.publish_attendance_removed!
       end
 
       def publish(event:)

--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -350,10 +350,7 @@ en:
       node_descriptions:
         "trigger:event_ended": "Fires when an event occurrence reaches its end time"
         "trigger:event_participation_changed": "Fires when a user adds, changes, or withdraws their RSVP"
-      event_ended:
-        topic_id: "Topic"
-        topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
-      event_participation_changed:
+      post_event:
         topic_id: "Topic"
         topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
     discourse_post_event:

--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -351,7 +351,7 @@ en:
         "trigger:event_ended": "Fires when an event occurrence reaches its end time"
         "trigger:event_participation_changed": "Fires when a user adds, changes, or withdraws their RSVP"
       post_event:
-        topic_id: "Topic"
+        topic_id: "Topic ID"
         topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
     discourse_post_event:
       new_event: "New Event"

--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -341,6 +341,21 @@ en:
     group_timezones:
       search: "Search..."
       group_availability: "%{group} availability"
+    discourse_workflows:
+      node_unavailable:
+        requires_post_event: "Requires events to be enabled"
+      nodes:
+        "trigger:event_ended": "Event ended"
+        "trigger:event_participation_changed": "Event participation changed"
+      node_descriptions:
+        "trigger:event_ended": "Fires when an event occurrence reaches its end time"
+        "trigger:event_participation_changed": "Fires when a user adds, changes, or withdraws their RSVP"
+      event_ended:
+        topic_id: "Topic"
+        topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
+      event_participation_changed:
+        topic_id: "Topic"
+        topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
     discourse_post_event:
       new_event: "New Event"
       notifications:

--- a/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
+++ b/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
@@ -41,7 +41,9 @@ module Jobs
         return if !event_date.ended?
         event_date.update!(finished_at: Time.current)
 
-        DiscourseEvent.trigger(:discourse_post_event_event_ended, event_date.event)
+        # The occurrence goes along with the event: `set_next_date` below moves
+        # the event on to the next one, so it can no longer name the one that ended.
+        DiscourseEvent.trigger(:discourse_post_event_event_ended, event_date.event, event_date)
         MessageBus.publish(
           "/topic/#{event_date.event.post.topic_id}",
           reload_topic: true,

--- a/plugins/discourse-events/lib/discourse_events/events/workflows/schema.rb
+++ b/plugins/discourse-events/lib/discourse_events/events/workflows/schema.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module DiscourseEvents
+  module Events
+    module Workflows
+      module Schema
+        EVENT_PROPERTIES = JSON.parse(<<~JSON).freeze
+        {
+          "id": { "type": "integer" },
+          "name": { "type": ["string", "null"] },
+          "description": { "type": ["string", "null"] },
+          "location": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] },
+          "timezone": { "type": ["string", "null"] },
+          "all_day": { "type": "boolean" },
+          "closed": { "type": "boolean" },
+          "recurring": { "type": "boolean" },
+          "recurrence": { "type": ["string", "null"] },
+          "starts_at": { "type": ["string", "null"], "format": "date-time" },
+          "ends_at": { "type": ["string", "null"], "format": "date-time" },
+          "custom_fields": { "type": "object" }
+        }
+      JSON
+
+        POST_PROPERTIES = JSON.parse(<<~JSON).freeze
+        {
+          "id": { "type": "integer" },
+          "post_number": { "type": "integer" },
+          "url": { "type": ["string", "null"] }
+        }
+      JSON
+
+        STATS_PROPERTIES = JSON.parse(<<~JSON).freeze
+        {
+          "going": { "type": "integer" },
+          "going_recurring": { "type": "integer" },
+          "interested": { "type": "integer" },
+          "not_going": { "type": "integer" },
+          "invited": { "type": "integer" },
+          "capacity": { "type": ["integer", "null"] }
+        }
+      JSON
+
+        PARTICIPATION_PROPERTIES = JSON.parse(<<~JSON).freeze
+        {
+          "status": { "type": ["string", "null"], "enum": ["going", "interested", "not_going", null] },
+          "previous_status": { "type": ["string", "null"], "enum": ["going", "interested", "not_going", null] },
+          "removed": { "type": "boolean" },
+          "recurring": { "type": "boolean" }
+        }
+      JSON
+
+        POST_SCHEMA =
+          DiscourseWorkflows::Schema.entity(
+            "post",
+            POST_PROPERTIES,
+            "Post the event is attached to",
+          )
+
+        # `going` counts RSVPs, not verified attendance, and every count excludes
+        # suspended, silenced and staged users.
+        STATS_SCHEMA =
+          DiscourseWorkflows::Schema.entity(
+            "stats",
+            STATS_PROPERTIES,
+            "RSVP counts when the workflow was triggered",
+          )
+
+        PARTICIPATION_SCHEMA =
+          DiscourseWorkflows::Schema.entity(
+            "participation",
+            PARTICIPATION_PROPERTIES,
+            "RSVP that changed. `status` is null and `removed` is true when the user withdrew",
+          )
+
+        # `starts_at`/`ends_at` name a single occurrence, and which one differs per
+        # trigger, so each gets its own description rather than a shared constant.
+        ENDED_EVENT_SCHEMA =
+          DiscourseWorkflows::Schema.entity(
+            "event",
+            EVENT_PROPERTIES,
+            "Event, with the dates of the occurrence that just ended",
+          )
+
+        CURRENT_EVENT_SCHEMA =
+          DiscourseWorkflows::Schema.entity(
+            "event",
+            EVENT_PROPERTIES,
+            "Event, with the dates of its current occurrence",
+          )
+
+        EVENT_ENDED_OUTPUT_SCHEMA =
+          DiscourseWorkflows::Schema.merge(
+            ENDED_EVENT_SCHEMA,
+            POST_SCHEMA,
+            DiscourseWorkflows::Schema::TOPIC_LIST_ITEM_SCHEMA,
+            STATS_SCHEMA,
+          ).freeze
+
+        EVENT_PARTICIPATION_CHANGED_OUTPUT_SCHEMA =
+          DiscourseWorkflows::Schema.merge(
+            CURRENT_EVENT_SCHEMA,
+            POST_SCHEMA,
+            DiscourseWorkflows::Schema::TOPIC_LIST_ITEM_SCHEMA,
+            DiscourseWorkflows::Schema::USER_SCHEMA,
+            PARTICIPATION_SCHEMA,
+            STATS_SCHEMA,
+          ).freeze
+      end
+    end
+  end
+end

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event_ended/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event_ended/v1.rb
@@ -15,7 +15,7 @@ if defined?(DiscourseWorkflows)
               color: "purple",
             },
             group: "discourse_triggers",
-            events: [:discourse_post_event_event_ended],
+            event: :discourse_post_event_event_ended,
             available: -> { SiteSetting.discourse_post_event_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_post_event",
             output_contracts: [

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event_ended/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event_ended/v1.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseWorkflows)
+  module DiscourseWorkflows
+    module Nodes
+      module EventEnded
+        class V1 < DiscourseWorkflows::NodeType
+          include PostEventScoping
+
+          description(
+            name: "trigger:event_ended",
+            version: "1.0",
+            defaults: {
+              icon: "calendar-days",
+              color: "purple",
+            },
+            group: "discourse_triggers",
+            events: [:discourse_post_event_event_ended],
+            available: -> { SiteSetting.discourse_post_event_enabled },
+            unavailable_reason_key: "discourse_workflows.node_unavailable.requires_post_event",
+            output_contracts: [
+              { schema: DiscourseEvents::Events::Workflows::Schema::EVENT_ENDED_OUTPUT_SCHEMA },
+            ],
+            properties: PostEventScoping::SCOPE_PROPERTIES,
+          )
+
+          def initialize(event, event_date = nil, *)
+            super(parameters: {})
+            @event = event
+            @event_date = event_date
+          end
+
+          # The occurrence is required rather than derived: the next one is
+          # scheduled immediately after this fires, so anything read from the
+          # event afterwards describes the wrong dates.
+          def valid?
+            SiteSetting.discourse_post_event_enabled && @event.present? && @event_date.present? &&
+              topic.present?
+          end
+
+          def output
+            {
+              event: event_data(starts_at: @event_date.starts_at, ends_at: @event_date.ends_at),
+              post: post_data,
+              topic: topic_data(topic),
+              stats: stats_data,
+            }
+          end
+
+          def matches?(trigger_ctx)
+            matches_topic_id?(trigger_ctx)
+          end
+
+          private
+
+          attr_reader :event
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event_ended/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event_ended/v1.rb
@@ -22,6 +22,7 @@ if defined?(DiscourseWorkflows)
               { schema: DiscourseEvents::Events::Workflows::Schema::EVENT_ENDED_OUTPUT_SCHEMA },
             ],
             properties: PostEventScoping::SCOPE_PROPERTIES,
+            i18n_scope: PostEventScoping::I18N_SCOPE,
           )
 
           def initialize(event, event_date = nil, *)

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event_participation_changed/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event_participation_changed/v1.rb
@@ -25,6 +25,7 @@ if defined?(DiscourseWorkflows)
               },
             ],
             properties: PostEventScoping::SCOPE_PROPERTIES,
+            i18n_scope: PostEventScoping::I18N_SCOPE,
           )
 
           def initialize(invitee, *)

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event_participation_changed/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event_participation_changed/v1.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseWorkflows)
+  module DiscourseWorkflows
+    module Nodes
+      module EventParticipationChanged
+        class V1 < DiscourseWorkflows::NodeType
+          include PostEventScoping
+
+          description(
+            name: "trigger:event_participation_changed",
+            version: "1.0",
+            defaults: {
+              icon: "user-check",
+              color: "teal",
+            },
+            group: "discourse_triggers",
+            events: [:discourse_calendar_post_event_invitee_status_changed],
+            available: -> { SiteSetting.discourse_post_event_enabled },
+            unavailable_reason_key: "discourse_workflows.node_unavailable.requires_post_event",
+            output_contracts: [
+              {
+                schema:
+                  DiscourseEvents::Events::Workflows::Schema::EVENT_PARTICIPATION_CHANGED_OUTPUT_SCHEMA,
+              },
+            ],
+            properties: PostEventScoping::SCOPE_PROPERTIES,
+          )
+
+          def initialize(invitee, *)
+            super(parameters: {})
+            @invitee = invitee
+          end
+
+          # Re-submitting an unchanged RSVP still publishes, so without the
+          # `saved_changes?` guard a repeated click would run the workflow again.
+          def valid?
+            return false if !SiteSetting.discourse_post_event_enabled
+            return false if @invitee.blank? || user.blank? || event.blank? || topic.blank?
+
+            @invitee.destroyed? || @invitee.saved_changes?
+          end
+
+          def output
+            {
+              event: event_data(starts_at: event.starts_at, ends_at: event.ends_at),
+              post: post_data,
+              topic: topic_data(topic),
+              user: serialize_user(user),
+              participation: {
+                status: removed? ? nil : status_name(@invitee.status),
+                previous_status: previous_status,
+                removed: removed?,
+                recurring: !removed? && !!@invitee.recurring,
+              },
+              stats: stats_data,
+            }
+          end
+
+          def matches?(trigger_ctx)
+            matches_topic_id?(trigger_ctx)
+          end
+
+          private
+
+          def event
+            return @event if defined?(@event)
+            @event = @invitee&.event
+          end
+
+          def user
+            return @user if defined?(@user)
+            @user = @invitee&.user
+          end
+
+          def removed?
+            !!@invitee&.destroyed?
+          end
+
+          def previous_status
+            status_name(removed? ? @invitee.status : @invitee.status_before_last_save)
+          end
+
+          def status_name(status)
+            return nil if status.blank?
+
+            ::DiscourseEvents::Events::Invitee.statuses[status]&.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event_participation_changed/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event_participation_changed/v1.rb
@@ -15,7 +15,7 @@ if defined?(DiscourseWorkflows)
               color: "teal",
             },
             group: "discourse_triggers",
-            events: [:discourse_calendar_post_event_invitee_status_changed],
+            event: :discourse_calendar_post_event_invitee_status_changed,
             available: -> { SiteSetting.discourse_post_event_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_post_event",
             output_contracts: [

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/post_event_scoping.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/post_event_scoping.rb
@@ -4,6 +4,10 @@ if defined?(DiscourseWorkflows)
   module DiscourseWorkflows
     module Nodes
       module PostEventScoping
+        # Shared locale scope so every node using these properties resolves
+        # `topic_id`/`topic_id_description` from one translated pair.
+        I18N_SCOPE = "post_event"
+
         SCOPE_PROPERTIES = {
           topic_id: {
             type: :string,

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/post_event_scoping.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/post_event_scoping.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseWorkflows)
+  module DiscourseWorkflows
+    module Nodes
+      module PostEventScoping
+        SCOPE_PROPERTIES = {
+          topic_id: {
+            type: :string,
+            required: false,
+            no_data_expression: true,
+          },
+        }.freeze
+
+        private
+
+        def topic
+          return @topic if defined?(@topic)
+          @topic = event&.post&.topic
+        end
+
+        def matches_topic_id?(trigger_ctx)
+          topic_id = trigger_ctx.get_node_parameter("topic_id").to_s.strip.presence
+          topic_id.blank? || topic_id.to_i == topic&.id
+        end
+
+        def event_data(starts_at:, ends_at:)
+          {
+            id: event.id,
+            name: event.name,
+            description: event.description,
+            location: event.location,
+            url: event.url,
+            timezone: event.timezone,
+            all_day: !!event.all_day,
+            closed: !!event.closed,
+            recurring: event.recurring?,
+            recurrence: event.recurrence,
+            starts_at: starts_at&.iso8601,
+            ends_at: ends_at&.iso8601,
+            custom_fields: event.custom_fields || {},
+          }
+        end
+
+        def post_data
+          post = event&.post
+          return nil if post.blank?
+
+          { id: post.id, post_number: post.post_number, url: post.url }
+        end
+
+        def stats_data
+          serialize_record(event, ::DiscourseEvents::Events::EventStatsSerializer)
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-events/plugin.rb
+++ b/plugins/discourse-events/plugin.rb
@@ -232,6 +232,20 @@ Dir
   .each { |f| require(f) }
 
 after_initialize do
+  if respond_to?(:register_discourse_workflows_node)
+    register_discourse_workflows_node do
+      require_relative "lib/discourse_events/events/workflows/schema"
+      require_relative "lib/discourse_workflows/nodes/post_event_scoping"
+      require_relative "lib/discourse_workflows/nodes/event_ended/v1"
+      require_relative "lib/discourse_workflows/nodes/event_participation_changed/v1"
+
+      [
+        DiscourseWorkflows::Nodes::EventEnded::V1,
+        DiscourseWorkflows::Nodes::EventParticipationChanged::V1,
+      ]
+    end
+  end
+
   reloadable_patch do
     register_category_type(DiscourseEvents::Categories::Types::Events)
     Category.register_custom_field_type("sort_topics_by_event_start_date", :boolean)
@@ -1012,6 +1026,9 @@ after_initialize do
   end
 
   on(:discourse_calendar_post_event_invitee_status_changed) do |invitee|
+    # Withdrawing leaves no attendance to sync, and the record is already gone.
+    next if invitee.destroyed?
+
     topic = invitee.event.post.topic
     topic_chat_channel = topic.topic_chat_channel
 

--- a/plugins/discourse-events/spec/integration/workflows_event_triggers_spec.rb
+++ b/plugins/discourse-events/spec/integration/workflows_event_triggers_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe "Post event workflow triggers" do
+  fab!(:admin)
+  fab!(:attendee) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:event) { Fabricate(:event, original_starts_at: 7.days.from_now) }
+  # Far enough out that it never ends inside the frozen window below.
+  fab!(:other_event) { Fabricate(:event, original_starts_at: 30.days.from_now) }
+
+  let(:topic) { event.post.topic }
+
+  before do
+    SiteSetting.discourse_events_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.enable_discourse_workflows = true
+  end
+
+  def publish_workflow(node_id, identifier, configuration = {})
+    Fabricate(
+      :discourse_workflows_workflow,
+      created_by: admin,
+      published: true,
+      **build_workflow_graph { |graph| graph.node node_id, identifier, configuration: },
+    )
+  end
+
+  def enqueued_workflow_ids(*node_ids)
+    Jobs::DiscourseWorkflows::ExecuteWorkflow
+      .jobs
+      .map { |job| job["args"].first }
+      .select { |args| args["trigger_node_id"].in?(node_ids) }
+      .map { |args| args["workflow_id"] }
+  end
+
+  describe "trigger:event_participation_changed" do
+    it "enqueues workflows matching the event's topic when a user RSVPs" do
+      all_events = publish_workflow("trigger-all", "trigger:event_participation_changed")
+      this_topic =
+        publish_workflow(
+          "trigger-topic",
+          "trigger:event_participation_changed",
+          { "topic_id" => topic.id.to_s },
+        )
+      publish_workflow(
+        "trigger-other",
+        "trigger:event_participation_changed",
+        { "topic_id" => other_event.post.topic.id.to_s },
+      )
+
+      DiscourseEvents::Events::CreateInvitee.call(
+        params: {
+          event_id: event.id,
+          user_id: attendee.id,
+          status: "going",
+        },
+        guardian: attendee.guardian,
+      )
+
+      expect(
+        enqueued_workflow_ids("trigger-all", "trigger-topic", "trigger-other"),
+      ).to contain_exactly(all_events.id, this_topic.id)
+    end
+
+    it "enqueues once when a user withdraws their RSVP" do
+      invitee = DiscourseEvents::Events::Invitee.create_attendance!(attendee.id, event.id, :going)
+      workflow = publish_workflow("trigger-all", "trigger:event_participation_changed")
+      Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.clear
+
+      DiscourseEvents::Events::DestroyInvitee.call(
+        params: {
+          post_id: event.id,
+          id: invitee.id,
+        },
+        guardian: attendee.guardian,
+      )
+
+      expect(enqueued_workflow_ids("trigger-all")).to eq([workflow.id])
+
+      trigger_data =
+        Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.first["args"].first["trigger_data"]
+      expect(trigger_data["participation"]).to include("removed" => true, "status" => nil)
+    end
+  end
+
+  describe "trigger:event_ended" do
+    it "enqueues workflows matching the event's topic when an occurrence ends" do
+      all_events = publish_workflow("trigger-all", "trigger:event_ended")
+      this_topic =
+        publish_workflow("trigger-topic", "trigger:event_ended", { "topic_id" => topic.id.to_s })
+      publish_workflow(
+        "trigger-other",
+        "trigger:event_ended",
+        { "topic_id" => other_event.post.topic.id.to_s },
+      )
+
+      freeze_time 8.days.from_now
+      Jobs::DiscourseCalendar::MonitorEventDates.new.execute({})
+
+      expect(
+        enqueued_workflow_ids("trigger-all", "trigger-topic", "trigger-other"),
+      ).to contain_exactly(all_events.id, this_topic.id)
+    end
+  end
+end

--- a/plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb
+++ b/plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb
@@ -164,10 +164,13 @@ describe Jobs::DiscourseCalendar::MonitorEventDates do
         (past_date_no_end_time.starts_at + 7.days).to_s,
       )
 
-      expect(events).to include(event_name: :discourse_post_event_event_ended, params: [past_event])
       expect(events).to include(
         event_name: :discourse_post_event_event_ended,
-        params: [past_event_no_end_time],
+        params: [past_event, past_date],
+      )
+      expect(events).to include(
+        event_name: :discourse_post_event_event_ended,
+        params: [past_event_no_end_time, past_date_no_end_time],
       )
     end
 

--- a/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event_ended/v1_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event_ended/v1_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Nodes::EventEnded::V1 do
+  fab!(:event)
+
+  let(:topic) { event.post.topic }
+  let(:event_date) { event.event_dates.first }
+
+  before do
+    SiteSetting.discourse_events_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.enable_discourse_workflows = true
+  end
+
+  def trigger_context(parameters)
+    DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+  end
+
+  it "returns the correct identifier" do
+    expect(described_class.identifier).to eq("trigger:event_ended")
+  end
+
+  describe "#valid?" do
+    it "returns true for an event with the occurrence that ended" do
+      expect(described_class.new(event, event_date)).to be_valid
+    end
+
+    it "returns false when the event is nil" do
+      expect(described_class.new(nil, event_date)).not_to be_valid
+    end
+
+    it "returns false when the occurrence is missing" do
+      expect(described_class.new(event)).not_to be_valid
+    end
+
+    it "returns false when events are disabled" do
+      SiteSetting.discourse_post_event_enabled = false
+
+      expect(described_class.new(event, event_date)).not_to be_valid
+    end
+  end
+
+  describe "#output" do
+    it "returns the event, post, topic and RSVP counts", :aggregate_failures do
+      DiscourseEvents::Events::Invitee.create_attendance!(Fabricate(:user).id, event.id, :going)
+
+      output = described_class.new(event, event_date).output
+
+      expect(output[:event]).to include(id: event.id, name: event.name)
+      expect(output[:post]).to include(id: event.post.id)
+      expect(output[:topic][:id]).to eq(topic.id)
+      expect(output[:stats][:going]).to eq(1)
+      expect(output).to match_node_output_schema(described_class)
+    end
+
+    it "reports the dates of the occurrence that ended, not the next one" do
+      ended_at = 2.days.ago
+      event_date.update!(starts_at: 3.days.ago, ends_at: ended_at)
+      event.event_dates.create!(starts_at: 5.days.from_now, ends_at: 6.days.from_now)
+
+      output = described_class.new(event.reload, event_date).output
+
+      expect(output[:event][:ends_at]).to eq(ended_at.iso8601)
+    end
+  end
+
+  describe "#matches?" do
+    it "matches every event when no topic is configured" do
+      expect(described_class.new(event, event_date).matches?(trigger_context({}))).to eq(true)
+    end
+
+    it "matches the configured topic" do
+      context = trigger_context("topic_id" => topic.id.to_s)
+
+      expect(described_class.new(event, event_date).matches?(context)).to eq(true)
+    end
+
+    it "does not match another topic" do
+      context = trigger_context("topic_id" => (topic.id + 1).to_s)
+
+      expect(described_class.new(event, event_date).matches?(context)).to eq(false)
+    end
+  end
+end

--- a/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event_participation_changed/v1_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event_participation_changed/v1_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Nodes::EventParticipationChanged::V1 do
+  fab!(:event)
+  fab!(:user)
+
+  let(:topic) { event.post.topic }
+  let(:invitee) { DiscourseEvents::Events::Invitee.create_attendance!(user.id, event.id, :going) }
+
+  before do
+    SiteSetting.discourse_events_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.enable_discourse_workflows = true
+  end
+
+  def trigger_context(parameters)
+    DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+  end
+
+  it "returns the correct identifier" do
+    expect(described_class.identifier).to eq("trigger:event_participation_changed")
+  end
+
+  describe "#valid?" do
+    it "returns true for a newly created RSVP" do
+      expect(described_class.new(invitee)).to be_valid
+    end
+
+    it "returns true when the status changed" do
+      invitee.update_attendance!(:not_going)
+
+      expect(described_class.new(invitee)).to be_valid
+    end
+
+    it "returns true when the RSVP was withdrawn" do
+      invitee.destroy!
+
+      expect(described_class.new(invitee)).to be_valid
+    end
+
+    it "returns false when the same status is submitted again" do
+      invitee.update_attendance!(:going)
+
+      expect(described_class.new(invitee)).not_to be_valid
+    end
+
+    it "returns false when the invitee is nil" do
+      expect(described_class.new(nil)).not_to be_valid
+    end
+
+    it "returns false when events are disabled" do
+      SiteSetting.discourse_post_event_enabled = false
+
+      expect(described_class.new(invitee)).not_to be_valid
+    end
+  end
+
+  describe "#output" do
+    it "reports a new RSVP with no previous status", :aggregate_failures do
+      output = described_class.new(invitee).output
+
+      expect(output[:user][:username]).to eq(user.username)
+      expect(output[:event][:id]).to eq(event.id)
+      expect(output[:topic][:id]).to eq(topic.id)
+      expect(output[:participation]).to include(
+        status: "going",
+        previous_status: nil,
+        removed: false,
+      )
+      expect(output).to match_node_output_schema(described_class)
+    end
+
+    it "reports the status the user moved away from", :aggregate_failures do
+      invitee.update_attendance!(:not_going)
+
+      output = described_class.new(invitee).output
+
+      expect(output[:participation]).to include(
+        status: "not_going",
+        previous_status: "going",
+        removed: false,
+      )
+      expect(output).to match_node_output_schema(described_class)
+    end
+
+    it "reports a withdrawal with no current status", :aggregate_failures do
+      invitee.destroy!
+
+      output = described_class.new(invitee).output
+
+      expect(output[:participation]).to include(
+        status: nil,
+        previous_status: "going",
+        removed: true,
+      )
+      expect(output).to match_node_output_schema(described_class)
+    end
+  end
+
+  describe "#matches?" do
+    it "matches every event when no topic is configured" do
+      expect(described_class.new(invitee).matches?(trigger_context({}))).to eq(true)
+    end
+
+    it "matches the configured topic" do
+      context = trigger_context("topic_id" => topic.id.to_s)
+
+      expect(described_class.new(invitee).matches?(context)).to eq(true)
+    end
+
+    it "does not match another topic" do
+      context = trigger_context("topic_id" => (topic.id + 1).to_s)
+
+      expect(described_class.new(invitee).matches?(context)).to eq(false)
+    end
+  end
+end

--- a/plugins/discourse-events/spec/services/discourse_events/events/destroy_invitee_spec.rb
+++ b/plugins/discourse-events/spec/services/discourse_events/events/destroy_invitee_spec.rb
@@ -123,6 +123,15 @@ RSpec.describe(DiscourseEvents::Events::DestroyInvitee) do
 
         expect(topic_user.reload.notification_level).to eq(TopicUser.notification_levels[:regular])
       end
+
+      it "publishes the attendance change so subscribers see the withdrawal" do
+        event =
+          DiscourseEvent
+            .track_events(:discourse_calendar_post_event_invitee_status_changed) { result }
+            .first
+
+        expect(event[:params].first).to have_attributes(id: invitee.id, destroyed?: true)
+      end
     end
 
     context "when staff destroys another user's invitee" do

--- a/plugins/discourse-topic-voting/lib/discourse_workflows/nodes/topic_received_vote/v1.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_workflows/nodes/topic_received_vote/v1.rb
@@ -13,7 +13,7 @@ if defined?(DiscourseWorkflows)
               color: "purple",
             },
             group: "discourse_triggers",
-            events: [:topic_voting_vote_created],
+            event: :topic_voting_vote_created,
             available: -> { SiteSetting.topic_voting_enabled },
             unavailable_reason_key: "discourse_workflows.node_unavailable.requires_topic_voting",
             output_contracts: [

--- a/plugins/discourse-topic-voting/plugin.rb
+++ b/plugins/discourse-topic-voting/plugin.rb
@@ -39,13 +39,6 @@ after_initialize do
       require_relative "lib/discourse_workflows/nodes/topic_received_vote/v1"
       DiscourseWorkflows::Nodes::TopicReceivedVote::V1
     end
-
-    on(:topic_voting_vote_created) do |vote|
-      DiscourseWorkflows::EventListener.handle(
-        DiscourseWorkflows::Nodes::TopicReceivedVote::V1,
-        vote,
-      )
-    end
   end
 
   reloadable_patch do

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -16,7 +16,7 @@ module DiscourseWorkflows
       },
       credentials: [],
       webhooks: [],
-      events: [],
+      event: nil,
       max_nodes: nil,
       capabilities: {
       },
@@ -202,7 +202,7 @@ module DiscourseWorkflows
     private_class_method :unknown_contract?
 
     def self.event_name
-      Array(description[:events]).first
+      description[:event]&.to_sym
     end
 
     def self.manually_triggerable?

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/badge_granted/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/badge_granted/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "yellow",
           },
           group: "discourse_triggers",
-          events: [:user_badge_granted],
+          event: :user_badge_granted,
           output_contracts: [{ schema: Schema::BADGE_GRANTED_SCHEMA }],
           properties: {
             badge_id: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
@@ -14,7 +14,7 @@ module DiscourseWorkflows
             color: "indigo",
           },
           group: "discourse_triggers",
-          events: [:post_created],
+          event: :post_created,
           output_contracts: [
             {
               schema:

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
@@ -14,7 +14,7 @@ module DiscourseWorkflows
             color: "violet",
           },
           group: "discourse_triggers",
-          events: [:post_edited],
+          event: :post_edited,
           output_contracts: [
             {
               schema:

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
@@ -26,7 +26,7 @@ module DiscourseWorkflows
             color: "deep-orange",
           },
           group: "discourse_triggers",
-          events: [:post_moved],
+          event: :post_moved,
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
           properties: {
             category_ids: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/reviewable_approved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/reviewable_approved/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "green",
           },
           group: "discourse_triggers",
-          events: [:reviewable_transitioned_to],
+          event: :reviewable_transitioned_to,
           output_contracts: [{ schema: Schema::REVIEWABLE_EVENT_SCHEMA }],
           properties: -> do
             {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/reviewable_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/reviewable_created/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "orange",
           },
           group: "discourse_triggers",
-          events: [:reviewable_created],
+          event: :reviewable_created,
           output_contracts: [{ schema: Schema::REVIEWABLE_EVENT_SCHEMA }],
           properties: -> do
             {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_category_changed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_category_changed/v1.rb
@@ -26,7 +26,7 @@ module DiscourseWorkflows
             color: "deep-orange",
           },
           group: "discourse_triggers",
-          events: [:topic_category_changed],
+          event: :topic_category_changed,
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
         )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "grey",
           },
           group: "discourse_triggers",
-          events: [:topic_status_updated],
+          event: :topic_status_updated,
           output_contracts: [{ schema: Schema::TOPIC_LIST_ITEM_SCHEMA }],
           properties: {
             category_ids: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
@@ -14,7 +14,7 @@ module DiscourseWorkflows
             color: "teal",
           },
           group: "discourse_triggers",
-          events: [:topic_created],
+          event: :topic_created,
           output_contracts: [
             { schema: Schema.merge(Schema::TOPIC_LIST_ITEM_SCHEMA, Schema::POST_SCHEMA) },
           ],

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
@@ -24,7 +24,7 @@ module DiscourseWorkflows
             color: "deep-orange",
           },
           group: "discourse_triggers",
-          events: [:topic_tags_changed],
+          event: :topic_tags_changed,
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
           properties: {
             category_ids: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_added_to_group/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_added_to_group/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "teal",
           },
           group: "discourse_triggers",
-          events: [:user_added_to_group],
+          event: :user_added_to_group,
           output_contracts: [{ schema: Schema::USER_ADDED_TO_GROUP_SCHEMA }],
           properties: {
             group_id: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_created/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "teal",
           },
           group: "discourse_triggers",
-          events: [:user_created],
+          event: :user_created,
           output_contracts: [{ schema: Schema::USER_EVENT_SCHEMA }],
           capabilities: {
             provides_current_user: true,

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_removed_from_group/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_removed_from_group/v1.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
             color: "grey",
           },
           group: "discourse_triggers",
-          events: [:user_removed_from_group],
+          event: :user_removed_from_group,
           output_contracts: [{ schema: Schema::USER_REMOVED_FROM_GROUP_SCHEMA }],
           properties: {
             group_id: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_search/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_search/v1.rb
@@ -22,7 +22,7 @@ module DiscourseWorkflows
             color: "blue",
           },
           group: "discourse_triggers",
-          events: [:user_search],
+          event: :user_search,
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
         )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_seen/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_seen/v1.rb
@@ -14,7 +14,7 @@ module DiscourseWorkflows
             color: "green",
           },
           group: "discourse_triggers",
-          events: [:user_seen],
+          event: :user_seen,
           output_contracts: [{ schema: Schema::USER_SEEN_SCHEMA }],
           properties: {
             trigger_conditions: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_updated/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user_updated/v1.rb
@@ -24,7 +24,7 @@ module DiscourseWorkflows
             color: "teal",
           },
           group: "discourse_triggers",
-          events: [:user_updated],
+          event: :user_updated,
           output_contracts: [{ schema: Schema::USER_UPDATED_EVENT_SCHEMA }],
           properties: {
             changed_fields: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/plugin_node_registration.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/plugin_node_registration.rb
@@ -8,6 +8,17 @@ module DiscourseWorkflows
       @node_registration_ready == true
     end
 
+    # A node class belongs to the first plugin that claims it, and claiming it is
+    # what subscribes its trigger event. Contributing plugins are flushed before
+    # the host registers its own nodes, so a node shipped by another plugin is
+    # attributed to that plugin and stops listening when it is disabled.
+    def register_node(node_class, plugin)
+      return if node_registered?(node_class)
+
+      DiscoursePluginRegistry.register_discourse_workflows_node(node_class, plugin)
+      subscribe_node_event(node_class, plugin)
+    end
+
     def register_plugin_node_registration(plugin, registration)
       node_classes =
         if registration.respond_to?(:call)
@@ -16,11 +27,7 @@ module DiscourseWorkflows
           registration
         end
 
-      Array
-        .wrap(node_classes)
-        .each do |node_class|
-          DiscoursePluginRegistry.register_discourse_workflows_node(node_class, plugin)
-        end
+      Array.wrap(node_classes).each { |node_class| register_node(node_class, plugin) }
     end
 
     def flush_plugin_node_registrations!
@@ -32,6 +39,23 @@ module DiscourseWorkflows
         end
         plugin.discourse_workflows_node_registrations.clear
       end
+    end
+
+    private
+
+    def node_registered?(node_class)
+      DiscoursePluginRegistry._raw_discourse_workflows_nodes.any? do |entry|
+        entry[:value] == node_class
+      end
+    end
+
+    # `Plugin::Instance#on` gates the handler on the owning plugin being enabled,
+    # so a node stops listening as soon as its plugin is turned off.
+    def subscribe_node_event(node_class, plugin)
+      event_name = node_class.event_name if node_class.respond_to?(:event_name)
+      return if event_name.blank?
+
+      plugin.on(event_name) { |*args| EventListener.handle(node_class, *args) }
     end
   end
 end

--- a/plugins/discourse-workflows/plugin.rb
+++ b/plugins/discourse-workflows/plugin.rb
@@ -70,17 +70,14 @@ after_initialize do
   nodes_dir = File.join(File.dirname(__FILE__), "lib/discourse_workflows/nodes")
   Dir.glob(File.join(nodes_dir, "**/*.rb")).each { |f| Rails.autoloaders.main.load_file(f) }
 
-  DiscourseWorkflows::NodeType.registered_nodes.each do |node_class|
-    DiscoursePluginRegistry.register_discourse_workflows_node(node_class, self)
-
-    next unless node_class.respond_to?(:event_name) && node_class.event_name
-    on(node_class.event_name) do |*args|
-      DiscourseWorkflows::EventListener.handle(node_class, *args)
-    end
-  end
-
+  # Contributing plugins claim their nodes first so that ownership — and the
+  # enabled check that rides on it — lands on them rather than on this plugin.
   DiscourseWorkflows.node_registration_ready = true
   DiscourseWorkflows.flush_plugin_node_registrations!
+
+  DiscourseWorkflows::NodeType.registered_nodes.each do |node_class|
+    DiscourseWorkflows.register_node(node_class, self)
+  end
   DiscourseWorkflows::Registry.reset_indexes!
 
   DiscoursePluginRegistry.register_discourse_workflows_credential_type(

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/plugin_node_registration_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/plugin_node_registration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DiscourseWorkflows do
         description(
           name: "trigger:plugin_node_registration_test",
           version: "1.0",
-          events: [:plugin_node_registration_test_event],
+          event: :plugin_node_registration_test_event,
         )
 
         def initialize(payload, *)
@@ -57,6 +57,25 @@ RSpec.describe DiscourseWorkflows do
       DiscourseEvent.trigger(event_name, "payload")
 
       expect(handled).to eq([[node_class, ["payload"]]])
+    end
+
+    it "subscribes under the symbol DiscourseEvent key when the event is declared as a string" do
+      string_event_class =
+        Class.new(DiscourseWorkflows::NodeType) do
+          description(
+            name: "trigger:plugin_node_registration_string_event_test",
+            version: "1.0",
+            event: "plugin_node_registration_test_event",
+          )
+        end
+
+      plugin.register_discourse_workflows_node(string_event_class)
+
+      DiscourseEvent.trigger(event_name, "payload")
+
+      expect(handled).to eq([[string_event_class, ["payload"]]])
+    ensure
+      unregister_workflow_nodes(string_event_class)
     end
 
     it "subscribes only once when the same node is registered again" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/plugin_node_registration_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/plugin_node_registration_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows do
+  describe ".register_node" do
+    let(:event_name) { :plugin_node_registration_test_event }
+    let(:plugin) { Plugin::Instance.new }
+    let(:handled) { [] }
+
+    let(:node_class) do
+      Class.new(DiscourseWorkflows::NodeType) do
+        description(
+          name: "trigger:plugin_node_registration_test",
+          version: "1.0",
+          events: [:plugin_node_registration_test_event],
+        )
+
+        def initialize(payload, *)
+          super(parameters: {})
+          @payload = payload
+        end
+
+        def output
+          { payload: @payload }
+        end
+      end
+    end
+
+    before do
+      DiscourseWorkflows.node_registration_ready = true
+      allow(DiscourseWorkflows::EventListener).to receive(:handle) do |klass, *args|
+        handled << [klass, args]
+      end
+    end
+
+    after do
+      DiscourseEvent.all_off(event_name)
+      unregister_workflow_nodes(node_class)
+    end
+
+    it "subscribes the trigger event for a node registered by another plugin" do
+      plugin.register_discourse_workflows_node(node_class)
+
+      DiscourseEvent.trigger(event_name, "payload")
+
+      expect(handled).to eq([[node_class, ["payload"]]])
+    end
+
+    it "subscribes a node contributed through the deferred block form" do
+      DiscourseWorkflows.node_registration_ready = false
+      registered = node_class
+      plugin.register_discourse_workflows_node { registered }
+
+      allow(Discourse).to receive(:plugins).and_return([plugin])
+      DiscourseWorkflows.node_registration_ready = true
+      DiscourseWorkflows.flush_plugin_node_registrations!
+
+      DiscourseEvent.trigger(event_name, "payload")
+
+      expect(handled).to eq([[node_class, ["payload"]]])
+    end
+
+    it "subscribes only once when the same node is registered again" do
+      plugin.register_discourse_workflows_node(node_class)
+      Plugin::Instance.new.register_discourse_workflows_node(node_class)
+
+      DiscourseEvent.trigger(event_name, "payload")
+
+      expect(handled.size).to eq(1)
+    end
+
+    it "keeps ownership with the plugin that registered the node first" do
+      plugin.register_discourse_workflows_node(node_class)
+      Plugin::Instance.new.register_discourse_workflows_node(node_class)
+
+      owners =
+        DiscoursePluginRegistry._raw_discourse_workflows_nodes.select do |entry|
+          entry[:value] == node_class
+        end
+
+      expect(owners.map { |entry| entry[:plugin] }).to eq([plugin])
+    end
+
+    it "stops dispatching while the owning plugin is disabled" do
+      plugin.enabled_site_setting(:discourse_sample_plugin_enabled)
+      SiteSetting.discourse_sample_plugin_enabled = false
+      plugin.register_discourse_workflows_node(node_class)
+
+      DiscourseEvent.trigger(event_name, "payload")
+      expect(handled).to be_empty
+
+      SiteSetting.discourse_sample_plugin_enabled = true
+      DiscourseEvent.trigger(event_name, "payload")
+      expect(handled).to eq([[node_class, ["payload"]]])
+    ensure
+      handler = plugin.instance_variable_get(:@discourse_workflows_node_cache_reset_handler)
+      DiscourseEvent.off(:site_setting_changed, &handler) if handler
+    end
+
+    it "does not subscribe a node that declares no trigger event" do
+      action_class =
+        Class.new(DiscourseWorkflows::NodeType) do
+          description(name: "action:plugin_node_registration_test", version: "1.0")
+        end
+
+      expect { plugin.register_discourse_workflows_node(action_class) }.not_to change {
+        DiscourseEvent.events.values.sum(&:count)
+      }
+    ensure
+      unregister_workflow_nodes(action_class)
+    end
+  end
+end


### PR DESCRIPTION
Previously, the events plugin had no way to drive a workflow from an RSVP or from an event finishing, and a trigger node contributed by any plugin was added to the registry but never subscribed to its `DiscourseEvent` — so it saved fine, showed up in the palette, and silently never fired.

This change wires the subscription into node registration, which drops the hand-rolled `on(...)` workarounds in assign, topic voting and chat, and adds `trigger:event_participation_changed` and `trigger:event_ended`, both scopable to a single topic.

---

Split into two commits, since the first touches shared infrastructure:

- **`FIX: Subscribe trigger events for workflow nodes added by plugins`** — claiming a node now registers *and* subscribes it, and contributing plugins are flushed before the host claims its own, so ownership lands on them. Because the subscription goes through `Plugin::Instance#on`, a node stops listening while *its own* plugin is disabled rather than following the host's setting. This also drops a duplicate registration that let `trigger:chat_message_created` show in the palette while chat was disabled.
- **`FEATURE: Workflow triggers for event participation and event end`** — the two triggers. No `on(...)` wiring needed in the events plugin thanks to the commit above.

Three behaviour changes in the events plugin, each deliberate:

- Withdrawing an RSVP destroyed the record without publishing anything, so attendance state built from these triggers could never recover from someone leaving. Removal now publishes, and reads as `status: null` with `removed: true`. The livestream chat sync skips removals, so its follow/unfollow behaviour is unchanged.
- The ended occurrence travels with `:discourse_post_event_event_ended`. `set_next_date` moves the event on immediately afterwards, and `Event#starts_at` returns `nil` once a bounded series is past `recurrence_until`, so the event alone cannot say which occurrence ended.
- Re-submitting an unchanged RSVP still publishes, so the trigger ignores it rather than running a workflow twice for one decision.

Payload is `{event, post, topic, stats}`, plus `{user, participation}` on the participation trigger — modelled on `WebHook.build_calendar_event_payload` rather than `EventSerializer`, which goes admin-truthy under a system guardian. No JS, no core changes, no new site settings.

### Known gaps, documented rather than fixed

Bulk invite, `Event#create_invitees` (`insert_all!`), `reset_invitee_notifications` (`update_all`), `enforce_private_invitees!` (`delete_all`) and event/user destroy stay silent. `create_attendance!` swallows `RecordNotUnique`, so a concurrent first RSVP fires nothing. `event_ended` can re-fire if an edit resets `finished_at`, and is missed when an event is closed early: `EventDate.pending` merges `Event.open`, so the in-flight occurrence leaves the job's scope.

`EventListener` does not rescue `new`/`valid?`/`matches?` and `DiscourseEvent.trigger` re-raises, so a raising subscriber aborts `MonitorEventDates` mid-`find_each`. Adding `continue_on_error:` there breaks existing `track_events` assertions, so it is left for its own commit.

### Testing

Full `discourse-workflows` and `discourse-events` backend suites pass (4005 examples), plus the workflow specs in chat, assign and topic voting. Verified at runtime that all 22 trigger nodes have exactly one subscription and there are no duplicate registrations, and that both new nodes disappear from the palette and stop dispatching when `discourse_events_enabled` is off.

Meta: https://meta.discourse.org/t/discourse-calendar-events-webhook-triggers-automations-plugin/409623

