### PR TITLE
FIX: Link to the right automation page from triage reviewables

### DIFF
--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -48,7 +48,7 @@ en:
           %{response}
         flagged_post_response: "Response from the model: %{llm_response}"
         flagged_post_score_reason: |
-          <b>Triggered by the <a href="%{base_path}/admin/plugins/automation/%{automation_id}">%{automation_name}</a> rule.</b>
+          <b>Triggered by the <a href="%{base_path}/admin/plugins/automation/automation/%{automation_id}">%{automation_name}</a> rule.</b>
         notify_author_pm:
           subject: "Your post was temporarily removed for review"
           body: |

--- a/plugins/discourse-ai/spec/lib/agents/tools/flag_post_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/flag_post_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe DiscourseAi::Agents::Tools::FlagPost do
       <p>
         <b>
           Triggered by the
-          <a href="/admin/plugins/automation/123">#{CGI.escapeHTML(automation_name)}</a>
+          <a href="/admin/plugins/automation/automation/123">#{CGI.escapeHTML(automation_name)}</a>
           rule.
         </b>
       </p>

--- a/plugins/discourse-ai/spec/lib/discourse_automation/automation_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discourse_automation/automation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DiscourseAi::Automation do
         ReviewableScoreSerializer.new(score, scope: Discourse.system_user.guardian, root: nil)
 
       expect(serialized.reason).to match_html(<<~HTML)
-        <p><b>Triggered by the <a href="/admin/plugins/automation/1">Test</a> rule.</b></p>
+        <p><b>Triggered by the <a href="/admin/plugins/automation/automation/1">Test</a> rule.</b></p>
         <p>Response from the model: <strong>Details</strong></p>
         <ul>
           <li>first</li>

--- a/plugins/discourse-ai/spec/lib/modules/automation/llm_triage_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/automation/llm_triage_spec.rb
@@ -515,7 +515,7 @@ describe DiscourseAi::Automation::LlmTriage do
     expect(reviewable.target_id).to eq(post.id)
     expect(reviewable.target_type).to eq("Post")
     expect(reviewable.reviewable_scores.first.reason).to include(
-      "<a href=\"#{Discourse.base_path}/admin/plugins/automation/",
+      "<a href=\"#{Discourse.base_path}/admin/plugins/automation/automation/",
     )
   end
 
@@ -540,7 +540,7 @@ describe DiscourseAi::Automation::LlmTriage do
       <p>
         <b>
           Triggered by the
-          <a href="/admin/plugins/automation/#{automation.id}">
+          <a href="/admin/plugins/automation/automation/#{automation.id}">
             #{CGI.escapeHTML(automation.name)}
           </a>
           rule.


### PR DESCRIPTION
When an LLM triage automation flags a post, the reviewable's score reason says:

> **Triggered by the [My automation](/admin/plugins/automation/1) rule.**

That link is broken — it leads to a page that does not exist.

The automation admin UI is nested under the plugin show route (`/admin/plugins/:plugin_id`), and registers its own `automation` child route. So its edit page lives at `/admin/plugins/automation/automation/:id` — the plugin id, then the nested route. The link only had one of the two segments.

This was originally broken when automation moved to the new show route and the URL changed from `/admin/plugins/discourse-automation/:id`. #35434 dropped the `discourse-` prefix but missed the extra segment, so the link stayed broken.

Reported by a customer who landed on `/admin/plugins/automation/1` from their review queue.

The translated locale files carry the same URL but are managed by Crowdin, so they are left to re-sync from `en`.