### PR TITLE
PERF: Lower the Site Traffic Explorer event limit

### DIFF
--- a/app/services/admin_dashboard_site_traffic_explorer.rb
+++ b/app/services/admin_dashboard_site_traffic_explorer.rb
@@ -132,7 +132,7 @@ class AdminDashboardSiteTrafficExplorer
   def query_params(start_date:, end_date:, filters:)
     retention_cutoff = BrowserPageviewEvent.retention_cutoff.to_date
     effective_start_date = [start_date, retention_cutoff].max
-    cap = SiteSetting.admin_site_traffic_event_cap
+    cap = SiteSetting.site_traffic_explorer_event_limit
 
     {
       start_date: effective_start_date,
@@ -565,7 +565,7 @@ class AdminDashboardSiteTrafficExplorer
       {
         reason: "retention_and_pageview_limit",
         available_start_date: BrowserPageviewEvent.retention_cutoff.to_date.iso8601,
-        pageview_limit: SiteSetting.admin_site_traffic_event_cap,
+        pageview_limit: SiteSetting.site_traffic_explorer_event_limit,
       }
     elsif retention_limited
       {
@@ -573,7 +573,7 @@ class AdminDashboardSiteTrafficExplorer
         available_start_date: BrowserPageviewEvent.retention_cutoff.to_date.iso8601,
       }
     else
-      { reason: "pageview_limit", pageview_limit: SiteSetting.admin_site_traffic_event_cap }
+      { reason: "pageview_limit", pageview_limit: SiteSetting.site_traffic_explorer_event_limit }
     end
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2913,6 +2913,7 @@ en:
     dashboard_visible_tabs: "Choose which dashboard tabs are visible."
     dashboard_general_tab_activity_metrics: "Choose reports to be displayed as activity metrics on the general tab."
     enable_site_traffic_explorer: "Link the admin dashboard's site traffic details action to the Site Traffic Explorer."
+    admin_site_traffic_event_cap: "Maximum number of browser pageview events the Site Traffic Explorer analyzes per query. Higher values include more traffic but can cause reports to time out on lower-resource database servers."
 
     gravatar_enabled: "Use the <a href='https://gravatar.com/'>Gravatar</a> service for user avatars. Disabling this will prevent users from switching to Gravatar for their avatars, but will not impact users who already use it."
     gravatar_name: "Specify the name of the Gravatar service provider. This name is typically used to identify the source providing Gravatar avatars to the site."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2913,7 +2913,7 @@ en:
     dashboard_visible_tabs: "Choose which dashboard tabs are visible."
     dashboard_general_tab_activity_metrics: "Choose reports to be displayed as activity metrics on the general tab."
     enable_site_traffic_explorer: "Link the admin dashboard's site traffic details action to the Site Traffic Explorer."
-    admin_site_traffic_event_cap: "Maximum number of browser pageview events the Site Traffic Explorer analyzes per query. Higher values include more traffic but can cause reports to time out on lower-resource database servers."
+    site_traffic_explorer_event_limit: "Controls the maximum number of recent pageviews the Site Traffic Explorer processes. Higher limits cover more traffic but may take longer to load or time out on lower-resource database servers."
 
     gravatar_enabled: "Use the <a href='https://gravatar.com/'>Gravatar</a> service for user avatars. Disabling this will prevent users from switching to Gravatar for their avatars, but will not impact users who already use it."
     gravatar_name: "Specify the name of the Gravatar service provider. This name is typically used to identify the source providing Gravatar avatars to the site."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4647,7 +4647,7 @@ dashboard:
       - user_to_user_private_messages_with_replies
       - signups
     area: "reports"
-  admin_site_traffic_event_cap:
+  site_traffic_explorer_event_limit:
     default: 200000
     type: integer
     min: 1

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -622,11 +622,11 @@ basic:
     max: 20000
     hidden: true
   admin_site_traffic_event_cap:
-    default: 1000000
+    default: 200000
     type: integer
     min: 1
     max: 1000000
-    hidden: true
+    area: "reports"
   browser_pageview_max_engaged_seconds:
     default: 1800
     type: integer

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -621,12 +621,6 @@ basic:
     min: 1
     max: 20000
     hidden: true
-  admin_site_traffic_event_cap:
-    default: 200000
-    type: integer
-    min: 1
-    max: 1000000
-    area: "reports"
   browser_pageview_max_engaged_seconds:
     default: 1800
     type: integer
@@ -4652,6 +4646,12 @@ dashboard:
       - flags
       - user_to_user_private_messages_with_replies
       - signups
+    area: "reports"
+  admin_site_traffic_event_cap:
+    default: 200000
+    type: integer
+    min: 1
+    max: 1000000
     area: "reports"
   enable_site_traffic_explorer:
     default: false

--- a/db/migrate/20260817054353_rename_admin_site_traffic_event_cap_setting.rb
+++ b/db/migrate/20260817054353_rename_admin_site_traffic_event_cap_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RenameAdminSiteTrafficEventCapSetting < ActiveRecord::Migration[7.0]
+  def up
+    execute "UPDATE site_settings SET name = 'site_traffic_explorer_event_limit' WHERE name = 'admin_site_traffic_event_cap'"
+  end
+
+  def down
+    execute "UPDATE site_settings SET name = 'admin_site_traffic_event_cap' WHERE name = 'site_traffic_explorer_event_limit'"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23159,6 +23159,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260817054353'),
 ('20260812094609'),
 ('20260811231259'),
 ('20260810154331'),

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -1752,7 +1752,7 @@ RSpec.describe Admin::DashboardController do
 
       before do
         sign_in(admin)
-        SiteSetting.admin_site_traffic_event_cap = 2
+        SiteSetting.site_traffic_explorer_event_limit = 2
       end
 
       it "returns no more than the configured pageview cap" do
@@ -1847,7 +1847,7 @@ RSpec.describe Admin::DashboardController do
 
       it "returns both partial-data reasons" do
         sign_in(admin)
-        SiteSetting.admin_site_traffic_event_cap = 2
+        SiteSetting.site_traffic_explorer_event_limit = 2
 
         get "/admin/dashboard/site-traffic-explorer.json",
             params: request_params.merge(start_date: "2026-01-01")

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -20,6 +20,23 @@ RSpec.describe Admin::SiteSettingsController do
         expect(locale.length).to eq(1)
       end
 
+      it "returns the Site Traffic Explorer event cap" do
+        get "/admin/site_settings.json"
+
+        setting =
+          response.parsed_body["site_settings"].find do |site_setting|
+            site_setting["setting"] == "admin_site_traffic_event_cap"
+          end
+
+        expect(setting.slice("default", "value", "min", "max", "primary_area")).to eq(
+          "default" => "200000",
+          "value" => "200000",
+          "min" => 1,
+          "max" => 1_000_000,
+          "primary_area" => "reports",
+        )
+      end
+
       it "does not return hidden site settings" do
         get "/admin/site_settings.json"
         expect(response.status).to eq(200)

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -20,23 +20,6 @@ RSpec.describe Admin::SiteSettingsController do
         expect(locale.length).to eq(1)
       end
 
-      it "returns the Site Traffic Explorer event cap" do
-        get "/admin/site_settings.json"
-
-        setting =
-          response.parsed_body["site_settings"].find do |site_setting|
-            site_setting["setting"] == "admin_site_traffic_event_cap"
-          end
-
-        expect(setting.slice("default", "value", "min", "max", "primary_area")).to eq(
-          "default" => "200000",
-          "value" => "200000",
-          "min" => 1,
-          "max" => 1_000_000,
-          "primary_area" => "reports",
-        )
-      end
-
       it "does not return hidden site settings" do
         get "/admin/site_settings.json"
         expect(response.status).to eq(200)

--- a/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
       end
 
       it "does not report partial data when the population exactly matches the cap" do
-        SiteSetting.admin_site_traffic_event_cap = 11
+        SiteSetting.site_traffic_explorer_event_limit = 11
 
         expect(result.traffic.slice(:partial_data, :summary)).to eq(
           partial_data: nil,
@@ -277,7 +277,7 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
       end
 
       it "does not promote a capped session continuation to an entry" do
-        SiteSetting.admin_site_traffic_event_cap = 1
+        SiteSetting.site_traffic_explorer_event_limit = 1
         Fabricate(
           :browser_pageview_event,
           url: "/capped-session-entry",

--- a/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
   it "warns an admin when the selected range has incomplete traffic data",
      time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
     sign_in(admin)
-    SiteSetting.admin_site_traffic_event_cap = 2
+    SiteSetting.site_traffic_explorer_event_limit = 2
 
     [
       ["/first-retained", "2026-02-15 09:00:00"],


### PR DESCRIPTION
The Site Traffic Explorer could analyze up to one million pageviews by default, which can make the page time out on lower-resource database servers.

This change lowers `site_traffic_explorer_event_limit` to 200,000 while retaining the one-million maximum. It exposes the setting in the Reports area so administrators with more database capacity can raise the limit deliberately, and migrates existing `admin_site_traffic_event_cap` overrides to the new name.

## Benchmark

On a low-end DigitalOcean droplet with 2 vCPUs, 2 GB RAM, and PostgreSQL `work_mem` set to 10 MB, the unfiltered Site Traffic Explorer query produced these median timings:

| Pageview limit | Median query time |
| ---: | ---: |
| 100,000 | 0.76 s |
| 200,000 | 2.60 s |
| 300,000 | 3.97 s |
| 400,000 | 28.99 s |
| 500,000 | 27.14 s |
| 1,000,000 | 32.56 s |

These measurements omitted the legacy source-selection predicate, reflecting the planned state after duplicate pageview sources are removed. The shipped query still applies source selection.

The 200,000 default stays comfortably below the query timeout on this machine, while still allowing better-provisioned sites to raise the limit.
