### PR TITLE
UX: Do not center reddit onebox in chat message

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -233,6 +233,10 @@ body.has-full-page-chat {
   > p:last-of-type {
     margin-bottom: 0.1em;
   }
+
+  iframe.reddit-onebox {
+    margin: var(--space-2) 0;
+  }
 }
 
 .reviewable-chat-message {


### PR DESCRIPTION
This takes up way too much space, everything else
is over to the left in chat too. Give a bit more spacing
on top as well.

**Before**

<img width="1080" height="604" alt="image" src="https://github.com/user-attachments/assets/c16e8a9a-8e47-4468-be04-11bb75f82bd9" />


**After**

<img width="1066" height="618" alt="image" src="https://github.com/user-attachments/assets/cf6b27e2-d098-4695-be79-9842df7d2353" />
