### PR TITLE
DEV: Add admin_ids scope to User model

### DIFF
--- a/app/jobs/regular/delete_inaccessible_notifications.rb
+++ b/app/jobs/regular/delete_inaccessible_notifications.rb
@@ -29,7 +29,7 @@ module Jobs
 
       accessible_ids = topic.all_allowed_users.where(id: user_ids).pluck(:id)
       if !SiteSetting.suppress_secured_categories_from_admin
-        accessible_ids |= User.where(id: user_ids, admin: true).pluck(:id)
+        accessible_ids |= User.admin_ids & user_ids
       end
       user_ids - accessible_ids
     end

--- a/app/jobs/scheduled/check_new_features.rb
+++ b/app/jobs/scheduled/check_new_features.rb
@@ -5,7 +5,7 @@ module Jobs
     every 1.day
 
     def execute(args)
-      admin_ids = User.human_users.where(admin: true).pluck(:id)
+      admin_ids = User.admin_ids
 
       # Before we download the latest list from Meta:
       #

--- a/app/models/concerns/reports/admin_logins.rb
+++ b/app/models/concerns/reports/admin_logins.rb
@@ -37,7 +37,7 @@ module Reports::AdminLogins
         FROM (
           SELECT DISTINCT ON (t.client_ip, t.user_id) t.client_ip, t.user_id, t.created_at
           FROM user_auth_token_logs t
-          WHERE t.user_id IN (#{User.admins.pluck(:id).join(",")})
+          WHERE t.user_id IN (#{User.admin_ids.join(",")})
             AND t.created_at >= :start_date
             AND t.created_at <= :end_date
           ORDER BY t.client_ip, t.user_id, t.created_at DESC

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -291,6 +291,8 @@ class User < ActiveRecord::Base
           end
         end
 
+  scope :admin_ids, -> { human_users.admins.pluck(:id) }
+
   # excluding fake users like the system user or anonymous users
   scope :real,
         ->(allowed_bot_user_ids: nil) do

--- a/app/services/upcoming_changes/notify_promotions.rb
+++ b/app/services/upcoming_changes/notify_promotions.rb
@@ -21,7 +21,7 @@ class UpcomingChanges::NotifyPromotions
   end
 
   def fetch_admin_user_ids
-    User.human_users.admins.pluck(:id)
+    User.admin_ids
   end
 
   def fetch_change_notification_statuses(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2693,6 +2693,15 @@ RSpec.describe User do
     end
   end
 
+  describe ".admin_ids" do
+    it "returns only human admin IDs" do
+      admin = Fabricate(:admin)
+      Fabricate(:user)
+
+      expect(User.admin_ids).to contain_exactly(admin.id)
+    end
+  end
+
   describe ".not_staged" do
     let!(:user0) { Fabricate(:user, staged: true) }
     let!(:user1) { Fabricate(:user) }


### PR DESCRIPTION
Adds a scope that will return all admin
IDs for human admin users.

Also replace usages in codebase of old chains
like User.human_users.admins.pluck(:id)
