### PR TITLE
UX: Improvements to twitter oneboxes in chat

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -237,6 +237,33 @@ body.has-full-page-chat {
   iframe.reddit-onebox {
     margin: var(--space-2) 0;
   }
+
+  .onebox.twitterstatus {
+    max-width: 500px;
+
+    .tweet-images {
+      .tweet-video {
+        height: calc(576px / (var(--aspect-ratio)));
+        max-height: 400px;
+      }
+    }
+
+    .aspect-image-full-size {
+      object-fit: initial;
+      max-height: 400px;
+
+      .tweet-image {
+        object-fit: initial;
+        max-height: 400px;
+      }
+    }
+
+    .thumbnail.onebox-avatar {
+      max-width: 38px;
+      margin-right: var(--space-2);
+      margin-top: var(--space-1);
+    }
+  }
 }
 
 .reviewable-chat-message {


### PR DESCRIPTION
* Stop showing the tweet at 100% width, its way too wide and unnecessary
* Fix spacing/alignment for user avatar + username
* Improve image and video heights and widths

**Before**

<img width="2263" height="421" alt="image" src="https://github.com/user-attachments/assets/ca101793-2484-4a7f-bfb4-ff5fdb3736bc" />

<img width="2258" height="538" alt="image" src="https://github.com/user-attachments/assets/60201877-ee42-49a5-8eee-58583c792c71" />

<img width="2238" height="368" alt="image" src="https://github.com/user-attachments/assets/86f1478f-9bfc-4874-8ae4-c0c23ebf29c8" />

<img width="1887" height="373" alt="image" src="https://github.com/user-attachments/assets/3566074b-d818-4ee2-84e3-c8b080271a52" />


**After**

<img width="746" height="686" alt="image" src="https://github.com/user-attachments/assets/0f362b9a-7d7c-4d30-ab2a-81f28d7b62f6" />

<img width="593" height="698" alt="image" src="https://github.com/user-attachments/assets/09ff8ea5-f957-4bf9-8b0c-1401be0b176c" />

<img width="554" height="587" alt="image" src="https://github.com/user-attachments/assets/7073164f-c429-4a77-8f6b-2b80b9eeebaf" />

<img width="558" height="588" alt="image" src="https://github.com/user-attachments/assets/6f43e1d6-f323-4f86-9103-644fe5b3d25f" />

