### PR TITLE
FIX: Return accurate group user counts

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -14,7 +14,7 @@ class Admin::GroupsController < Admin::StaffController
         dynamic_attributes: group_params.slice(*DiscoursePluginRegistry.group_params),
       },
     ) do |result|
-      on_success { |group:| render_serialized(group, BasicGroupSerializer) }
+      on_success { |group:| render_serialized(group.reload, BasicGroupSerializer) }
       on_failed_policy(:can_create_group) { |policy| raise Discourse::InvalidAccess }
       on_failed_policy(:can_request_access) do
         render json:

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -468,8 +468,6 @@ class GroupsController < ApplicationController
       group.notify_added_to_group(user, owner: true) if params[:notify_users].to_s == "true"
     end
 
-    group.restore_user_count!
-
     render json: success_json.merge!(usernames: users.pluck(:username))
   end
 

--- a/app/services/groups/create.rb
+++ b/app/services/groups/create.rb
@@ -150,7 +150,6 @@ class Groups::Create
 
   def save(group:)
     group.save!
-    group.restore_user_count!
   end
 
   def log_group_histories(guardian:, group:)

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -40,6 +40,40 @@ RSpec.describe Admin::GroupsController do
         expect(group.users).to contain_exactly(admin, user)
       end
 
+      it "returns the persisted user count for initial members and owners" do
+        member = Fabricate(:user)
+        owner = Fabricate(:user)
+
+        post "/admin/groups.json",
+             params: {
+               group: {
+                 name: "builders",
+                 usernames: [member.username, owner.username].join(","),
+                 owner_usernames: owner.username,
+               },
+             }
+
+        expect(response).to have_http_status(:ok)
+
+        created_group = Group.find(response.parsed_body.dig("basic_group", "id"))
+
+        expect(created_group.users).to contain_exactly(member, owner)
+        expect(created_group.user_count).to eq(2)
+        expect(response.parsed_body.dig("basic_group", "user_count")).to eq(2)
+      end
+
+      it "returns a zero user count for a group without initial members" do
+        post "/admin/groups.json", params: { group: { name: "empty-group" } }
+
+        expect(response).to have_http_status(:ok)
+
+        created_group = Group.find(response.parsed_body.dig("basic_group", "id"))
+
+        expect(created_group.users).to be_empty
+        expect(created_group.user_count).to eq(0)
+        expect(response.parsed_body.dig("basic_group", "user_count")).to eq(0)
+      end
+
       context "with custom_fields" do
         before do
           plugin = Plugin::Instance.new

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2330,6 +2330,7 @@ RSpec.describe GroupsController do
           expect(response_body["usernames"]).to contain_exactly(user.username, admin.username)
 
           expect(group.group_users.where(owner: true).map(&:user)).to contain_exactly(user, admin)
+          expect(group.reload.user_count).to eq(2)
         end
 
         it "returns not-found error when there is no group" do


### PR DESCRIPTION
Rely on group membership counter updates instead of manually restoring the
count, which could overwrite persisted changes. Reload newly created groups
before serialization so the response includes the current user count.
