### PR TITLE
DEV: Add user options for discoveries

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -277,6 +277,10 @@ end
 # Table name: user_options
 #
 #  ai_search_discoveries                          :boolean          default(TRUE), not null
+#  ai_search_discoveries_mode                     :integer          default(1), not null
+#  ai_search_discoveries_related_count            :integer          default(2), not null
+#  ai_search_discoveries_show_summary             :boolean          default(TRUE), not null
+#  ai_search_discoveries_summary_detail           :integer          default(1), not null
 #  allow_private_messages                         :boolean          default(TRUE), not null
 #  auto_image_caption                             :boolean          default(FALSE), not null
 #  auto_track_topics_after_msecs                  :integer

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11807,7 +11807,11 @@ CREATE TABLE public.user_options (
     push_notification_level integer DEFAULT 1 NOT NULL,
     automatically_translate boolean DEFAULT true NOT NULL,
     understood_languages character varying[] DEFAULT '{}'::character varying[] NOT NULL,
-    send_shortcut integer DEFAULT 0 NOT NULL
+    send_shortcut integer DEFAULT 0 NOT NULL,
+    ai_search_discoveries_mode integer DEFAULT 1 NOT NULL,
+    ai_search_discoveries_show_summary boolean DEFAULT true NOT NULL,
+    ai_search_discoveries_summary_detail integer DEFAULT 1 NOT NULL,
+    ai_search_discoveries_related_count integer DEFAULT 2 NOT NULL
 );
 
 
@@ -23160,6 +23164,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260817054353'),
+('20260814083721'),
 ('20260812094609'),
 ('20260811231259'),
 ('20260810154331'),

--- a/plugins/discourse-ai/db/migrate/20260814083721_add_ai_search_discovery_preferences_to_user_options.rb
+++ b/plugins/discourse-ai/db/migrate/20260814083721_add_ai_search_discovery_preferences_to_user_options.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddAiSearchDiscoveryPreferencesToUserOptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :user_options, :ai_search_discoveries_mode, :integer, default: 1, null: false
+    add_column :user_options,
+               :ai_search_discoveries_show_summary,
+               :boolean,
+               default: true,
+               null: false
+    add_column :user_options,
+               :ai_search_discoveries_summary_detail,
+               :integer,
+               default: 1,
+               null: false
+    add_column :user_options,
+               :ai_search_discoveries_related_count,
+               :integer,
+               default: 2,
+               null: false
+  end
+end


### PR DESCRIPTION
User options to power the AI Discoveries feature.

<img width="324" height="283" alt="Screenshot 2026-08-17 at 3 55 52 PM" src="https://github.com/user-attachments/assets/d2a49ad7-ed74-4bce-a47e-d2d322e2c7b6" />
