### PR TITLE
FIX: Make inline `code` and code blocks visible inside quotes

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -1,36 +1,30 @@
-p > code,
-li > code,
-strong > code,
-em > code {
+code {
   padding: 2px 4px;
   background: var(--inline-code-bg);
   white-space: pre-wrap;
   color: var(--primary);
-}
-
-a > code {
-  padding: 2px 4px;
-  background: var(--inline-code-bg);
-  white-space: pre-wrap;
-  color: var(--tertiary);
-}
-
-code {
-  color: var(--primary-very-high);
-  background: var(--hljs-bg);
   border-radius: var(--d-border-radius);
   font-size: 0.875rem;
   line-height: calc((13 + 4) / 13);
+}
 
-  small & {
-    font-size: 0.875em;
-  }
+a > code {
+  color: var(--tertiary);
 }
 
 pre > code {
   display: block;
   padding: 12px;
   max-height: 500px;
+  background: var(--hljs-bg);
+  color: var(--primary-very-high);
+
+  // wrapping is the `pre`'s call; a value here would override it
+  white-space: inherit;
+}
+
+small code {
+  font-size: 0.875em;
 }
 
 h1 code,
@@ -50,14 +44,8 @@ h6 code {
   font-style: italic;
 }
 
-.hljs-color {
-  color: var(--hljs-color);
-}
-
 .hljs-keyword,
-.hljs-subst,
-.hljs-request,
-.hljs-status {
+.hljs-subst {
   color: var(--hljs-keyword);
 }
 
@@ -130,13 +118,11 @@ h6 code {
   color: var(--success);
 }
 
-.hljs-symbol,
-.hljs-prompt {
+.hljs-symbol {
   color: var(--hljs-symbol);
 }
 
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: var(--hljs-name);
 }
 

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -104,7 +104,6 @@
   pre code {
     overflow-wrap: anywhere; // prevent long strings from breaking modal width
     min-width: 0;
-    overflow: auto;
     flex: 0 1 auto;
   }
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -203,11 +203,6 @@ html:not(.keyboard-visible).mobile-device {
         margin-right: 10px;
       }
     }
-
-    pre code {
-      white-space: pre-wrap;
-      max-width: 100%;
-    }
   }
 
   &__footer {

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -470,7 +470,9 @@ pre.onebox code ol.lines li::before {
   text-align: right;
   padding-right: 0.5em;
   font-size: var(--font-down-1);
-  line-height: calc((13 + 9.4) / 13); // matches the `code` line-height
+
+  // lines the gutter number up with the `min-height` of the line it labels
+  line-height: calc((13 + 9.4) / 13);
   content: counter(li-counter);
   counter-increment: li-counter;
 }
@@ -503,7 +505,7 @@ pre.onebox code ol {
 }
 
 pre.onebox code {
-  background-color: var(--primary-very-low);
+  // the template indents the line list; each line re-asserts `pre` for itself
   white-space: normal;
 }
 

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1237,6 +1237,7 @@ aside.quote {
 }
 
 pre {
+  // safety cap; also covers a `pre` with no `code` child
   max-height: 2000px;
 
   .bidi-warning,
@@ -1282,7 +1283,7 @@ pre {
   }
 
   @include viewport.until(sm) {
-    code {
+    > code {
       padding-right: 2.75em;
     }
   }
@@ -2081,12 +2082,6 @@ span.highlighted {
 
   html.discourse-no-touch & {
     transition: box-shadow 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-  }
-}
-
-.fullscreen-code-modal {
-  pre code {
-    max-width: none;
   }
 }
 

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -164,8 +164,10 @@ $twitter-or-white: dark-light-choose($twitter, string.unquote("#fff")) !default;
 $hljs-attr: dark-light-choose(#015692, #88aece) !default;
 $hljs-attribute: dark-light-choose(#803378, #c59bc1) !default;
 $hljs-addition: dark-light-choose(#2f6f44, #76c490) !default;
-$hljs-bg: dark-light-choose($primary-50, rgb(0, 0, 0, 0.25)) !default;
 $inline-code-bg: dark-light-choose($primary-100, rgb(0, 0, 0, 0.35)) !default;
+
+// a lighter surface here is indistinguishable from a quote's background
+$hljs-bg: $inline-code-bg !default;
 $hljs-comment: $primary-500 !default;
 $hljs-deletion: dark-light-choose(#c02d2e, #de7176) !default;
 $hljs-keyword: dark-light-choose(#015692, #88aece) !default;

--- a/app/assets/stylesheets/qunit-custom.scss
+++ b/app/assets/stylesheets/qunit-custom.scss
@@ -249,12 +249,11 @@ body {
     --hljs-comment: #bba;
     --hljs-number: #aff;
     --hljs-string: #f99;
-    --hljs-literal: #9ae;
     --hljs-tag: #99f;
     --hljs-attribute: #0ee;
     --hljs-symbol: #fbe;
     --hljs-bg: #333;
-    --hljs-builtin-name: #14aeea;
+    --inline-code-bg: #2c2c2c;
     --google: #fff;
     --google-hover: #f2f2f2;
     --instagram: #e1306c;

--- a/frontend/discourse/app/lib/codeblock-buttons.js
+++ b/frontend/discourse/app/lib/codeblock-buttons.js
@@ -107,6 +107,8 @@ export default class CodeblockButtons {
   }
 
   _createButtons(codeBlocks) {
+    const pendingOffsets = [];
+
     codeBlocks.forEach((codeBlock) => {
       const wrapperEl = document.createElement("div");
       wrapperEl.classList.add("codeblock-button-wrapper");
@@ -120,9 +122,7 @@ export default class CodeblockButtons {
         copyButton.ariaLabel = i18n("copy_codeblock.copy");
         copyButton.innerHTML = iconHTML("copy");
         wrapperEl.appendChild(copyButton);
-        wrapperEl.style.right = `${
-          codeBlock.offsetWidth - codeBlock.clientWidth
-        }px`;
+        pendingOffsets.push([wrapperEl, codeBlock]);
       }
 
       if (this.#site?.desktopView && this.showFullscreen) {
@@ -137,6 +137,16 @@ export default class CodeblockButtons {
         fullscreenButton.innerHTML = iconHTML("discourse-expand");
         wrapperEl.appendChild(fullscreenButton);
       }
+    });
+
+    // read every scrollbar gutter before writing any of them back; interleaving
+    // the two forces a synchronous layout per code block
+    const gutters = pendingOffsets.map(
+      ([, codeBlock]) => codeBlock.offsetWidth - codeBlock.clientWidth
+    );
+
+    pendingOffsets.forEach(([wrapperEl], index) => {
+      wrapperEl.style.right = `${gutters[index]}px`;
     });
   }
 

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -11,6 +11,7 @@ module Email
       "max-height: 80%; max-width: 20%; height: auto; float: left; margin-right: 10px;"
     ONEBOX_IMAGE_THUMBNAIL_STYLE = "width: 60px;"
     ONEBOX_INLINE_AVATAR_STYLE = "width: 20px; height: 20px; float: none; vertical-align: middle;"
+    CODE_BACKGROUND_COLOR = "#f9f9f9"
 
     @@plugin_callbacks = []
 
@@ -285,8 +286,11 @@ module Email
       style("div.summary-footer", "color:#666; font-size:95%; text-align:center; padding-top:15px;")
       style("span.post-count", "margin: 0 5px; color: #777;")
       style("pre", "word-wrap: break-word; max-width: 694px;")
-      style("code", "background-color: #f9f9f9; padding: 2px 5px;")
-      style("pre code", "display: block; background-color: #f9f9f9; overflow: auto; padding: 5px;")
+      style("code", "background-color: #{CODE_BACKGROUND_COLOR}; padding: 2px 5px;")
+      style(
+        "pre code",
+        "display: block; background-color: #{CODE_BACKGROUND_COLOR}; overflow: auto; padding: 5px;",
+      )
       style("pre.onebox code", "white-space: normal;")
       style("pre code li", "white-space: pre;")
       style(

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -75,7 +75,6 @@
     code {
       box-sizing: border-box;
       font-size: var(--font-down-1);
-      width: 100%;
     }
 
     span.mention {


### PR DESCRIPTION
Previously, inline `code` only got its chip styling when its direct parent was `p`, `li`, `strong`, `em` or `a` — every other container (`small`, `b`, `i`, `sub`, `sup`, `span`, `del`, headings, table cells, …) fell through to the code-block rule, whose light-mode background is a 3% blend of primary over secondary and is therefore indistinguishable from a quote's 5% blend, and *exactly identical* inside a nested quote. Fenced code blocks sat on the same collision, so they vanished in quotes too.

This change makes the inline style the default for `code` and scopes the block style to `pre > code`, and derives `$hljs-bg` from `$inline-code-bg` so the two code surfaces match by default and neither disappears against a quote background. `--hljs-bg` and `--inline-code-bg` both keep their names and meanings, so themes that differentiate them are unaffected.

Reported in https://meta.discourse.org/t/code-is-invisible-solely-when-directly-inside-small/410078

### Screenshots

<img width="3200" height="1538" alt="comparison-dark" src="https://github.com/user-attachments/assets/28263913-6d94-46b5-a8e6-4178a601521f" />
<img width="3200" height="1538" alt="comparison-light" src="https://github.com/user-attachments/assets/86ab9405-f53e-423c-8e31-6b438bf2e5c5" />