### PR TITLE
FIX: Don't treat medium font weights as bold when pasting

### DIFF
--- a/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
+++ b/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
@@ -24,6 +24,7 @@ import orderedList from "./ordered-list";
 import overrideDragGhost from "./override-drag-ghost";
 import quote from "./quote";
 import strikethrough from "./strikethrough";
+import strong from "./strong";
 import table from "./table";
 import trailingInlineSpace from "./trailing-inline-space";
 import trailingParagraph from "./trailing-paragraph";
@@ -50,6 +51,7 @@ const defaultExtensions: RichEditorExtension[] = [
   hashtag,
   mention,
   strikethrough,
+  strong,
   underline,
   htmlInline,
   htmlBlock,

--- a/frontend/discourse/app/static/prosemirror/extensions/strong.ts
+++ b/frontend/discourse/app/static/prosemirror/extensions/strong.ts
@@ -1,0 +1,37 @@
+import { schema } from "prosemirror-markdown";
+import type { Mark } from "prosemirror-model";
+import type { RichEditorExtension } from "discourse/lib/composer/rich-editor-extensions";
+
+const extension: RichEditorExtension = {
+  markSpec: {
+    strong: {
+      ...schema.marks.strong.spec,
+      parseDOM: [
+        { tag: "strong" },
+        {
+          tag: "b",
+          getAttrs: (node: HTMLElement) =>
+            node.style.fontWeight !== "normal" && null,
+        },
+        {
+          style: "font-weight=400",
+          clearMark: (m: Mark) => m.type.name === "strong",
+        },
+        {
+          // a copied page inlines theme weights; 500 is CSS medium, not authored bold
+          style: "font-weight",
+          getAttrs: (value: string) => {
+            const weight = Number.parseFloat(value);
+            return (
+              (/^bold(er)?$/.test(value) ||
+                (weight >= 600 && weight <= 1000)) &&
+              null
+            );
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default extension;

--- a/frontend/discourse/tests/unit/lib/to-markdown-test.js
+++ b/frontend/discourse/tests/unit/lib/to-markdown-test.js
@@ -50,6 +50,41 @@ module("Unit | Utility | to-markdown", function (hooks) {
     assert.true(result.includes("**bold**"), "bold formatting preserved");
   });
 
+  test("only treats bold font weights as strong", async function (assert) {
+    assert.strictEqual(
+      await toMarkdown(
+        `some <span style="font-weight: 500;">medium</span> text`
+      ),
+      "some medium text"
+    );
+
+    assert.strictEqual(
+      await toMarkdown(`some <span style="font-weight: 700;">bold</span> text`),
+      "some **bold** text"
+    );
+
+    assert.strictEqual(
+      await toMarkdown(
+        `some <span style="font-weight: 1000;">black</span> text`
+      ),
+      "some **black** text"
+    );
+
+    assert.strictEqual(
+      await toMarkdown(
+        `some <span style="font-weight: 650.5;">variable</span> text`
+      ),
+      "some **variable** text"
+    );
+
+    assert.strictEqual(
+      await toMarkdown(
+        `some <span style="font-weight: bold;">bold</span> text`
+      ),
+      "some **bold** text"
+    );
+  });
+
   test("converts a link", async function (assert) {
     let html = `<a href="https://discourse.org">Discourse</a>`;
     let markdown = `[Discourse](https://discourse.org)`;


### PR DESCRIPTION
Previously, pasting content copied from a rendered page could come out wrapped in `**`, because browsers inline computed theme styles onto copied elements and the `strong` mark treated any `font-weight` of 500+ as bold — while 500 is CSS medium, a common base weight in themes. The classic composer was affected alike, since `enable_rich_text_paste` shares these parse rules through `toMarkdown()`.

This change overrides the mark's style rule to require `bold`, `bolder`, or a weight of 600+, which every editor that writes bold as an inline style satisfies, so authored bold still pastes as bold while inlined theme weights are ignored.
