### PR TITLE
DEV: more specific class to fix test race condition

### DIFF
--- a/plugins/chat/spec/system/keyboard_message_actions_spec.rb
+++ b/plugins/chat/spec/system/keyboard_message_actions_spec.rb
@@ -103,9 +103,11 @@ RSpec.describe "Chat | keyboard access to message actions" do
     expect(page).to have_css(
       ".chat-message-actions[role='toolbar'][aria-label='#{I18n.t("js.chat.message_actions")}']",
     )
-    expect(page).to have_css(".react-btn[title='#{I18n.t("js.chat.react")}']")
-    expect(page).to have_css(".reply-btn[title='#{I18n.t("js.chat.reply")}']")
-    expect(page).to have_css(".bookmark-btn[aria-label='#{I18n.t("js.chat.bookmark_message")}']")
+    expect(page).to have_css(".chat-message-actions .react-btn[title='#{I18n.t("js.chat.react")}']")
+    expect(page).to have_css(".chat-message-actions .reply-btn[title='#{I18n.t("js.chat.reply")}']")
+    expect(page).to have_css(
+      ".chat-message-actions .bookmark-btn[aria-label='#{I18n.t("js.chat.bookmark_message")}']",
+    )
     expect(page).to have_css(
       ".more-buttons [aria-label='#{I18n.t("js.chat.more_message_actions")}']",
     )

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -124,7 +124,7 @@ module PageObjects
         if emoji_name
           message.find(".chat-message-actions [data-emoji-name=\"#{emoji_name}\"]").click
         else
-          message.find(".react-btn").click
+          message.find(".chat-message-react-btn").click
         end
       end
 


### PR DESCRIPTION
in https://github.com/discourse/discourse/commit/bd29f856937246b30a8a30c2bf28bbacc3f5f339 tests passed initially, but one fails intermittently because the change introduces a race condition where there may be multiple class matches... the more specific class gets it passing consistently 