### PR TITLE
FIX: Score bounces against the address they were sent to

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -36,13 +36,14 @@ class WebhooksController < ActionController::Base
         # so we set the error code to 5.1.2 which translates to permanent failure bad destination system address.
         error_code = "5.1.2" if !error_code && event["type"] == "blocked"
 
-        if error_code&.[](Email::SMTP_STATUS_TRANSIENT_FAILURE)
-          process_bounce(message_id, to_address, SiteSetting.soft_bounce_score, error_code)
-        else
-          process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
-        end
+        process_bounce(
+          message_id,
+          to_address,
+          permanent: !Email.smtp_transient_failure?(error_code),
+          bounce_error_code: error_code,
+        )
       elsif event["event"] == "dropped"
-        process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
+        process_bounce(message_id, to_address, permanent: true, bounce_error_code: error_code)
       end
     end
 
@@ -61,11 +62,7 @@ class WebhooksController < ActionController::Base
       message_id = event["CustomID"]
       to_address = event["email"]
       if event["event"] == "bounce"
-        if event["hard_bounce"]
-          process_bounce(message_id, to_address, SiteSetting.hard_bounce_score)
-        else
-          process_bounce(message_id, to_address, SiteSetting.soft_bounce_score)
-        end
+        process_bounce(message_id, to_address, permanent: !!event["hard_bounce"])
       end
     end
 
@@ -87,9 +84,9 @@ class WebhooksController < ActionController::Base
 
     case status
     when "bounced"
-      process_bounce(message_id, to_address, SiteSetting.hard_bounce_score)
+      process_bounce(message_id, to_address, permanent: true)
     when "deferred"
-      process_bounce(message_id, to_address, SiteSetting.soft_bounce_score)
+      process_bounce(message_id, to_address, permanent: false)
     end
 
     success
@@ -111,9 +108,9 @@ class WebhooksController < ActionController::Base
 
         case event["event"]
         when "hard_bounce"
-          process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
+          process_bounce(message_id, to_address, permanent: true, bounce_error_code: error_code)
         when "soft_bounce"
-          process_bounce(message_id, to_address, SiteSetting.soft_bounce_score, error_code)
+          process_bounce(message_id, to_address, permanent: false, bounce_error_code: error_code)
         end
       end
 
@@ -141,9 +138,9 @@ class WebhooksController < ActionController::Base
     type = params["Type"]
     case type
     when "HardBounce", "SpamNotification", "SpamComplaint"
-      process_bounce(message_id, to_address, SiteSetting.hard_bounce_score)
+      process_bounce(message_id, to_address, permanent: true)
     when "SoftBounce"
-      process_bounce(message_id, to_address, SiteSetting.soft_bounce_score)
+      process_bounce(message_id, to_address, permanent: false)
     end
 
     success
@@ -171,9 +168,9 @@ class WebhooksController < ActionController::Base
       # bounce class definitions: https://support.sparkpost.com/customer/portal/articles/1929896
       if bounce_class < 80
         if bounce_class == 10 || bounce_class == 25 || bounce_class == 30
-          process_bounce(message_id, to_address, SiteSetting.hard_bounce_score)
+          process_bounce(message_id, to_address, permanent: true)
         else
-          process_bounce(message_id, to_address, SiteSetting.soft_bounce_score)
+          process_bounce(message_id, to_address, permanent: false)
         end
       end
     end
@@ -235,15 +232,16 @@ class WebhooksController < ActionController::Base
     event = params["event"]
     message_id = Email::MessageIdService.message_id_clean(params["Message-Id"])
     to_address = params["recipient"]
-    error_code = params["code"]
+    # older payloads only carry the status inside the free-form diagnostic
+    error_code = params["code"].presence || Email.extract_smtp_status(params["error"])
 
     # only handle soft bounces, because hard bounces are also handled
     # by the "dropped" event and we don't want to increase bounce score twice
     # for the same message
-    if event == "bounced" && params["error"]&.[](Email::SMTP_STATUS_TRANSIENT_FAILURE)
-      process_bounce(message_id, to_address, SiteSetting.soft_bounce_score, error_code)
+    if event == "bounced" && Email.smtp_transient_failure?(error_code)
+      process_bounce(message_id, to_address, permanent: false, bounce_error_code: error_code)
     elsif event == "dropped"
-      process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
+      process_bounce(message_id, to_address, permanent: true, bounce_error_code: error_code)
     end
 
     success
@@ -260,16 +258,16 @@ class WebhooksController < ActionController::Base
     end
 
     data = params["event-data"]
-    error_code = params.dig("delivery-status", "code")
+    error_code = data.dig("delivery-status", "code")
     message_id = data.dig("message", "headers", "message-id")
     to_address = data["recipient"]
     severity = data["severity"]
 
     if data["event"] == "failed"
       if severity == "temporary"
-        process_bounce(message_id, to_address, SiteSetting.soft_bounce_score, error_code)
+        process_bounce(message_id, to_address, permanent: false, bounce_error_code: error_code)
       elsif severity == "permanent"
-        process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
+        process_bounce(message_id, to_address, permanent: true, bounce_error_code: error_code)
       end
     end
 
@@ -338,15 +336,14 @@ class WebhooksController < ActionController::Base
     ActiveSupport::SecurityUtils.secure_compare(params[:t], SiteSetting.sparkpost_webhook_token)
   end
 
-  def process_bounce(message_id, to_address, bounce_score, bounce_error_code = nil)
+  def process_bounce(message_id, to_address, permanent:, bounce_error_code: nil)
     return if message_id.blank? || to_address.blank?
 
     email_log = EmailLog.find_by(message_id: message_id, to_address: to_address)
-    return if email_log.nil?
-
-    email_log.update_columns(bounced: true, bounce_error_code: bounce_error_code)
-    return if email_log.user.nil? || email_log.user.email.blank?
-
-    Email::Receiver.update_bounce_score(email_log.user.email, bounce_score)
+    Email::Receiver.record_bounce(
+      email_log,
+      permanent: permanent,
+      bounce_error_code: bounce_error_code,
+    )
   end
 end

--- a/app/jobs/regular/process_sns_notification.rb
+++ b/app/jobs/regular/process_sns_notification.rb
@@ -25,18 +25,12 @@ module Jobs
 
       Array(message.dig("bounce", "bouncedRecipients")).each do |r|
         email_log = EmailLog.find_by(message_id: message_id, to_address: r["emailAddress"])
-        next if email_log.nil? || email_log.bounced?
 
-        email_log.update!(bounced: true, bounce_error_code: r["status"])
-
-        next if email_log.user&.email.blank?
-
-        if email_log.user.user_stat.bounce_score.to_s.start_with?("4.") ||
-             bounce_type == "Transient"
-          Email::Receiver.update_bounce_score(email_log.user.email, SiteSetting.soft_bounce_score)
-        else
-          Email::Receiver.update_bounce_score(email_log.user.email, SiteSetting.hard_bounce_score)
-        end
+        Email::Receiver.record_bounce(
+          email_log,
+          permanent: bounce_type != "Transient",
+          bounce_error_code: r["status"],
+        )
       end
     end
   end

--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -15,9 +15,6 @@ class EmailLog < ActiveRecord::Base
               signup_after_approval
             ]
 
-  # cf. https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml
-  SMTP_ERROR_CODE_REGEXP = Regexp.new(/\d\.\d\.\d+|\d{3}/).freeze
-
   belongs_to :user
   belongs_to :post
   belongs_to :smtp_group, class_name: "Group"
@@ -36,11 +33,52 @@ class EmailLog < ActiveRecord::Base
       )
     SQL
 
-  before_save do
-    if bounce_error_code.present?
-      match = SMTP_ERROR_CODE_REGEXP.match(bounce_error_code)
-      self.bounce_error_code = match.present? ? match[0] : nil
+  before_save { self.bounce_error_code = self.class.normalize_bounce_error_code(bounce_error_code) }
+
+  # generic enhanced statuses, stored when a provider reports a bounce without
+  # one, so that the column always says something about the failure
+  BOUNCE_ERROR_CODE_TRANSIENT = "4.0.0"
+  BOUNCE_ERROR_CODE_PERMANENT = "5.0.0"
+
+  # every channel reports the status differently, from a bare code to the whole
+  # free-form diagnostic, so they all get read the same way
+  def self.normalize_bounce_error_code(bounce_error_code)
+    Email.extract_smtp_status(bounce_error_code)
+  end
+
+  # Atomically claims a bounce report for this log so that duplicate or
+  # concurrent reports of the same bounce are recorded (and scored) only once.
+  # A permanent failure may supersede an earlier transient report of the same
+  # message, since providers often retry after a transient failure and then
+  # report a final permanent one.
+  def claim_bounce(permanent:, bounce_error_code: nil)
+    generic = permanent ? BOUNCE_ERROR_CODE_PERMANENT : BOUNCE_ERROR_CODE_TRANSIENT
+    attributes = {
+      bounced: true,
+      bounce_error_code: self.class.normalize_bounce_error_code(bounce_error_code) || generic,
+      bounce_permanent: permanent,
+    }
+
+    if !bounced? && self.class.where(id: id, bounced: false).update_all(attributes) == 1
+      assign_attributes(attributes)
+      return true
     end
+
+    return false if !permanent
+
+    # `bounce_permanent` is NULL for bounces recorded before the severity was
+    # tracked. Their error code says what the provider reported, not what they
+    # were scored at, so escalating off it would charge a second hard bounce as
+    # often as it would catch a real escalation
+    escalated =
+      self
+        .class
+        .where(id: id, bounced: true, bounce_permanent: false)
+        .update_all(bounce_error_code: attributes[:bounce_error_code], bounce_permanent: true) == 1
+
+    assign_attributes(attributes) if escalated
+
+    escalated
   end
 
   after_create do
@@ -126,6 +164,7 @@ end
 #  bcc_addresses             :text
 #  bounce_error_code         :string
 #  bounce_key                :uuid
+#  bounce_permanent          :boolean
 #  bounced                   :boolean          default(FALSE), not null
 #  cc_addresses              :text
 #  cc_user_ids               :integer          is an Array

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -48,7 +48,7 @@ class EmailToken < ActiveRecord::Base
     @token
   end
 
-  def self.confirm(token, scope: nil, skip_reviewable: false)
+  def self.confirm(token, scope: nil, skip_reviewable: false, skip_reset_bounce_score: false)
     User.transaction do
       email_token = confirmable(token, scope: scope)
       return if email_token.blank?
@@ -62,6 +62,10 @@ class EmailToken < ActiveRecord::Base
       user.custom_fields.delete("activation_reminder")
       user.save!
       user.create_reviewable if !skip_reviewable
+      # the user acted on an email sent to this address, so it is proven
+      # deliverable and previous bounces (e.g. from a typo fixed on the
+      # activation screen) no longer apply
+      user.user_stat&.reset_bounce_score! if !skip_reset_bounce_score
       user.set_automatic_groups
       DiscourseEvent.trigger(:user_confirmed_email, user, scope)
       Invite.redeem_for_existing_user(user) if scope == EmailToken.scopes[:signup]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1513,7 +1513,12 @@ class User < ActiveRecord::Base
 
   def activate
     email_token = email_tokens.create!(email: email, scope: EmailToken.scopes[:signup])
-    EmailToken.confirm(email_token.token, scope: EmailToken.scopes[:signup])
+    # this programmatic confirmation proves nothing about deliverability
+    EmailToken.confirm(
+      email_token.token,
+      scope: EmailToken.scopes[:signup],
+      skip_reset_bounce_score: true,
+    )
     reload
   end
 

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -285,6 +285,8 @@ class UserStat < ActiveRecord::Base
   end
 
   def reset_bounce_score!
+    return if bounce_score == 0 && reset_bounce_score_after.nil?
+
     update_columns(reset_bounce_score_after: nil, bounce_score: 0)
   end
 

--- a/db/migrate/20260818162304_add_bounce_permanent_to_email_logs.rb
+++ b/db/migrate/20260818162304_add_bounce_permanent_to_email_logs.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddBouncePermanentToEmailLogs < ActiveRecord::Migration[8.0]
+  def change
+    # deliberately nullable with no default: NULL means the bounce was recorded
+    # before the severity was tracked, which is what keeps those rows out of the
+    # escalation in `EmailLog#claim_bounce`
+    add_column :email_logs, :bounce_permanent, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5379,7 +5379,8 @@ CREATE TABLE public.email_logs (
     topic_id integer,
     bounce_error_code character varying,
     smtp_transaction_response character varying(500),
-    bcc_addresses text
+    bcc_addresses text,
+    bounce_permanent boolean
 );
 
 
@@ -23364,6 +23365,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260821164114'),
 ('20260820171539'),
 ('20260820143851'),
+('20260818162304'),
 ('20260818143417'),
 ('20260818081537'),
 ('20260818045317'),

--- a/lib/discourse_dev/email_log.rb
+++ b/lib/discourse_dev/email_log.rb
@@ -23,6 +23,7 @@ module DiscourseDev
           bounced: true,
           bounce_key: bounce_key,
           bounce_error_code: "5.0.0",
+          bounce_permanent: true,
         )
 
       # Bounced email logs require a matching incoming email record

--- a/lib/email.rb
+++ b/lib/email.rb
@@ -4,9 +4,27 @@ require "mail"
 
 module Email
   # See https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml#smtp-enhanced-status-codes-1
-  SMTP_STATUS_SUCCESS = "2."
-  SMTP_STATUS_TRANSIENT_FAILURE = "4."
-  SMTP_STATUS_PERMANENT_FAILURE = "5."
+  # both enhanced ("4.X.X") and basic ("4XX") statuses start with the class digit
+  def self.smtp_transient_failure?(status)
+    status.to_s.start_with?("4")
+  end
+
+  # A relay IP, a port, a date and a version string all look like a status, so
+  # one is only read where SMTP would put it: leading the diagnostic (after the
+  # optional "smtp;" the DSN Diagnostic-Code field carries), or introducing an
+  # enhanced status. Anything looser scores bounces off software version numbers.
+  SMTP_STATUS_IN_TEXT_REGEXP =
+    /
+    (?: \A (?:[\w-]+;\s*)? \K [245] (?: \.\d{1,3}\.\d{1,3} | \d\d ) (?![.\d])
+      | (?<![.\w]) [245]\d\d (?= [ -]\s? [245]\.\d{1,3}\.\d{1,3} (?![.\d]) )
+    )
+  /x
+
+  # nil when the text holds no status, so a report that can't be classified is
+  # left alone rather than guessed at
+  def self.extract_smtp_status(text)
+    text.to_s[SMTP_STATUS_IN_TEXT_REGEXP]
+  end
 
   def self.is_valid?(email)
     return false unless String === email

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -316,19 +316,27 @@ module Email
       @incoming_email.update_columns(is_bounce: true)
       mail_error_statuses = Array.wrap(@mail.error_status)
 
+      # a DSN can report one status per recipient: any transient one keeps the
+      # whole report transient, so record the status the decision was made on
+      transient_status = mail_error_statuses.find { |status| Email.smtp_transient_failure?(status) }
+      permanent = transient_status.nil?
+
       if email_log.present?
-        email_log.update_columns(bounced: true, bounce_error_code: mail_error_statuses.first)
+        Email::Receiver.record_bounce(
+          email_log,
+          permanent: permanent,
+          bounce_error_code: transient_status || mail_error_statuses.first,
+        )
         post = email_log.post
         topic = email_log.topic
+      else
+        Email::Receiver.update_bounce_score(
+          @from_email,
+          permanent ? SiteSetting.hard_bounce_score : SiteSetting.soft_bounce_score,
+        )
       end
 
       DiscourseEvent.trigger(:email_bounce, @mail, @incoming_email, @email_log)
-
-      if mail_error_statuses.any? { |s| s.start_with?(Email::SMTP_STATUS_TRANSIENT_FAILURE) }
-        Email::Receiver.update_bounce_score(@from_email, SiteSetting.soft_bounce_score)
-      else
-        Email::Receiver.update_bounce_score(@from_email, SiteSetting.hard_bounce_score)
-      end
 
       if SiteSetting.whispers_allowed_groups.present? && @from_user&.staged?
         return if email_log.blank?
@@ -369,30 +377,56 @@ module Email
       @email_log ||= EmailLog.find_by(bounce_key: bounce_key)
     end
 
+    # Records a bounce for an email we sent: claims the email log so that
+    # duplicate reports of the same bounce score only once, then applies the
+    # score — but only when the bounced address still belongs to the user the
+    # email was sent to, so late reports can't penalize an unrelated account.
+    def self.record_bounce(email_log, permanent:, bounce_error_code: nil)
+      return false if email_log.nil?
+      if !email_log.claim_bounce(permanent: permanent, bounce_error_code: bounce_error_code)
+        return false
+      end
+
+      if email_log.user_id.present?
+        user = User.find_by_email(email_log.to_address)
+        if user && user.id == email_log.user_id
+          score = permanent ? SiteSetting.hard_bounce_score : SiteSetting.soft_bounce_score
+          update_bounce_score_for(user, score)
+        end
+      end
+
+      true
+    end
+
     def self.update_bounce_score(email, score)
       if user = User.find_by_email(email)
-        old_bounce_score = user.user_stat.bounce_score
+        update_bounce_score_for(user, score)
+      end
+    end
+
+    def self.update_bounce_score_for(user, score)
+      user_stat = user.user_stat
+      crossed_threshold = false
+
+      user_stat.with_lock do
+        threshold = SiteSetting.bounce_score_threshold
+        old_bounce_score = user_stat.bounce_score
         new_bounce_score = old_bounce_score + score
-        range = (old_bounce_score + 1..new_bounce_score)
+        crossed_threshold = old_bounce_score < threshold && new_bounce_score >= threshold
 
-        user.user_stat.bounce_score = new_bounce_score
-        user.user_stat.reset_bounce_score_after =
-          SiteSetting.reset_bounce_score_after_days.days.from_now
-        user.user_stat.save!
+        user_stat.bounce_score = new_bounce_score
+        user_stat.reset_bounce_score_after = SiteSetting.reset_bounce_score_after_days.days.from_now
+        user_stat.save!
+      end
 
-        if range === SiteSetting.bounce_score_threshold
-          # NOTE: we check bounce_score before sending emails
-          # So log we revoked the email...
-          reason =
-            I18n.t(
-              "user.email.revoked",
-              email: user.email,
-              date: user.user_stat.reset_bounce_score_after,
-            )
-          StaffActionLogger.new(Discourse.system_user).log_revoke_email(user, reason)
-          # ... and PM the user
-          SystemMessage.create_from_system_user(user, :email_revoked)
-        end
+      if crossed_threshold
+        # NOTE: we check bounce_score before sending emails
+        # So log we revoked the email...
+        reason =
+          I18n.t("user.email.revoked", email: user.email, date: user_stat.reset_bounce_score_after)
+        StaffActionLogger.new(Discourse.system_user).log_revoke_email(user, reason)
+        # ... and PM the user
+        SystemMessage.create_from_system_user(user, :email_revoked)
       end
     end
 

--- a/spec/lib/email/email_spec.rb
+++ b/spec/lib/email/email_spec.rb
@@ -3,6 +3,56 @@
 require "email"
 
 RSpec.describe Email do
+  describe ".extract_smtp_status" do
+    it "reads a status that leads the diagnostic" do
+      expect(
+        Email.extract_smtp_status("5.1.1 The email account that you tried to reach does not exist"),
+      ).to eq("5.1.1")
+      expect(Email.extract_smtp_status("smtp; 550-5.1.1 The email account does not exist")).to eq(
+        "550",
+      )
+      expect(Email.extract_smtp_status("smtp;550 5.1.1 RESOLVER.ADR.RecipNotFound")).to eq("550")
+      expect(Email.extract_smtp_status("451, temporary local problem")).to eq("451")
+    end
+
+    it "reads a status that introduces an enhanced one further into the text" do
+      expect(
+        Email.extract_smtp_status(
+          "smtp; host mx.example.com[74.125.24.27] said: 450 4.2.1 receiving mail too quickly",
+        ),
+      ).to eq("450")
+      expect(
+        Email.extract_smtp_status("smtp; host mail.example.com[4.4.1.9] said: 450 4.2.1 too fast"),
+      ).to eq("450")
+      expect(
+        Email.extract_smtp_status("smtp; Sat, 12 Mar 2022 10:11:12 +0000: 452 4.2.2 Over quota"),
+      ).to eq("452")
+    end
+
+    it "does not mistake an IP, a port, a date, a version or a count for a status" do
+      [
+        "Error: mail.example.com[93.184.216.34]:25: Connection timed out",
+        "Error: mail.example.com[5.9.44.234]:25: Connection refused",
+        "Error: mail.example.com[4.3.2.1]:25: Connection refused",
+        "Error: mail.example.com[5.1.24.7]:25: Connection refused",
+        "Error: mail.example.com[93.184.216.34]:465 Connection refused",
+        "Error: [IPv6:2a00:1450:4013:c07::1a]:587 Connection timed out",
+        "Delivery delayed. Last attempt: Mon, 12 Feb 2024 09:31:04 +0000",
+        "smtp; <20240212093104.ABC123@mx1.example.com> queued",
+        "smtp; mta450.example.com refused the connection",
+        "This message was created automatically by mail delivery software (Exim 4.94.2)",
+        "Messages temporarily deferred - 4.16.50. Please refer to",
+        "Mailbox full - quota exceeded (450 of 500 MB used)",
+        "Mailgun could not deliver the message. DNS lookup failed",
+      ].each { |diagnostic| expect(Email.extract_smtp_status(diagnostic)).to eq(nil) }
+    end
+
+    it "returns nil when there is nothing to read" do
+      expect(Email.extract_smtp_status(nil)).to eq(nil)
+      expect(Email.extract_smtp_status("")).to eq(nil)
+    end
+  end
+
   describe "is_valid?" do
     it "treats a nil as invalid" do
       expect(Email.is_valid?(nil)).to eq(false)

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -140,6 +140,16 @@ RSpec.describe Email::Receiver do
 
       expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
     end
+
+    it "sends a system message when a score eroded by sending crosses the threshold" do
+      # every send erodes the score, so it is rarely a whole number by the time
+      # it crosses
+      user.user_stat.update!(bounce_score: SiteSetting.bounce_score_threshold - 0.1)
+
+      SystemMessage.expects(:create_from_system_user).with(user, :email_revoked)
+
+      expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+    end
   end
 
   shared_examples "creates topic with forwarded message as quote" do |destination, address|

--- a/spec/models/email_log_spec.rb
+++ b/spec/models/email_log_spec.rb
@@ -199,5 +199,105 @@ RSpec.describe EmailLog do
       email_log.update!(bounce_error_code: "blah")
       expect(email_log.reload.bounce_error_code).to eq(nil)
     end
+
+    it "does not read a status out of a free-form diagnostic that has none" do
+      # providers that report the whole diagnostic rather than a code, e.g. mandrill
+      email_log.update!(
+        bounce_error_code: "smtp; host mx.example.com[74.125.24.27] said: 550 5.1.1",
+      )
+      expect(email_log.reload.bounce_error_code).to eq("550")
+      email_log.update!(bounce_error_code: "Error: mail.example.com[93.184.216.34]:25: timed out")
+      expect(email_log.reload.bounce_error_code).to eq(nil)
+    end
+  end
+
+  describe "#claim_bounce" do
+    fab!(:email_log)
+
+    it "claims an unbounced log and stores the normalized error code" do
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1 (blah)")).to eq(true)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("5.1.1")
+    end
+
+    it "stores a generic error code reflecting the severity when none is reported" do
+      expect(email_log.claim_bounce(permanent: false)).to eq(true)
+      expect(email_log.reload.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_TRANSIENT)
+    end
+
+    it "claims an already bounced log only once" do
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1")).to eq(true)
+      expect(email_log.claim_bounce(permanent: false, bounce_error_code: "5.1.1")).to eq(false)
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1")).to eq(false)
+    end
+
+    it "lets a permanent failure supersede a transient one exactly once" do
+      expect(email_log.claim_bounce(permanent: false, bounce_error_code: "4.2.1")).to eq(true)
+      expect(email_log.claim_bounce(permanent: false, bounce_error_code: "4.4.7")).to eq(false)
+
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1")).to eq(true)
+      expect(email_log.reload.bounce_error_code).to eq("5.1.1")
+
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1")).to eq(false)
+    end
+
+    it "lets a permanent failure supersede a transient one reported without an error code" do
+      expect(email_log.claim_bounce(permanent: false)).to eq(true)
+      expect(email_log.claim_bounce(permanent: true)).to eq(true)
+      expect(email_log.reload.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_PERMANENT)
+    end
+
+    it "claims a permanent failure reported with a transient error code only once" do
+      diagnostic = "smtp; 450 4.2.1 mailbox is busy"
+
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: diagnostic)).to eq(true)
+      expect(email_log.reload.bounce_error_code).to eq("450")
+
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: diagnostic)).to eq(false)
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: diagnostic)).to eq(false)
+    end
+
+    it "reflects the claim on the record in memory" do
+      email_log.claim_bounce(permanent: false, bounce_error_code: "4.2.1")
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("4.2.1")
+      expect(email_log.bounce_permanent).to eq(false)
+
+      email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1")
+      expect(email_log.bounce_error_code).to eq("5.1.1")
+      expect(email_log.bounce_permanent).to eq(true)
+    end
+
+    it "stores the reported code even when it contradicts the severity" do
+      expect(email_log.claim_bounce(permanent: false, bounce_error_code: "5.1.1")).to eq(true)
+
+      email_log.reload
+      expect(email_log.bounce_error_code).to eq("5.1.1")
+      expect(email_log.bounce_permanent).to eq(false)
+    end
+
+    it "escalates a transient claim that reported a permanent code" do
+      expect(email_log.claim_bounce(permanent: false, bounce_error_code: "5.1.1")).to eq(true)
+      expect(email_log.claim_bounce(permanent: true, bounce_error_code: "5.1.1")).to eq(true)
+
+      email_log.reload
+      expect(email_log.bounce_error_code).to eq("5.1.1")
+      expect(email_log.bounce_permanent).to eq(true)
+    end
+
+    it "does not escalate a bounce recorded before the severity was tracked" do
+      # a bounce recorded straight onto the columns, which is all a NULL severity can mean
+      email_log.update_columns(bounced: true, bounce_error_code: "4.4.7")
+
+      expect(email_log.reload.claim_bounce(permanent: true, bounce_error_code: "5.1.1")).to eq(
+        false,
+      )
+
+      email_log.reload
+      expect(email_log.bounce_error_code).to eq("4.4.7")
+      expect(email_log.bounce_permanent).to eq(nil)
+    end
   end
 end

--- a/spec/models/email_token_spec.rb
+++ b/spec/models/email_token_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe EmailToken do
       end
     end
 
+    context "with a bounce score" do
+      before do
+        user.user_stat.update!(bounce_score: 3.0, reset_bounce_score_after: 1.week.from_now)
+      end
+
+      it "resets the bounce score, since the address is proven deliverable" do
+        EmailToken.confirm(email_token.token)
+
+        user.user_stat.reload
+        expect(user.user_stat.bounce_score).to eq(0)
+        expect(user.user_stat.reset_bounce_score_after).to eq(nil)
+      end
+
+      it "keeps the bounce score when skip_reset_bounce_score is true" do
+        EmailToken.confirm(email_token.token, skip_reset_bounce_score: true)
+
+        expect(user.user_stat.reload.bounce_score).to eq(3.0)
+      end
+    end
+
     context "with success" do
       let!(:confirmed_user) { EmailToken.confirm(email_token.token) }
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -104,6 +104,23 @@ RSpec.describe UsersController do
         end
       end
 
+      context "with a bounce score accrued before activation" do
+        it "resets the bounce score, since the address is proven deliverable" do
+          user_deferred.update(active: false)
+          user_deferred.user_stat.update!(
+            bounce_score: 3.0,
+            reset_bounce_score_after: 1.week.from_now,
+          )
+
+          put "/u/activate-account/#{email_token.token}"
+          expect(response.status).to eq(200)
+
+          user_deferred.user_stat.reload
+          expect(user_deferred.user_stat.bounce_score).to eq(0)
+          expect(user_deferred.user_stat.reset_bounce_score_after).to eq(nil)
+        end
+      end
+
       context "with response" do
         it "correctly logs on user" do
           email_token
@@ -4962,6 +4979,16 @@ RSpec.describe UsersController do
         SiteSetting.blocked_email_domains = "example.com"
         put "/u/update-activation-email.json", params: { email: "test@example.com" }
         expect(response.status).to eq(422)
+      end
+
+      it "keeps the bounce score until the new email is confirmed" do
+        user = post_user
+        user.user_stat.update!(bounce_score: 3.0)
+
+        put "/u/update-activation-email.json", params: { email: "updatedemail@example.com" }
+
+        expect(response.status).to eq(200)
+        expect(user.user_stat.reload.bounce_score).to eq(3.0)
       end
 
       it "can be updated" do

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -43,6 +43,189 @@ RSpec.describe WebhooksController do
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
 
+    it "applies the soft bounce score to transient failures" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "bounced",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" =>
+               "smtp; 450 4.2.1 The user you are trying to contact is receiving mail too quickly.",
+             "code" => "4.2.1",
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("4.2.1")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+    end
+
+    it "applies the soft bounce score when the status is only in the diagnostic text" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "bounced",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" =>
+               "smtp; 450 4.2.1 The user you are trying to contact is receiving mail too quickly.",
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+    end
+
+    it "reads a status that trails the relaying host in the diagnostic text" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "bounced",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" =>
+               "smtp; host mx.example.com[74.125.24.27] said: 450 4.2.1 The user you are trying to contact is receiving mail too quickly.",
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("450")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+    end
+
+    it "does not read a status out of the octets of the relaying host's IP" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "dropped",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" => "Error: mail.example.com[5.1.24.7]:25: Connection refused",
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_PERMANENT)
+    end
+
+    it "ignores a diagnostic that carries no status" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "bounced",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" => "Error: mail.example.com[93.184.216.34]:25: Connection timed out",
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(false)
+      expect(email_log.user.user_stat.bounce_score).to eq(0)
+    end
+
+    it "does not apply the soft bounce score to permanent 5.4.x failures" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "bounced",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" => "smtp; 550-5.4.7 Delivery time expired.",
+             "code" => "5.4.7",
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(false)
+      expect(email_log.user.user_stat.bounce_score).to eq(0)
+    end
+
+    it "escalates a transient bounce to a hard bounce when the message is later dropped" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => token,
+             "timestamp" => timestamp,
+             "event" => "bounced",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" => signature,
+             "error" =>
+               "smtp; 450 4.2.1 The user you are trying to contact is receiving mail too quickly.",
+             "code" => "4.2.1",
+           }
+      expect(response.status).to eq(200)
+
+      other_token = token.reverse
+      post "/webhooks/mailgun.json",
+           params: {
+             "token" => other_token,
+             "timestamp" => timestamp,
+             "event" => "dropped",
+             "recipient" => email,
+             "Message-Id" => "<#{message_id}>",
+             "signature" =>
+               OpenSSL::HMAC.hexdigest(
+                 "SHA256",
+                 SiteSetting.mailgun_api_key,
+                 "#{timestamp}#{other_token}",
+               ),
+             "error" => "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
+             "code" => "5.1.1",
+           }
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounce_error_code).to eq("5.1.1")
+      expect(email_log.user.user_stat.reload.bounce_score).to eq(
+        SiteSetting.soft_bounce_score + SiteSetting.hard_bounce_score,
+      )
+    end
+
     it "works (new)" do
       user = Fabricate(:user, email: email)
       email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
@@ -63,12 +246,12 @@ RSpec.describe WebhooksController do
                    "message-id" => message_id,
                  },
                },
-             },
-             "delivery-status" => {
-               "message" =>
-                 "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
-               "code" => "5.1.1",
-               "description" => "",
+               "delivery-status" => {
+                 "message" =>
+                   "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
+                 "code" => "5.1.1",
+                 "description" => "",
+               },
              },
            }
 
@@ -76,8 +259,48 @@ RSpec.describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
+      # the payload reports a permanent code at a temporary severity: the code is
+      # what the provider said, the severity is what we scored
       expect(email_log.bounce_error_code).to eq("5.1.1")
+      expect(email_log.bounce_permanent).to eq(false)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+    end
+
+    it "scores a permanent severity as a hard bounce (new)" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/mailgun.json",
+           params: {
+             "signature" => {
+               "token" => token,
+               "timestamp" => timestamp,
+               "signature" => signature,
+             },
+             "event-data" => {
+               "event" => "failed",
+               "severity" => "permanent",
+               "recipient" => email,
+               "message" => {
+                 "headers" => {
+                   "message-id" => message_id,
+                 },
+               },
+               "delivery-status" => {
+                 "message" =>
+                   "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
+                 "code" => 550,
+                 "description" => "",
+               },
+             },
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("550")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
 
     context "when readonly mode is enabled" do
@@ -150,6 +373,29 @@ RSpec.describe WebhooksController do
       email_log.reload
       expect(email_log.bounced).to eq(true)
       expect(email_log.bounce_error_code).to eq("5.0.0")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "applies the hard bounce score to permanent 5.4.x statuses" do
+      SiteSetting.sendgrid_verification_key = "test"
+      WebhooksController.any_instance.stubs(:valid_sendgrid_signature?).returns(true)
+
+      post "/webhooks/sendgrid.json",
+           params: {
+             "_json" => [
+               {
+                 "email" => email,
+                 "smtp-id" => "<12345@il.com>",
+                 "event" => "bounce",
+                 "status" => "5.4.7",
+               },
+             ],
+           }
+
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
 
@@ -293,8 +539,70 @@ RSpec.describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq(nil) # mailjet doesn't give us this
+      # mailjet doesn't report an error code, so a generic one is stored
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_PERMANENT)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "does not increase the bounce score for duplicate events" do
+      SiteSetting.mailjet_webhook_token = "foo"
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      2.times do
+        post "/webhooks/mailjet.json?t=foo",
+             params: {
+               "event" => "bounce",
+               "email" => email,
+               "hard_bounce" => true,
+               "CustomID" => message_id,
+             }
+
+        expect(response.status).to eq(200)
+      end
+
+      expect(email_log.reload.bounced).to eq(true)
+      expect(email_log.user.user_stat.reload.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "leaves the bounce score unchanged when the user has since changed their email address" do
+      SiteSetting.mailjet_webhook_token = "foo"
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+      user.primary_email.update!(email: "fixed@email.com")
+
+      post "/webhooks/mailjet.json?t=foo",
+           params: {
+             "event" => "bounce",
+             "email" => email,
+             "hard_bounce" => true,
+             "CustomID" => message_id,
+           }
+
+      expect(response.status).to eq(200)
+      expect(email_log.reload.bounced).to eq(true)
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+    end
+
+    it "does not increase the bounce score of another user who now owns the recipient address" do
+      SiteSetting.mailjet_webhook_token = "foo"
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+      user.primary_email.update!(email: "fixed@email.com")
+      other_user = Fabricate(:user, email: email)
+
+      post "/webhooks/mailjet.json?t=foo",
+           params: {
+             "event" => "bounce",
+             "email" => email,
+             "hard_bounce" => true,
+             "CustomID" => message_id,
+           }
+
+      expect(response.status).to eq(200)
+      expect(email_log.reload.bounced).to eq(true)
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+      expect(other_user.user_stat.reload.bounce_score).to eq(0)
     end
 
     it "verifies signatures" do
@@ -369,8 +677,35 @@ RSpec.describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq(nil) # mailpace doesn't give us this
+      # mailpace doesn't report an error code, so a generic one is stored
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_PERMANENT)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "escalates a deferred email to a hard bounce when it later bounces" do
+      SiteSetting.mailpace_webhook_token = "foo"
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      %w[deferred bounced].each do |status|
+        post "/webhooks/mailpace.json?t=foo",
+             params: {
+               event: "email.#{status}",
+               payload: {
+                 status: status,
+                 to: email,
+                 message_id: "<#{message_id}>",
+               },
+             }
+
+        expect(response.status).to eq(200)
+      end
+
+      email_log.reload
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_PERMANENT)
+      expect(email_log.user.user_stat.reload.bounce_score).to eq(
+        SiteSetting.soft_bounce_score + SiteSetting.hard_bounce_score,
+      )
     end
 
     it "soft bounces" do
@@ -392,7 +727,8 @@ RSpec.describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq(nil) # mailpace doesn't give us this
+      # mailpace doesn't report an error code, so a generic one is stored
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_TRANSIENT)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
     end
 
@@ -578,7 +914,8 @@ RSpec.describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq(nil) # postmark doesn't give us this
+      # postmark doesn't report an error code, so a generic one is stored
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_PERMANENT)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
 
@@ -597,7 +934,8 @@ RSpec.describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq(nil) # postmark doesn't give us this
+      # postmark doesn't report an error code, so a generic one is stored
+      expect(email_log.bounce_error_code).to eq(EmailLog::BOUNCE_ERROR_CODE_TRANSIENT)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
     end
 
@@ -794,6 +1132,7 @@ RSpec.describe WebhooksController do
     let(:topic_arn) { "arn:aws:sns:us-east-1:123456789012:discourse-bounces" }
     let(:other_topic_arn) { "arn:aws:sns:us-east-1:999999999999:attacker-topic" }
     let(:bounce_status) { "5.1.1" }
+    let(:bounce_type) { "Permanent" }
     let(:payload) do
       {
         "Type" => "Notification",
@@ -801,7 +1140,7 @@ RSpec.describe WebhooksController do
         "Message" => {
           "notificationType" => "Bounce",
           :bounce => {
-            "bounceType" => "Permanent",
+            "bounceType" => bounce_type,
             "reportingMTA" => "dns; email.example.com",
             :bouncedRecipients => [
               {
@@ -907,6 +1246,75 @@ RSpec.describe WebhooksController do
 
       expect(email_log.reload.bounced).to eq(true)
       expect(email_log.user.user_stat.reload.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "applies the hard bounce score to permanent bounces regardless of the current bounce score" do
+      user = Fabricate(:user, email: email)
+      user.user_stat.update!(bounce_score: 4.2)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/aws.json", headers: { "RAW_POST_DATA" => payload }
+      expect(response.status).to eq(200)
+
+      expect(email_log.reload.bounced).to eq(true)
+      expect(user.user_stat.reload.bounce_score).to eq(4.2 + SiteSetting.hard_bounce_score)
+    end
+
+    it "leaves the bounce score unchanged when the user has since changed their email address" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+      user.primary_email.update!(email: "fixed@email.com")
+
+      post "/webhooks/aws.json", headers: { "RAW_POST_DATA" => payload }
+      expect(response.status).to eq(200)
+
+      expect(email_log.reload.bounced).to eq(true)
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+    end
+
+    context "with a transient SMTP status" do
+      let(:bounce_status) { "4.4.7" }
+
+      it "applies the hard bounce score, since the provider gave up on the address" do
+        user = Fabricate(:user, email: email)
+        email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+        post "/webhooks/aws.json", headers: { "RAW_POST_DATA" => payload }
+        expect(response.status).to eq(200)
+
+        expect(email_log.reload.bounced).to eq(true)
+        expect(email_log.bounce_error_code).to eq("4.4.7")
+        expect(user.user_stat.reload.bounce_score).to eq(SiteSetting.hard_bounce_score)
+      end
+
+      it "does not score a notification redelivered for a bounce recorded before the severity was tracked" do
+        user = Fabricate(:user, email: email)
+        email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+        # a bounce recorded straight onto the columns, which is all a NULL severity can mean
+        email_log.update_columns(bounced: true, bounce_error_code: bounce_status)
+        user.user_stat.update!(bounce_score: SiteSetting.hard_bounce_score)
+
+        post "/webhooks/aws.json", headers: { "RAW_POST_DATA" => payload }
+        expect(response.status).to eq(200)
+
+        expect(email_log.reload.bounce_error_code).to eq("4.4.7")
+        expect(user.user_stat.reload.bounce_score).to eq(SiteSetting.hard_bounce_score)
+      end
+    end
+
+    context "with a transient bounce type" do
+      let(:bounce_type) { "Transient" }
+
+      it "applies the soft bounce score" do
+        user = Fabricate(:user, email: email)
+        email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+        post "/webhooks/aws.json", headers: { "RAW_POST_DATA" => payload }
+        expect(response.status).to eq(200)
+
+        expect(email_log.reload.bounced).to eq(true)
+        expect(user.user_stat.reload.bounce_score).to eq(SiteSetting.soft_bounce_score)
+      end
     end
 
     context "with a non-normalized bounce status" do


### PR DESCRIPTION
Previously, bounces were scored against the user's current primary address rather than the address the email was actually sent to, duplicate webhook deliveries were scored repeatedly, and the score was never reset when a user fixed a typoed email address — leaving them "email revoked" for a month after correcting it (reported in [meta](https://meta.discourse.org/t/bounce-score-does-not-reset-when-email-address-is-changed/409581)).

This change records each bounce exactly once against the sent-to address via a shared atomic claim on the email log (a permanent failure may supersede an earlier transient report), fixes soft/hard bounce classification in the SendGrid, Mailgun, and AWS SES webhooks, and resets the bounce score whenever the user confirms a token emailed to them — proving the address deliverable.

Notes for review:
- All three bounce channels (provider webhooks, SES/SNS, inbound VERP/DSN) now share `Email::Receiver.record_bounce`, which claims the `EmailLog` atomically, guards against scoring a user the mail was not sent to, and serializes concurrent score updates.
- The claim stores a status whose class always matches the severity it was claimed at, falling back to a generic `4.0.0`/`5.0.0` when the provider reports none or reports one that contradicts itself. That is what makes the transient-to-permanent escalation exact: without it, a permanent report carrying a `4.x` diagnostic re-escalates and re-scores on every retry, and a transient report carrying a `5.x` one can never be escalated at all. (Precedent for synthesizing a status: the SendGrid handler already synthesizes `5.1.2` for blocked events.)
- SES reports whether it has given up on an address in `bounceType`, so that is what decides the score; the per-recipient SMTP status is kept as a diagnostic. The previous check read the *user's stored score* rather than the reported status, so it misfired whenever a user's score happened to start with `4.`.
- The threshold-crossing test was `(old + 1..new) === threshold`, which only ever matches whole-number scores — but every send erodes the score by `bounce_score_erode_on_send`, so in practice a user could cross the threshold, be silently cut off from email, and get neither the staff log entry nor the "is your email address correct?" PM.
- The reset lives in `EmailToken.confirm`, so every user-clicked confirmation link (signup activation, password reset, email login) proves deliverability; the programmatic `User#activate` path opts out.
- `Email::SMTP_STATUS_TRANSIENT_FAILURE` / `SMTP_STATUS_PERMANENT_FAILURE` are removed in favour of `Email.smtp_transient_failure?`. They encoded a *substring* test, so `"550-5.4.7"` matched `"4."` and was classified soft — the bug this fixes in two handlers. They had no remaining callers in core or bundled plugins.

This is the first PR of a planned series: follow-ups move bounce state to a per-address ledger so it survives email changes and address reassignment.

First reported in https://meta.discourse.org/t/409581
