### PR TITLE
UX: Add btn-default class to 4 buttons

### DIFF
--- a/frontend/discourse/admin/components/form-template/form.gjs
+++ b/frontend/discourse/admin/components/form-template/form.gjs
@@ -189,7 +189,7 @@ export default class FormTemplateForm extends Component {
           @label="admin.form_templates.new_template_form.preview"
           @action={{this.showPreview}}
           @disabled={{this.disablePreviewButton}}
-          class="form-templates__preview-button"
+          class="btn-default form-templates__preview-button"
         />
       </div>
 
@@ -214,6 +214,7 @@ export default class FormTemplateForm extends Component {
           @label="admin.form_templates.new_template_form.cancel"
           @icon="xmark"
           @action={{this.onCancel}}
+          class="btn-default"
         />
 
         {{#if this.isEditing}}

--- a/plugins/discourse-gamification/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
+++ b/plugins/discourse-gamification/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
@@ -81,7 +81,7 @@ export default class AdminCreateLeaderboard extends Component {
 
           <form.Button
             @action={{@onCancel}}
-            class="new-leaderboard__cancel form-kit__button"
+            class="new-leaderboard__cancel form-kit__button btn-default"
             @label="gamification.cancel"
             @title="gamification.cancel"
           />

--- a/plugins/discourse-gamification/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.gjs
+++ b/plugins/discourse-gamification/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.gjs
@@ -72,7 +72,7 @@ export default <template>
                     <LinkTo
                       @route="adminPlugins.show.discourse-gamification-leaderboards.show"
                       @model={{leaderboard}}
-                      class="btn leaderboard-admin__edit btn-text btn-small"
+                      class="btn btn-default leaderboard-admin__edit btn-text btn-small"
                     >{{i18n "gamification.edit"}} </LinkTo>
 
                     <DButton


### PR DESCRIPTION


|Before|After|
|---|---|
|<img width="1101" height="828" alt="Screenshot 2026-08-17 234235" src="https://github.com/user-attachments/assets/0a7dcf25-d85b-4558-8495-12db8d92bbfb" />|<img width="1095" height="826" alt="Screenshot 2026-08-17 234250" src="https://github.com/user-attachments/assets/dc7ca3f3-906e-4d73-a2f7-d2dbccb9cf42" />|
|<img width="1094" height="409" alt="Screenshot 2026-08-17 234655" src="https://github.com/user-attachments/assets/1bb5d065-0399-4806-8503-e5f17d9ec7fd" />|<img width="887" height="420" alt="Screenshot 2026-08-17 235709" src="https://github.com/user-attachments/assets/c4b6e684-1cec-47cc-ae7f-76dbb7d1fadd" />|
