### PR TITLE
FIX: sentiment analysis report failing on the admin dashboard

### DIFF
--- a/plugins/discourse-ai/lib/sentiment/sentiment_analysis_report.rb
+++ b/plugins/discourse-ai/lib/sentiment/sentiment_analysis_report.rb
@@ -177,7 +177,7 @@ module DiscourseAi
             model_name: model_name,
           )
 
-        grouped_sentiments
+        grouped_sentiments.map(&:to_h)
       end
     end
   end

--- a/plugins/discourse-ai/spec/reports/sentiment_analysis_spec.rb
+++ b/plugins/discourse-ai/spec/reports/sentiment_analysis_spec.rb
@@ -22,4 +22,14 @@ RSpec.describe DiscourseAi::Sentiment::SentimentAnalysisReport do
     report = Report.find("sentiment_analysis")
     expect(report.labels).to eq(%w[Positive Neutral Negative])
   end
+
+  it "produces data that can be cached for the admin dashboard" do
+    Fabricate(:sentiment_classification, target: post)
+
+    report = Report.find("sentiment_analysis")
+
+    expect(report.data).to be_present
+    expect(report.data).to all(be_a(Hash))
+    expect { Report.cache(report) }.not_to raise_error
+  end
 end


### PR DESCRIPTION
The report's raw query rows couldn't be cached for the dashboard due to the object type returned by `DB.query(...)` being an anonymous class which cannot be marshalled. This caused the report to always fail to load in the dashboard even though it worked on its own page.