### PR TITLE
FIX: prevent unmountable Data Explorer queries on the admin dashboard

### DIFF
--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
@@ -17,19 +17,22 @@ module DiscourseDataExplorer
       return {} if guardian.nil?
 
       load_queries(identifiers).each_with_object({}) do |query, hash|
-        next if !guardian.user_can_access_query?(query)
+        next if !guardian.user_can_access_query?(query) || !mountable?(query)
         hash[query.id.to_s] = build_resolved(query)
       end
     end
 
     def self.list_all(search: nil, after: nil, limit: nil)
       persisted =
-        persisted_after(search: search, after: after, limit: limit).map do |query|
-          build_resolved(query)
-        end
+        persisted_after(search: search, after: after, limit: limit)
+          .select { |query| mountable?(query) }
+          .map { |query| build_resolved(query) }
       unpersisted =
         seek(
-          Query.unpersisted_defaults(search: search).map { |query| build_resolved(query) },
+          Query
+            .unpersisted_defaults(search: search)
+            .select { |query| mountable?(query) }
+            .map { |query| build_resolved(query) },
           after: after,
           limit: limit,
         )
@@ -45,7 +48,7 @@ module DiscourseDataExplorer
       params = filters.with_indifferent_access
 
       load_queries(identifiers).each_with_object({}) do |query, hash|
-        next if !guardian.user_can_access_query?(query)
+        next if !guardian.user_can_access_query?(query) || !mountable?(query)
         result =
           QueryRunner.cached_result(query, params, max_age: CACHE_MAX_AGE) ||
             QueryRunner.run(query, params, current_user: guardian.user)
@@ -103,6 +106,11 @@ module DiscourseDataExplorer
       queries
     end
     private_class_method :load_queries
+
+    def self.mountable?(query)
+      query.params.all? { |param| param.internal? || param.nullable || param.default.present? }
+    end
+    private_class_method :mountable?
 
     def self.prewarmable?(query, params)
       QueryRunner.cacheable?(query) &&

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
@@ -25,8 +25,8 @@ module DiscourseDataExplorer
 
     def self.list_all(search: nil, after: nil, limit: nil)
       persisted =
-        persisted_after(search: search, after: after, limit: limit).filter_map do |query|
-          build_resolved(query) if mountable?(query)
+        persisted_after(search: search, after: after, limit: limit).map do |query|
+          build_resolved(query)
         end
       unpersisted =
         seek(
@@ -124,6 +124,33 @@ module DiscourseDataExplorer
     private_class_method :prewarmable?
 
     def self.persisted_after(search:, after:, limit:)
+      if limit.nil?
+        return(
+          persisted_batch(search: search, after: after, limit: nil).select do |query|
+            mountable?(query)
+          end
+        )
+      end
+
+      mountable_queries = []
+      cursor = after
+
+      loop do
+        batch = persisted_batch(search: search, after: cursor, limit: limit)
+        break if batch.empty?
+
+        mountable_queries.concat(batch.select { |query| mountable?(query) })
+        break if mountable_queries.size >= limit || batch.size < limit
+
+        last = batch.last
+        cursor = { title: last.name, key: "#{SOURCE_NAME}:#{last.id}" }
+      end
+
+      mountable_queries.first(limit)
+    end
+    private_class_method :persisted_after
+
+    def self.persisted_batch(search:, after:, limit:)
       scope = Query.where(hidden: false)
       if search.present?
         scope =
@@ -151,6 +178,6 @@ module DiscourseDataExplorer
       scope = scope.limit(limit) if limit
       scope.to_a
     end
-    private_class_method :persisted_after
+    private_class_method :persisted_batch
   end
 end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
@@ -4,6 +4,7 @@ module DiscourseDataExplorer
   class AdminDashboardReportProvider < ::AdminDashboard::Reports::SourceProvider
     SOURCE_NAME = "data_explorer_query"
     CACHE_MAX_AGE = 1.hour
+    DASHBOARD_SUPPLIED_PARAMS = %w[start_date end_date].freeze
 
     def self.source_name
       SOURCE_NAME
@@ -24,15 +25,14 @@ module DiscourseDataExplorer
 
     def self.list_all(search: nil, after: nil, limit: nil)
       persisted =
-        persisted_after(search: search, after: after, limit: limit)
-          .select { |query| mountable?(query) }
-          .map { |query| build_resolved(query) }
+        persisted_after(search: search, after: after, limit: limit).filter_map do |query|
+          build_resolved(query) if mountable?(query)
+        end
       unpersisted =
         seek(
           Query
             .unpersisted_defaults(search: search)
-            .select { |query| mountable?(query) }
-            .map { |query| build_resolved(query) },
+            .filter_map { |query| build_resolved(query) if mountable?(query) },
           after: after,
           limit: limit,
         )
@@ -108,7 +108,10 @@ module DiscourseDataExplorer
     private_class_method :load_queries
 
     def self.mountable?(query)
-      query.params.all? { |param| param.internal? || param.nullable || param.default.present? }
+      query.params.all? do |param|
+        param.internal? || param.nullable || param.default.present? ||
+          DASHBOARD_SUPPLIED_PARAMS.include?(param.identifier)
+      end
     end
     private_class_method :mountable?
 

--- a/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
@@ -128,6 +128,18 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
       result = described_class.resolve_many([query.id.to_s], guardian: admin_guardian)
       expect(result.keys).to eq([query.id.to_s])
     end
+
+    it "resolves a query whose required parameters are start_date and end_date" do
+      query =
+        Fabricate(
+          :query,
+          sql: "-- [params]\n-- date :start_date\n-- date :end_date\n\nSELECT :start_date AS value",
+          user: admin,
+        )
+
+      result = described_class.resolve_many([query.id.to_s], guardian: admin_guardian)
+      expect(result.keys).to eq([query.id.to_s])
+    end
   end
 
   describe ".list_all" do
@@ -182,6 +194,19 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
           :query,
           name: "Has a nullable parameter",
           sql: "-- [params]\n-- null int :topic_id\n\nSELECT :topic_id AS value",
+          user: admin,
+        )
+
+      reports = described_class.list_all
+      expect(reports.map(&:identifier)).to include(query.id.to_s)
+    end
+
+    it "includes a query whose required parameters are start_date and end_date" do
+      query =
+        Fabricate(
+          :query,
+          name: "Uses dashboard date range",
+          sql: "-- [params]\n-- date :start_date\n-- date :end_date\n\nSELECT :start_date AS value",
           user: admin,
         )
 
@@ -288,6 +313,29 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
 
       result = described_class.fetch_many([query.id.to_s], guardian: admin_guardian)
       expect(result).to be_empty
+    end
+
+    it "runs a query whose required parameters are start_date and end_date, using the dashboard's date range" do
+      query =
+        Fabricate(
+          :query,
+          sql: "-- [params]\n-- date :start_date\n-- date :end_date\n\nSELECT :start_date AS value",
+          user: admin,
+        )
+
+      result =
+        described_class.fetch_many(
+          [query.id.to_s],
+          guardian: admin_guardian,
+          filters: {
+            start_date: "2026-01-01",
+            end_date: "2026-01-30",
+          },
+        )
+
+      payload = result[query.id.to_s]
+      expect(payload[:success]).to eq(true)
+      expect(payload[:rows]).to eq([["2026-01-01"]])
     end
   end
 

--- a/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
@@ -214,6 +214,21 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
       expect(reports.map(&:identifier)).to include(query.id.to_s)
     end
 
+    it "keeps paginating past unmountable queries to fill the page instead of coming back short" do
+      Fabricate(
+        :query,
+        name: "zzq_aaa unmountable",
+        sql: "-- [params]\n-- int :topic_id\n\nSELECT :topic_id AS value",
+        user: admin,
+      )
+      mountable =
+        Fabricate(:query, name: "zzq_bbb mountable", sql: "SELECT 1 AS value", user: admin)
+
+      reports = described_class.list_all(search: "zzq_", limit: 1)
+
+      expect(reports.map(&:identifier)).to eq([mountable.id.to_s])
+    end
+
     it "returns a title-sorted page and resumes after the cursor across persisted + defaults" do
       all = described_class.list_all
       titles = all.map { |report| report.title.to_s.downcase }

--- a/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
@@ -92,6 +92,42 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
         expect(result.keys).to eq([visible_query.id.to_s])
       end
     end
+
+    it "omits a query with a required parameter that has no default" do
+      query =
+        Fabricate(
+          :query,
+          sql: "-- [params]\n-- int :topic_id\n\nSELECT :topic_id AS value",
+          user: admin,
+        )
+
+      result = described_class.resolve_many([query.id.to_s], guardian: admin_guardian)
+      expect(result).to be_empty
+    end
+
+    it "resolves a query whose only parameter has a default" do
+      query =
+        Fabricate(
+          :query,
+          sql: "-- [params]\n-- int :limit = 10\n\nSELECT :limit AS value",
+          user: admin,
+        )
+
+      result = described_class.resolve_many([query.id.to_s], guardian: admin_guardian)
+      expect(result.keys).to eq([query.id.to_s])
+    end
+
+    it "resolves a query whose only parameter is nullable" do
+      query =
+        Fabricate(
+          :query,
+          sql: "-- [params]\n-- null int :topic_id\n\nSELECT :topic_id AS value",
+          user: admin,
+        )
+
+      result = described_class.resolve_many([query.id.to_s], guardian: admin_guardian)
+      expect(result.keys).to eq([query.id.to_s])
+    end
   end
 
   describe ".list_all" do
@@ -112,6 +148,45 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
 
     it "returns nothing when search matches no query" do
       expect(described_class.list_all(search: "zz_no_match_zz")).to be_empty
+    end
+
+    it "omits a query with a required parameter that has no default" do
+      query =
+        Fabricate(
+          :query,
+          name: "Requires topic id",
+          sql: "-- [params]\n-- int :topic_id\n\nSELECT :topic_id AS value",
+          user: admin,
+        )
+
+      reports = described_class.list_all
+      expect(reports.map(&:identifier)).not_to include(query.id.to_s)
+    end
+
+    it "includes a query whose only parameter has a default" do
+      query =
+        Fabricate(
+          :query,
+          name: "Has a default",
+          sql: "-- [params]\n-- int :limit = 10\n\nSELECT :limit AS value",
+          user: admin,
+        )
+
+      reports = described_class.list_all
+      expect(reports.map(&:identifier)).to include(query.id.to_s)
+    end
+
+    it "includes a query whose only parameter is nullable" do
+      query =
+        Fabricate(
+          :query,
+          name: "Has a nullable parameter",
+          sql: "-- [params]\n-- null int :topic_id\n\nSELECT :topic_id AS value",
+          user: admin,
+        )
+
+      reports = described_class.list_all
+      expect(reports.map(&:identifier)).to include(query.id.to_s)
     end
 
     it "returns a title-sorted page and resumes after the cursor across persisted + defaults" do
@@ -201,6 +276,18 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
       result = described_class.fetch_many(%w[-1], guardian: admin_guardian)
       expect(result["-1"]).to be_present
       expect(result["-1"][:success]).to eq(true)
+    end
+
+    it "omits a query with a required parameter that has no default instead of erroring" do
+      query =
+        Fabricate(
+          :query,
+          sql: "-- [params]\n-- int :topic_id\n\nSELECT :topic_id AS value",
+          user: admin,
+        )
+
+      result = described_class.fetch_many([query.id.to_s], guardian: admin_guardian)
+      expect(result).to be_empty
     end
   end
 


### PR DESCRIPTION
Data Explorer queries with a required parameter and no default value could be added to the admin dashboard, where there's no way to supply that value, so they always failed. Such queries can no longer be mounted, and any already mounted stop showing up.