### PR TITLE
FIX: Schedule translations cater for posts without locale and topics without titles

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/translation/translation_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/translation/translation_controller.rb
@@ -49,7 +49,7 @@ module DiscourseAi
 
         untranslated_posts = find_untranslated_posts(topic, guardian)
 
-        if !untranslated_posts.exists?
+        if !topic_needs_translation?(topic) && !untranslated_posts.exists?
           return(
             render_json_error(
               I18n.t("discourse_ai.translation.errors.all_posts_translated"),
@@ -79,24 +79,32 @@ module DiscourseAi
         render_json_error(I18n.t("rate_limiter.slow_down"))
       end
 
+      def topic_needs_translation?(topic)
+        locales = DiscourseAi::Translation.locales
+
+        return false if locales.blank?
+        return true if topic.locale.blank?
+
+        locales.any? do |locale|
+          next false if LocaleNormalizer.is_same?(locale, topic.locale)
+
+          topic.get_localization(locale, fallback: false).nil?
+        end
+      end
+
       def find_untranslated_posts(topic, guardian)
         supported_locales = DiscourseAi::Translation.locales
         base_locales = supported_locales.map { |locale| locale.split("_").first }
 
-        # Find posts that:
-        # 1. Have a detected locale
-        # 2. Need translation to other supported locales (excluding their own locale)
-        # 3. Don't have PostLocalization records for those target locales yet
-        # 4. Are not deleted and have content
+        # Find posts that need locale detection or translation to another supported locale.
         posts = topic.posts.secured(guardian)
         posts =
           posts.where("posts.user_id > 0") unless SiteSetting.ai_translation_include_bot_content
         posts
           .where.not(raw: "")
           .where(deleted_at: nil)
-          .where.not(locale: nil)
           .where(
-            "EXISTS (
+            "posts.locale IS NULL OR EXISTS (
               SELECT 1 FROM unnest(ARRAY[?]) AS target_locale
               WHERE split_part(posts.locale, '_', 1) != target_locale
               AND NOT EXISTS (

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-translation-topic-admin.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-translation-topic-admin.gjs
@@ -46,19 +46,26 @@ export default apiInitializer((api) => {
               type: "POST",
             }
           );
+          const message =
+            result.scheduled_posts === 0
+              ? i18n(
+                  "discourse_ai.features.translation.schedule_topic_only_success"
+                )
+              : i18n(
+                  "discourse_ai.features.translation.schedule_topic_success",
+                  { count: result.scheduled_posts }
+                );
 
           toasts.success({
             duration: "long",
             data: {
-              message: i18n("discourse_ai.translation.schedule_topic_success", {
-                count: result.scheduled_posts,
-              }),
+              message,
             },
           });
         } catch (error) {
           const errorMessage =
             error.jqXHR?.responseJSON?.errors?.[0] ||
-            i18n("discourse_ai.translation.schedule_topic_error");
+            i18n("discourse_ai.features.translation.schedule_topic_error");
 
           toasts.error({
             duration: "long",

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -405,6 +405,7 @@ en:
           topic_title_translator: "Topic title translator"
           short_text_translator: "Short text translator"
           schedule_untranslated: "Schedule translations"
+          schedule_topic_only_success: "Scheduled translation for the topic."
           schedule_topic_success:
             one: "Scheduled translation for %{count} untranslated post."
             other: "Scheduled translation for %{count} untranslated posts."

--- a/plugins/discourse-ai/spec/requests/translation/translation_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/translation/translation_controller_spec.rb
@@ -154,33 +154,58 @@ describe DiscourseAi::Translation::TranslationController do
         expect(response.parsed_body["scheduled_posts"]).to eq(2)
       end
 
-      it "returns error when all posts are already translated" do
-        post1.update!(locale: "en")
-        post2.update!(locale: "en")
-        SiteSetting.content_localization_supported_locales = "en"
-
-        post "/discourse-ai/translate/topics/#{topic.id}"
-        expect(response.status).to eq(422)
-        expect(response.parsed_body["errors"]).to include(
-          I18n.t("discourse_ai.translation.errors.all_posts_translated"),
-        )
-      end
-
-      it "ignores posts without detected locale" do
+      it "schedules posts without a detected locale when other posts are fully translated" do
         post1.update!(locale: "en")
         post2.update!(locale: nil)
         SiteSetting.content_localization_supported_locales = "en|es"
+        Fabricate(:post_localization, post: post1, locale: "es")
 
         expect_enqueued_with(
           job: Jobs::DetectTranslatePost,
           args: {
-            post_id: post1.id,
+            post_id: post2.id,
             force: true,
           },
         ) { post "/discourse-ai/translate/topics/#{topic.id}" }
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["scheduled_posts"]).to eq(1)
+      end
+
+      it "schedules the topic when all posts are translated but the title is not" do
+        topic.update!(locale: "en")
+        post1.update!(locale: "en")
+        post2.update!(locale: "en")
+        SiteSetting.content_localization_supported_locales = "en|es"
+        Fabricate(:post_localization, post: post1, locale: "es")
+        Fabricate(:post_localization, post: post2, locale: "es")
+
+        expect_enqueued_with(
+          job: Jobs::DetectTranslateTopic,
+          args: {
+            topic_id: topic.id,
+            force: true,
+          },
+        ) { post "/discourse-ai/translate/topics/#{topic.id}" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["scheduled_posts"]).to eq(0)
+      end
+
+      it "returns error when all posts are already translated" do
+        topic.update!(locale: "en")
+        post1.update!(locale: "en")
+        post2.update!(locale: "en")
+        SiteSetting.content_localization_supported_locales = "en|es"
+        Fabricate(:topic_localization, topic: topic, locale: "es")
+        Fabricate(:post_localization, post: post1, locale: "es")
+        Fabricate(:post_localization, post: post2, locale: "es")
+
+        post "/discourse-ai/translate/topics/#{topic.id}"
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          I18n.t("discourse_ai.translation.errors.all_posts_translated"),
+        )
       end
 
       it "ignores deleted posts" do
@@ -273,7 +298,9 @@ describe DiscourseAi::Translation::TranslationController do
       it "excludes bot posts by default" do
         bot_post = Fabricate(:post, topic: topic, user: Discourse.system_user, locale: "en")
         post1.update!(locale: "en")
+        post2.update!(locale: "en")
         SiteSetting.content_localization_supported_locales = "en|es"
+        Fabricate(:post_localization, post: post2, locale: "es")
 
         expect_enqueued_with(
           job: Jobs::DetectTranslatePost,
@@ -291,7 +318,9 @@ describe DiscourseAi::Translation::TranslationController do
         SiteSetting.ai_translation_include_bot_content = true
         bot_post = Fabricate(:post, topic: topic, user: Discourse.system_user, locale: "en")
         post1.update!(locale: "en")
+        post2.update!(locale: "en")
         SiteSetting.content_localization_supported_locales = "en|es"
+        Fabricate(:post_localization, post: post2, locale: "es")
 
         expect_enqueued_with(
           job: Jobs::DetectTranslatePost,


### PR DESCRIPTION
When a topic contains posts without a detected locale, “Schedule translations” excludes them and can incorrectly report that the topic is fully translated. The same happens when every post is translated but the topic title is not, because the completion check only considers posts.

<img width="350" height="729" alt="Screenshot 2026-08-18 at 2 48 02 PM" src="https://github.com/user-attachments/assets/3d524a71-4d11-4a15-80d8-a420fc19e4a3" />

This PR treats posts without a detected locale as pending translation work, and checks topic title localizations independently. The action now schedules locale detection for those posts and schedules the topic translation job for missing titles. 

t/189993