### PR TITLE
DEV: Record bounce scores per email address

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -578,6 +578,7 @@ class Admin::UsersController < Admin::StaffController
   def reset_bounce_score
     guardian.ensure_can_reset_bounce_score!(@user)
     @user.user_stat&.reset_bounce_score!
+    EmailBounceScore.for_user(@user).delete_all
     StaffActionLogger.new(current_user).log_reset_bounce_score(@user)
     render json: success_json
   end

--- a/app/controllers/users_email_controller.rb
+++ b/app/controllers/users_email_controller.rb
@@ -62,7 +62,6 @@ class UsersEmailController < ApplicationController
     if result.no_second_factors_enabled? || result.second_factor_auth_completed?
       updater = EmailUpdater.new
       if updater.confirm(params[:token]) == :complete
-        updater.user.user_stat.reset_bounce_score!
         render json: success_json
       else
         render json: { error: I18n.t("change_email.already_done") }, status: :bad_request

--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -79,12 +79,12 @@ module Jobs
       if message
         Email::Sender.new(message, type, user).send
 
-        if (b = user.user_stat.bounce_score) > SiteSetting.bounce_score_erode_on_send
-          # erode bounce score each time we send an email
-          # this means that we are punished a lot less for bounces
-          # and we can recover more quickly
-          user.user_stat.update(bounce_score: b - SiteSetting.bounce_score_erode_on_send)
-        end
+        # erode bounce score each time we send an email
+        # this means that we are punished a lot less for bounces
+        # and we can recover more quickly
+        erode = SiteSetting.bounce_score_erode_on_send
+        UserStat.erode_bounce_score!(user.id, erode)
+        EmailBounceScore.erode!(to_address, erode)
       else
         skip_reason_type
       end

--- a/app/jobs/scheduled/ensure_db_consistency.rb
+++ b/app/jobs/scheduled/ensure_db_consistency.rb
@@ -31,6 +31,7 @@ module Jobs
         ::UserAction,
         ::UserStat,
         ::GroupUser,
+        ::EmailBounceScore,
       ].each do |klass|
         measure_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 

--- a/app/models/email_bounce_score.rb
+++ b/app/models/email_bounce_score.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Per-address bounce state, keyed case-insensitively. Every write goes through
+# the class methods below rather than through Active Record, so that concurrent
+# bounces for the same address can't lose an update.
+class EmailBounceScore < ActiveRecord::Base
+  def self.canonicalize(email)
+    Email.downcase(email.to_s.strip)
+  end
+
+  def self.for_email(email)
+    where(email: canonicalize(email))
+  end
+
+  def self.for_user(user)
+    where(email: user.user_emails.select("lower(user_emails.email)"))
+  end
+
+  def self.record_bounce!(email, score)
+    email = canonicalize(email)
+    return if !Email.is_valid?(email)
+
+    DB.exec(
+      <<~SQL,
+      INSERT INTO email_bounce_scores
+        (email, bounce_score, reset_bounce_score_after, created_at, updated_at)
+      VALUES
+        (:email, :score, :reset_after, :now, :now)
+      ON CONFLICT (email)
+      DO UPDATE SET
+        bounce_score = email_bounce_scores.bounce_score + EXCLUDED.bounce_score,
+        reset_bounce_score_after = EXCLUDED.reset_bounce_score_after,
+        updated_at = EXCLUDED.updated_at
+    SQL
+      email:,
+      score:,
+      reset_after: SiteSetting.reset_bounce_score_after_days.days.from_now,
+      now: Time.zone.now,
+    )
+  end
+
+  def self.erode!(email, amount)
+    return if amount <= 0
+
+    for_email(email).where("bounce_score > 0").update_all(
+      ["bounce_score = GREATEST(bounce_score - ?, 0), updated_at = ?", amount, Time.zone.now],
+    )
+  end
+
+  def self.reset!(email)
+    for_email(email).delete_all
+  end
+
+  def self.score_for(email)
+    for_email(email).pick(:bounce_score).to_f
+  end
+
+  # rows only matter while an address is in bad standing, so drop the ones that
+  # have eroded away or whose window has run out
+  def self.ensure_consistency!
+    where("reset_bounce_score_after < now() OR bounce_score <= 0").delete_all
+  end
+end
+
+# == Schema Information
+#
+# Table name: email_bounce_scores
+#
+#  id                       :bigint           not null, primary key
+#  bounce_score             :float            default(0.0), not null
+#  email                    :string(513)      not null
+#  reset_bounce_score_after :datetime         not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_email_bounce_scores_on_email  (email) UNIQUE
+#

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -65,7 +65,10 @@ class EmailToken < ActiveRecord::Base
       # the user acted on an email sent to this address, so it is proven
       # deliverable and previous bounces (e.g. from a typo fixed on the
       # activation screen) no longer apply
-      user.user_stat&.reset_bounce_score! if !skip_reset_bounce_score
+      if !skip_reset_bounce_score
+        user.user_stat&.reset_bounce_score!
+        EmailBounceScore.reset!(email_token.email)
+      end
       user.set_automatic_groups
       DiscourseEvent.trigger(:user_confirmed_email, user, scope)
       Invite.redeem_for_existing_user(user) if scope == EmailToken.scopes[:signup]

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -147,6 +147,15 @@ class UserStat < ActiveRecord::Base
       .update_all(bounce_score: 0)
   end
 
+  def self.erode_bounce_score!(user_id, amount)
+    return if amount <= 0
+
+    UserStat
+      .where(user_id: user_id)
+      .where("bounce_score > 0")
+      .update_all(["bounce_score = GREATEST(bounce_score - ?, 0)", amount])
+  end
+
   # Updates the denormalized view counts for all users
   def self.update_view_counts(last_seen = 1.hour.ago)
     # NOTE: we only update the counts for users we have seen in the last hour

--- a/db/migrate/20260817214148_create_email_bounce_scores.rb
+++ b/db/migrate/20260817214148_create_email_bounce_scores.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateEmailBounceScores < ActiveRecord::Migration[8.0]
+  def change
+    create_table :email_bounce_scores do |t|
+      t.string :email, limit: 513, null: false
+      t.float :bounce_score, null: false, default: 0
+      t.datetime :reset_bounce_score_after, null: false
+      t.timestamps
+    end
+
+    add_index :email_bounce_scores, :email, unique: true
+
+    # seed the addresses that are in bad standing right now, so that upgrading
+    # doesn't lift every suppression already in effect
+    up_only { execute <<~SQL }
+        INSERT INTO email_bounce_scores
+          (email, bounce_score, reset_bounce_score_after, created_at, updated_at)
+        SELECT
+          lower(user_emails.email),
+          user_stats.bounce_score,
+          user_stats.reset_bounce_score_after,
+          now(),
+          now()
+        FROM user_stats
+        INNER JOIN user_emails
+          ON user_emails.user_id = user_stats.user_id AND user_emails.primary
+        WHERE user_stats.bounce_score > 0
+          AND user_stats.reset_bounce_score_after IS NOT NULL
+      SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5285,6 +5285,39 @@ ALTER SEQUENCE public.drafts_id_seq OWNED BY public.drafts.id;
 
 
 --
+-- Name: email_bounce_scores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.email_bounce_scores (
+    id bigint NOT NULL,
+    email character varying(513) NOT NULL,
+    bounce_score double precision DEFAULT 0.0 NOT NULL,
+    reset_bounce_score_after timestamp(6) without time zone NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: email_bounce_scores_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.email_bounce_scores_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_bounce_scores_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.email_bounce_scores_id_seq OWNED BY public.email_bounce_scores.id;
+
+
+--
 -- Name: email_change_requests; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -13539,6 +13572,13 @@ ALTER TABLE ONLY public.drafts ALTER COLUMN id SET DEFAULT nextval('public.draft
 
 
 --
+-- Name: email_bounce_scores id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_bounce_scores ALTER COLUMN id SET DEFAULT nextval('public.email_bounce_scores_id_seq'::regclass);
+
+
+--
 -- Name: email_change_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -15967,6 +16007,14 @@ ALTER TABLE ONLY public.draft_sequences
 
 ALTER TABLE ONLY public.drafts
     ADD CONSTRAINT drafts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: email_bounce_scores email_bounce_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.email_bounce_scores
+    ADD CONSTRAINT email_bounce_scores_pkey PRIMARY KEY (id);
 
 
 --
@@ -19816,6 +19864,13 @@ CREATE UNIQUE INDEX index_drafts_on_user_id_and_draft_key ON public.drafts USING
 
 
 --
+-- Name: index_email_bounce_scores_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_email_bounce_scores_on_email ON public.email_bounce_scores USING btree (email);
+
+
+--
 -- Name: index_email_change_requests_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -23373,6 +23428,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260818045311'),
 ('20260818045308'),
 ('20260818045305'),
+('20260817214148'),
 ('20260817092359'),
 ('20260817054353'),
 ('20260817054044'),

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -378,30 +378,46 @@ module Email
     end
 
     # Records a bounce for an email we sent: claims the email log so that
-    # duplicate reports of the same bounce score only once, then applies the
-    # score — but only when the bounced address still belongs to the user the
-    # email was sent to, so late reports can't penalize an unrelated account.
+    # duplicate reports of the same bounce score only once, then charges the
+    # address it was sent to — and the user as well, but only while that address
+    # is still theirs, so late reports can't penalize an unrelated account.
     def self.record_bounce(email_log, permanent:, bounce_error_code: nil)
       return false if email_log.nil?
-      if !email_log.claim_bounce(permanent: permanent, bounce_error_code: bounce_error_code)
-        return false
-      end
 
+      score = permanent ? SiteSetting.hard_bounce_score : SiteSetting.soft_bounce_score
+
+      # the claim can only be made once, so it shares a transaction with the
+      # score it authorizes: failing in between would leave the provider's
+      # retry with nothing to do
+      claimed =
+        EmailLog.transaction do
+          if !email_log.claim_bounce(permanent: permanent, bounce_error_code: bounce_error_code)
+            next false
+          end
+
+          EmailBounceScore.record_bounce!(email_log.to_address, score)
+          true
+        end
+
+      return false if !claimed
+
+      # deliberately outside the transaction above: crossing the threshold
+      # creates a topic, which has no business holding the claim's row lock
       if email_log.user_id.present?
         user = User.find_by_email(email_log.to_address)
-        if user && user.id == email_log.user_id
-          score = permanent ? SiteSetting.hard_bounce_score : SiteSetting.soft_bounce_score
-          update_bounce_score_for(user, score)
-        end
+        update_bounce_score_for(user, score) if user && user.id == email_log.user_id
       end
 
       true
     end
 
     def self.update_bounce_score(email, score)
-      if user = User.find_by_email(email)
-        update_bounce_score_for(user, score)
-      end
+      # unlike a bounce we can tie back to an email log, this address is taken
+      # from the report itself, so only trust it when it names a known account
+      return if !(user = User.find_by_email(email))
+
+      EmailBounceScore.record_bounce!(email, score)
+      update_bounce_score_for(user, score)
     end
 
     def self.update_bounce_score_for(user, score)

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -152,6 +152,11 @@ class EmailUpdater
     end
     @user.reload
 
+    # the user acted on an email sent to the new address, so it is proven
+    # deliverable — but adding a secondary says nothing about the primary
+    EmailBounceScore.reset!(new_email)
+    @user.user_stat&.reset_bounce_score! if old_email.present?
+
     DiscourseEvent.trigger(:user_updated, @user, %w[email])
     @user.set_automatic_groups
   end

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -753,6 +753,7 @@ RSpec.describe Jobs::UserEmail do
         SiteSetting.bounce_score_erode_on_send = 0.2
 
         user.user_stat.update(bounce_score: 2.7)
+        EmailBounceScore.record_bounce!(user.email, 2.7)
 
         Jobs::UserEmail.new.execute(
           type: :user_mentioned,
@@ -763,6 +764,7 @@ RSpec.describe Jobs::UserEmail do
 
         user.user_stat.reload
         expect(user.user_stat.bounce_score).to eq(2.5)
+        expect(EmailBounceScore.score_for(user.email)).to eq(2.5)
 
         user.user_stat.update(bounce_score: 0)
 

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -104,6 +104,20 @@ RSpec.describe Email::Receiver do
       email_log.reload
       expect(email_log.bounced).to eq(true)
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+      expect(EmailBounceScore.score_for(user.email)).to eq(SiteSetting.soft_bounce_score)
+    end
+
+    it "records the bounce for the address even when it no longer belongs to a user" do
+      user.primary_email.update!(email: "fixed@email.com")
+
+      expect { process(:soft_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+      expect(EmailBounceScore.score_for("linux-admin@b-s-c.co.jp")).to eq(
+        SiteSetting.soft_bounce_score,
+      )
     end
 
     it "deals with hard bounces" do

--- a/spec/migrations/create_email_bounce_scores_spec.rb
+++ b/spec/migrations/create_email_bounce_scores_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require Rails.root.join("db/migrate/20260817214148_create_email_bounce_scores.rb")
+
+RSpec.describe CreateEmailBounceScores do
+  subject(:migrate) { described_class.new.migrate(:up) }
+
+  before do
+    @verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.connection.drop_table(:email_bounce_scores)
+  end
+
+  after { ActiveRecord::Migration.verbose = @verbose }
+
+  it "seeds the primary address of every user currently in bad standing" do
+    bouncing = Fabricate(:user)
+    bouncing.user_stat.update!(bounce_score: 4.0, reset_bounce_score_after: 1.week.from_now)
+    clean = Fabricate(:user)
+
+    migrate
+
+    expect(EmailBounceScore.score_for(bouncing.email)).to eq(4.0)
+    expect(EmailBounceScore.for_email(clean.email)).to be_empty
+  end
+
+  it "ignores a score that is no longer in effect" do
+    user = Fabricate(:user)
+    user.user_stat.update!(bounce_score: 4.0, reset_bounce_score_after: nil)
+
+    migrate
+
+    expect(EmailBounceScore.for_email(user.email)).to be_empty
+  end
+end

--- a/spec/models/email_bounce_score_spec.rb
+++ b/spec/models/email_bounce_score_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe EmailBounceScore do
+  describe ".record_bounce!" do
+    it "creates a row for the first bounce and accumulates on subsequent ones" do
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+      EmailBounceScore.record_bounce!("john@example.com", 2.0)
+
+      expect(EmailBounceScore.score_for("john@example.com")).to eq(3.0)
+    end
+
+    it "stores the canonical address and matches case-insensitively" do
+      EmailBounceScore.record_bounce!(" John.Doe@Example.COM ", 1.0)
+
+      row = EmailBounceScore.for_email("john.doe@example.com").first
+      expect(row.email).to eq("john.doe@example.com")
+
+      EmailBounceScore.record_bounce!("JOHN.DOE@example.com", 1.0)
+      expect(EmailBounceScore.count).to eq(1)
+    end
+
+    it "re-arms the reset window on every bounce" do
+      freeze_time
+
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+      row = EmailBounceScore.for_email("john@example.com").first
+      expect(row.reset_bounce_score_after).to eq_time(
+        SiteSetting.reset_bounce_score_after_days.days.from_now,
+      )
+
+      freeze_time(2.days.from_now)
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+      expect(row.reload.reset_bounce_score_after).to eq_time(
+        SiteSetting.reset_bounce_score_after_days.days.from_now,
+      )
+    end
+
+    it "ignores addresses it could never have sent to" do
+      EmailBounceScore.record_bounce!("", 1.0)
+      EmailBounceScore.record_bounce!(nil, 1.0)
+      EmailBounceScore.record_bounce!("not an address", 1.0)
+
+      expect(EmailBounceScore.count).to eq(0)
+    end
+  end
+
+  describe ".erode!" do
+    it "lowers the score" do
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+
+      EmailBounceScore.erode!("john@example.com", 0.1)
+
+      expect(EmailBounceScore.score_for("john@example.com")).to eq(0.9)
+    end
+
+    it "floors the score at zero rather than leaving a residue" do
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+
+      11.times { EmailBounceScore.erode!("john@example.com", 0.1) }
+
+      expect(EmailBounceScore.score_for("john@example.com")).to eq(0)
+    end
+  end
+
+  describe ".reset!" do
+    it "removes the address's row" do
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+
+      EmailBounceScore.reset!("John@Example.com")
+
+      expect(EmailBounceScore.for_email("john@example.com")).to be_empty
+    end
+  end
+
+  describe ".ensure_consistency!" do
+    it "removes rows whose reset window has passed" do
+      EmailBounceScore.record_bounce!("expired@example.com", 1.0)
+      # the sweep compares against the database clock, which freeze_time can't move
+      EmailBounceScore.for_email("expired@example.com").update_all(
+        reset_bounce_score_after: 1.day.ago,
+      )
+      EmailBounceScore.record_bounce!("active@example.com", 1.0)
+
+      EmailBounceScore.ensure_consistency!
+
+      expect(EmailBounceScore.pluck(:email)).to contain_exactly("active@example.com")
+    end
+
+    it "removes rows that eroded back to zero" do
+      EmailBounceScore.record_bounce!("eroded@example.com", 1.0)
+      EmailBounceScore.erode!("eroded@example.com", 1.0)
+      EmailBounceScore.record_bounce!("active@example.com", 1.0)
+
+      EmailBounceScore.ensure_consistency!
+
+      expect(EmailBounceScore.pluck(:email)).to contain_exactly("active@example.com")
+    end
+  end
+end

--- a/spec/models/email_token_spec.rb
+++ b/spec/models/email_token_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe EmailToken do
     context "with a bounce score" do
       before do
         user.user_stat.update!(bounce_score: 3.0, reset_bounce_score_after: 1.week.from_now)
+        EmailBounceScore.record_bounce!(email_token.email, 3.0)
       end
 
       it "resets the bounce score, since the address is proven deliverable" do
@@ -93,12 +94,14 @@ RSpec.describe EmailToken do
         user.user_stat.reload
         expect(user.user_stat.bounce_score).to eq(0)
         expect(user.user_stat.reset_bounce_score_after).to eq(nil)
+        expect(EmailBounceScore.score_for(email_token.email)).to eq(0)
       end
 
       it "keeps the bounce score when skip_reset_bounce_score is true" do
         EmailToken.confirm(email_token.token, skip_reset_bounce_score: true)
 
         expect(user.user_stat.reload.bounce_score).to eq(3.0)
+        expect(EmailBounceScore.score_for(email_token.email)).to eq(3.0)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3038,6 +3038,16 @@ RSpec.describe User do
       inactive.activate
       expect(inactive.active).to eq(true)
     end
+
+    it "keeps the bounce score, since activating proves nothing about deliverability" do
+      inactive.user_stat.update!(bounce_score: 3.0)
+      EmailBounceScore.record_bounce!(inactive.email, 3.0)
+
+      inactive.activate
+
+      expect(inactive.user_stat.reload.bounce_score).to eq(3.0)
+      expect(EmailBounceScore.score_for(inactive.email)).to eq(3.0)
+    end
   end
 
   def filter_by(method)

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -3377,6 +3377,18 @@ RSpec.describe Admin::UsersController do
         expect(user.reload.user_stat.bounce_score).to eq(0)
         expect(UserHistory.last.action).to eq(UserHistory.actions[:reset_bounce_score])
       end
+
+      it "will reset the score of every address the user owns" do
+        secondary = Fabricate(:secondary_email, user: user).email
+        EmailBounceScore.record_bounce!(user.email, 4)
+        EmailBounceScore.record_bounce!(secondary, 4)
+
+        post "/admin/users/#{user.id}/reset-bounce-score.json"
+
+        expect(response.status).to eq(200)
+        expect(EmailBounceScore.score_for(user.email)).to eq(0)
+        expect(EmailBounceScore.score_for(secondary)).to eq(0)
+      end
     end
 
     context "when logged in as a non-staff user" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe UsersController do
             bounce_score: 3.0,
             reset_bounce_score_after: 1.week.from_now,
           )
+          EmailBounceScore.record_bounce!(user_deferred.email, 3.0)
 
           put "/u/activate-account/#{email_token.token}"
           expect(response.status).to eq(200)
@@ -118,6 +119,7 @@ RSpec.describe UsersController do
           user_deferred.user_stat.reload
           expect(user_deferred.user_stat.bounce_score).to eq(0)
           expect(user_deferred.user_stat.reset_bounce_score_after).to eq(nil)
+          expect(EmailBounceScore.score_for(user_deferred.email)).to eq(0)
         end
       end
 

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe UsersEmailController do
 
       it "confirms with a correct token" do
         user.user_stat.update_columns(bounce_score: 42, reset_bounce_score_after: 1.week.from_now)
+        EmailBounceScore.record_bounce!("bubblegum@adventuretime.ooo", 42)
 
         put "/u/confirm-new-email/#{updater.change_req.new_email_token.token}.json"
 
@@ -60,6 +61,30 @@ RSpec.describe UsersEmailController do
         expect(user.user_stat.bounce_score).to eq(0)
         expect(user.user_stat.reset_bounce_score_after).to eq(nil)
         expect(user.email).to eq("bubblegum@adventuretime.ooo")
+        expect(EmailBounceScore.score_for("bubblegum@adventuretime.ooo")).to eq(0)
+      end
+    end
+
+    context "when adding a secondary email" do
+      let(:updater) { EmailUpdater.new(guardian: user.guardian, user: user) }
+
+      before do
+        SiteSetting.enable_secondary_emails = true
+        sign_in(user)
+        updater.change_to("bubblegum@adventuretime.ooo", add: true)
+      end
+
+      it "leaves the bounce state of the primary email alone" do
+        user.user_stat.update_columns(bounce_score: 42, reset_bounce_score_after: 1.week.from_now)
+        EmailBounceScore.record_bounce!(user.email, 42)
+
+        put "/u/confirm-new-email/#{updater.change_req.new_email_token.token}.json"
+
+        expect(response.status).to eq(200)
+        user.reload
+        expect(user.secondary_emails).to contain_exactly("bubblegum@adventuretime.ooo")
+        expect(EmailBounceScore.score_for(user.email)).to eq(42)
+        expect(user.user_stat.bounce_score).to eq(42)
       end
     end
 


### PR DESCRIPTION
Previously, bounce score lived on `user_stats`, keyed to the account rather than to the mailbox that actually bounced — so a bounce for an address a user no longer owns still penalized them, bounces for addresses owned by nobody were dropped entirely, and confirming a *secondary* email cleared the score for a primary that was still bouncing.

This change adds an `email_bounce_scores` ledger keyed by address, written from every bounce channel alongside the existing `user_stats` columns (which stay authoritative for now), and moves the reset into `EmailUpdater#update_user_email` so that only a primary address change clears the account-wide score.

Notes for review:
- The ledger deliberately has no `user_id`. Bounces legitimately arrive for addresses owned by nobody — invite recipients, DSN `Final-Recipient` fallbacks — and that signal is silently dropped today. Rows exist only while an address is in bad standing: they are deleted once it is proven deliverable, manually reset, eroded back to zero, or its window expires, so the table stays small.
- `user_stats.bounce_score` / `reset_bounce_score_after` are still written and are not going away — the admin user response marks both required in the OpenAPI schema, and data-explorer exposes them to admin SQL. A follow-up demotes them to a maintained mirror of the primary address's row and moves the four suppression gates onto the ledger.
- The migration seeds the addresses that are in bad standing at upgrade time, so no suppression currently in effect is silently lifted once the ledger becomes authoritative.
- `EmailBounceScore.canonicalize` is deliberately neither `ScreenedEmail.canonical` (which strips dots and plus-tags) nor `user_emails.normalized_email` — both collapse distinct mailboxes, and bounce state has to key on the exact mailbox that was written to.
- Erosion moved to `UserStat.erode_bounce_score!` so both stores erode by the same rule, and the at-most-once claim in `Email::Receiver.record_bounce` now shares a transaction with the ledger write, so failing in between doesn't consume the provider's retry.

Stacked on #42660.

First reported in https://meta.discourse.org/t/409581
