### PR TITLE
FEATURE: Support paginated MCP tool discovery

### DIFF
--- a/plugins/discourse-ai/lib/mcp/client.rb
+++ b/plugins/discourse-ai/lib/mcp/client.rb
@@ -8,6 +8,7 @@ module DiscourseAi
       PROTOCOL_VERSION = "2025-03-26"
       USER_AGENT = "Discourse AI MCP Client"
       MAX_RESPONSE_BODY_LENGTH = 5.megabytes
+      MAX_PAGINATION_PAGES = 100
 
       Error = Class.new(StandardError)
       AuthorizationRequiredError = Class.new(Error)
@@ -52,9 +53,31 @@ module DiscourseAi
       end
 
       def list_tools(session_id: nil)
-        response = post_jsonrpc("tools/list", session_id: session_id)
-        result = extract_result!(response.payload)
-        Array(result["tools"])
+        tools = []
+        cursor = nil
+        seen_cursors = Set.new
+        page_count = 0
+
+        loop do
+          page_count += 1
+          if page_count > MAX_PAGINATION_PAGES
+            raise Error, "MCP tools/list exceeded the #{MAX_PAGINATION_PAGES}-page limit"
+          end
+
+          params = { cursor: cursor } unless cursor.nil?
+          response = post_jsonrpc("tools/list", params: params, session_id: session_id)
+          result = extract_result!(response.payload)
+
+          tools.concat(Array(result["tools"]))
+          cursor = result["nextCursor"]
+          break if cursor.nil?
+
+          if !seen_cursors.add?(cursor)
+            raise Error, "MCP tools/list returned a repeated pagination cursor"
+          end
+        end
+
+        tools
       end
 
       def call_tool(tool_name, arguments, session_id: nil)

--- a/plugins/discourse-ai/spec/lib/mcp/client_spec.rb
+++ b/plugins/discourse-ai/spec/lib/mcp/client_spec.rb
@@ -62,6 +62,81 @@ RSpec.describe DiscourseAi::Mcp::Client do
     end
   end
 
+  describe "#list_tools" do
+    it "returns tools from every page" do
+      stub_request(:post, server.url).to_return(
+        {
+          status: 200,
+          body: {
+            jsonrpc: "2.0",
+            result: {
+              tools: [{ name: "search_issues" }],
+              nextCursor: "opaque-page-2",
+            },
+          }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        },
+        {
+          status: 200,
+          body: { jsonrpc: "2.0", result: { tools: [{ name: "create_issue" }] } }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        },
+      )
+
+      tools = described_class.new(server).list_tools(session_id: "session-1")
+
+      expect(tools).to eq([{ "name" => "search_issues" }, { "name" => "create_issue" }])
+      expect(
+        a_request(:post, server.url).with do |request|
+          payload = JSON.parse(request.body)
+
+          payload["method"] == "tools/list" &&
+            payload["params"] == { "cursor" => "opaque-page-2" } &&
+            request.headers["Mcp-Session-Id"] == "session-1"
+        end,
+      ).to have_been_made.once
+    end
+
+    it "rejects a repeated pagination cursor" do
+      stub_request(:post, server.url).to_return(
+        status: 200,
+        body: { jsonrpc: "2.0", result: { tools: [], nextCursor: "repeated-cursor" } }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+
+      expect { described_class.new(server).list_tools }.to raise_error(
+        described_class::Error,
+        "MCP tools/list returned a repeated pagination cursor",
+      )
+    end
+
+    it "rejects pagination beyond the page limit" do
+      stub_const(described_class, :MAX_PAGINATION_PAGES, 2) do
+        stub_request(:post, server.url).to_return(
+          {
+            status: 200,
+            body: { jsonrpc: "2.0", result: { tools: [], nextCursor: "page-2" } }.to_json,
+          },
+          {
+            status: 200,
+            body: { jsonrpc: "2.0", result: { tools: [], nextCursor: "page-3" } }.to_json,
+          },
+        )
+
+        expect { described_class.new(server).list_tools }.to raise_error(
+          described_class::Error,
+          "MCP tools/list exceeded the 2-page limit",
+        )
+      end
+    end
+  end
+
   describe "#call_tool" do
     it "parses streamable HTTP SSE responses with CRLF separators" do
       stub_request(:post, server.url).to_return(


### PR DESCRIPTION
Previously, MCP tool discovery only read the first `tools/list` response. Servers that paginate their tool catalog therefore exposed an incomplete set of tools to Discourse AI.

This change follows opaque `nextCursor` values while preserving server order and the MCP session ID. It also rejects repeated cursors and stops after 100 pages so a misbehaving server cannot keep a refresh worker or connection test running indefinitely.

Tests: `bin/rspec plugins/discourse-ai/spec/lib/mcp/client_spec.rb` (12 examples, 0 failures)

Lint: `bin/lint --fix plugins/discourse-ai/lib/mcp/client.rb plugins/discourse-ai/spec/lib/mcp/client_spec.rb`