### PR TITLE
UX: Adjust alignment of checklist box

### DIFF
--- a/plugins/checklist/assets/stylesheets/checklist.scss
+++ b/plugins/checklist/assets/stylesheets/checklist.scss
@@ -19,7 +19,7 @@ span.chcklst-stroked {
 span.chcklst-box {
   cursor: pointer;
   display: inline-flex;
-  vertical-align: text-bottom;
+  vertical-align: -0.125em;
 
   &:not(.checked) {
     &.fa-square-o {


### PR DESCRIPTION
Change vertical alignment of checklist box and adjust transform.
    
The vertical alignment is clearly broken. The `translate` nudge
I'm proposing is more opiniated. It is what we are using in our
discourse instances though.

----

| main | PR |
| -- | -- |
|  <img width="712" height="347" alt="image" src="https://github.com/user-attachments/assets/5aa8e411-aee7-4d92-9603-cbd9d6dec56d" /> | <img width="712" height="347" alt="image" src="https://github.com/user-attachments/assets/e3d6d8d1-bbdf-4d59-80a3-298737776019" /> |

Example text:
```
## Follow-ups

**Dalai**:
  * [x] Create a TODO task to keep track of the missing tasks and their priorities. [#162781](https://projects.blender.org/blender/blender/issues/162781)
  * [ ] Create a post in devtalk about the proposal to welcome commercial asset libraries to the extensions platform (as long as they have an honest free-offering of assets) .

**Campbell**
  * [ ] Check with Julian Eisel the best way to handle the virtualization of the asset libraries (RNA? UI?)
    * It cannot be a 100% UI hack because the users can still define an authentication token.
  * [ ] Create TODO task for the UI team to look at drag&drop pop-up wizard.
    * As oppose to have a massive single-window install dialog [!139431](https://projects.blender.org/blender/blender/pulls/139431)
```