### PR TITLE
DEV: Add an eval run limit

### DIFF
--- a/plugins/discourse-ai/evals/lib/cli.rb
+++ b/plugins/discourse-ai/evals/lib/cli.rb
@@ -17,7 +17,8 @@ class DiscourseAi::Evals::Cli
                 :feature_key,
                 :judge_name,
                 :comparison_mode,
-                :dataset_path
+                :dataset_path,
+                :limit
 
   def self.parse_options!(features_registry)
     cli = new
@@ -43,6 +44,15 @@ class DiscourseAi::Evals::Cli
         ) { |models| cli.models = models }
 
         opts.on("-l", "--list", "List evals") { cli.list = true }
+
+        opts.on("--limit N", Integer, "Maximum number of evaluations to run") do |limit|
+          if !limit.positive?
+            $stderr.puts("--limit must be a positive integer.")
+            exit 1
+          end
+
+          cli.limit = limit
+        end
 
         opts.on(
           "-f",
@@ -140,7 +150,15 @@ class DiscourseAi::Evals::Cli
       exit 1
     end
 
-    evals
+    apply_limit(evals)
+  end
+
+  def apply_limit(evals)
+    limit ? evals.first(limit) : evals
+  end
+
+  def select_dataset_evals(path:, feature:)
+    apply_limit(DiscourseAi::Evals::Eval.from_dataset_csv(path: path, feature: feature))
   end
 
   def validate_comparison_requirements!(llms:, agent_variants:)

--- a/plugins/discourse-ai/evals/run
+++ b/plugins/discourse-ai/evals/run
@@ -51,7 +51,7 @@ end
 
 selected_evals =
   if cli.dataset_path.present?
-    DiscourseAi::Evals::Eval.from_dataset_csv(path: cli.dataset_path, feature: cli.feature_key)
+    cli.select_dataset_evals(path: cli.dataset_path, feature: cli.feature_key)
   else
     cli.select_evals(available_evals)
   end

--- a/plugins/discourse-ai/spec/evals/cli_spec.rb
+++ b/plugins/discourse-ai/spec/evals/cli_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "../../evals/lib/cli"
+require_relative "../../evals/lib/eval"
+
+RSpec.describe DiscourseAi::Evals::Cli do
+  describe ".parse_options!" do
+    it "parses a positive eval limit" do
+      cli = nil
+      stub_const(Object, :ARGV, %w[--limit 2]) do
+        cli = described_class.parse_options!(stub(valid_feature_key?: true))
+      end
+
+      expect(cli.limit).to eq(2)
+    end
+
+    it "rejects a non-positive eval limit" do
+      stub_const(Object, :ARGV, %w[--limit 0]) do
+        expect { described_class.parse_options!(stub(valid_feature_key?: true)) }.to raise_error(
+          SystemExit,
+        ).and output("--limit must be a positive integer.\n").to_stderr
+      end
+    end
+  end
+
+  describe "#select_evals" do
+    it "limits evals after applying feature and name filters" do
+      cli = described_class.new
+      cli.feature_key = "summarization:topic_summaries"
+      cli.eval_name = "matching"
+      cli.limit = 1
+      matching = Struct.new(:id, :feature).new("matching", cli.feature_key)
+      wrong_name = Struct.new(:id, :feature).new("extra", cli.feature_key)
+      other = Struct.new(:id, :feature).new("other", "translation:post")
+
+      expect(cli.select_evals([other, wrong_name, matching])).to eq([matching])
+    end
+  end
+
+  describe "#select_dataset_evals" do
+    it "loads and limits dataset evals while preserving their order" do
+      cli = described_class.new
+      cli.limit = 2
+      evals = %i[first second third]
+      allow(DiscourseAi::Evals::Eval).to receive(:from_dataset_csv).with(
+        path: "evals.csv",
+        feature: "summarization:topic_summaries",
+      ).and_return(evals)
+
+      expect(
+        cli.select_dataset_evals(path: "evals.csv", feature: "summarization:topic_summaries"),
+      ).to eq(%i[first second])
+    end
+  end
+end


### PR DESCRIPTION
Previously, the discourse-ai eval runner always executed every matching registered or dataset evaluation. Iterating on prompts or harness changes could require a full run even when a small deterministic sample was sufficient.

This change adds `--limit N`, validates that the value is a positive integer, and applies it after registered-eval filters or CSV dataset loading while preserving evaluation order.

Tests: `bin/rspec plugins/discourse-ai/spec/evals/cli_spec.rb` (4 examples, 0 failures)

Lint: `bin/lint --fix plugins/discourse-ai/evals/lib/cli.rb plugins/discourse-ai/evals/run plugins/discourse-ai/spec/evals/cli_spec.rb`