### PR TITLE
UX: UC composer redesign > horizon 

### DIFF
--- a/app/assets/stylesheets/common/components/composer-toggle-switch.scss
+++ b/app/assets/stylesheets/common/components/composer-toggle-switch.scss
@@ -6,7 +6,6 @@
   align-items: center;
   border: 0;
   padding: 0;
-  margin-left: var(--space-2);
   background: transparent;
 
   &:focus-visible {

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -87,7 +87,7 @@
 
 .d-editor-input {
   border: 0;
-  padding: 10px;
+  padding: var(--space-2);
   height: 100%;
   overflow-x: hidden;
   overscroll-behavior: contain;
@@ -316,11 +316,13 @@
 .d-editor-button-bar__wrap {
   position: relative;
   min-width: 0;
-  margin-left: 1px;
-  margin-right: 1px;
   overflow: clip;
   border-start-start-radius: inherit;
   border-start-end-radius: inherit;
+
+  :where(body:not(.uc-enable-composer-redesign) &) {
+    margin-inline: var(--space-2);
+  }
 }
 
 .d-editor-button-bar {

--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -43,6 +43,7 @@
   }
 
   .reply-area {
+    container-type: inline-size;
     padding: 0 !important;
   }
 
@@ -206,6 +207,7 @@
   #reply-control .d-editor-textarea-wrapper {
     --composer-slide-easing: cubic-bezier(0.2, 0, 0, 1);
     border: 0;
+    border-radius: 0; // core overrule
 
     // padding and border-radius must animate in lockstep with margin,
     // otherwise the text counter-jumps when the focus state toggles
@@ -269,6 +271,10 @@
 
   .d-editor-input {
     padding-inline: var(--space-4) !important;
+
+    &:focus-visible {
+      outline: 0;
+    }
   }
 
   .wmd-controls:not(.toolbar-visible)
@@ -294,6 +300,7 @@
 
     .composer-fields {
       grid-area: fields;
+      min-width: 0;
 
       @include viewport.until(sm) {
         max-width: 100vw;
@@ -325,34 +332,45 @@
     align-items: center;
     flex-wrap: nowrap;
 
-    @include viewport.from(sm) {
-      padding: var(--space-2) var(--space-4);
-      border-top: 1px solid var(--primary-low);
+    @container (width < 600px) {
+      flex-direction: column;
     }
 
-    @include viewport.until(sm) {
-      flex-direction: column;
+    @container (width > 600px) {
+      border-top: 1px solid var(--primary-low);
+      padding: var(--space-2) var(--space-4);
     }
 
     &__toolbar {
       overflow: hidden;
       flex-grow: 1;
+      max-width: 100%;
+      box-sizing: border-box;
+
+      @container (width < 600px) {
+        padding: 0 var(--space-4);
+        border-top: 1px solid var(--primary-low);
+        border-bottom: 1px solid var(--primary-low);
+      }
 
       @include viewport.until(sm) {
         width: 100%;
         padding-inline: var(--space-2);
-        box-sizing: border-box;
         border-top: 1px solid var(--primary-low);
-        border-bottom: 1px solid var(--primary-low);
       }
     }
 
     .submit-panel {
       margin: 0 !important;
 
+      @container (width < 600px) {
+        padding: var(--space-2) var(--space-4);
+        align-self: end;
+      }
+
       @include viewport.until(sm) {
         width: 100%;
-        padding-inline: var(--space-2);
+        padding: var(--space-2) var(--space-2) 0; // parent has env safe area padding for bottom
         box-sizing: border-box;
 
         .save-or-cancel {

--- a/themes/horizon/scss/composer-peek-mode.scss
+++ b/themes/horizon/scss/composer-peek-mode.scss
@@ -26,7 +26,7 @@
           }
 
           .reply-area {
-            padding-inline: 0.67em;
+            height: 100%;
           }
         }
 

--- a/themes/horizon/scss/composer.scss
+++ b/themes/horizon/scss/composer.scss
@@ -2,36 +2,28 @@
 
 #reply-control.hide-preview:not(.draft) {
   @include viewport.from(sm) {
-    background: var(--d-content-background);
-
     .user-selector,
     .title-and-category {
-      padding: 0 var(--space-4);
-      width: calc(100% - var(--space-4) * 2);
-    }
-
-    .d-editor-button-bar {
-      padding: 3px var(--space-4);
-      border: none;
-    }
-
-    .d-editor-input {
-      padding: var(--space-4);
-    }
-
-    .reply-area {
-      padding-inline: 0;
+      :where(body:not(.uc-enable-composer-redesign) &) {
+        padding: 0 var(--space-2);
+        width: calc(100% - var(--space-2) * 2) !important;
+      }
     }
 
     .reply-to,
     .submit-panel {
-      padding-inline: var(--space-2);
+      :where(body:not(.uc-enable-composer-redesign) &) {
+        padding-inline: var(--space-2);
+      }
     }
 
     .d-editor-textarea-wrapper {
       border: 0;
-      border-bottom: 1px solid var(--content-border-color);
       border-radius: 0;
+
+      :where(body:not(.uc-enable-composer-redesign) &) {
+        border-bottom: 1px solid var(--content-border-color) !important;
+      }
 
       &.in-focus {
         outline: 0;

--- a/themes/horizon/scss/main.scss
+++ b/themes/horizon/scss/main.scss
@@ -131,12 +131,6 @@ aside.onebox {
   background-color: var(--d-content-background);
 }
 
-.d-editor-preview-wrapper {
-  border-radius: var(--d-border-radius);
-  padding: 1em;
-  background-color: var(--d-content-background);
-}
-
 .no-ember {
   #main-outlet {
     border-radius: var(--d-border-radius-large);

--- a/themes/horizon/scss/misc.scss
+++ b/themes/horizon/scss/misc.scss
@@ -61,10 +61,6 @@ input[type="color"]:focus,
   outline: 2px solid var(--accent-color);
 }
 
-#reply-control {
-  background-color: var(--background-color);
-}
-
 @include viewport.until(sm) {
   // pinned topic excerpts are hidden on small screens too
   .fk-d-menu__trigger.topic-list-layout-trigger {

--- a/themes/horizon/scss/mobile-stuff.scss
+++ b/themes/horizon/scss/mobile-stuff.scss
@@ -218,7 +218,3 @@
 .mobile-device #reply-control.show-preview .submit-panel {
   background-color: var(--background-color);
 }
-
-.d-editor-preview-wrapper {
-  outline: 2px solid var(--background-color);
-}


### PR DESCRIPTION
Collection of small fixes, mainly for Horizon.

The commit removes some Horizon specific composer styling, and moves the wrapping logic for the redesigned composer footer to a container query so the toolbar/action buttons stack on narrow composer views, not just on mobile.

| What | BC | AC |
|--------|--------|--------|
| Narrow composer | <img width="1210" height="1264" alt="CleanShot 2026-08-18 at 14 59 22@2x" src="https://github.com/user-attachments/assets/c14dae26-3491-4400-9edf-35b811a87ece" /> | <img width="1182" height="1262" alt="CleanShot 2026-08-18 at 14 53 15@2x" src="https://github.com/user-attachments/assets/a50757c4-5288-4463-9b6c-8bfd2c9fdb0d" /> |
| Horizon styling | <img width="3032" height="1914" alt="CleanShot 2026-08-18 at 14 56 43@2x" src="https://github.com/user-attachments/assets/d4795d2c-def7-4c44-9191-5f06e02c5398" /> | <img width="2580" height="1936" alt="CleanShot 2026-08-18 at 14 54 19@2x" src="https://github.com/user-attachments/assets/d8eca452-5b8c-4368-9907-95570843c784" /> | 

