### PR TITLE
DEV: remove redundant disabled styles

### DIFF
--- a/plugins/discourse-subscriptions/assets/stylesheets/common/main.scss
+++ b/plugins/discourse-subscriptions/assets/stylesheets/common/main.scss
@@ -1,15 +1,3 @@
-// TODO: This gets overridden somewhere. It is defined in common/base/discourse.scss
-input[disabled],
-input[readonly],
-select[disabled],
-select[readonly],
-textarea[disabled],
-textarea[readonly] {
-  cursor: not-allowed;
-  background-color: #e9e9e9;
-  border-color: #e9e9e9;
-}
-
 .admin-plugins.discourse-subscriptions .discourse-subscriptions-buttons {
   margin: 1em 0 2.5em;
 }


### PR DESCRIPTION
These styles are defined in `common/base/discourse.scss` and seem to work fine without the additional coverage here, which causes issues broadly across the app when the plugin is enabled. Reported here: https://meta.discourse.org/t/compose-input-box-bg-color-incorrect-in-dark-mode/410289