### PR TITLE
SECURITY: Restrict chat history reads to joinable channels

### DIFF
--- a/plugins/chat/app/services/chat/list_channel_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_messages.rb
@@ -70,12 +70,8 @@ module Chat
     end
 
     def can_view_channel(guardian:, channel:)
-      if guardian.anonymous?
-        return false if !Chat.anonymous_public_channel_access_allowed?
-        return false if !channel&.category_channel?
-      end
-
-      guardian.can_preview_chat_channel?(channel)
+      guardian.can_join_chat_channel?(channel) ||
+        guardian.can_preview_anonymous_public_chat_channel?(channel)
     end
 
     def fetch_membership(channel:, guardian:)

--- a/plugins/chat/app/services/chat/list_channel_pins.rb
+++ b/plugins/chat/app/services/chat/list_channel_pins.rb
@@ -22,7 +22,8 @@ module Chat
     end
 
     def can_view_channel(guardian:, channel:)
-      guardian.can_preview_chat_channel?(channel)
+      guardian.can_join_chat_channel?(channel) ||
+        guardian.can_preview_anonymous_public_chat_channel?(channel)
     end
 
     def fetch_membership(channel:, guardian:)

--- a/plugins/chat/app/services/chat/list_channel_thread_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_thread_messages.rb
@@ -75,7 +75,10 @@ module Chat
     end
 
     def can_view_thread(guardian:, thread:)
-      guardian.user == Discourse.system_user || guardian.can_preview_chat_channel?(thread.channel)
+      return true if guardian.user == Discourse.system_user
+
+      guardian.can_join_chat_channel?(thread.channel) ||
+        guardian.can_preview_anonymous_public_chat_channel?(thread.channel)
     end
 
     def threading_enabled_for_channel(thread:)

--- a/plugins/chat/app/services/chat/lookup_channel_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_channel_threads.rb
@@ -68,7 +68,7 @@ module Chat
     end
 
     def can_view_channel(guardian:, channel:)
-      guardian.can_preview_chat_channel?(channel)
+      guardian.can_join_chat_channel?(channel)
     end
 
     def fetch_threads(guardian:, channel:, params:)

--- a/plugins/chat/app/services/chat/lookup_thread.rb
+++ b/plugins/chat/app/services/chat/lookup_thread.rb
@@ -48,7 +48,8 @@ module Chat
     end
 
     def invalid_access(guardian:, thread:)
-      guardian.can_preview_chat_channel?(thread.channel)
+      guardian.can_join_chat_channel?(thread.channel) ||
+        guardian.can_preview_anonymous_public_chat_channel?(thread.channel)
     end
 
     def threading_enabled_for_channel(thread:)

--- a/plugins/chat/app/services/chat/search_message.rb
+++ b/plugins/chat/app/services/chat/search_message.rb
@@ -62,7 +62,8 @@ module Chat
     end
 
     def can_view_channel(guardian:, channel:)
-      guardian.can_preview_chat_channel?(channel)
+      guardian.can_join_chat_channel?(channel) ||
+        guardian.can_preview_anonymous_public_chat_channel?(channel)
     end
 
     def fetch_metadata(params:, guardian:)

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -150,6 +150,7 @@ module Chat
 
     def can_preview_chat_channel?(chat_channel)
       return false if !chat_channel&.chatable
+
       can_see_chatable?(chat_channel.chatable)
     end
 

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -153,6 +153,13 @@ module Chat
       can_see_chatable?(chat_channel.chatable)
     end
 
+    def can_preview_anonymous_public_chat_channel?(chat_channel)
+      return false if !Chat.anonymous_public_channel_access_allowed?
+      return false if !chat_channel&.category_channel?
+
+      Guardian.new(nil).can_preview_chat_channel?(chat_channel)
+    end
+
     def can_see_chat_message?(message)
       return false if !can_preview_chat_channel?(message.chat_channel)
       return true if !message.trashed?

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -225,6 +225,31 @@ RSpec.describe Chat::GuardianExtensions do
       end
     end
 
+    describe "#can_preview_anonymous_public_chat_channel?" do
+      before do
+        SiteSetting.enable_public_channels = true
+        SiteSetting.chat_allowed_groups =
+          "#{Group::AUTO_GROUPS[:everyone]}|#{Group::AUTO_GROUPS[:anonymous_users]}"
+      end
+
+      it "returns true for channels backed by categories anonymous users can see" do
+        expect(guardian.can_preview_anonymous_public_chat_channel?(channel)).to eq(true)
+      end
+
+      it "returns false for private category channels visible only to the user" do
+        category =
+          Fabricate(
+            :private_category,
+            group: Fabricate(:group, users: [user]),
+            permission_type: CategoryGroup.permission_types[:readonly],
+          )
+        channel.update!(chatable: category)
+
+        expect(guardian.can_preview_chat_channel?(channel)).to eq(true)
+        expect(guardian.can_preview_anonymous_public_chat_channel?(channel)).to eq(false)
+      end
+    end
+
     describe "#can_post_in_chatable?" do
       alias_matcher :be_able_to_post_in_chatable, :be_can_post_in_chatable
 

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -114,6 +114,63 @@ RSpec.describe Chat::Api::ChannelMessagesController do
       end
     end
 
+    context "when user can only see a readonly category channel" do
+      fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+      fab!(:channel) do
+        category =
+          Fabricate(
+            :private_category,
+            group: readonly_group,
+            permission_type: CategoryGroup.permission_types[:readonly],
+          )
+        Fabricate(:category_channel, chatable: category)
+      end
+      fab!(:restricted_message) do
+        Fabricate(
+          :chat_message,
+          chat_channel: channel,
+          message: "Confidential restricted channel history",
+        )
+      end
+
+      it "does not expose the channel messages" do
+        get "/chat/api/channels/#{channel.id}/messages"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(response.body).not_to include(restricted_message.message)
+      end
+    end
+
+    context "when logged-in user can only read an anonymous-public category channel" do
+      fab!(:channel) do
+        category = Fabricate(:category)
+        category.set_permissions(everyone: :readonly)
+        category.save!
+        Fabricate(:category_channel, chatable: category)
+      end
+      fab!(:message) { Fabricate(:chat_message, chat_channel: channel) }
+
+      before do
+        SiteSetting.chat_allowed_groups =
+          "#{Group::AUTO_GROUPS[:everyone]}|#{Group::AUTO_GROUPS[:anonymous_users]}"
+      end
+
+      it "exposes the same channel messages anonymous users can read" do
+        expect(current_user.guardian.can_join_chat_channel?(channel)).to eq(false)
+        expect(current_user.guardian.can_preview_anonymous_public_chat_channel?(channel)).to eq(
+          true,
+        )
+
+        get "/chat/api/channels/#{channel.id}/messages"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["messages"].map { |message| message["id"] }).to contain_exactly(
+          message.id,
+        )
+      end
+    end
+
     context "when page_size is above limit" do
       fab!(:messages) { Fabricate.times(5, :chat_message, chat_channel: channel) }
 

--- a/plugins/chat/spec/requests/chat/api/channel_pins_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_pins_controller_spec.rb
@@ -72,6 +72,38 @@ RSpec.describe Chat::Api::ChannelPinsController do
         expect(response.status).to eq(403)
       end
     end
+
+    context "when user can only see a readonly category channel" do
+      fab!(:readonly_group) { Fabricate(:group, users: [user]) }
+      fab!(:channel) do
+        category =
+          Fabricate(
+            :private_category,
+            group: readonly_group,
+            permission_type: CategoryGroup.permission_types[:readonly],
+          )
+        Fabricate(:category_channel, chatable: category)
+      end
+      fab!(:message) do
+        Fabricate(
+          :chat_message,
+          chat_channel: channel,
+          message: "Confidential restricted pinned message",
+        )
+      end
+
+      before { sign_in(user) }
+
+      it "does not expose pinned messages" do
+        Fabricate(:chat_pinned_message, chat_channel: channel, chat_message: message)
+
+        get "/chat/api/channels/#{channel.id}/pins"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(response.body).not_to include(message.message)
+      end
+    end
   end
 
   describe "#mark_read" do

--- a/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
@@ -91,6 +91,36 @@ RSpec.describe Chat::Api::ChannelThreadMessagesController do
       end
     end
 
+    context "when user can only see a readonly category channel" do
+      fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+      fab!(:thread) do
+        category =
+          Fabricate(
+            :private_category,
+            group: readonly_group,
+            permission_type: CategoryGroup.permission_types[:readonly],
+          )
+        channel = Fabricate(:category_channel, chatable: category, threading_enabled: true)
+        Fabricate(:chat_thread, channel:)
+      end
+      fab!(:restricted_message) do
+        Fabricate(
+          :chat_message,
+          chat_channel: thread.channel,
+          thread:,
+          message: "Confidential restricted thread history",
+        )
+      end
+
+      it "does not expose the thread messages" do
+        get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(response.body).not_to include(restricted_message.message)
+      end
+    end
+
     context "when page_size is above limit" do
       fab!(:message_3) { Fabricate(:chat_message, thread:, chat_channel: thread.channel) }
 

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -138,6 +138,37 @@ RSpec.describe Chat::Api::ChannelThreadsController do
         end
       end
 
+      context "when user can only see a readonly category channel" do
+        fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+        fab!(:readonly_channel) do
+          category =
+            Fabricate(
+              :private_category,
+              group: readonly_group,
+              permission_type: CategoryGroup.permission_types[:readonly],
+            )
+          Fabricate(:category_channel, chatable: category, threading_enabled: true)
+        end
+        fab!(:restricted_message) do
+          Fabricate(
+            :chat_message,
+            chat_channel: readonly_channel,
+            message: "Confidential restricted thread lookup",
+          )
+        end
+        fab!(:thread) do
+          Fabricate(:chat_thread, channel: readonly_channel, original_message: restricted_message)
+        end
+
+        it "does not expose the thread" do
+          get "/chat/api/channels/#{readonly_channel.id}/threads/#{thread.id}"
+
+          expect(response.status).to eq(403)
+          expect(response.parsed_body["error_type"]).to eq("invalid_access")
+          expect(response.body).not_to include(restricted_message.message)
+        end
+      end
+
       context "when user cannot chat" do
         before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:trust_level_4] }
 
@@ -225,6 +256,43 @@ RSpec.describe Chat::Api::ChannelThreadsController do
       it "returns 404" do
         get "/chat/api/channels/#{public_channel.id}/threads"
         expect(response.status).to eq(403)
+      end
+    end
+
+    context "when user can only see a readonly category channel" do
+      fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+      fab!(:readonly_channel) do
+        category =
+          Fabricate(
+            :private_category,
+            group: readonly_group,
+            permission_type: CategoryGroup.permission_types[:readonly],
+          )
+        Fabricate(:category_channel, chatable: category, threading_enabled: true)
+      end
+      fab!(:restricted_message) do
+        Fabricate(
+          :chat_message,
+          chat_channel: readonly_channel,
+          message: "Confidential restricted thread list",
+        )
+      end
+
+      before do
+        Fabricate(
+          :chat_thread,
+          channel: readonly_channel,
+          original_message: restricted_message,
+          with_replies: 1,
+        )
+      end
+
+      it "does not expose thread list messages" do
+        get "/chat/api/channels/#{readonly_channel.id}/threads"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(response.body).not_to include(restricted_message.message)
       end
     end
 

--- a/plugins/chat/spec/requests/chat/api/search_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/search_controller_spec.rb
@@ -140,6 +140,37 @@ RSpec.describe Chat::Api::SearchController do
 
           expect(response.status).to eq(200)
         end
+
+        context "when channel_id refers to a readonly category channel" do
+          fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+          fab!(:readonly_channel) do
+            category =
+              Fabricate(
+                :private_category,
+                group: readonly_group,
+                permission_type: CategoryGroup.permission_types[:readonly],
+              )
+            Fabricate(:category_channel, chatable: category)
+          end
+          fab!(:restricted_message) do
+            Fabricate(
+              :chat_message,
+              chat_channel: readonly_channel,
+              message: "Confidential restricted search message",
+            )
+          end
+
+          it "does not expose scoped search results" do
+            get "/chat/api/search.json",
+                params: {
+                  query: restricted_message.message,
+                  channel_id: readonly_channel.id,
+                }
+
+            expect(response.status).to eq(404)
+            expect(response.body).not_to include(restricted_message.message)
+          end
+        end
       end
     end
   end

--- a/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
@@ -66,7 +66,10 @@ RSpec.describe Chat::ListChannelMessages do
     let(:params) { { channel_id:, **optional_params } }
     let(:dependencies) { { guardian: } }
 
-    before { channel.add(user) }
+    before do
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+      channel.add(user)
+    end
 
     context "when data is not valid" do
       let(:channel_id) { nil }

--- a/plugins/chat/spec/services/chat/list_channel_pins_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_pins_spec.rb
@@ -45,6 +45,21 @@ RSpec.describe Chat::ListChannelPins do
       it { is_expected.to fail_a_policy(:can_view_channel) }
     end
 
+    context "when anonymous public channel access is allowed" do
+      let(:guardian) { Guardian.new(nil) }
+
+      before do
+        SiteSetting.chat_allowed_groups =
+          "#{Group::AUTO_GROUPS[:everyone]}|#{Group::AUTO_GROUPS[:anonymous_users]}"
+      end
+
+      it { is_expected.to run_successfully }
+
+      it "returns pinned messages" do
+        expect(result[:pins]).to contain_exactly(pin_1, pin_2)
+      end
+    end
+
     context "when all conditions are met" do
       it { is_expected.to run_successfully }
 

--- a/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
@@ -94,7 +94,10 @@ RSpec.describe Chat::ListChannelThreadMessages do
     let(:params) { { thread_id:, channel_id: thread.channel_id, **optional_params } }
     let(:dependencies) { { guardian: } }
 
-    before { thread.channel.add(user) }
+    before do
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+      thread.channel.add(user)
+    end
 
     context "when data is not valid" do
       let(:thread_id) { nil }

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe ::Chat::LookupChannelThreads do
   let(:params) { { channel_id:, limit:, offset: } }
   let(:dependencies) { { guardian: } }
 
+  before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone] }
+
   context "when data is invalid" do
     let(:channel_id) { nil }
 
@@ -112,6 +114,21 @@ RSpec.describe ::Chat::LookupChannelThreads do
 
   context "when channel cannot be previewed" do
     fab!(:channel) { Fabricate(:private_category_channel, threading_enabled: true) }
+
+    it { is_expected.to fail_a_policy(:can_view_channel) }
+  end
+
+  context "when the user can only see a readonly category channel" do
+    fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+    fab!(:channel) do
+      category =
+        Fabricate(
+          :private_category,
+          group: readonly_group,
+          permission_type: CategoryGroup.permission_types[:readonly],
+        )
+      Fabricate(:category_channel, chatable: category, threading_enabled: true)
+    end
 
     it { is_expected.to fail_a_policy(:can_view_channel) }
   end

--- a/plugins/chat/spec/services/chat/lookup_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_thread_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Chat::LookupThread do
     let(:params) { { thread_id: thread.id, channel_id: thread.channel_id } }
     let(:dependencies) { { guardian: } }
 
+    before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone] }
+
     context "when all steps pass" do
       it { is_expected.to run_successfully }
 
@@ -47,6 +49,23 @@ RSpec.describe Chat::LookupThread do
 
     context "when user cannot see channel" do
       before { thread.update!(channel: private_channel) }
+
+      it { is_expected.to fail_a_policy(:invalid_access) }
+    end
+
+    context "when the user can only see a readonly category channel" do
+      fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+      fab!(:readonly_channel) do
+        category =
+          Fabricate(
+            :private_category,
+            group: readonly_group,
+            permission_type: CategoryGroup.permission_types[:readonly],
+          )
+        Fabricate(:category_channel, chatable: category, threading_enabled: true)
+      end
+
+      before { thread.update!(channel: readonly_channel) }
 
       it { is_expected.to fail_a_policy(:invalid_access) }
     end

--- a/plugins/chat/spec/services/chat/search_message_spec.rb
+++ b/plugins/chat/spec/services/chat/search_message_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Chat::SearchMessage do
     before do
       SearchIndexer.enable
       SiteSetting.chat_enabled = true
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
     end
 
     context "when contract is not valid" do
@@ -41,6 +42,21 @@ RSpec.describe Chat::SearchMessage do
 
       context "when the user cannot view the channel" do
         fab!(:channel, :direct_message_channel)
+
+        it { is_expected.to fail_a_policy(:can_view_channel) }
+      end
+
+      context "when the user can only see a readonly category channel" do
+        fab!(:readonly_group) { Fabricate(:group, users: [current_user]) }
+        fab!(:channel) do
+          category =
+            Fabricate(
+              :private_category,
+              group: readonly_group,
+              permission_type: CategoryGroup.permission_types[:readonly],
+            )
+          Fabricate(:category_channel, chatable: category)
+        end
 
         it { is_expected.to fail_a_policy(:can_view_channel) }
       end


### PR DESCRIPTION
### Description 

Previously, authenticated chat reads could use category preview access, allowing users with readonly category access to fetch restricted chat message history by known channel or thread IDs.

This change requires join eligibility for authenticated message-bearing chat reads while preserving access to channels that are genuinely anonymous-public.