### PR TITLE
DEV: Enforce bounce scores per email address

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -577,8 +577,7 @@ class Admin::UsersController < Admin::StaffController
 
   def reset_bounce_score
     guardian.ensure_can_reset_bounce_score!(@user)
-    @user.user_stat&.reset_bounce_score!
-    EmailBounceScore.for_user(@user).delete_all
+    EmailBounceScore.reset_for_user!(@user)
     StaffActionLogger.new(current_user).log_reset_bounce_score(@user)
     render json: success_json
   end

--- a/app/jobs/regular/notify_mailing_list_subscribers.rb
+++ b/app/jobs/regular/notify_mailing_list_subscribers.rb
@@ -109,7 +109,7 @@ module Jobs
             next
           end
 
-          if user.user_stat.bounce_score >= SiteSetting.bounce_score_threshold
+          if !EmailBounceScore.deliverable?(user.email)
             skip(
               user.email,
               user.id,

--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -82,12 +82,17 @@ module Jobs
         # erode bounce score each time we send an email
         # this means that we are punished a lot less for bounces
         # and we can recover more quickly
-        erode = SiteSetting.bounce_score_erode_on_send
-        UserStat.erode_bounce_score!(user.id, erode)
-        EmailBounceScore.erode!(to_address, erode)
+        EmailBounceScore.erode!(to_address, SiteSetting.bounce_score_erode_on_send)
       else
         skip_reason_type
       end
+    end
+
+    # a digest consults this at both gates below, and the job only ever sends to
+    # the one address, so ask the ledger once
+    def deliverable?(address)
+      @deliverable = EmailBounceScore.deliverable?(address) if @deliverable.nil?
+      @deliverable
     end
 
     def set_skip_context(type, user_id, to_address, post_id)
@@ -103,8 +108,9 @@ module Jobs
       notification_data_hash = args[:notification_data_hash]
       email_token = args[:email_token]
       to_address = args[:to_address]
+      recipient = to_address.presence || user.email
 
-      set_skip_context(type, user.id, to_address || user.email, post.try(:id))
+      set_skip_context(type, user.id, recipient, post.try(:id))
 
       if user.anonymous?
         return skip_message(SkippedEmailLog.reason_types[:user_email_anonymous_user])
@@ -126,7 +132,7 @@ module Jobs
         return if user.bot? || user.anonymous? || !user.active || user.suspended? || user.staged
 
         return if !user.user_stat
-        return if user.user_stat.bounce_score >= SiteSetting.bounce_score_threshold
+        return if !deliverable?(recipient)
 
         return if !user.user_option
         return if !user.user_option.email_digests
@@ -224,8 +230,7 @@ module Jobs
         return skip_message(SkippedEmailLog.reason_types[:exceeded_emails_limit])
       end
 
-      if !EmailLog::CRITICAL_EMAIL_TYPES.include?(type) &&
-           user.user_stat.bounce_score >= SiteSetting.bounce_score_threshold
+      if !EmailLog::CRITICAL_EMAIL_TYPES.include?(type) && !deliverable?(recipient)
         return skip_message(SkippedEmailLog.reason_types[:exceeded_bounces_limit])
       end
 

--- a/app/jobs/scheduled/enqueue_digest_emails.rb
+++ b/app/jobs/scheduled/enqueue_digest_emails.rb
@@ -28,8 +28,8 @@ module Jobs
             "COALESCE(user_options.digest_after_minutes, ?) > 0",
             SiteSetting.default_email_digest_frequency,
           )
-          .where("user_stats.bounce_score < ?", SiteSetting.bounce_score_threshold)
           .where("user_emails.primary")
+          .where(EmailBounceScore.deliverable_sql)
           .where(
             "COALESCE(user_stats.digest_attempted_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * COALESCE(user_options.digest_after_minutes, ?))",
             SiteSetting.default_email_digest_frequency,

--- a/app/models/email_bounce_score.rb
+++ b/app/models/email_bounce_score.rb
@@ -3,6 +3,10 @@
 # Per-address bounce state, keyed case-insensitively. Every write goes through
 # the class methods below rather than through Active Record, so that concurrent
 # bounces for the same address can't lose an update.
+#
+# This table decides whether an address may be emailed. `user_stats.bounce_score`
+# and `user_stats.reset_bounce_score_after` are a derived mirror of the row for
+# the user's current primary address, kept for the admin API and for reporting.
 class EmailBounceScore < ActiveRecord::Base
   def self.canonicalize(email)
     Email.downcase(email.to_s.strip)
@@ -16,49 +20,95 @@ class EmailBounceScore < ActiveRecord::Base
     where(email: user.user_emails.select("lower(user_emails.email)"))
   end
 
+  def self.deliverable?(email)
+    score_for(email) < SiteSetting.bounce_score_threshold
+  end
+
+  # An address is in this table only while it is in bad standing, so membership
+  # has to be tested with an anti-join: joining the table in would drop every
+  # address that has never bounced. Correlates against `user_emails`, which the
+  # caller is expected to have joined already.
+  def self.deliverable_sql
+    sql = <<~SQL
+      NOT EXISTS (
+        SELECT 1
+        FROM email_bounce_scores
+        WHERE email_bounce_scores.email = lower(user_emails.email)
+          AND email_bounce_scores.bounce_score >= ?
+      )
+    SQL
+
+    sanitize_sql_array([sql, SiteSetting.bounce_score_threshold])
+  end
+
+  # Returns the row as it stands after the bounce, or nil for an address we
+  # could never have sent to. The upsert either inserts `score` or adds it, so
+  # the score before this bounce is always `bounce_score - score`.
   def self.record_bounce!(email, score)
     email = canonicalize(email)
     return if !Email.is_valid?(email)
 
-    DB.exec(
-      <<~SQL,
-      INSERT INTO email_bounce_scores
-        (email, bounce_score, reset_bounce_score_after, created_at, updated_at)
-      VALUES
-        (:email, :score, :reset_after, :now, :now)
-      ON CONFLICT (email)
-      DO UPDATE SET
-        bounce_score = email_bounce_scores.bounce_score + EXCLUDED.bounce_score,
-        reset_bounce_score_after = EXCLUDED.reset_bounce_score_after,
-        updated_at = EXCLUDED.updated_at
-    SQL
-      email:,
-      score:,
-      reset_after: SiteSetting.reset_bounce_score_after_days.days.from_now,
-      now: Time.zone.now,
-    )
+    recorded =
+      DB.query(
+        <<~SQL,
+        INSERT INTO email_bounce_scores
+          (email, bounce_score, reset_bounce_score_after, created_at, updated_at)
+        VALUES
+          (:email, :score, :reset_after, :now, :now)
+        ON CONFLICT (email)
+        DO UPDATE SET
+          bounce_score = email_bounce_scores.bounce_score + EXCLUDED.bounce_score,
+          reset_bounce_score_after = EXCLUDED.reset_bounce_score_after,
+          updated_at = EXCLUDED.updated_at
+        RETURNING bounce_score, reset_bounce_score_after
+      SQL
+        email:,
+        score:,
+        reset_after: SiteSetting.reset_bounce_score_after_days.days.from_now,
+        now: Time.zone.now,
+      ).first
+
+    sync_user_stat!(email)
+    recorded
   end
 
   def self.erode!(email, amount)
     return if amount <= 0
 
-    for_email(email).where("bounce_score > 0").update_all(
-      ["bounce_score = GREATEST(bounce_score - ?, 0), updated_at = ?", amount, Time.zone.now],
-    )
+    eroded =
+      for_email(email).where("bounce_score > 0").update_all(
+        ["bounce_score = GREATEST(bounce_score - ?, 0), updated_at = ?", amount, Time.zone.now],
+      )
+
+    sync_user_stat!(email) if eroded > 0
   end
 
   def self.reset!(email)
-    for_email(email).delete_all
+    sync_user_stat!(email) if for_email(email).delete_all > 0
+  end
+
+  def self.reset_for_user!(user)
+    for_user(user).delete_all
+    UserStat.refresh_bounce_score(user.id)
   end
 
   def self.score_for(email)
     for_email(email).pick(:bounce_score).to_f
   end
 
-  # rows only matter while an address is in bad standing, so drop the ones that
+  # `user_stats` mirrors the ledger row of the user's primary address, so a
+  # write here has to tell whoever owns this one as theirs.
+  def self.sync_user_stat!(email)
+    UserStat.refresh_bounce_score(User.with_primary_email(canonicalize(email)).pick(:id))
+  end
+
+  # Rows only matter while an address is in bad standing, so drop the ones that
   # have eroded away or whose window has run out
   def self.ensure_consistency!
     where("reset_bounce_score_after < now() OR bounce_score <= 0").delete_all
+    # here rather than in `UserStat.ensure_consistency!` so it runs after the
+    # rows it has to account for are gone
+    UserStat.refresh_bounce_scores!
   end
 end
 

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -65,10 +65,7 @@ class EmailToken < ActiveRecord::Base
       # the user acted on an email sent to this address, so it is proven
       # deliverable and previous bounces (e.g. from a typo fixed on the
       # activation screen) no longer apply
-      if !skip_reset_bounce_score
-        user.user_stat&.reset_bounce_score!
-        EmailBounceScore.reset!(email_token.email)
-      end
+      EmailBounceScore.reset!(email_token.email) if !skip_reset_bounce_score
       user.set_automatic_groups
       DiscourseEvent.trigger(:user_confirmed_email, user, scope)
       Invite.redeem_for_existing_user(user) if scope == EmailToken.scopes[:signup]

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -22,6 +22,13 @@ class UserEmail < ActiveRecord::Base
   before_save -> { destroy_email_tokens(email_was) }, if: :will_save_change_to_email?
 
   after_destroy { destroy_email_tokens(email) }
+
+  # Which address is primary, and what it says, both decide the user's mirrored
+  # bounce score. Deliberately unconditional: Rails collapses several saves of
+  # one row in a transaction into a single callback carrying only the last
+  # save's changes, so a `saved_change_to_email?` guard would miss real changes.
+  after_commit(on: %i[create update destroy]) { UserStat.refresh_bounce_score(user_id) }
+
   def self.ensure_consistency!
     user_ids_without_primary_email = DB.query_single <<~SQL
       SELECT u.id

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -4,7 +4,6 @@ class UserStat < ActiveRecord::Base
   after_save :trigger_badges
 
   def self.ensure_consistency!(last_seen = 1.hour.ago)
-    reset_bounce_scores
     update_distinct_badge_count
     update_view_counts(last_seen)
     update_first_unread(last_seen)
@@ -140,20 +139,83 @@ class UserStat < ActiveRecord::Base
     SQL
   end
 
-  def self.reset_bounce_scores
-    UserStat
-      .where("reset_bounce_score_after < now()")
-      .where("bounce_score > 0")
-      .update_all(bounce_score: 0)
+  # `bounce_score` / `reset_bounce_score_after` mirror the `email_bounce_scores`
+  # row for the user's current primary address — 0 / NULL when there is none.
+  # Best effort, and deferred out of the caller's transaction: the columns are
+  # derived, so refreshing them must never roll back, or fail, the write that
+  # changed the underlying score. `refresh_bounce_scores!` repairs the rest.
+  def self.refresh_bounce_score(user_id)
+    DB.after_commit do
+      refresh_bounce_score!(user_id)
+    rescue => e
+      Discourse.warn_exception(e, message: "Failed to refresh the bounce score of ##{user_id}")
+    end
   end
 
-  def self.erode_bounce_score!(user_id, amount)
-    return if amount <= 0
+  # The two `LEFT JOIN`s are what make "no ledger row" and "no primary address"
+  # both mean clean, rather than leaving a stale mirror behind. The
+  # `IS DISTINCT FROM` guard is what lets `UserEmail` call this on every save:
+  # a refresh that changes nothing writes nothing, so it dirties no page.
+  def self.refresh_bounce_score!(user_id)
+    return if user_id.blank?
 
-    UserStat
-      .where(user_id: user_id)
-      .where("bounce_score > 0")
-      .update_all(["bounce_score = GREATEST(bounce_score - ?, 0)", amount])
+    DB.exec(<<~SQL, user_id:)
+      UPDATE user_stats
+      SET bounce_score = COALESCE(email_bounce_scores.bounce_score, 0),
+          reset_bounce_score_after = email_bounce_scores.reset_bounce_score_after
+      FROM (VALUES (:user_id::bigint)) AS seed(user_id)
+      LEFT JOIN user_emails
+        ON user_emails.user_id = seed.user_id AND user_emails.primary
+      LEFT JOIN email_bounce_scores
+        ON email_bounce_scores.email = lower(user_emails.email)
+      WHERE user_stats.user_id = seed.user_id
+        AND (
+          user_stats.bounce_score
+            IS DISTINCT FROM COALESCE(email_bounce_scores.bounce_score, 0) OR
+          user_stats.reset_bounce_score_after
+            IS DISTINCT FROM email_bounce_scores.reset_bounce_score_after
+        )
+    SQL
+  end
+
+  # Repairs mirrors whose ledger row was just swept away, plus any that drifted
+  # because a primary address changed without the callback reaching them. This
+  # is what makes `refresh_bounce_score` safe to swallow its own failures.
+  def self.refresh_bounce_scores!
+    # Driven from the ledger, which only holds addresses in bad standing
+    DB.exec(<<~SQL)
+      UPDATE user_stats
+      SET bounce_score = email_bounce_scores.bounce_score,
+          reset_bounce_score_after = email_bounce_scores.reset_bounce_score_after
+      FROM email_bounce_scores
+      INNER JOIN user_emails
+        ON user_emails.primary AND lower(user_emails.email) = email_bounce_scores.email
+      WHERE user_emails.user_id = user_stats.user_id
+        AND (
+          user_stats.bounce_score IS DISTINCT FROM email_bounce_scores.bounce_score OR
+          user_stats.reset_bounce_score_after
+            IS DISTINCT FROM email_bounce_scores.reset_bounce_score_after
+        )
+    SQL
+
+    # A full scan of `user_stats`, like the expiry sweep it replaces. Keyed on
+    # the score alone because that sweep zeroed the score but left the timestamp
+    # behind, so every user who has ever bounced carries an orphaned one; those
+    # render as nothing, and rewriting them all would make the first run after
+    # an upgrade a site-wide UPDATE.
+    DB.exec(<<~SQL)
+      UPDATE user_stats
+      SET bounce_score = 0, reset_bounce_score_after = NULL
+      WHERE bounce_score <> 0
+        AND NOT EXISTS (
+          SELECT 1
+          FROM user_emails
+          INNER JOIN email_bounce_scores
+            ON email_bounce_scores.email = lower(user_emails.email)
+          WHERE user_emails.user_id = user_stats.user_id
+            AND user_emails.primary
+        )
+    SQL
   end
 
   # Updates the denormalized view counts for all users
@@ -291,12 +353,6 @@ class UserStat < ActiveRecord::Base
 
   def update_time_read!
     UserStat.update_time_read!(id)
-  end
-
-  def reset_bounce_score!
-    return if bounce_score == 0 && reset_bounce_score_after.nil?
-
-    update_columns(reset_bounce_score_after: nil, bounce_score: 0)
   end
 
   def self.last_seen_key(id)

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -379,8 +379,8 @@ module Email
 
     # Records a bounce for an email we sent: claims the email log so that
     # duplicate reports of the same bounce score only once, then charges the
-    # address it was sent to — and the user as well, but only while that address
-    # is still theirs, so late reports can't penalize an unrelated account.
+    # address it was sent to. Whoever owns that address is told only when it is
+    # their primary, which is exactly when the suppression reaches them.
     def self.record_bounce(email_log, permanent:, bounce_error_code: nil)
       return false if email_log.nil?
 
@@ -389,13 +389,12 @@ module Email
       # the claim can only be made once, so it shares a transaction with the
       # score it authorizes: failing in between would leave the provider's
       # retry with nothing to do
+      recorded = nil
       claimed =
         EmailLog.transaction do
-          if !email_log.claim_bounce(permanent: permanent, bounce_error_code: bounce_error_code)
-            next false
-          end
+          next false if !email_log.claim_bounce(permanent:, bounce_error_code:)
 
-          EmailBounceScore.record_bounce!(email_log.to_address, score)
+          recorded = EmailBounceScore.record_bounce!(email_log.to_address, score)
           true
         end
 
@@ -403,10 +402,7 @@ module Email
 
       # deliberately outside the transaction above: crossing the threshold
       # creates a topic, which has no business holding the claim's row lock
-      if email_log.user_id.present?
-        user = User.find_by_email(email_log.to_address)
-        update_bounce_score_for(user, score) if user && user.id == email_log.user_id
-      end
+      revoke_email(email_log.to_address, recorded, score)
 
       true
     end
@@ -414,36 +410,28 @@ module Email
     def self.update_bounce_score(email, score)
       # unlike a bounce we can tie back to an email log, this address is taken
       # from the report itself, so only trust it when it names a known account
-      return if !(user = User.find_by_email(email))
+      return if !User.find_by_email(email)
 
-      EmailBounceScore.record_bounce!(email, score)
-      update_bounce_score_for(user, score)
+      revoke_email(email, EmailBounceScore.record_bounce!(email, score), score)
     end
 
-    def self.update_bounce_score_for(user, score)
-      user_stat = user.user_stat
-      crossed_threshold = false
+    # Only the user this address is the *primary* of actually stops receiving
+    # mail, and only the bounce that pushes it over is worth telling them about.
+    def self.revoke_email(email, recorded, score)
+      return if recorded.nil?
 
-      user_stat.with_lock do
-        threshold = SiteSetting.bounce_score_threshold
-        old_bounce_score = user_stat.bounce_score
-        new_bounce_score = old_bounce_score + score
-        crossed_threshold = old_bounce_score < threshold && new_bounce_score >= threshold
+      threshold = SiteSetting.bounce_score_threshold
+      return if recorded.bounce_score < threshold
+      return if recorded.bounce_score - score >= threshold
+      return if !(user = User.find_by_email(email, primary: true))
 
-        user_stat.bounce_score = new_bounce_score
-        user_stat.reset_bounce_score_after = SiteSetting.reset_bounce_score_after_days.days.from_now
-        user_stat.save!
-      end
-
-      if crossed_threshold
-        # NOTE: we check bounce_score before sending emails
-        # So log we revoked the email...
-        reason =
-          I18n.t("user.email.revoked", email: user.email, date: user_stat.reset_bounce_score_after)
-        StaffActionLogger.new(Discourse.system_user).log_revoke_email(user, reason)
-        # ... and PM the user
-        SystemMessage.create_from_system_user(user, :email_revoked)
-      end
+      # NOTE: we check bounce_score before sending emails
+      # So log we revoked the email...
+      reason =
+        I18n.t("user.email.revoked", email:, date: recorded.reset_bounce_score_after.in_time_zone)
+      StaffActionLogger.new(Discourse.system_user).log_revoke_email(user, reason)
+      # ... and PM the user
+      SystemMessage.create_from_system_user(user, :email_revoked)
     end
 
     def is_auto_generated?

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -155,7 +155,6 @@ class EmailUpdater
     # the user acted on an email sent to the new address, so it is proven
     # deliverable — but adding a secondary says nothing about the primary
     EmailBounceScore.reset!(new_email)
-    @user.user_stat&.reset_bounce_score! if old_email.present?
 
     DiscourseEvent.trigger(:user_updated, @user, %w[email])
     @user.set_automatic_groups

--- a/script/import_scripts/friendsmegplus.rb
+++ b/script/import_scripts/friendsmegplus.rb
@@ -44,7 +44,6 @@ class ImportScripts::FMGP < ImportScripts::Base
     # handle the same video extension as the rest of Discourse
     SiteSetting.authorized_extensions =
       (SiteSetting.authorized_extensions.split("|") + %w[mp4 mov webm ogv]).uniq.join("|")
-    @invalid_bounce_score = 5.0
     @min_title_words = 3
     @max_title_words = 14
     @min_title_characters = 12
@@ -334,12 +333,6 @@ class ImportScripts::FMGP < ImportScripts::Base
                 user_id: newuser.id,
                 provider_uid: id,
               )
-              # Do not send email to the invalid email addresses
-              # this can be removed after merging with #7162
-              s = UserStat.where(user_id: newuser.id).first
-              s.bounce_score = @invalid_bounce_score
-              s.reset_bounce_score_after = 1000.years.from_now
-              s.save
             end,
         }
       else

--- a/spec/jobs/enqueue_digest_emails_spec.rb
+++ b/spec/jobs/enqueue_digest_emails_spec.rb
@@ -87,9 +87,23 @@ RSpec.describe Jobs::EnqueueDigestEmails do
       expect(job.target_user_ids).not_to include(user.id)
     end
 
-    it "never returns users who have a bounce score above the threshold" do
-      user.user_stat.update!(bounce_score: SiteSetting.bounce_score_threshold + 1)
+    it "never returns users whose primary email is above the bounce score threshold" do
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold + 1)
       expect(job.target_user_ids).not_to include(user.id)
+    end
+
+    # bounce scores are only stored for addresses in bad standing, so joining
+    # that table in rather than testing it with an anti-join would drop every
+    # user who has never bounced and stop digests site-wide
+    it "returns users who have never bounced while other addresses are in bad standing" do
+      EmailBounceScore.record_bounce!("someone-else@example.com", 10)
+      expect(job.target_user_ids).to include(user.id)
+    end
+
+    it "returns users whose secondary email is above the bounce score threshold" do
+      secondary = Fabricate(:secondary_email, user: user)
+      EmailBounceScore.record_bounce!(secondary.email, SiteSetting.bounce_score_threshold + 1)
+      expect(job.target_user_ids).to include(user.id)
     end
 
     it "never returns users who doesn't have a primary email" do

--- a/spec/jobs/notify_mailing_list_subscribers_spec.rb
+++ b/spec/jobs/notify_mailing_list_subscribers_spec.rb
@@ -253,10 +253,13 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
 
       context "when bounce score was reached" do
         it "doesn't send any emails" do
-          mailing_list_user.user_stat.update(bounce_score: SiteSetting.bounce_score_threshold + 1)
+          EmailBounceScore.record_bounce!(
+            mailing_list_user.email,
+            SiteSetting.bounce_score_threshold + 1,
+          )
 
-          Jobs::NotifyMailingListSubscribers.new.execute(post_id: post.id)
           UserNotifications.expects(:mailing_list_notify).with(mailing_list_user, post).never
+          Jobs::NotifyMailingListSubscribers.new.execute(post_id: post.id)
 
           expect(
             SkippedEmailLog.exists?(
@@ -267,6 +270,15 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
               reason_type: SkippedEmailLog.reason_types[:exceeded_bounces_limit],
             ),
           ).to eq(true)
+        end
+
+        it "still sends when it is a secondary email that bounced" do
+          secondary = Fabricate(:secondary_email, user: mailing_list_user)
+          EmailBounceScore.record_bounce!(secondary.email, SiteSetting.bounce_score_threshold + 1)
+
+          UserNotifications.expects(:mailing_list_notify).with(mailing_list_user, post).once
+
+          Jobs::NotifyMailingListSubscribers.new.execute(post_id: post.id)
         end
       end
     end

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -60,6 +60,40 @@ RSpec.describe Jobs::UserEmail do
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
+    context "when the primary email is above the bounce score threshold" do
+      before { EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold + 1) }
+
+      it "doesn't call the mailer" do
+        Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+        expect(ActionMailer::Base.deliveries).to eq([])
+      end
+
+      # unlike every other email type, a suppressed digest is not worth a row of
+      # its own — the enqueue job filters them out in bulk
+      it "doesn't log a skipped email" do
+        expect { Jobs::UserEmail.new.execute(type: :digest, user_id: user.id) }.not_to change {
+          SkippedEmailLog.count
+        }
+      end
+
+      it "still records the attempt so the next one is not brought forward" do
+        freeze_time
+
+        Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+
+        expect(user.user_stat.reload.digest_attempted_at).to eq_time(Time.zone.now)
+      end
+    end
+
+    it "still calls the mailer when only a secondary email is above the threshold" do
+      secondary = Fabricate(:secondary_email, user: user)
+      EmailBounceScore.record_bounce!(secondary.email, SiteSetting.bounce_score_threshold + 1)
+
+      Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+
+      expect(ActionMailer::Base.deliveries.first.to).to contain_exactly(user.email)
+    end
+
     it "doesn't call the mailer when the user has disabled email digests" do
       user.user_option.update!(email_digests: false)
       Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
@@ -124,7 +158,7 @@ RSpec.describe Jobs::UserEmail do
   context "with bounce score" do
     it "always sends critical emails when bounce score threshold has been reached" do
       email_token = Fabricate(:email_token)
-      user.user_stat.update(bounce_score: SiteSetting.bounce_score_threshold + 1)
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold + 1)
 
       Jobs::CriticalUserEmail.new.execute(
         type: "signup",
@@ -751,8 +785,6 @@ RSpec.describe Jobs::UserEmail do
 
       it "erodes bounce score each time an email is sent" do
         SiteSetting.bounce_score_erode_on_send = 0.2
-
-        user.user_stat.update(bounce_score: 2.7)
         EmailBounceScore.record_bounce!(user.email, 2.7)
 
         Jobs::UserEmail.new.execute(
@@ -762,11 +794,12 @@ RSpec.describe Jobs::UserEmail do
           post_id: post.id,
         )
 
-        user.user_stat.reload
-        expect(user.user_stat.bounce_score).to eq(2.5)
         expect(EmailBounceScore.score_for(user.email)).to eq(2.5)
+        expect(user.user_stat.reload.bounce_score).to eq(2.5)
+      end
 
-        user.user_stat.update(bounce_score: 0)
+      it "leaves a score that is already zero alone" do
+        SiteSetting.bounce_score_erode_on_send = 0.2
 
         Jobs::UserEmail.new.execute(
           type: :user_mentioned,
@@ -775,12 +808,12 @@ RSpec.describe Jobs::UserEmail do
           post_id: post.id,
         )
 
-        user.user_stat.reload
-        expect(user.user_stat.bounce_score).to eq(0)
+        expect(EmailBounceScore.score_for(user.email)).to eq(0)
+        expect(user.user_stat.reload.bounce_score).to eq(0)
       end
 
       it "does not send notification if bounce threshold is reached" do
-        user.user_stat.update(bounce_score: SiteSetting.bounce_score_threshold)
+        EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold)
 
         expect do
           Jobs::UserEmail.new.execute(
@@ -800,6 +833,36 @@ RSpec.describe Jobs::UserEmail do
             reason_type: SkippedEmailLog.reason_types[:exceeded_bounces_limit],
           ),
         ).to eq(true)
+      end
+
+      it "gates on the address it is about to send to, not on the user" do
+        EmailBounceScore.record_bounce!("bouncing@example.com", SiteSetting.bounce_score_threshold)
+
+        expect do
+          Jobs::UserEmail.new.execute(
+            type: :user_mentioned,
+            user_id: user.id,
+            notification_id: notification.id,
+            post_id: post.id,
+            to_address: "bouncing@example.com",
+          )
+        end.to change { SkippedEmailLog.count }.by(1)
+
+        expect(ActionMailer::Base.deliveries).to eq([])
+      end
+
+      it "still sends to a clean address when the user's own address bounced" do
+        EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold)
+
+        Jobs::UserEmail.new.execute(
+          type: :user_mentioned,
+          user_id: user.id,
+          notification_id: notification.id,
+          post_id: post.id,
+          to_address: "clean@example.com",
+        )
+
+        expect(ActionMailer::Base.deliveries.first.to).to contain_exactly("clean@example.com")
       end
 
       it "doesn't send the mail if the user is using individual mailing list mode" do

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -147,8 +147,7 @@ RSpec.describe Email::Receiver do
     it "sends a system message once they reach the 'bounce_score_threshold'" do
       expect(user.active).to eq(true)
 
-      user.user_stat.bounce_score = SiteSetting.bounce_score_threshold - 1
-      user.user_stat.save!
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold - 1)
 
       SystemMessage.expects(:create_from_system_user).with(user, :email_revoked)
 
@@ -158,11 +157,59 @@ RSpec.describe Email::Receiver do
     it "sends a system message when a score eroded by sending crosses the threshold" do
       # every send erodes the score, so it is rarely a whole number by the time
       # it crosses
-      user.user_stat.update!(bounce_score: SiteSetting.bounce_score_threshold - 0.1)
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold - 0.1)
 
       SystemMessage.expects(:create_from_system_user).with(user, :email_revoked)
 
       expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+    end
+
+    it "does not send a system message before the threshold is reached" do
+      SystemMessage.expects(:create_from_system_user).never
+
+      expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+    end
+
+    it "does not send a second system message once the address is already over it" do
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold)
+
+      SystemMessage.expects(:create_from_system_user).never
+
+      expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+    end
+
+    it "still tells the address owner when the bounced mail had no user of its own" do
+      email_log.update!(user_id: nil)
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold - 1)
+
+      SystemMessage.expects(:create_from_system_user).with(user, :email_revoked)
+
+      expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+    end
+
+    it "keeps the bounce even when the user_stats mirror cannot be refreshed" do
+      UserStat.stubs(:refresh_bounce_score!).raises(StandardError.new("boom"))
+
+      expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+
+      expect(email_log.reload.bounced).to eq(true)
+      expect(EmailBounceScore.score_for(user.email)).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "does not claim the email was revoked when a secondary address crossed" do
+      user.user_emails.first.update!(email: "someone-else@example.com")
+      Fabricate(:secondary_email, user: user, email: "linux-admin@b-s-c.co.jp")
+      EmailBounceScore.record_bounce!(
+        "linux-admin@b-s-c.co.jp",
+        SiteSetting.bounce_score_threshold - 1,
+      )
+
+      SystemMessage.expects(:create_from_system_user).never
+
+      expect { process(:hard_bounce_via_verp) }.to raise_error(Email::Receiver::BouncedEmailError)
+      expect(EmailBounceScore.score_for("linux-admin@b-s-c.co.jp")).to eq(
+        SiteSetting.bounce_score_threshold - 1 + SiteSetting.hard_bounce_score,
+      )
     end
   end
 

--- a/spec/migrations/create_email_bounce_scores_spec.rb
+++ b/spec/migrations/create_email_bounce_scores_spec.rb
@@ -3,12 +3,16 @@
 require Rails.root.join("db/migrate/20260817214148_create_email_bounce_scores.rb")
 
 RSpec.describe CreateEmailBounceScores do
-  subject(:migrate) { described_class.new.migrate(:up) }
+  # dropped here rather than in a `before` so that the users each example sets
+  # up are still fabricated against a schema that has the table
+  subject(:migrate) do
+    ActiveRecord::Base.connection.drop_table(:email_bounce_scores)
+    described_class.new.migrate(:up)
+  end
 
   before do
     @verbose = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.connection.drop_table(:email_bounce_scores)
   end
 
   after { ActiveRecord::Migration.verbose = @verbose }

--- a/spec/models/email_bounce_score_spec.rb
+++ b/spec/models/email_bounce_score_spec.rb
@@ -1,6 +1,186 @@
 # frozen_string_literal: true
 
 RSpec.describe EmailBounceScore do
+  describe ".for_user" do
+    it "matches every address the user owns, whatever case they are stored in" do
+      user = Fabricate(:user, email: "primary@example.com")
+      Fabricate(:secondary_email, user: user, email: "secondary@example.com")
+      user.user_emails.update_all("email = upper(email)")
+      EmailBounceScore.record_bounce!("primary@example.com", 1.0)
+      EmailBounceScore.record_bounce!("secondary@example.com", 1.0)
+      EmailBounceScore.record_bounce!("someone-else@example.com", 1.0)
+
+      expect(EmailBounceScore.for_user(user).pluck(:email)).to contain_exactly(
+        "primary@example.com",
+        "secondary@example.com",
+      )
+    end
+  end
+
+  describe ".deliverable?" do
+    it "is true for an address that has never bounced" do
+      expect(EmailBounceScore.deliverable?("john@example.com")).to eq(true)
+    end
+
+    it "is false from the threshold up" do
+      EmailBounceScore.record_bounce!("john@example.com", SiteSetting.bounce_score_threshold)
+
+      expect(EmailBounceScore.deliverable?("john@example.com")).to eq(false)
+    end
+
+    it "is true below the threshold" do
+      EmailBounceScore.record_bounce!("john@example.com", SiteSetting.bounce_score_threshold - 1)
+
+      expect(EmailBounceScore.deliverable?("john@example.com")).to eq(true)
+    end
+
+    it "matches case-insensitively" do
+      EmailBounceScore.record_bounce!("john@example.com", SiteSetting.bounce_score_threshold)
+
+      expect(EmailBounceScore.deliverable?(" John@Example.COM ")).to eq(false)
+    end
+  end
+
+  describe ".deliverable_sql" do
+    def deliverable_user_ids
+      User
+        .joins(:user_emails)
+        .where("user_emails.primary")
+        .where(described_class.deliverable_sql)
+        .pluck(:id)
+    end
+
+    it "selects an address with no row at all" do
+      user = Fabricate(:user)
+
+      expect(deliverable_user_ids).to include(user.id)
+    end
+
+    it "selects an address whose row is below the threshold" do
+      user = Fabricate(:user)
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold - 1)
+
+      expect(deliverable_user_ids).to include(user.id)
+    end
+
+    it "rejects an address from the threshold up" do
+      user = Fabricate(:user)
+      EmailBounceScore.record_bounce!(user.email, SiteSetting.bounce_score_threshold)
+
+      expect(deliverable_user_ids).not_to include(user.id)
+    end
+
+    it "rejects an address stored in a different case than the ledger key" do
+      user = Fabricate(:user, email: "mixed@example.com")
+      EmailBounceScore.record_bounce!("mixed@example.com", SiteSetting.bounce_score_threshold)
+      user.user_emails.update_all(email: "MiXeD@Example.COM")
+
+      expect(deliverable_user_ids).not_to include(user.id)
+    end
+  end
+
+  describe "the user_stats mirror" do
+    fab!(:user)
+
+    it "follows a bounce, an erosion and a reset of the primary address" do
+      EmailBounceScore.record_bounce!(user.email, 3.0)
+      expect(user.user_stat.reload.bounce_score).to eq(3.0)
+      expect(user.user_stat.reset_bounce_score_after).to be_present
+
+      EmailBounceScore.erode!(user.email, 0.5)
+      expect(user.user_stat.reload.bounce_score).to eq(2.5)
+
+      EmailBounceScore.reset!(user.email)
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+      expect(user.user_stat.reset_bounce_score_after).to eq(nil)
+    end
+
+    it "canonicalizes the address it was handed before looking for the owner" do
+      EmailBounceScore.record_bounce!(user.email, 3.0)
+
+      EmailBounceScore.erode!(" #{user.email.upcase} ", 0.5)
+
+      expect(user.user_stat.reload.bounce_score).to eq(2.5)
+    end
+
+    it "ignores a bounce for an address the user only owns as a secondary" do
+      Fabricate(:secondary_email, user: user, email: "secondary@example.com")
+
+      EmailBounceScore.record_bounce!("secondary@example.com", 3.0)
+
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+    end
+
+    it "switches to the new address when the primary changes" do
+      EmailBounceScore.record_bounce!(user.email, 3.0)
+
+      user.primary_email.update!(email: "elsewhere@example.com")
+
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+      expect(EmailBounceScore.score_for("elsewhere@example.com")).to eq(0)
+    end
+
+    it "follows a secondary address that gets promoted to primary" do
+      secondary = Fabricate(:secondary_email, user: user, email: "secondary@example.com")
+      EmailBounceScore.record_bounce!("secondary@example.com", 3.0)
+
+      User.transaction do
+        user.primary_email.update!(primary: false)
+        secondary.update!(primary: true)
+      end
+
+      expect(user.user_stat.reload.bounce_score).to eq(3.0)
+    end
+
+    it "waits for the caller's transaction, so it can never roll the bounce back" do
+      ActiveRecord::Base.transaction do
+        EmailBounceScore.record_bounce!(user.email, 3.0)
+        expect(user.user_stat.reload.bounce_score).to eq(0)
+      end
+
+      expect(user.user_stat.reload.bounce_score).to eq(3.0)
+    end
+
+    it "is left alone when a bounce lands on an address nobody owns" do
+      EmailBounceScore.record_bounce!("nobody@example.com", 3.0)
+
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+    end
+
+    it "does not let a failure to sync take down the write that triggered it" do
+      UserStat.expects(:refresh_bounce_score!).raises(StandardError.new("boom"))
+
+      expect { user.primary_email.update!(email: "elsewhere@example.com") }.not_to raise_error
+      expect(user.reload.email).to eq("elsewhere@example.com")
+    end
+  end
+
+  describe ".reset_for_user!" do
+    fab!(:user)
+
+    it "clears every address the user owns" do
+      Fabricate(:secondary_email, user: user, email: "secondary@example.com")
+      EmailBounceScore.record_bounce!(user.email, 3.0)
+      EmailBounceScore.record_bounce!("secondary@example.com", 3.0)
+      EmailBounceScore.record_bounce!("someone-else@example.com", 3.0)
+
+      EmailBounceScore.reset_for_user!(user)
+
+      expect(EmailBounceScore.pluck(:email)).to contain_exactly("someone-else@example.com")
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+    end
+
+    it "clears the mirror of a user who has no primary address" do
+      EmailBounceScore.record_bounce!(user.email, 3.0)
+      user.user_emails.update_all(primary: false)
+
+      EmailBounceScore.reset_for_user!(user)
+
+      expect(user.user_stat.reload.bounce_score).to eq(0)
+      expect(user.user_stat.reset_bounce_score_after).to eq(nil)
+    end
+  end
+
   describe ".record_bounce!" do
     it "creates a row for the first bounce and accumulates on subsequent ones" do
       EmailBounceScore.record_bounce!("john@example.com", 1.0)
@@ -41,6 +221,19 @@ RSpec.describe EmailBounceScore do
       EmailBounceScore.record_bounce!("not an address", 1.0)
 
       expect(EmailBounceScore.count).to eq(0)
+    end
+
+    it "returns the row as it stands after the bounce" do
+      EmailBounceScore.record_bounce!("john@example.com", 1.0)
+
+      recorded = EmailBounceScore.record_bounce!("john@example.com", 2.0)
+
+      expect(recorded.bounce_score).to eq(3.0)
+      expect(recorded.reset_bounce_score_after).to be_present
+    end
+
+    it "returns nothing for an address it ignored" do
+      expect(EmailBounceScore.record_bounce!("not an address", 1.0)).to eq(nil)
     end
   end
 
@@ -94,6 +287,66 @@ RSpec.describe EmailBounceScore do
       EmailBounceScore.ensure_consistency!
 
       expect(EmailBounceScore.pluck(:email)).to contain_exactly("active@example.com")
+    end
+
+    describe "repairing the user_stats mirror" do
+      fab!(:user)
+
+      it "corrects a mirror that drifted away from a live row" do
+        EmailBounceScore.record_bounce!(user.email, 3.0)
+        user.user_stat.update_columns(bounce_score: 99.0)
+
+        EmailBounceScore.ensure_consistency!
+
+        expect(user.user_stat.reload.bounce_score).to eq(3.0)
+      end
+
+      it "clears a mirror whose address no longer has a row" do
+        user.user_stat.update_columns(bounce_score: 3.0, reset_bounce_score_after: 1.week.from_now)
+
+        EmailBounceScore.ensure_consistency!
+
+        expect(user.user_stat.reload.bounce_score).to eq(0)
+        expect(user.user_stat.reset_bounce_score_after).to eq(nil)
+      end
+
+      it "clears a mirror once the sweep drops the expired row it reflected" do
+        EmailBounceScore.record_bounce!(user.email, 3.0)
+        # the sweep compares against the database clock, which freeze_time can't move
+        EmailBounceScore.for_email(user.email).update_all(reset_bounce_score_after: 1.day.ago)
+
+        EmailBounceScore.ensure_consistency!
+
+        expect(user.user_stat.reload.bounce_score).to eq(0)
+      end
+
+      it "does not let a secondary address hold the mirror up" do
+        Fabricate(:secondary_email, user: user, email: "secondary@example.com")
+        EmailBounceScore.record_bounce!("secondary@example.com", 3.0)
+        user.user_stat.update_columns(bounce_score: 3.0)
+
+        EmailBounceScore.ensure_consistency!
+
+        expect(user.user_stat.reload.bounce_score).to eq(0)
+      end
+
+      it "clears the mirror of a user who has no primary address" do
+        user.user_stat.update_columns(bounce_score: 3.0)
+        user.user_emails.update_all(primary: false)
+
+        EmailBounceScore.ensure_consistency!
+
+        expect(user.user_stat.reload.bounce_score).to eq(0)
+      end
+
+      it "leaves a mirror that already agrees alone" do
+        EmailBounceScore.record_bounce!(user.email, 3.0)
+
+        # xmin changes on every UPDATE, even one that writes identical values
+        expect { EmailBounceScore.ensure_consistency! }.not_to change {
+          DB.query_single("SELECT xmin::text FROM user_stats WHERE user_id = ?", user.id)
+        }
+      end
     end
   end
 end

--- a/spec/models/email_token_spec.rb
+++ b/spec/models/email_token_spec.rb
@@ -83,10 +83,7 @@ RSpec.describe EmailToken do
     end
 
     context "with a bounce score" do
-      before do
-        user.user_stat.update!(bounce_score: 3.0, reset_bounce_score_after: 1.week.from_now)
-        EmailBounceScore.record_bounce!(email_token.email, 3.0)
-      end
+      before { EmailBounceScore.record_bounce!(email_token.email, 3.0) }
 
       it "resets the bounce score, since the address is proven deliverable" do
         EmailToken.confirm(email_token.token)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3040,7 +3040,6 @@ RSpec.describe User do
     end
 
     it "keeps the bounce score, since activating proves nothing about deliverability" do
-      inactive.user_stat.update!(bounce_score: 3.0)
       EmailBounceScore.record_bounce!(inactive.email, 3.0)
 
       inactive.activate

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -3365,7 +3365,7 @@ RSpec.describe Admin::UsersController do
   end
 
   describe "#reset_bounce_score" do
-    before { user.user_stat.update!(bounce_score: 10) }
+    before { EmailBounceScore.record_bounce!(user.email, 10) }
 
     context "when logged in as a moderator" do
       before { sign_in(moderator) }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -107,10 +107,6 @@ RSpec.describe UsersController do
       context "with a bounce score accrued before activation" do
         it "resets the bounce score, since the address is proven deliverable" do
           user_deferred.update(active: false)
-          user_deferred.user_stat.update!(
-            bounce_score: 3.0,
-            reset_bounce_score_after: 1.week.from_now,
-          )
           EmailBounceScore.record_bounce!(user_deferred.email, 3.0)
 
           put "/u/activate-account/#{email_token.token}"
@@ -4983,14 +4979,17 @@ RSpec.describe UsersController do
         expect(response.status).to eq(422)
       end
 
-      it "keeps the bounce score until the new email is confirmed" do
+      it "leaves the bounce score with the address that earned it" do
         user = post_user
-        user.user_stat.update!(bounce_score: 3.0)
+        typo = user.email
+        EmailBounceScore.record_bounce!(typo, 3.0)
 
         put "/u/update-activation-email.json", params: { email: "updatedemail@example.com" }
 
         expect(response.status).to eq(200)
-        expect(user.user_stat.reload.bounce_score).to eq(3.0)
+        expect(EmailBounceScore.score_for(typo)).to eq(3.0)
+        expect(EmailBounceScore.score_for("updatedemail@example.com")).to eq(0)
+        expect(user.user_stat.reload.bounce_score).to eq(0)
       end
 
       it "can be updated" do

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe UsersEmailController do
       end
 
       it "confirms with a correct token" do
+        # the new address is not the primary yet, so the mirror is deliberately
+        # seeded out of step with it: confirming has to bring it back in line
         user.user_stat.update_columns(bounce_score: 42, reset_bounce_score_after: 1.week.from_now)
         EmailBounceScore.record_bounce!("bubblegum@adventuretime.ooo", 42)
 

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -584,12 +584,16 @@ RSpec.describe WebhooksController do
       expect(user.user_stat.reload.bounce_score).to eq(0)
     end
 
-    it "does not increase the bounce score of another user who now owns the recipient address" do
+    it "charges the recipient address rather than whoever used to own it" do
       SiteSetting.mailjet_webhook_token = "foo"
       user = Fabricate(:user, email: email)
       email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
       user.primary_email.update!(email: "fixed@email.com")
+      # the address is what bounced, so its new owner inherits its standing —
+      # but they are never accused of it, and it expires on its own
       other_user = Fabricate(:user, email: email)
+
+      SystemMessage.expects(:create_from_system_user).never
 
       post "/webhooks/mailjet.json?t=foo",
            params: {
@@ -602,7 +606,9 @@ RSpec.describe WebhooksController do
       expect(response.status).to eq(200)
       expect(email_log.reload.bounced).to eq(true)
       expect(user.user_stat.reload.bounce_score).to eq(0)
-      expect(other_user.user_stat.reload.bounce_score).to eq(0)
+      expect(EmailBounceScore.score_for("fixed@email.com")).to eq(0)
+      expect(EmailBounceScore.score_for(email)).to eq(SiteSetting.hard_bounce_score)
+      expect(other_user.user_stat.reload.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
 
     it "verifies signatures" do
@@ -1250,7 +1256,7 @@ RSpec.describe WebhooksController do
 
     it "applies the hard bounce score to permanent bounces regardless of the current bounce score" do
       user = Fabricate(:user, email: email)
-      user.user_stat.update!(bounce_score: 4.2)
+      EmailBounceScore.record_bounce!(email, 4.2)
       email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
 
       post "/webhooks/aws.json", headers: { "RAW_POST_DATA" => payload }

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe UserAnonymizer do
       expect(user.reload.email).to eq("#{user.username}@anonymized.invalid")
     end
 
+    it "clears the bounce score, since it belonged to the original address" do
+      EmailBounceScore.record_bounce!(original_email, 3.0)
+
+      make_anonymous
+
+      expect(user.reload.user_stat.bounce_score).to eq(0)
+    end
+
     it "changes the primary email normalized email address" do
       make_anonymous
 


### PR DESCRIPTION
Previously, `user_stats.bounce_score` decided whether we could email someone. It is a per-user counter, so mail was suppressed for the *account* rather than for the mailbox that actually bounced: a user who corrected a typo'd address stayed cut off for 30 days, and a recycled address carried its history to whoever owned the account.

This change makes `email_bounce_scores` — the per-address ledger added in #42670 — authoritative for that decision, and demotes `user_stats.bounce_score` / `reset_bounce_score_after` to a maintained mirror of the row for the user's current primary address. The columns are never dropped: the admin user response marks both required, and they are visible to admin SQL.

All four enforcement sites now key on the address the mail is going to:

- `Jobs::UserEmail`'s gate for non-critical types, and its digest short-circuit
- `Jobs::NotifyMailingListSubscribers`
- `Jobs::EnqueueDigestEmails`' bulk query

`Email::Receiver.update_bounce_score_for` is split: it no longer writes a score, only decides whether crossing the threshold is worth telling the user about, so it loses its `with_lock`. `UserStat.reset_bounce_scores`, `UserStat.erode_bounce_score!` and `UserStat#reset_bounce_score!` are removed — the mirror derives all three.

Notes for review:

- **The digest query uses `NOT EXISTS`, not a join.** `email_bounce_scores` only holds addresses in bad standing, so joining it in would drop every user who has never bounced and silently stop all digests, with no error anywhere. There is a named regression test for exactly this; it fails under an inner join.
- **The mirror refresh is deferred through `DB.after_commit` and swallows its own failures.** `user_stats` is a hot row, and an inline refresh inside the claim transaction would let a lock timeout roll back the authoritative bounce record. `UserStat.refresh_bounce_scores!` is what makes swallowing safe — remove that backstop and a rescued failure would never heal.
- **The `UserEmail` `after_commit` is deliberately unconditional.** Rails collapses several saves of one row in a transaction into a single callback carrying only the last save's changes, so a `saved_change_to_email?` guard misses real changes — `UserAnonymizer` is the case that proves it. The `IS DISTINCT FROM` guard in the SQL is what makes the unconditional call cheap: a refresh that changes nothing dirties no page (measured 0.44 ms, 4 index scans, no writes).
- **A bounce to a secondary address no longer moves the admin bounce score, and no longer PMs its owner.** Nothing is gated on a secondary, so a suppression notice would have been untrue. Per-address visibility is the follow-up PR.
- **A late bounce for a recycled address now charges the address, so its new owner inherits the standing.** That is the intended semantics — the mailbox is what bounced — and it expires on its own. They are never accused of it: the revoke notice only fires for the user whose *primary* it is. `webhooks_controller_spec.rb` covers this.
- Bounces for email logs with no `user_id` (invites, group SMTP) previously scored nothing; they now suppress the address and notify its owner.
- `script/import_scripts/friendsmegplus.rb` no longer hand-writes a suppression for its synthetic `@gplus.invalid` addresses. `Email::Sender` already refuses anything ending in `.invalid`, so the three lines were dead.
- Deliberately left for the follow-up PR: the four bounce site setting descriptions that still say "the user", and the `UserDestroyer` / `UserAnonymizer` lifecycle question for ledger rows.
- Known limitation: the threshold-crossing test reconstructs the prior score as `bounce_score - score`. Missing a crossing needs the prior value within one ULP of the threshold; the address is still suppressed, only the notice is lost. An exact fix costs a column.
- Measured on a synthetic 1M-user database: the digest query goes from 858 ms to 999 ms, because reading `user_emails.email` gives up an index-only scan. Reading the mirror instead would be faster, but a mirror stale in the restrictive direction silently costs a user their digests for up to 12 h, which is the bug class this stack exists to close.
- `Jobs::EnsureDbConsistency`'s bounce work goes from ~59 ms to ~440 ms on that database. A partial index on `user_stats (user_id) WHERE bounce_score <> 0` would remove most of the remainder if it ever matters.
