### PR TITLE
SECURITY: Clear stale add-users-to-group when policy removes the assignment

### DIFF
--- a/plugins/discourse-policy/plugin.rb
+++ b/plugins/discourse-policy/plugin.rb
@@ -160,6 +160,8 @@ after_initialize do
             if add_to_group && Guardian.new(post.user).can_edit_group?(add_to_group)
               add_to_group.id
             end
+        else
+          post_policy.add_users_to_group = nil
         end
 
         if has_group

--- a/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
+++ b/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
@@ -64,6 +64,46 @@ describe DiscoursePolicy::PolicyController do
     end
   end
 
+  context "when an add-users-to-group assignment is removed" do
+    it "does not grant accepters access to topics restricted to the former group" do
+      group_to_add = Fabricate(:group)
+      group_to_add.add_owner(moderator)
+      private_category = Fabricate(:private_category, group: group_to_add)
+      private_topic = Fabricate(:topic, category: private_category, user: moderator)
+      private_post = Fabricate(:post, topic: private_topic, user: moderator, raw: "Restricted post")
+      policy_post = create_post(raw: <<~MD, user: moderator)
+            [policy group=#{group.name} add-users-to-group=#{group_to_add.name}]
+            I always open **doors**!
+            [/policy]
+          MD
+
+      sign_in(moderator)
+      put "/posts/#{policy_post.id}.json", params: { post: { raw: <<~MD } }
+                [policy group=#{group.name}]
+                I always open **doors**!
+                [/policy]
+              MD
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["post"]["raw"]).not_to include("add-users-to-group")
+
+      sign_in(user1)
+      get "/t/#{private_topic.id}.json"
+      expect(response.status).to eq(404)
+      expect(response.body).not_to include(private_post.raw)
+
+      put "/policy/accept.json", params: { post_id: policy_post.id }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["success"]).to eq("OK")
+
+      get "/t/#{private_topic.id}.json"
+
+      expect(response.status).to eq(404)
+      expect(response.body).not_to include(private_post.raw)
+    end
+  end
+
   describe "#accepted" do
     before { sign_in(user1) }
 


### PR DESCRIPTION
## Summary

Clearing a policy's add-users-to-group field previously left the former group ID persisted in the database, so later eligible accepters were still enrolled into that group and could access group-restricted content. The fix now explicitly nils the derived ID whenever the cooked policy markup omits the assignment, restoring the invariant that PostPolicy#add_users_to_group exactly reflects the current policy declaration.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1815

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>