### PR TITLE
FIX: allow RFC 3986 IPv6 literals in link href sanitizer

### DIFF
--- a/frontend/discourse/tests/unit/lib/sanitizer-test.js
+++ b/frontend/discourse/tests/unit/lib/sanitizer-test.js
@@ -52,6 +52,24 @@ module("Unit | Utility | sanitizer", function (hooks) {
       "we can embed proper links"
     );
 
+    cooked(
+      "[visit](http://[2001:db8:0:0:0:0:0:1]:1896/)",
+      '<p><a href="http://[2001:db8:0:0:0:0:0:1]:1896/">visit</a></p>',
+      "allows fully expanded IPv6 markdown links"
+    );
+
+    cooked(
+      "[visit](http://[2001:db8::1]:1926/)",
+      '<p><a href="http://[2001:db8::1]:1926/">visit</a></p>',
+      "allows compressed IPv6 markdown links"
+    );
+
+    cooked(
+      '<a href="http://[::1]/">loopback</a>',
+      '<p><a href="http://[::1]/">loopback</a></p>',
+      "allows IPv6 loopback hrefs"
+    );
+
     cooked("<center>hello</center>", "hello", "does not allow centering");
     cooked(
       "<blockquote>a\n</blockquote>\n",
@@ -318,6 +336,22 @@ module("Unit | Utility | sanitizer", function (hooks) {
     allowed("http://eviltrout.com/evil/trout", "allows full urls");
     allowed("https://eviltrout.com/evil/trout", "allows https urls");
     allowed("//eviltrout.com/evil/trout", "allows protocol relative urls");
+    allowed(
+      "http://[2001:db8:0:0:0:0:0:1]:2026/",
+      "allows fully expanded IPv6 urls with a port"
+    );
+    allowed(
+      "http://[2001:db8::1]:2026/",
+      "allows compressed IPv6 urls with a port"
+    );
+    allowed("http://[::1]/", "allows IPv6 loopback urls");
+    allowed("http://[::ffff:192.0.2.1]/", "allows IPv4-mapped IPv6 urls");
+
+    assert.strictEqual(
+      hrefAllowed("http://[]/"),
+      undefined,
+      "rejects empty IPv6 brackets"
+    );
 
     assert.strictEqual(
       hrefAllowed("http://google.com/test'onmouseover=alert('XSS!');//.swf"),

--- a/frontend/pretty-text/addon/sanitizer.js
+++ b/frontend/pretty-text/addon/sanitizer.js
@@ -15,12 +15,16 @@ function attr(name, value) {
 
 export { escape };
 
+// Hostnames, IPv4, IPv6 literals
+const ALLOWED_HREF_HOST = "(?:\\[[\\da-f:.]+\\]|[\\w.\\-]+)";
+const ALLOWED_HTTP_HREF = new RegExp(`^(https?:)?//${ALLOWED_HREF_HOST}`, "i");
+
 export function hrefAllowed(href, extraHrefMatchers) {
   // escape single quotes
   href = href.replace(/'/g, "%27");
 
   // absolute urls
-  if (/^(https?:)?\/\/[\w\.\-]+/i.test(href)) {
+  if (ALLOWED_HTTP_HREF.test(href)) {
     return href;
   }
   // relative urls
@@ -104,7 +108,10 @@ export function sanitize(text, allowLister) {
 
   if (allowedHrefSchemes && allowedHrefSchemes.length > 0) {
     extraHrefMatchers = [
-      new RegExp("^(" + allowedHrefSchemes.join("|") + ")://[\\w\\.\\-]+", "i"),
+      new RegExp(
+        "^(" + allowedHrefSchemes.join("|") + ")://" + ALLOWED_HREF_HOST,
+        "i"
+      ),
     ];
     if (allowedHrefSchemes.includes("tel")) {
       extraHrefMatchers.push(new RegExp("^tel://\\+?[\\w\\.\\-]+", "i"));


### PR DESCRIPTION
The hrefAllowed check only accepted domain-style characters ([A-Za-z0-9_.-]) after the scheme, so markdown links whose host is an IPv6 literal (containing '[' ']' and ':') were stripped during cook.

Extend the host pattern to accept bracketed IPv6 literals such as `http://[2001:db8::1]:1896`.

Before: The `href` of `[link](http://[2001:db8::1]:1896)` `<http://[2001:db8::1]:1896>` `<a href="http://[2001:db8::1]:1896">link</a>` were stripped.
After: The `href` are kept correctly.