### PR TITLE
FIX: Close streamed thinking block before content from the same delta

### DIFF
--- a/plugins/discourse-ai/lib/completions/endpoints/vllm.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/vllm.rb
@@ -47,8 +47,8 @@ module DiscourseAi
             @tool_batch_id = parsed_json[:id] if parsed_json[:id].present?
 
             if output_thinking
-              reasoning = parsed_json.dig(:choices, 0, :delta, :reasoning).presence
-              reasoning ||= parsed_json.dig(:choices, 0, :delta, :reasoning_content)
+              delta = parsed_json.dig(:choices, 0, :delta) || {}
+              reasoning = delta[:reasoning].presence || delta[:reasoning_content]
               if reasoning.present?
                 if @thinking.nil?
                   @thinking = Thinking.new(message: reasoning.dup, partial: true)
@@ -56,7 +56,11 @@ module DiscourseAi
                   @thinking.message << reasoning
                 end
                 elements << Thinking.new(message: reasoning, partial: true)
-              elsif @thinking
+              end
+
+              # a delta may carry both reasoning and content; close the thinking
+              # block before any content from the same delta is emitted
+              if @thinking && (delta[:content].present? || delta[:tool_calls].present?)
                 @thinking.partial = false
                 elements << @thinking
                 @thinking = nil

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/vllm_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/vllm_spec.rb
@@ -647,6 +647,35 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Vllm do
 
       expect(text_partials.join).to eq("The answer is 4.")
     end
+
+    it "finalizes Thinking before content when a delta carries both" do
+      chunks = []
+
+      chunks << "data: #{({ choices: [{ delta: { role: "assistant", reasoning: "Let me " } }] }).to_json}\n\n"
+      chunks << "data: #{({ choices: [{ delta: { content: "The answer", reasoning: "think." } }] }).to_json}\n\n"
+      chunks << "data: #{({ choices: [{ delta: { content: " is 4." } }] }).to_json}\n\n"
+      chunks << "data: [DONE]\n\n"
+
+      stub_request(:post, "https://test.dev/v1/chat/completions").to_return(
+        status: 200,
+        body: chunks.join,
+      )
+
+      partials = []
+      llm.generate("what is 2+2?", user: Discourse.system_user, output_thinking: true) do |partial|
+        partials << partial
+      end
+
+      first_content_index = partials.index { |partial| partial.is_a?(String) }
+      final_thinking_index =
+        partials.index do |partial|
+          partial.is_a?(DiscourseAi::Completions::Thinking) && !partial.partial?
+        end
+
+      expect(final_thinking_index).to be < first_content_index
+      expect(partials[final_thinking_index].message).to eq("Let me think.")
+      expect(partials.select { |partial| partial.is_a?(String) }.join).to eq("The answer is 4.")
+    end
   end
 
   describe "reasoning_content" do


### PR DESCRIPTION
Previously, when a vLLM streamed delta carried both `reasoning` and `content` (as happens at the thinking/output boundary on models like DeepSeek V4), the decoder emitted the content before finalizing the accumulated `Thinking`, so in AI bot posts the first words of the reply landed inside/before the closing of the thinking `details` block.

This change finalizes the in-progress `Thinking` before any content or tool calls from the same delta are emitted, so the thinking block always closes before the reply text starts. As a side effect, empty deltas (role-only or finish-reason chunks) no longer split an in-progress thinking block in two.