### PR TITLE
FIX: Keep focus in AI logs filter inputs while typing

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { cached, tracked } from "@glimmer/tracking";
+import { tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
@@ -63,6 +63,7 @@ export default class AiLogs extends Component {
     this.models = this.args.model.models || [];
     this.features = this.mergedFeatures(this.args.model.features, this.logs);
     this.initializeFilters(this.args.queryParams);
+    this.filterFormData = this.buildFilterFormData();
 
     if (this.args.queryParams.details) {
       next(() =>
@@ -119,8 +120,9 @@ export default class AiLogs extends Component {
       : new Date();
   }
 
-  @cached
-  get filterFormData() {
+  // must stay referentially stable: a new object passed as Form @data
+  // recreates the form and drops input focus
+  buildFilterFormData() {
     return {
       period: this.selectedPeriod,
       date_range: { from: this.startDate, to: this.endDate },

--- a/plugins/discourse-ai/spec/system/ai_logs_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_logs_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe "AI logs admin page" do
     expect(ai_logs_page).to have_log(log)
   end
 
+  it "keeps focus in the feature input while typing" do
+    ai_logs_page.visit
+
+    feature_input =
+      find("input[placeholder='#{I18n.t("js.discourse_ai.logs.feature_placeholder")}']")
+    feature_input.click
+    "abc".each_char { |char| feature_input.send_keys(char) }
+
+    expect(feature_input.value).to eq("abc")
+    expect(page.evaluate_script("document.activeElement.placeholder")).to eq(
+      I18n.t("js.discourse_ai.logs.feature_placeholder"),
+    )
+  end
+
   it "restores model and period filters from the URL" do
     other_model = Fabricate(:llm_model)
     other_log =


### PR DESCRIPTION
Previously, typing in the AI logs "Feature" or "ID value" filter inputs dropped focus on every keystroke: each keystroke updated tracked filter state that rebuilt the object passed as the form's `@data`, and FormKit keys the form on `@data` identity, so the entire form (and its inputs) was recreated mid-typing.

This change builds the form's initial data once in the constructor so the `@data` reference stays stable, keeping inputs focused while typing; the form's state is already kept in sync through `filterFormApi.set`.