### PR TITLE
SECURITY: Gate include_staged_users in UserSearch with a Guardian policy

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -69,7 +69,12 @@ class DirectoryItemsController < ApplicationController
 
     user_ids = nil
     if params[:name].present?
-      opts = { include_staged_users: true, limit: 200, search_custom_fields: true }
+      opts = {
+        include_staged_users: true,
+        user_directory_search: true,
+        limit: 200,
+        search_custom_fields: true,
+      }
       user_ids = UserSearch.new(params[:name], opts).search.pluck(:id)
       if user_ids.present?
         # Add the current user if we have at least one other match

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -13,8 +13,11 @@ class UserSearch
     @prioritized_user_id = opts[:prioritized_user_id]
     @topic_allowed_users = opts[:topic_allowed_users]
     @searching_user = opts[:searching_user]
-    @include_staged_users = opts[:include_staged_users] || false
-    @last_seen_users = opts[:last_seen_users] || false
+    @guardian = Guardian.new(@searching_user)
+    @include_staged_users =
+      !!opts[:include_staged_users] &&
+        @guardian.can_search_staged_users?(user_directory_search: opts[:user_directory_search])
+    @last_seen_users = !!opts[:last_seen_users] && !@include_staged_users
     @limit = opts[:limit] || 20
     @groups = opts[:groups]
     @can_review = opts[:can_review] || false
@@ -23,17 +26,16 @@ class UserSearch
     @topic = Topic.find(@topic_id) if @topic_id
     @category = Category.find(@category_id) if @category_id
 
-    guardian = @searching_user&.guardian || Guardian.new
-    @groups&.each { |group| guardian.ensure_can_see_group_and_members!(group) }
-    guardian.ensure_can_see_category!(@category) if @category
-    guardian.ensure_can_see_topic!(@topic) if @topic
+    @groups&.each { |group| @guardian.ensure_can_see_group_and_members!(group) }
+    @guardian.ensure_can_see_category!(@category) if @category
+    @guardian.ensure_can_see_topic!(@topic) if @topic
   end
 
   def scoped_users
     users = User.where(active: true)
     users = users.where(approved: true) if SiteSetting.must_approve_users?
     users = users.where(staged: false) unless @include_staged_users
-    users = users.not_suspended unless @searching_user&.staff?
+    users = users.not_suspended unless @guardian.is_staff?
 
     if @groups
       users = users.joins(:group_users).where("group_users.group_id IN (?)", @groups.map(&:id))

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -154,6 +154,10 @@ module UserGuardian
     true
   end
 
+  def can_search_staged_users?(user_directory_search: false)
+    is_staff? || (user_directory_search == true && SiteSetting.enable_user_directory?)
+  end
+
   def public_can_see_profiles?
     !SiteSetting.hide_user_profiles_from_public || !anonymous?
   end

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -354,11 +354,24 @@ RSpec.describe UserSearch do
       expect(results).to be_blank
 
       results = search_for(staged.username, include_staged_users: true)
+      expect(results).to be_blank
+
+      results = search_for(staged.username, include_staged_users: true, searching_user: admin)
+      expect(results).to eq [staged.username]
+
+      results = search_for(staged.username, include_staged_users: true, user_directory_search: true)
       expect(results).to eq [staged.username]
 
       # mrb is omitted since they're the searching user
       results = search_for("", topic_id: topic.id, searching_user: mr_b)
       expect(results).to eq [mr_pink, mr_orange].map(&:username)
+    end
+
+    it "does not return last-seen suggestions when staged users are included" do
+      results =
+        search_for("", include_staged_users: true, last_seen_users: true, searching_user: admin)
+
+      expect(results).to be_blank
     end
 
     it "works with last_seen_users option" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -6131,10 +6131,33 @@ RSpec.describe UsersController do
     end
 
     context "with `include_staged_users`" do
-      it "includes staged users when the param is true" do
+      it "does not include staged users for public callers" do
         get "/u/search/users.json", params: { term: staged_user.name, include_staged_users: true }
-        json = response.parsed_body
-        expect(json["users"].map { |u| u["name"] }).to include(staged_user.name)
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body["users"].map { |found_user| found_user["name"] },
+        ).not_to include(staged_user.name)
+      end
+
+      it "includes staged users for staff callers" do
+        sign_in(Fabricate(:admin))
+
+        get "/u/search/users.json", params: { term: staged_user.name, include_staged_users: true }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["users"].map { |found_user| found_user["name"] }).to include(
+          staged_user.name,
+        )
+      end
+
+      it "does not allow last-seen suggestions when staged users are included" do
+        sign_in(Fabricate(:admin))
+
+        get "/u/search/users.json", params: { include_staged_users: true, last_seen_users: true }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["users"]).to be_empty
       end
 
       it "doesn't include staged users when the param is not passed" do


### PR DESCRIPTION
## Summary

Add a Guardian authorization check to `UserSearch` so that `include_staged_users` is honored only for staff or the intentional user-directory search path. When staged users are included, blank-term last-seen suggestions are disabled to prevent broad enumeration. Anonymous or non-staff callers no longer disclose active staged-account identity metadata through the public user-search endpoint.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1532

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>