### PR TITLE
DEV: remove old btn-secondary references

### DIFF
--- a/frontend/discourse/admin/components/changes-banner.gjs
+++ b/frontend/discourse/admin/components/changes-banner.gjs
@@ -45,7 +45,7 @@ export default class ChangesBanner extends Component {
         }}</span>
       <div class="controls">
         <DButton
-          class="btn-default btn-secondary btn-small"
+          class="btn-default btn-small"
           @action={{@discard}}
           @disabled={{this.isSaving}}
           @translatedLabel={{@discardLabel}}

--- a/frontend/discourse/app/components/modal/edit-user-directory-columns.gjs
+++ b/frontend/discourse/app/components/modal/edit-user-directory-columns.gjs
@@ -173,7 +173,7 @@ export default class EditUserDirectoryColumns extends Component {
         <DButton
           @label="directory.edit_columns.reset_to_default"
           @action={{this.resetToDefault}}
-          class="btn-default btn-secondary reset-to-default"
+          class="btn-default reset-to-default"
         />
       </:footer>
     </DModal>

--- a/frontend/discourse/app/components/topic-dismiss-buttons.gjs
+++ b/frontend/discourse/app/components/topic-dismiss-buttons.gjs
@@ -170,7 +170,7 @@ export default class TopicDismissButtons extends Component {
                       @translatedLabel={{i18n
                         "topics.bulk.dismiss_and_stop_tracking"
                       }}
-                      class="btn-secondary dismiss-new-stop-tracking"
+                      class="dismiss-new-stop-tracking"
                     />
                   </dropdown.item>
                 </DDropdownMenu>

--- a/frontend/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/frontend/discourse/app/components/topic-drafts-dropdown.gjs
@@ -134,7 +134,6 @@ export default class TopicDraftsDropdown extends Component {
                   draft.title
                   (i18n "drafts.dropdown.untitled")
                 }}
-                class="btn-secondary"
               />
             </dropdown.item>
           {{/each}}

--- a/plugins/discourse-gamification/assets/javascripts/discourse/components/modal/recalculate-scores-form.gjs
+++ b/plugins/discourse-gamification/assets/javascripts/discourse/components/modal/recalculate-scores-form.gjs
@@ -197,7 +197,7 @@ export default class RecalculateScoresForm extends Component {
           }}
           @ariaLabel="gamification.cancel"
           id="cancel-section"
-          class="btn-secondary"
+          class="btn-default"
         />
 
         <div class="recalculate-modal__footer-text">{{this.remainingText}}</div>

--- a/plugins/styleguide/assets/javascripts/discourse/components/examples/molecules/combo-button.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/examples/molecules/combo-button.gjs
@@ -17,7 +17,6 @@ export default <template>
               @translatedLabel="Resume draft"
               @icon="reply"
               @action={{noop}}
-              class="btn-secondary"
             />
           </dropdown.item>
         </DDropdownMenu>
@@ -33,7 +32,6 @@ export default <template>
               @translatedLabel="Resume draft"
               @icon="reply"
               @action={{noop}}
-              class="btn-secondary"
             />
           </dropdown.item>
         </DDropdownMenu>

--- a/spec/system/page_objects/components/admin_changes_banner.rb
+++ b/spec/system/page_objects/components/admin_changes_banner.rb
@@ -20,7 +20,7 @@ module PageObjects
       end
 
       def click_discard
-        element.find(".btn-secondary").click
+        element.find(".btn-default").click
       end
 
       def has_label?(label)


### PR DESCRIPTION
We don't actually style `btn-secondary` anywhere, and it should often be `btn-default` anyway