### PR TITLE
DEV: Avoid pointer race in chat original-message system tests

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -57,7 +57,7 @@ module PageObjects
       end
 
       def open_original_message
-        find(".chat-message-info__original-message").click
+        find(".chat-message-info__original-message").send_keys(:enter)
       end
 
       def has_back_link_to_thread_list?(channel)

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -57,7 +57,7 @@ module PageObjects
       end
 
       def open_original_message
-        find(".chat-message-info__original-message").send_keys(:enter)
+        find(".chat-message-info__original-message__text").click
       end
 
       def has_back_link_to_thread_list?(channel)

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -107,7 +107,7 @@ describe "Single thread in side panel" do
     end
 
     context "when in drawer" do
-      it "opens the channel and highlights the message from the original message link" do
+      it "takes the user to the highlighted message after they click the original message link" do
         visit("/latest")
         chat_page.open_from_header
         chat_drawer_page.open_channel(channel)
@@ -122,7 +122,7 @@ describe "Single thread in side panel" do
       end
     end
 
-    it "highlights the message in the channel from the original message link" do
+    it "takes the user to the highlighted message after they click the original message link" do
       chat_page.visit_thread(thread)
 
       thread_page.open_original_message
@@ -246,7 +246,8 @@ describe "Single thread in side panel" do
         expect(side_panel).to have_open_thread(thread)
       end
 
-      it "navigates back to channel from the original message link", mobile: true do
+      it "takes the user back to the channel after they click the original message link",
+         mobile: true do
         chat_page.visit_thread(thread)
 
         thread_page.open_original_message

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -107,12 +107,12 @@ describe "Single thread in side panel" do
     end
 
     context "when in drawer" do
-      it "opens the channel and highlights the message when clicking original message link" do
+      it "opens the channel and highlights the message from the original message link" do
         visit("/latest")
         chat_page.open_from_header
         chat_drawer_page.open_channel(channel)
         channel_page.message_thread_indicator(thread.original_message).click
-        find(".chat-message-info__original-message").click
+        thread_page.open_original_message
 
         expect(chat_drawer_page).to have_open_channel(channel)
         expect(channel_page.messages).to have_message(
@@ -122,10 +122,10 @@ describe "Single thread in side panel" do
       end
     end
 
-    it "highlights the message in the channel when clicking original message link" do
+    it "highlights the message in the channel from the original message link" do
       chat_page.visit_thread(thread)
 
-      find(".chat-message-info__original-message").click
+      thread_page.open_original_message
 
       expect(channel_page.messages).to have_message(
         id: thread.original_message.id,
@@ -246,10 +246,10 @@ describe "Single thread in side panel" do
         expect(side_panel).to have_open_thread(thread)
       end
 
-      it "navigates back to channel when clicking original message link", mobile: true do
+      it "navigates back to channel from the original message link", mobile: true do
         chat_page.visit_thread(thread)
 
-        find(".chat-message-info__original-message").click
+        thread_page.open_original_message
 
         expect(page).to have_current_path("/chat/c/#{channel.slug}/#{channel.id}")
       end


### PR DESCRIPTION
Chat original-message system tests clicked the broad link target immediately after the thread route rendered. The hover actions toolbar could appear under the pointer and intercept that click, causing nondeterministic timeouts.

This commit routes the flows through `ChatThread#open_original_message` and clicks the visible text inside the link. The pointer interaction still activates the anchor while targeting the unobstructed label outside the toolbar's overlapping hitbox. The tests continue to assert navigation and highlighting.

Flaky in https://github.com/discourse/discourse/actions/runs/32194485737/job/95895589983?pr=42669