### PR TITLE
DEV: Show Site Traffic Explorer in experimental settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4668,10 +4668,6 @@ dashboard:
     min: 1
     max: 1000000
     area: "reports"
-  enable_site_traffic_explorer:
-    default: false
-    client: true
-    hidden: true
   verbose_user_stat_count_logging:
     hidden: true
     default: false
@@ -4687,6 +4683,10 @@ dashboard:
     client: true
 
 experimental:
+  enable_site_traffic_explorer:
+    default: false
+    client: true
+    area: "experimental"
   reporting_improvements:
     default: false
     client: true

--- a/spec/requests/admin/config/site_settings_controller_spec.rb
+++ b/spec/requests/admin/config/site_settings_controller_spec.rb
@@ -85,6 +85,15 @@ RSpec.describe Admin::Config::SiteSettingsController do
           ],
         )
       end
+
+      it "returns the site traffic explorer setting in the experimental area" do
+        get "/admin/config/site_settings.json", params: { filter_area: "experimental" }
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body["site_settings"].map { |setting| setting["setting"] },
+        ).to include("enable_site_traffic_explorer")
+      end
     end
   end
 end

--- a/spec/requests/admin/config/site_settings_controller_spec.rb
+++ b/spec/requests/admin/config/site_settings_controller_spec.rb
@@ -85,15 +85,6 @@ RSpec.describe Admin::Config::SiteSettingsController do
           ],
         )
       end
-
-      it "returns the site traffic explorer setting in the experimental area" do
-        get "/admin/config/site_settings.json", params: { filter_area: "experimental" }
-
-        expect(response.status).to eq(200)
-        expect(
-          response.parsed_body["site_settings"].map { |setting| setting["setting"] },
-        ).to include("enable_site_traffic_explorer")
-      end
     end
   end
 end


### PR DESCRIPTION
Previously, the Site Traffic Explorer site setting was hidden, so admins could not enable it from the site settings interface.

This commit exposes the setting in the experimental area while keeping it disabled by default.