### PR TITLE
FIX: Allow YouTube URLs with a list= query param to use lazy-video

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -1,4 +1,5 @@
 $max_image_height: 150px;
+$max_video_height: 250px;
 
 .chat-message {
   // append selectors to set images to a
@@ -105,8 +106,9 @@ $max_image_height: 150px;
     + div
     .chat-message-collapser-lazy-video {
     object-fit: contain;
-    max-height: $max_image_height;
-    max-width: calc(#{$max_image_height} / 9 * 16);
+    max-height: $max_video_height;
+    max-width: calc(#{$max_video_height} / 9 * 16);
+    margin-top: var(--space-2);
 
     &:has(div[data-provider-name="tiktok"]) {
       max-height: unset;

--- a/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.gjs
+++ b/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.gjs
@@ -19,6 +19,9 @@ export default class LazyIframe extends Component {
     switch (this.args.providerName) {
       case "youtube":
         let url = `https://www.youtube.com/embed/${this.args.videoId}?autoplay=1&rel=0`;
+        if (this.args.listId) {
+          url += `&list=${encodeURIComponent(this.args.listId)}`;
+        }
         if (this.args.startTime) {
           url += `&start=${convertToSeconds(this.args.startTime)}`;
         }

--- a/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-video.gjs
+++ b/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-video.gjs
@@ -39,6 +39,7 @@ export default class LazyVideo extends Component {
       data-video-id={{@videoAttributes.id}}
       data-video-title={{@videoAttributes.title}}
       data-video-start-time={{@videoAttributes.startTime}}
+      data-video-list-id={{@videoAttributes.listId}}
       data-provider-name={{@videoAttributes.providerName}}
       class={{dConcatClass
         "lazy-video-container"
@@ -52,6 +53,7 @@ export default class LazyVideo extends Component {
           @title={{@videoAttributes.title}}
           @videoId={{@videoAttributes.id}}
           @startTime={{@videoAttributes.startTime}}
+          @listId={{@videoAttributes.listId}}
         />
       {{else}}
         <div

--- a/plugins/discourse-lazy-videos/assets/javascripts/lib/lazy-video-attributes.js
+++ b/plugins/discourse-lazy-videos/assets/javascripts/lib/lazy-video-attributes.js
@@ -9,8 +9,18 @@ export default function getVideoAttributes(cooked) {
   const dominantColor = img?.dataset?.dominantColor;
   const title = cooked.dataset.videoTitle;
   const startTime = cooked.dataset.videoStartTime;
+  const listId = cooked.dataset.videoListId;
   const providerName = cooked.dataset.providerName;
   const id = cooked.dataset.videoId;
 
-  return { url, thumbnail, title, providerName, id, dominantColor, startTime };
+  return {
+    url,
+    thumbnail,
+    title,
+    providerName,
+    id,
+    dominantColor,
+    startTime,
+    listId,
+  };
 }

--- a/plugins/discourse-lazy-videos/lib/discourse_lazy_videos/lazy_youtube.rb
+++ b/plugins/discourse-lazy-videos/lib/discourse_lazy_videos/lazy_youtube.rb
@@ -7,8 +7,7 @@ class Onebox::Engine::YoutubeOnebox
   alias_method :default_onebox_to_html, :to_html
 
   def to_html
-    if SiteSetting.lazy_videos_enabled && SiteSetting.lazy_youtube_enabled && video_id &&
-         !params["list"]
+    if SiteSetting.lazy_videos_enabled && SiteSetting.lazy_youtube_enabled && video_id
       result = parse_embed_response
       result ||= get_opengraph.data
 
@@ -24,15 +23,18 @@ class Onebox::Engine::YoutubeOnebox
 
       escaped_title = ERB::Util.html_escape(video_title)
       escaped_start_time = ERB::Util.html_escape(params["t"])
+      escaped_list_id = ERB::Util.html_escape(list_id)
       t_param = "&t=#{escaped_start_time}" if escaped_start_time.present?
+      list_param = "&list=#{escaped_list_id}" if escaped_list_id.present?
 
       <<~HTML
         <div class="youtube-onebox lazy-video-container"
           data-video-id="#{video_id}"
           data-video-title="#{escaped_title}"
           data-video-start-time="#{escaped_start_time}"
+          data-video-list-id="#{escaped_list_id}"
           data-provider-name="youtube">
-          <a href="https://www.youtube.com/watch?v=#{video_id}#{t_param}" target="_blank" class="video-thumbnail">
+          <a href="https://www.youtube.com/watch?v=#{video_id}#{list_param}#{t_param}" target="_blank" class="video-thumbnail">
             <img class="youtube-thumbnail"
               src="#{thumbnail_url}"
               title="#{escaped_title}">

--- a/plugins/discourse-lazy-videos/spec/lib/lazy-videos/lazy_youtube_spec.rb
+++ b/plugins/discourse-lazy-videos/spec/lib/lazy-videos/lazy_youtube_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Onebox::Engine::YoutubeOnebox do
+  let(:video_id) { "IYH7_GzP4Tg" }
+  let(:list_id) { "RDIYH7_GzP4Tg" }
+  let(:video_url) { "https://www.youtube.com/watch?v=#{video_id}&list=#{list_id}&start_radio=1" }
+
+  before do
+    SiteSetting.lazy_videos_enabled = true
+    SiteSetting.lazy_youtube_enabled = true
+
+    stub_request(:get, video_url).to_return(status: 200, body: onebox_response("youtube"))
+    stub_request(:get, %r{https://www\.youtube\.com/oembed\?}).to_return(
+      status: 200,
+      body: {
+        title: "Lil Jon & The East Side Boyz - Get Low",
+        thumbnail_url: "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg",
+      }.to_json,
+    )
+    stub_request(:get, "https://img.youtube.com/vi/#{video_id}/maxresdefault.jpg").to_return(
+      status: 200,
+    )
+  end
+
+  it "creates a lazy video that preserves its playlist" do
+    html = Onebox.preview(video_url).to_s
+
+    expect(html).to include(
+      "lazy-video-container",
+      %(data-video-list-id="#{list_id}"),
+      "https://www.youtube.com/watch?v=#{video_id}&amp;list=#{list_id}",
+    )
+  end
+end

--- a/plugins/discourse-lazy-videos/test/javascripts/components/lazy-video-test.gjs
+++ b/plugins/discourse-lazy-videos/test/javascripts/components/lazy-video-test.gjs
@@ -7,11 +7,12 @@ module("Component | LazyVideo", function (hooks) {
   setupRenderingTest(hooks);
 
   this.attributes = {
-    url: "https://www.youtube.com/watch?v=kPRA0W1kECg",
+    url: "https://www.youtube.com/watch?v=kPRA0W1kECg&list=RDkPRA0W1kECg",
     thumbnail: "thumbnail.jpeg",
     title: "15 Sorting Algorithms in 6 Minutes",
     providerName: "youtube",
     id: "kPRA0W1kECg",
+    listId: "RDkPRA0W1kECg",
     dominantColor: "00ffff",
     startTime: 234,
   };
@@ -30,6 +31,30 @@ module("Component | LazyVideo", function (hooks) {
     );
 
     assert.dom(".youtube-onebox").hasAttribute("data-video-start-time", "234");
+  });
+
+  test("preserves the YouTube playlist", async function (assert) {
+    await render(
+      <template><LazyVideo @videoAttributes={{this.attributes}} /></template>
+    );
+
+    assert
+      .dom(".youtube-onebox")
+      .hasAttribute(
+        "data-video-list-id",
+        this.attributes.listId,
+        "the playlist ID is retained on the lazy video"
+      );
+
+    await click(".video-thumbnail.youtube");
+
+    assert
+      .dom(".lazy-video-container.video-loaded iframe")
+      .hasAttribute(
+        "src",
+        "https://www.youtube.com/embed/kPRA0W1kECg?autoplay=1&rel=0&list=RDkPRA0W1kECg&start=234",
+        "the loaded iframe includes the playlist ID"
+      );
   });
 
   test("displays the correct provider icon", async function (assert) {

--- a/plugins/discourse-lazy-videos/test/javascripts/unit/lib/lazy-video-attributes-test.js
+++ b/plugins/discourse-lazy-videos/test/javascripts/unit/lib/lazy-video-attributes-test.js
@@ -1,0 +1,19 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import getVideoAttributes from "../../lib/lazy-video-attributes";
+
+module("Unit | Lib | lazy-video-attributes", function (hooks) {
+  setupTest(hooks);
+
+  test("extracts the playlist ID", function (assert) {
+    const cooked = document.createElement("div");
+    cooked.classList.add("lazy-video-container");
+    cooked.dataset.videoListId = "RDkPRA0W1kECg";
+
+    assert.strictEqual(
+      getVideoAttributes(cooked).listId,
+      "RDkPRA0W1kECg",
+      "the playlist ID is read from the cooked markup"
+    );
+  });
+});


### PR DESCRIPTION
YouTube links like https://www.youtube.com/watch?v=IYH7_GzP4Tg&list=RDIYH7_GzP4Tg&start_radio=1
where not being oneboxed by lazy-video because it explicitly excluded
URLs with a list= query param. This commit removes that exclusion, allowing
lazy-video to onebox YouTube links with a list= query param.

This is especially noticable in chat, where before this would change
one of those videos would be absolutely enormous and take up the full
screen.

Also slightly increases height of videos in chat to 250px, and adds
margin top so the collapser link isn't right up against the top of the
video.

**Before**

<img width="2203" height="802" alt="image" src="https://github.com/user-attachments/assets/a6bbe15e-51fb-4370-b9af-688a312990db" />

**After**

<img width="1072" height="375" alt="image" src="https://github.com/user-attachments/assets/1582b369-2663-45b5-b55f-96e6c204d971" />
