### PR TITLE
FEATURE: add unassigned workflow trigger to Discourse Assign

### DIFF
--- a/plugins/discourse-assign/config/locales/client.en.yml
+++ b/plugins/discourse-assign/config/locales/client.en.yml
@@ -206,10 +206,12 @@ en:
         "action:assign_topic": "Assign topic or post"
         "action:check_assignment": "Check assignment"
         "trigger:assigned": "Assigned"
+        "trigger:unassigned": "Unassigned"
       node_descriptions:
         "action:assign_topic": "Assign or unassign a topic or post"
         "action:check_assignment": "Check whether a user or group is assigned to a topic or post"
         "trigger:assigned": "Fires when a topic or post is assigned"
+        "trigger:unassigned": "Fires when a topic or post is unassigned"
       assign_topic:
         resource: "Resource"
         resources:
@@ -232,5 +234,8 @@ en:
         post_id: "Post ID"
         assignee: "Assignee"
       assigned:
+        topic_assignments_only: "Only trigger when the assignment target is the topic, not an individual post"
+        topic_assignments_only_description: "Topic assignments only"
+      unassigned:
         topic_assignments_only: "Only trigger when the assignment target is the topic, not an individual post"
         topic_assignments_only_description: "Topic assignments only"

--- a/plugins/discourse-assign/lib/assigner.rb
+++ b/plugins/discourse-assign/lib/assigner.rb
@@ -477,6 +477,8 @@ class ::Assigner
         WebHook.enqueue_assign_hooks(type, payload.to_json)
       end
 
+      DiscourseEvent.trigger(:unassigned, assignment)
+
       if allowed_user_ids.present?
         MessageBus.publish(
           "/staff/topic-assignment",

--- a/plugins/discourse-assign/lib/discourse_assign/workflows/schema.rb
+++ b/plugins/discourse-assign/lib/discourse_assign/workflows/schema.rb
@@ -89,6 +89,13 @@ module DiscourseAssign
           DiscourseWorkflows::Schema::TOPIC_LIST_ITEM_SCHEMA,
           ASSIGNMENT_SCHEMA,
         ).freeze
+
+      UNASSIGNED_OUTPUT_SCHEMA =
+        DiscourseWorkflows::Schema.merge(
+          DiscourseWorkflows::Schema::POST_SCHEMA,
+          DiscourseWorkflows::Schema::TOPIC_LIST_ITEM_SCHEMA,
+          ASSIGNMENT_SCHEMA,
+        ).freeze
     end
   end
 end

--- a/plugins/discourse-assign/lib/discourse_workflows/nodes/unassigned/v1.rb
+++ b/plugins/discourse-assign/lib/discourse_workflows/nodes/unassigned/v1.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseWorkflows)
+  module DiscourseWorkflows
+    module Nodes
+      module Unassigned
+        class V1 < DiscourseWorkflows::NodeType
+          description(
+            name: "trigger:unassigned",
+            version: "1.0",
+            defaults: {
+              icon: "user-xmark",
+              color: "cyan",
+            },
+            group: "discourse_triggers",
+            events: [:unassigned],
+            available: -> { SiteSetting.assign_enabled },
+            unavailable_reason_key: "discourse_workflows.node_unavailable.requires_assign",
+            output_contracts: [
+              { schema: DiscourseAssign::Workflows::Schema::UNASSIGNED_OUTPUT_SCHEMA },
+            ],
+            properties: {
+              topic_assignments_only: {
+                type: :boolean,
+                default: false,
+                ui: {
+                  control: :checkbox,
+                },
+              },
+            },
+          )
+
+          def initialize(assignment, *)
+            super(parameters: {})
+            @assignment = assignment
+          end
+
+          def valid?
+            @assignment.present? && @assignment.topic.present? &&
+              @assignment.assigned_to.present? && post.present?
+          end
+
+          def output
+            {
+              assignment: assignment_data,
+              post: serialize_post(post),
+              topic: serialize_record(@assignment.topic, TopicListItemSerializer),
+            }
+          end
+
+          def matches?(trigger_ctx)
+            !trigger_ctx.get_node_parameter("topic_assignments_only", false) || topic_assignment?
+          end
+
+          private
+
+          def assignment_data
+            {
+              id: @assignment.id,
+              target_type: @assignment.target_type,
+              target_id: @assignment.target_id,
+              topic_id: @assignment.topic_id,
+              topic_assignment: topic_assignment?,
+              assigned_to_id: @assignment.assigned_to_id,
+              assigned_to_type: @assignment.assigned_to_type,
+              assigned_to: assignee_data(@assignment.assigned_to),
+              assigned_by_user: serialize_record(@assignment.assigned_by_user, BasicUserSerializer),
+              note: @assignment.note,
+              status: @assignment.status,
+            }
+          end
+
+          def assignee_data(assignee)
+            case assignee
+            when ::User
+              { type: "user", user: serialize_record(assignee, BasicUserSerializer), group: {} }
+            when ::Group
+              { type: "group", user: {}, group: serialize_record(assignee, BasicGroupSerializer) }
+            else
+              { type: nil, user: {}, group: {} }
+            end
+          end
+
+          def post
+            @post ||= @assignment.post
+          end
+
+          def topic_assignment?
+            @assignment.target_type == "Topic"
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -29,16 +29,25 @@ after_initialize do
     register_discourse_workflows_node do
       require_relative "lib/discourse_workflows/nodes/assign_topic/v1"
       require_relative "lib/discourse_workflows/nodes/assigned/v1"
+      require_relative "lib/discourse_workflows/nodes/unassigned/v1"
       require_relative "lib/discourse_workflows/nodes/check_assignment/v1"
       [
         DiscourseWorkflows::Nodes::AssignTopic::V1,
         DiscourseWorkflows::Nodes::Assigned::V1,
+        DiscourseWorkflows::Nodes::Unassigned::V1,
         DiscourseWorkflows::Nodes::CheckAssignment::V1,
       ]
     end
 
     on(:assigned) do |assignment|
       DiscourseWorkflows::EventListener.handle(DiscourseWorkflows::Nodes::Assigned::V1, assignment)
+    end
+
+    on(:unassigned) do |assignment|
+      DiscourseWorkflows::EventListener.handle(
+        DiscourseWorkflows::Nodes::Unassigned::V1,
+        assignment,
+      )
     end
   end
   UserUpdater::OPTION_ATTR.push(:notification_level_when_assigned)

--- a/plugins/discourse-assign/spec/lib/assigner_spec.rb
+++ b/plugins/discourse-assign/spec/lib/assigner_spec.rb
@@ -161,6 +161,28 @@ RSpec.describe Assigner do
       expect(assignment.target).to eq(topic)
     end
 
+    it "triggers unassigned event after unassigning" do
+      assigner.assign(moderator)
+      assignment_id = topic.assignment.id
+
+      event = DiscourseEvent.track(:unassigned) { assigner.unassign }
+
+      assignment = event[:params].first
+      expect(assignment.id).to eq(assignment_id)
+      expect(assignment.topic_id).to eq(topic.id)
+      expect(assignment.assigned_to_id).to eq(moderator.id)
+    end
+
+    it "triggers unassigned event when deactivating instead of destroying" do
+      assigner.assign(moderator)
+      assignment_id = topic.assignment.id
+
+      event = DiscourseEvent.track(:unassigned) { assigner.unassign(deactivate: true) }
+
+      assignment = event[:params].first
+      expect(assignment.id).to eq(assignment_id)
+    end
+
     context "with published assignment workflows" do
       fab!(:all_assignments_workflow) do
         Fabricate(

--- a/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/unassigned/v1_spec.rb
+++ b/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/unassigned/v1_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Nodes::Unassigned::V1 do
+  fab!(:post)
+  fab!(:topic) { post.topic }
+  fab!(:assigned_by_user, :admin)
+  fab!(:assignee, :moderator)
+  fab!(:group)
+
+  before do
+    SiteSetting.assign_enabled = true
+    SiteSetting.enable_discourse_workflows = true
+  end
+
+  describe "#valid?" do
+    it "returns true when an assignment is present" do
+      assignment =
+        Fabricate(
+          :post_assignment,
+          post:,
+          assigned_to: assignee,
+          assigned_by_user: assigned_by_user,
+        )
+
+      expect(described_class.new(assignment)).to be_valid
+    end
+
+    it "returns false when assignment is nil" do
+      expect(described_class.new(nil)).not_to be_valid
+    end
+  end
+
+  describe "#output" do
+    it "returns assignment, post, topic, and assignee data for post assignments",
+       :aggregate_failures do
+      assignment =
+        Fabricate(
+          :post_assignment,
+          post: post,
+          assigned_to: assignee,
+          assigned_by_user: assigned_by_user,
+          note: "Please handle this",
+          status: "In Progress",
+        )
+
+      output = described_class.new(assignment).output
+
+      expect(output[:assignment]).to include(
+        id: assignment.id,
+        target_type: "Post",
+        target_id: post.id,
+        topic_id: topic.id,
+        topic_assignment: false,
+        assigned_to_id: assignee.id,
+        assigned_to_type: "User",
+        note: "Please handle this",
+        status: "In Progress",
+      )
+      expect(output[:assignment][:assigned_to][:type]).to eq("user")
+      expect(output[:assignment][:assigned_to][:user][:username]).to eq(assignee.username)
+      expect(output[:assignment][:assigned_by_user][:username]).to eq(assigned_by_user.username)
+      expect(output[:post][:id]).to eq(post.id)
+      expect(output[:topic][:id]).to eq(topic.id)
+      expect(output).to match_node_output_schema(described_class)
+    end
+
+    it "uses the topic first post for topic assignments", :aggregate_failures do
+      assignment =
+        Fabricate(:topic_assignment, topic:, assigned_to: group, assigned_by_user: assigned_by_user)
+
+      output = described_class.new(assignment).output
+
+      expect(output[:assignment]).to include(
+        target_type: "Topic",
+        target_id: topic.id,
+        topic_assignment: true,
+        assigned_to_type: "Group",
+      )
+      expect(output[:assignment][:assigned_to][:type]).to eq("group")
+      expect(output[:assignment][:assigned_to][:group][:name]).to eq(group.name)
+      expect(output[:post][:id]).to eq(topic.first_post.id)
+      expect(output).to match_node_output_schema(described_class)
+    end
+
+    it "returns valid output for an assignment destroyed by unassign", :aggregate_failures do
+      assigner = Assigner.new(topic, assigned_by_user)
+      assigner.assign(assignee)
+      assignment = topic.reload.assignment
+
+      DiscourseEvent.track(:unassigned) { assigner.unassign }
+
+      output = described_class.new(assignment).output
+
+      expect(output[:assignment]).to include(target_type: "Topic", target_id: topic.id)
+      expect(output[:topic][:id]).to eq(topic.id)
+      expect(output).to match_node_output_schema(described_class)
+    end
+  end
+
+  describe "#matches?" do
+    fab!(:post_assignment) do
+      Fabricate(:post_assignment, post:, assigned_to: assignee, assigned_by_user: assigned_by_user)
+    end
+    fab!(:topic_assignment) do
+      Fabricate(
+        :topic_assignment,
+        topic:,
+        assigned_to: assignee,
+        assigned_by_user: assigned_by_user,
+      )
+    end
+
+    it "matches all assignments by default" do
+      expect(described_class.new(post_assignment).matches?(trigger_context({}))).to eq(true)
+      expect(described_class.new(topic_assignment).matches?(trigger_context({}))).to eq(true)
+    end
+
+    it "matches only topic assignments when configured" do
+      context = trigger_context("topic_assignments_only" => true)
+
+      expect(described_class.new(post_assignment).matches?(context)).to eq(false)
+      expect(described_class.new(topic_assignment).matches?(context)).to eq(true)
+    end
+  end
+
+  def trigger_context(parameters)
+    DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+  end
+end


### PR DESCRIPTION
Workflows could only react to a topic or post being assigned. They can now also trigger when one is unassigned.