### PR TITLE
UX: Match Site Traffic Explorer loading skeleton

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -49,12 +49,36 @@
 
     .db-skeleton__heading-line {
       width: min(24rem, 100%);
-      height: 2rem;
+      height: 1.625rem;
+    }
+
+    .db-skeleton__metric {
+      gap: var(--space-1);
+    }
+
+    .db-skeleton__metric-number {
+      height: 2.125rem;
+    }
+
+    .db-skeleton__metric-label {
+      height: 1.22rem;
     }
 
     .db-skeleton__chart {
       height: 360px;
       min-height: 260px;
+    }
+
+    .db-skeleton__row-block-title {
+      height: 2.4rem;
+    }
+
+    .db-skeleton__list {
+      gap: 0;
+    }
+
+    .db-skeleton__list-row {
+      min-height: 1.72rem;
     }
 
     @include viewport.until(md) {

--- a/frontend/discourse/admin/components/site-traffic-explorer.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer.gjs
@@ -14,7 +14,7 @@ import I18n, { i18n } from "discourse-i18n";
 
 const SKELETON_METRICS = Array.from({ length: 4 });
 const SKELETON_BREAKDOWNS = Array.from({ length: 3 });
-const SKELETON_ROWS = Array.from({ length: 5 });
+const SKELETON_ROWS = Array.from({ length: 8 });
 const TRAFFIC_TYPE_BY_SERIES = {
   page_view_logged_in_browser: "logged_in",
   page_view_anon_browser: "anonymous",


### PR DESCRIPTION
Previously, the loading skeleton used shorter metric and breakdown placeholders than the rendered report, so the graph and cards shifted when traffic finished loading.

Match the skeleton's metric, tab, and row dimensions to the rendered report so the page keeps its layout while data loads.

## Screenshots

### Before

<img width="997" height="949" alt="Before" src="https://github.com/user-attachments/assets/94dc5213-de79-4767-9376-70a15d7bfb28" />

### After

<img width="997" height="949" alt="After" src="https://github.com/user-attachments/assets/fa243eb2-f9bc-4e9e-8eee-91e954e86d12" />