### PR TITLE
FIX: Truncate Site Traffic dashboard list labels

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/traffic.scss
+++ b/app/assets/stylesheets/admin/dashboard/traffic.scss
@@ -21,7 +21,7 @@
 
   &__list {
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     column-gap: var(--space-4);
     row-gap: var(--space-2);
     list-style: none;
@@ -46,6 +46,10 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5em;
+    min-width: 0;
+  }
+
+  &__label {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -476,8 +476,11 @@ export default class DashboardTraffic extends Component {
                             href={{concat "https://" row.normalized_referrer}}
                             rel="noopener noreferrer nofollow ugc"
                             target="_blank"
+                            title={{row.normalized_referrer}}
                           >
-                            {{row.normalized_referrer}}
+                            <span class="db-traffic__label">
+                              {{row.normalized_referrer}}
+                            </span>
                           </a>
                           <span class="db-traffic__metric">
                             <span class="db-traffic__percent">
@@ -532,8 +535,11 @@ export default class DashboardTraffic extends Component {
                             <a
                               class="db-traffic__link"
                               href={{getURL row.entry_url}}
+                              title={{row.entry_url}}
                             >
-                              {{row.entry_url}}
+                              <span class="db-traffic__label">
+                                {{row.entry_url}}
+                              </span>
                             </a>
                             <span class="db-traffic__metric">
                               <span class="db-traffic__percent">
@@ -587,11 +593,16 @@ export default class DashboardTraffic extends Component {
                           class="db-traffic__list-row"
                           data-test-country-code={{row.country_code}}
                         >
-                          <span class="db-traffic__name">
+                          <span
+                            class="db-traffic__name"
+                            title={{countryName row.country_code}}
+                          >
                             <span aria-hidden="true">
                               {{countryFlag row.country_code}}
                             </span>
-                            {{countryName row.country_code}}
+                            <span class="db-traffic__label">
+                              {{countryName row.country_code}}
+                            </span>
                           </span>
                           <span class="db-traffic__metric">
                             <span class="db-traffic__percent">

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -254,9 +254,9 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
 
       expect(traffic).to have_top_country_rows(
         [
-          { country: "DE", percent: 70 },
-          { country: "US", percent: 20 },
-          { country: "GB", percent: 10 },
+          { country: "DE", name: "Germany", percent: 70 },
+          { country: "US", name: "United States", percent: 20 },
+          { country: "GB", name: "United Kingdom", percent: 10 },
         ],
       )
       expect(traffic).to have_top_referrer_rows(

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -98,7 +98,8 @@ module PageObjects
           rows.each_with_index.all? do |row, index|
             nth =
               ".db-traffic__list-row:nth-child(#{index + 1})[data-test-country-code='#{row[:country]}']"
-            has_css?(nth) && has_css?("#{nth} .db-traffic__percent", text: "#{row[:percent]}%")
+            has_css?("#{nth} .db-traffic__name[title='#{row[:name]}']") &&
+              has_css?("#{nth} .db-traffic__percent", text: "#{row[:percent]}%")
           end
         end
       end
@@ -109,7 +110,12 @@ module PageObjects
 
           rows.each_with_index.all? do |row, index|
             nth = ".db-traffic__list-row:nth-child(#{index + 1})"
-            next false unless has_css?("#{nth} a.db-traffic__link", text: row[:referrer])
+            unless has_css?(
+                     "#{nth} a.db-traffic__link[title='#{row[:referrer]}']",
+                     text: row[:referrer],
+                   )
+              next false
+            end
             next true unless row.key?(:percent)
 
             has_css?("#{nth} .db-traffic__percent", text: "#{row[:percent]}%")
@@ -123,8 +129,10 @@ module PageObjects
 
           rows.each_with_index.all? do |row, index|
             nth = ".db-traffic__list-row:nth-child(#{index + 1})"
-            has_css?("#{nth} a.db-traffic__link[href='#{row[:path]}']", text: row[:path]) &&
-              has_css?("#{nth} .db-traffic__percent", exact_text: "#{row[:percent]}%") &&
+            has_css?(
+              "#{nth} a.db-traffic__link[href='#{row[:path]}'][title='#{row[:path]}']",
+              text: row[:path],
+            ) && has_css?("#{nth} .db-traffic__percent", exact_text: "#{row[:percent]}%") &&
               has_css?("#{nth} .db-traffic__count", exact_text: "(#{row[:count]})")
           end
         end


### PR DESCRIPTION
Long labels in the Site Traffic dashboard cards could be clipped without an ellipsis because the flex label itself owned the overflow styling. The full value was also unavailable when a label did not fit.

This commit moves truncation to an inner label with a shrinkable grid column and adds title attributes for Top referrers, Top entry URLs, and Top countries.

### Screenshots

#### Before

<img width="381" height="199" alt="Top entry URLs before truncation fix" src="https://github.com/user-attachments/assets/2472fa93-8202-461c-99b7-a45c354455a9" />

#### After

<img width="1060" height="160" alt="Top referrers, Top entry URLs, and Top countries after truncation fix" src="https://github.com/user-attachments/assets/c4423ab2-f172-4d37-b3f5-d2c9cecbcb14" />