### PR TITLE
UX: dfilterinput icons case insensitive

### DIFF
--- a/frontend/discourse/app/ui-kit/d-filter-input.gts
+++ b/frontend/discourse/app/ui-kit/d-filter-input.gts
@@ -93,6 +93,9 @@ export default class DFilterInput extends Component<DFilterInputSignature> {
         type="text"
         value={{@value}}
         class="filter-input"
+        autocapitalize="none"
+        autocorrect="off"
+        autocomplete="off"
         ...attributes
       />
 

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -473,7 +473,7 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
 
   def self.icon_picker_search(keyword, only_available, page:, per_page:, theme_id: nil)
     ids = picker_icon_ids(theme_id, only_available)
-    ids = ids.lazy.select { |id| id.include?(keyword) } if keyword.present?
+    ids = ids.lazy.select { |id| id.include?(keyword.downcase) } if keyword.present?
     ids = ids.drop(page * per_page).first(per_page + 1)
 
     has_more = ids.size > per_page

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -473,7 +473,12 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
 
   def self.icon_picker_search(keyword, only_available, page:, per_page:, theme_id: nil)
     ids = picker_icon_ids(theme_id, only_available)
-    ids = ids.lazy.select { |id| id.include?(keyword.downcase) } if keyword.present?
+
+    if keyword.present?
+      downcased_keyword = keyword.downcase
+      ids = ids.lazy.select { |id| id.downcase.include?(downcased_keyword) }
+    end
+
     ids = ids.drop(page * per_page).first(per_page + 1)
 
     has_more = ids.size > per_page


### PR DESCRIPTION
This fixes https://meta.discourse.org/t/icon-picker-search-doesnt-support-capital-letters/410385

* The icon names are now matched case-insensitive
* The `DFilterInput`, which only has ~30 consumers that are list filters, not content-entry fields, benefits from turning these off generally:
   *  `autocapitalize="none"`:  mobile keyboards capitalizing the first letter is actively harmful here (see report)
   * `autocorrect="off"`: OS autocorrecting a partial token ("cate" → "Kate") as you type
   * `autocomplete="off"`:  the browser dropdown physically covers the results list you're filtering.

| BC | AC |
|--------|--------|
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/ed61b463-64c0-4ef3-8cc6-ac339986c316" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/0152f9df-586f-4d08-abad-32233d85be19" /> | 


