### PR TITLE
FIX: add missing topic to discobot regex for oneboxing tutorial

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -272,7 +272,7 @@ module DiscourseNarrativeBot
       # the user drops some other random link, but we accept that risk for now.
       found_link =
         @post.raw.match(
-          %r{https://en\.wikipedia\.org/wiki/(Inherently_funny_word|Death_by_coconut|Calculator_spelling)},
+          %r{https://en\.wikipedia\.org/wiki/(Inherently_funny_word|Death_by_coconut|Calculator_spelling|Exotic_Shorthair)},
         )
 
       if found_link


### PR DESCRIPTION
Reported https://meta.discourse.org/t/discobot-broken-when-i-send-it-a-com-example-com-in-its-tutorial/410406

