### PR TITLE
UX: Show bounce scores against each of a user's email addresses

### DIFF
--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -41,6 +41,25 @@
     list-style: none;
   }
 
+  .email-bounce {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    margin: 0.25em 0 0.5em;
+
+    &__link {
+      color: var(--danger);
+      white-space: nowrap;
+    }
+
+    &__explanation {
+      flex-basis: 100%;
+      color: var(--primary-medium);
+      font-size: var(--font-down-1);
+    }
+  }
+
   .field {
     font-weight: bold;
     width: 17.65765%;

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -577,7 +577,23 @@ class Admin::UsersController < Admin::StaffController
 
   def reset_bounce_score
     guardian.ensure_can_reset_bounce_score!(@user)
-    EmailBounceScore.reset_for_user!(@user)
+
+    if (email = params[:email].presence)
+      # naming one address only makes sense to someone allowed to see them, and
+      # the 404 below would otherwise answer "does this user own this address?"
+      guardian.ensure_can_check_emails!(@user)
+      email = EmailBounceScore.canonicalize(email)
+      # only the user's own addresses, so this can't clear a stranger's embargo.
+      # An address that has already eroded away is a no-op rather than a 404,
+      # since the admin asked for a state the row's absence already satisfies
+      raise Discourse::NotFound if !@user.user_emails.exists?(email:)
+      EmailBounceScore.reset!(email)
+    else
+      EmailBounceScore.reset_for_user!(@user)
+    end
+
+    # deliberately not logging which address: `:reset_bounce_score` stays visible
+    # to moderators when `moderators_view_emails` is off
     StaffActionLogger.new(current_user).log_reset_bounce_score(@user)
     render json: success_json
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -311,12 +311,19 @@ class UsersController < ApplicationController
     email, *secondary_emails = user.emails
     unconfirmed_emails = user.unconfirmed_emails
 
-    render json: {
-             email: email,
-             secondary_emails: secondary_emails,
-             unconfirmed_emails: unconfirmed_emails,
-             associated_accounts: user.associated_accounts,
-           }
+    payload = {
+      email: email,
+      secondary_emails: secondary_emails,
+      unconfirmed_emails: unconfirmed_emails,
+      associated_accounts: user.associated_accounts,
+    }
+    # deliverability is staff-facing, and this endpoint also serves users looking
+    # at their own addresses
+    payload[:bounce_scores] = EmailBounceScore.for_user_by_email(
+      user,
+    ) if guardian.can_check_emails?(user)
+
+    render json: payload
   rescue Discourse::InvalidAccess
     render json: failed_json, status: :forbidden
   end

--- a/app/models/email_bounce_score.rb
+++ b/app/models/email_bounce_score.rb
@@ -20,6 +20,16 @@ class EmailBounceScore < ActiveRecord::Base
     where(email: user.user_emails.select("lower(user_emails.email)"))
   end
 
+  # Keyed by the canonical address, and only holds the addresses in bad standing
+  # — the caller is expected to treat a missing key as a clean address.
+  def self.for_user_by_email(user)
+    for_user(user)
+      .pluck(:email, :bounce_score, :reset_bounce_score_after)
+      .to_h do |email, score, reset_after|
+        [email, { bounce_score: score, reset_bounce_score_after: reset_after }]
+      end
+  end
+
   def self.deliverable?(email)
     score_for(email) < SiteSetting.bounce_score_threshold
   end

--- a/app/services/user_anonymizer.rb
+++ b/app/services/user_anonymizer.rb
@@ -25,6 +25,10 @@ class UserAnonymizer
           UserAssociatedAccount.where(user_id: @user.id).pluck(Arel.sql("info->>'email'")).compact
       @prev_username = @user.username
 
+      # the ledger is keyed by address, so it has to be cleared while the user
+      # still owns the addresses they are about to lose
+      EmailBounceScore.for_user(@user).delete_all
+
       unless UsernameChanger.new(@user, make_anon_username).change(run_update_job: false)
         raise "Failed to change username"
       end

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -63,7 +63,13 @@ class UserDestroyer
         user.user_emails.pluck(:email) |
           UserAssociatedAccount.where(user_id: user.id).pluck(Arel.sql("info->>'email'")).compact
 
+      # the ledger is keyed by address, so the addresses have to be read while
+      # the user still owns them, and cleared only once the destroy has stuck
+      bounced_emails = EmailBounceScore.for_user(user).pluck(:email)
+
       if result = user.destroy
+        EmailBounceScore.where(email: bounced_emails).delete_all
+
         if opts[:block_email]
           emails.each do |email|
             ScreenedEmail.block(email, ip_address: result.ip_address)&.record_match!

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9741,20 +9741,20 @@ en:
         silence_failed: "There was a problem silencing the user."
         silence_confirm: "Are you sure you want to silence this user? They will not be able to create any new topics or posts."
         silence_accept: "Yes, silence this user"
-        bounce_score: "Bounce Score"
+        bounce_score_for_email: "Bounce score %{score}"
+        bounce_score_hidden: "This user's primary email address is bouncing"
         reset_bounce_score:
           label: "Reset"
-          title: "Reset bounce score back to 0"
+          title: "Reset the bounce score of %{email} back to 0"
         visit_profile: "Visit <a href='%{url}'>this user's preferences page</a> to edit their profile"
 
         deactivate_explanation: "A deactivated user must re-validate their email."
         suspended_explanation: "A suspended user can't log in."
         silence_explanation: "A silenced user can't post or start topics."
         staged_explanation: "A staged user can only post via email in specific topics."
-        bounce_score_explanation:
-          none: "No bounces were received recently from that email."
-          some: "Some bounces were received recently from that email."
-          threshold_reached: "Received too many bounces from that email."
+        bounce_score_state:
+          some: "Some bounces were received recently from that email. The score resets on %{date}."
+          threshold_reached: "Received too many bounces from that email, so it is not emailed until %{date}."
         trust_level_change_failed: "There was a problem changing the user's trust level."
         suspend_modal_title: "Suspend User"
         confirm_cancel_penalty: "Are you sure you want to discard the penalty?"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2561,9 +2561,9 @@ en:
     postmark_webhook_token: "Token used to verify webhook payload. It must be passed as the 't' query parameter of the webhook, for example: https://example.com/webhook/postmark?t=supersecret"
     sparkpost_webhook_token: "Token used to verify webhook payload. It must be passed as the 't' query parameter of the webhook, for example: https://example.com/webhook/sparkpost?t=supersecret"
 
-    soft_bounce_score: "Bounce score added to the user when a temporary bounce happens."
-    hard_bounce_score: "Bounce score added to the user when a permanent bounce happens."
-    bounce_score_threshold: "Max bounce score before we will stop emailing a user."
+    soft_bounce_score: "Bounce score added to the email address when a temporary bounce happens."
+    hard_bounce_score: "Bounce score added to the email address when a permanent bounce happens."
+    bounce_score_threshold: "Max bounce score before we will stop emailing an address."
     reset_bounce_score_after_days: "Automatically reset bounce score after X days."
 
     blocked_attachment_content_types: "List of keywords used to blocklist attachments based on the content type."

--- a/frontend/discourse/admin/controllers/admin-user/index.js
+++ b/frontend/discourse/admin/controllers/admin-user/index.js
@@ -225,8 +225,8 @@ export default class AdminUserIndexController extends Controller {
   }
 
   @action
-  resetBounceScore() {
-    return this.model.resetBounceScore();
+  resetBounceScore(email) {
+    return this.model.resetBounceScore(email);
   }
 
   @action

--- a/frontend/discourse/admin/models/admin-user.js
+++ b/frontend/discourse/admin/models/admin-user.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import { computed } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -30,6 +31,8 @@ export default class AdminUser extends User {
     }).then((users) => users.map((u) => AdminUser.create(u)));
   }
 
+  // arrives from `checkEmail`, not from the admin payload
+  @tracked bounce_scores;
   adminUserView = true;
 
   @autoTrackedArray groups;
@@ -37,11 +40,6 @@ export default class AdminUser extends User {
   @computed("active", "staged")
   get canViewProfile() {
     return this.active || this.staged;
-  }
-
-  @computed("bounce_score")
-  get canResetBounceScore() {
-    return this.bounce_score > 0;
   }
 
   @computed("originalTrustLevel", "trust_level")
@@ -72,42 +70,51 @@ export default class AdminUser extends User {
     return this.groups?.filter((g) => g.automatic) ?? [];
   }
 
-  @computed("bounce_score", "reset_bounce_score_after")
-  get bounceScore() {
-    if (this.bounce_score > 0) {
-      return `${this.bounce_score} - ${moment(
-        this.reset_bounce_score_after
-      ).format("LL")}`;
-    } else {
-      return this.bounce_score;
-    }
-  }
-
-  @computed("bounce_score")
-  get bounceScoreExplanation() {
-    if (this.bounce_score === 0) {
-      return i18n("admin.user.bounce_score_explanation.none");
-    } else if (this.bounce_score < this.siteSettings.bounce_score_threshold) {
-      return i18n("admin.user.bounce_score_explanation.some");
-    } else {
-      return i18n("admin.user.bounce_score_explanation.threshold_reached");
-    }
-  }
-
   @computed
   get bounceLink() {
     return getURL("/admin/email-logs/bounced");
   }
 
-  resetBounceScore() {
-    return ajax(`/admin/users/${this.id}/reset-bounce-score`, {
-      type: "POST",
-    }).then(() =>
-      this.setProperties({
-        bounce_score: 0,
-        reset_bounce_score_after: null,
-      })
-    );
+  /**
+   * The bounce state of one address, or null while it is in good standing.
+   * `bounce_scores` is keyed by the canonical (lowercased) address and only
+   * holds the addresses that have bounced recently, so a miss means clean.
+   *
+   * @param {string} email
+   * @returns {{score: number, resetTitle: string, explanation: string}|null}
+   */
+  bounceStateFor(email) {
+    const state = this.bounce_scores?.[email?.toLowerCase()];
+    if (!state || state.bounce_score <= 0) {
+      return null;
+    }
+
+    const date = moment(state.reset_bounce_score_after).format("ll");
+
+    return {
+      // erosion subtracts floats, so the stored score carries residue
+      score: Math.round(state.bounce_score * 10) / 10,
+      resetTitle: i18n("admin.user.reset_bounce_score.title", { email }),
+      explanation:
+        state.bounce_score < this.siteSettings.bounce_score_threshold
+          ? i18n("admin.user.bounce_score_state.some", { date })
+          : i18n("admin.user.bounce_score_state.threshold_reached", { date }),
+    };
+  }
+
+  async resetBounceScore(email) {
+    try {
+      await ajax(`/admin/users/${this.id}/reset-bounce-score`, {
+        type: "POST",
+        data: { email },
+      });
+    } catch (error) {
+      return popupAjaxError(error);
+    }
+
+    const remaining = { ...this.bounce_scores };
+    delete remaining[email.toLowerCase()];
+    this.bounce_scores = remaining;
   }
 
   async groupAdded(added) {

--- a/frontend/discourse/admin/templates/admin-user/index.gjs
+++ b/frontend/discourse/admin/templates/admin-user/index.gjs
@@ -21,6 +21,27 @@ import dFormatDuration from "discourse/ui-kit/helpers/d-format-duration";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+const bounceStateFor = (user, email) => user.bounceStateFor(email);
+
+const EmailBounceState = <template>
+  {{#if @state}}
+    <div class="email-bounce">
+      <a class="email-bounce__link" href={{@bounceLink}}>
+        {{dIcon "triangle-exclamation"}}
+        {{i18n "admin.user.bounce_score_for_email" score=@state.score}}
+      </a>
+      <DButton
+        @action={{fn @reset @email}}
+        @label="admin.user.reset_bounce_score.label"
+        @translatedTitle={{@state.resetTitle}}
+        @translatedAriaLabel={{@state.resetTitle}}
+        class="btn-default email-bounce__reset"
+      />
+      <div class="email-bounce__explanation">{{@state.explanation}}</div>
+    </div>
+  {{/if}}
+</template>;
+
 export default <template>
   <section class="details {{unless @controller.model.active 'not-activated'}}">
     <div class="user-controls">
@@ -93,6 +114,15 @@ export default <template>
             <a
               href="mailto:{{@controller.model.email}}"
             >{{@controller.model.email}}</a>
+            <EmailBounceState
+              @state={{bounceStateFor
+                @controller.model
+                @controller.model.email
+              }}
+              @email={{@controller.model.email}}
+              @bounceLink={{@controller.model.bounceLink}}
+              @reset={{@controller.resetBounceScore}}
+            />
           {{else}}
             <DButton
               @action={{fn (routeAction "checkEmail") @controller.model}}
@@ -101,6 +131,16 @@ export default <template>
               @title="admin.users.check_email.title"
               class="btn-default"
             />
+            {{! `bounce_score` mirrors the primary address, which is the only one
+                delivery is gated on; naming it costs a `check_email` audit entry }}
+            {{#if (gt @controller.model.bounce_score 0)}}
+              <div class="email-bounce email-bounce--unrevealed">
+                <span class="email-bounce__link">
+                  {{dIcon "triangle-exclamation"}}
+                  {{i18n "admin.user.bounce_score_hidden"}}
+                </span>
+              </div>
+            {{/if}}
           {{/if}}
         </div>
         <div class="controls">
@@ -122,7 +162,15 @@ export default <template>
             {{#if @controller.model.secondary_emails}}
               <ul>
                 {{#each @controller.model.secondary_emails as |email|}}
-                  <li><a href="mailto:{{email}}">{{email}}</a></li>
+                  <li>
+                    <a href="mailto:{{email}}">{{email}}</a>
+                    <EmailBounceState
+                      @state={{bounceStateFor @controller.model email}}
+                      @email={{email}}
+                      @bounceLink={{@controller.model.bounceLink}}
+                      @reset={{@controller.resetBounceScore}}
+                    />
+                  </li>
                 {{/each}}
               </ul>
             {{else}}
@@ -153,24 +201,6 @@ export default <template>
               {{/if}}
             {{/if}}
           {{/if}}
-        </div>
-      </div>
-
-      <div class="display-row bounce-score">
-        <div class="field"><a href={{@controller.model.bounceLink}}>{{i18n
-              "admin.user.bounce_score"
-            }}</a></div>
-        <div class="value">{{@controller.model.bounceScore}}</div>
-        <div class="controls">
-          {{#if @controller.model.canResetBounceScore}}
-            <DButton
-              @action={{@controller.resetBounceScore}}
-              @label="admin.user.reset_bounce_score.label"
-              @title="admin.user.reset_bounce_score.title"
-              class="btn-default"
-            />
-          {{/if}}
-          {{@controller.model.bounceScoreExplanation}}
         </div>
       </div>
 

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -1245,6 +1245,8 @@ export default class User extends RestModel.extend(Evented) {
           secondary_emails: result.secondary_emails,
           unconfirmed_emails: result.unconfirmed_emails,
           associated_accounts: result.associated_accounts,
+          // only present for staff looking at someone else's addresses
+          bounce_scores: result.bounce_scores,
         });
       }
     });

--- a/frontend/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/frontend/discourse/tests/acceptance/admin-user-emails-test.js
@@ -66,4 +66,79 @@ acceptance("Admin - User Emails", function (needs) {
       "regular2alt2@example.com"
     );
   });
+
+  test("a bouncing address is flagged before the addresses are revealed", async function (assert) {
+    await visit("/admin/users/1235/regular1");
+
+    assert
+      .dom(".display-row.email .email-bounce--unrevealed")
+      .exists(
+        "warns without spending a check_email audit entry on the address"
+      );
+
+    await click(`.display-row.secondary-emails button`);
+
+    assert
+      .dom(".display-row.email .email-bounce--unrevealed")
+      .doesNotExist(
+        "gives way to the per-address badge once they are revealed"
+      );
+  });
+
+  test("bounce state is shown against the address that bounced", async function (assert) {
+    await visit("/admin/users/1235/regular1");
+    await click(`.display-row.secondary-emails button`);
+
+    assert
+      .dom(".display-row.email .email-bounce__link")
+      .includesText("6", "shows the primary address's bounce score");
+
+    assert
+      .dom(".display-row.secondary-emails li:first-of-type .email-bounce")
+      .doesNotExist("leaves a secondary address in good standing alone");
+
+    assert
+      .dom(".display-row.secondary-emails li:last-of-type .email-bounce__link")
+      .hasText("Bounce score 2", "rounds off the float residue in the score");
+
+    assert.dom(".display-row.email .email-bounce__explanation").hasText(
+      i18n("admin.user.bounce_score_state.threshold_reached", {
+        date: moment("2100-01-01T00:00:00.000Z").format("ll"),
+      }),
+      "explains a score at or above the threshold"
+    );
+
+    assert
+      .dom(
+        ".display-row.secondary-emails li:last-of-type .email-bounce__explanation"
+      )
+      .includesText(
+        i18n("admin.user.bounce_score_state.some", {
+          date: moment("2100-01-01T00:00:00.000Z").format("ll"),
+        }),
+        "explains a score below the threshold"
+      );
+
+    assert.dom(".display-row.email .email-bounce__reset").hasAttribute(
+      "aria-label",
+      i18n("admin.user.reset_bounce_score.title", {
+        email: "regular2@example.com",
+      }),
+      "names the address each Reset button acts on"
+    );
+  });
+
+  test("resetting one address leaves the others alone", async function (assert) {
+    await visit("/admin/users/1235/regular1");
+    await click(`.display-row.secondary-emails button`);
+    await click(".display-row.email .email-bounce__reset");
+
+    assert
+      .dom(".display-row.email .email-bounce")
+      .doesNotExist("clears the address that was reset");
+
+    assert
+      .dom(".display-row.secondary-emails li:last-of-type .email-bounce__link")
+      .includesText("2", "keeps the other address's score");
+  });
 });

--- a/frontend/discourse/tests/helpers/create-pretender.js
+++ b/frontend/discourse/tests/helpers/create-pretender.js
@@ -290,6 +290,18 @@ export function applyDefaultHandlers() {
           "regular2alt1@example.com",
           "regular2alt2@example.com",
         ],
+        // only the addresses in bad standing are listed
+        bounce_scores: {
+          "regular2@example.com": {
+            bounce_score: 6,
+            reset_bounce_score_after: "2100-01-01T00:00:00.000Z",
+          },
+          "regular2alt2@example.com": {
+            // erosion leaves float residue in the stored score
+            bounce_score: 2.0000000000000004,
+            reset_bounce_score_after: "2100-01-01T00:00:00.000Z",
+          },
+        },
       });
     }
     return response({ email: "eviltrout@example.com" });
@@ -1146,12 +1158,16 @@ export function applyDefaultHandlers() {
     return response(200, {
       id: 1235,
       username: "regular2",
+      // the mirror of the primary address, which is all the admin payload knows
+      bounce_score: 6,
+      reset_bounce_score_after: "2100-01-01T00:00:00.000Z",
     });
   });
 
   pretender.delete("/admin/users/:user_id.json", () =>
     response(200, { deleted: true })
   );
+  pretender.post("/admin/users/:user_id/reset-bounce-score", success);
   pretender.post("/admin/badges", success);
   pretender.delete("/admin/badges/:id", success);
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -3389,6 +3389,41 @@ RSpec.describe Admin::UsersController do
         expect(EmailBounceScore.score_for(user.email)).to eq(0)
         expect(EmailBounceScore.score_for(secondary)).to eq(0)
       end
+
+      it "will reset only the address it was given" do
+        SiteSetting.moderators_view_emails = true
+        secondary = Fabricate(:secondary_email, user: user, email: "Spare@Email.com").email
+        EmailBounceScore.record_bounce!(secondary, 4)
+
+        # addresses are stored downcased, so the param has to be canonicalized
+        post "/admin/users/#{user.id}/reset-bounce-score.json", params: { email: secondary.upcase }
+
+        expect(response.status).to eq(200)
+        expect(EmailBounceScore.score_for(secondary)).to eq(0)
+        expect(EmailBounceScore.score_for(user.email)).to eq(10)
+      end
+
+      it "will not name an address to a moderator who cannot see them" do
+        SiteSetting.moderators_view_emails = false
+        secondary = Fabricate(:secondary_email, user: user).email
+        EmailBounceScore.record_bounce!(secondary, 4)
+
+        post "/admin/users/#{user.id}/reset-bounce-score.json", params: { email: secondary }
+
+        expect(response.status).to eq(403)
+        expect(EmailBounceScore.score_for(secondary)).to eq(4)
+      end
+
+      it "will not reset an address the user does not own" do
+        SiteSetting.moderators_view_emails = true
+        stranger = Fabricate(:user)
+        EmailBounceScore.record_bounce!(stranger.email, 4)
+
+        post "/admin/users/#{user.id}/reset-bounce-score.json", params: { email: stranger.email }
+
+        expect(response.status).to eq(404)
+        expect(EmailBounceScore.score_for(stranger.email)).to eq(4)
+      end
     end
 
     context "when logged in as a non-staff user" do

--- a/spec/requests/api/schemas/json/user_emails_response.json
+++ b/spec/requests/api/schemas/json/user_emails_response.json
@@ -15,6 +15,21 @@
     "associated_accounts": {
       "type": "array",
       "items": {}
+    },
+    "bounce_scores": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "bounce_score": {
+            "type": "number"
+          },
+          "reset_bounce_score_after": {
+            "type": "string"
+          }
+        },
+        "required": ["bounce_score", "reset_bounce_score_after"]
+      }
     }
   },
   "required": [

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4404,6 +4404,29 @@ RSpec.describe UsersController do
         expect(json["unconfirmed_emails"]).to eq(inactive_user.unconfirmed_emails)
         expect(json["associated_accounts"]).to eq([])
       end
+
+      it "returns the bounce score of every address in bad standing" do
+        Fabricate(:secondary_email, user: user, email: "Spare@Email.com")
+        EmailBounceScore.record_bounce!(user.email, 2)
+        sign_in_admin
+
+        get "/u/#{user.username}/emails.json"
+
+        expect(response.status).to eq(200)
+        # keyed by the canonical address, and clean addresses are simply absent
+        expect(response.parsed_body["bounce_scores"].keys).to eq([user.email])
+        expect(response.parsed_body["bounce_scores"][user.email]["bounce_score"]).to eq(2.0)
+      end
+
+      it "does not return bounce scores to a user looking at their own addresses" do
+        EmailBounceScore.record_bounce!(user.email, 2)
+        sign_in(user)
+
+        get "/u/#{user.username}/emails.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).not_to have_key("bounce_scores")
+      end
     end
   end
 

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe UserAnonymizer do
 
       make_anonymous
 
+      expect(EmailBounceScore.score_for(original_email)).to eq(0)
       expect(user.reload.user_stat.bounce_score).to eq(0)
     end
 

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -455,6 +455,17 @@ RSpec.describe UserDestroyer do
 
         include_examples "successfully destroy a user"
         include_examples "email block list"
+
+        it "clears the bounce score of every address the user owned" do
+          secondary = Fabricate(:secondary_email, user: user).email
+          EmailBounceScore.record_bounce!(user.email, 3.0)
+          EmailBounceScore.record_bounce!(secondary, 3.0)
+
+          destroy
+
+          expect(EmailBounceScore.score_for(user.email)).to eq(0)
+          expect(EmailBounceScore.score_for(secondary)).to eq(0)
+        end
       end
 
       context "when destroy fails" do


### PR DESCRIPTION
Previously, the admin user page showed a single "Bounce Score" row backed by `user_stats.bounce_score`. Now that bounce state is keyed by email address, that row had no referent — it reported the primary address's score under a label that implied the account.

This change moves bounce state onto the addresses it belongs to. Each primary and secondary address that is in bad standing shows its own score, its own explanation, and its own Reset button, and the standalone row is gone.

Notes for review:

- The scores ride along on `/u/:username/emails.json` rather than the admin user payload, so they are gated by the same `can_check_emails?` permission as the addresses themselves and arrive in the same request. `user_stats.bounce_score` and `reset_bounce_score_after` are left on `AdminDetailedUserSerializer` untouched — the OpenAPI schema marks both required.
- Because the addresses load lazily, the page would otherwise show nothing about deliverability until an admin clicks "Show email". The primary email row therefore keeps a non-identifying warning driven by the mirror, so the state stays discoverable without spending a `check_email` audit entry.
- `reset-bounce-score` takes an optional `email`. That branch is gated on `can_check_emails?`: naming one address only makes sense to someone allowed to see them, and without the gate the 404 would answer "does this user own this address?" for staff who cannot. The staff log deliberately does not record which address — `:reset_bounce_score` stays visible to moderators when `moderators_view_emails` is off.
- `UserDestroyer` and `UserAnonymizer` now clear the user's ledger rows. PR1 skipped this on the grounds that the rows carry no user linkage and self-expire; the calculus changes once the address and its score are rendered together in admin. The destroyer reads the addresses before `destroy` and deletes only once it has succeeded, since a falsey non-raising destroy is a supported outcome.
- `bounce_score_explanation` was replaced by `bounce_score_state` rather than mutated in place, because the strings gained a `%{date}` placeholder and the 42 translated locales would otherwise have silently dropped the date.
- Displayed scores are rounded: erosion subtracts floats, so a stored score carries residue that would otherwise render as `1.3877787807814457e-16`.
