### PR TITLE
DEV: Move `prioritize_recently_used_tags` to experimental

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4735,8 +4735,9 @@ experimental:
     hidden: true
     area: "experimental"
     upcoming_change:
-      status: "conceptual"
+      status: "experimental"
       impact: "feature,all_members"
+      learn_more_url: "https://meta.discourse.org/t/-/410419"
   rename_faq_to_guidelines:
     default: false
     hidden: true


### PR DESCRIPTION
Previously, the `prioritize_recently_used_tags` upcoming change was `conceptual`, so it was hidden from the upcoming changes admin page and admins had no way to preview it.

This change promotes it to `experimental` and adds the `learn_more_url` pointing at the meta topic, so admins can opt themselves, staff, or specific groups in.
