### PR TITLE
DEV: Expose avatar and profile images to workflows

### DIFF
--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/user_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/user_serializer.rb
@@ -13,7 +13,9 @@ module DiscourseWorkflows
                :created_at,
                :approved,
                :silenced,
-               :suspended
+               :suspended,
+               :uploaded_avatar_id,
+               :avatar_template
 
     def trust_level_name
       TrustLevel.name(object.trust_level)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/user/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/user/v1.rb
@@ -247,21 +247,17 @@ module DiscourseWorkflows
         end
 
         def user_data(user, guardian, extensions:)
-          include_profile_details = include_profile_details?(user, guardian)
+          profile = user.user_profile if include_profile_details?(user, guardian)
 
           serialize_user(user, guardian: guardian).merge(
             title: user.title,
-            bio_raw: include_profile_details ? user.user_profile.bio_raw : nil,
+            bio_raw: profile&.bio_raw,
+            website: profile&.website,
+            profile_background_upload_id: profile&.profile_background_upload_id,
+            card_background_upload_id: profile&.card_background_upload_id,
             manual_locked_trust_level: user.manual_locked_trust_level,
             trust_level_locked: !user.manual_locked_trust_level.nil?,
-            user_fields:
-              (
-                if include_profile_details
-                  user.user_fields(guardian.allowed_user_field_ids(user))
-                else
-                  {}
-                end
-              ),
+            user_fields: profile ? user.user_fields(guardian.allowed_user_field_ids(user)) : {},
             groups: groups_data(user, guardian),
           ).merge(extensions_data(user, guardian, extensions))
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
@@ -122,7 +122,9 @@ module DiscourseWorkflows
         "created_at": { "type": "string", "format": "date-time" },
         "approved": { "type": "boolean" },
         "silenced": { "type": "boolean" },
-        "suspended": { "type": "boolean" }
+        "suspended": { "type": "boolean" },
+        "uploaded_avatar_id": { "type": ["integer", "null"] },
+        "avatar_template": { "type": "string" }
       }
     JSON
 
@@ -186,6 +188,9 @@ module DiscourseWorkflows
           {
             "title": { "type": ["string", "null"] },
             "bio_raw": { "type": ["string", "null"] },
+            "website": { "type": ["string", "null"] },
+            "profile_background_upload_id": { "type": ["integer", "null"] },
+            "card_background_upload_id": { "type": ["integer", "null"] },
             "manual_locked_trust_level": { "type": ["integer", "null"] },
             "trust_level_locked": { "type": "boolean" },
             "user_fields": { "type": "object" },

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/user_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/user_spec.rb
@@ -40,6 +40,35 @@ RSpec.describe DiscourseWorkflows::Nodes::User::V1 do
       expect(result["user"]).not_to have_key("email")
     end
 
+    it "returns profile images and website", :aggregate_failures do
+      avatar = Fabricate(:upload)
+      profile_background = Fabricate(:upload)
+      card_background = Fabricate(:upload)
+      user.update!(uploaded_avatar_id: avatar.id)
+      user.user_profile.update!(
+        website: "https://example.com",
+        profile_background_upload_id: profile_background.id,
+        card_background_upload_id: card_background.id,
+      )
+
+      result = execute_node(configuration: { "operation" => "get", "username" => user.username })
+
+      expect(result["user"]).to include(
+        "uploaded_avatar_id" => avatar.id,
+        "website" => "https://example.com",
+        "profile_background_upload_id" => profile_background.id,
+        "card_background_upload_id" => card_background.id,
+      )
+      expect(result.dig("user", "avatar_template")).to include(avatar.id.to_s)
+      expect(
+        DiscourseWorkflows::Schema::USER_ACTION_SCHEMA.dig(
+          "properties",
+          "user",
+          "properties",
+        ).keys - result["user"].keys,
+      ).to be_empty
+    end
+
     it "always returns account status signals", :aggregate_failures do
       user.update!(silenced_till: 1.day.from_now, approved: true)
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/user_updated_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/user_updated_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe DiscourseWorkflows::Nodes::UserUpdated::V1 do
       )
       expect(output).to match_node_output_schema(described_class)
     end
+
+    it "exposes the avatar so vision triage can reach it", :aggregate_failures do
+      avatar = Fabricate(:upload)
+      user.update!(uploaded_avatar_id: avatar.id)
+
+      output = described_class.new(user).output
+
+      expect(output.dig(:user, :uploaded_avatar_id)).to eq(avatar.id)
+      expect(output.dig(:user, :avatar_template)).to include(avatar.id.to_s)
+    end
   end
 
   describe "#matches?" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_serializer_sync_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_serializer_sync_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Schema do
+  fab!(:user)
+
+  let(:guardian) { Discourse.system_user.guardian }
+
+  def serialized_keys(serializer_class, object)
+    MultiJson.load(serializer_class.new(object, scope: guardian, root: false).to_json).keys
+  end
+
+  def expect_emitted(declared, emitted)
+    expect(declared.keys - emitted).to be_empty
+  end
+
+  it "emits every property USER_PROPERTIES declares" do
+    expect_emitted(
+      described_class::USER_PROPERTIES,
+      serialized_keys(DiscourseWorkflows::UserSerializer, user),
+    )
+  end
+
+  it "emits every property BASIC_USER_PROPERTIES declares" do
+    expect_emitted(
+      described_class::BASIC_USER_PROPERTIES,
+      serialized_keys(BasicUserSerializer, user),
+    )
+  end
+end


### PR DESCRIPTION
Workflow user payloads carried no reference to any user-supplied image. The AI agent node already accepts `upload_ids` and routes them to a vision-enabled agent, but nothing in a workflow could produce an avatar's upload id, so profile images were unreachable.

### Changes

- `uploaded_avatar_id` and `avatar_template` on the shared user serializer, which reaches every user-emitting node at once (`user_created`, `user_updated`, `user_seen`, the group membership triggers, `badge_granted`, `action:user`, `action:user_search`). `User#avatar_template` is string interpolation over `username` and `uploaded_avatar_id`, so this adds no query to the trigger path.
- `website`, `profile_background_upload_id` and `card_background_upload_id` on the user node, behind the same profile-detail guard as `bio_raw`. `user_profile` is already loaded there.

`uploaded_avatar_id` is nil for system and letter avatars, so the nil check a workflow has to do is also the "only look at user-supplied images" filter.

### On the spec

Schema constants drive the builder's output pane and expression picker, but nothing at runtime forces them to agree with the payloads they document, and `match_node_output_schema` does not catch it either. A property that is declared but never emitted becomes an expression that silently resolves to nil.

This adds a spec pinning that direction for the user constants. Only that direction: schemas are curated views that deliberately omit fields their source emits (`TOPIC_PROPERTIES` hides around twenty), so extra payload keys are not a failure and `additionalProperties: false` would be wrong here.

The user constants were the only ones in the file already in sync both ways, so this pins them before the first new field goes in. The same spec extends to the post, topic and group constants later, with allowlists for their conditional fields.