### PR TITLE
FEATURE: Let staff remove an avatar from the review queue

### DIFF
--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -31,6 +31,10 @@ class ReviewableUser < Reviewable
       delete_user_actions(actions, bundle, require_reject_reason: false)
     end
 
+    if status == "pending" && target&.uploaded_avatar_id.present?
+      build_action(actions, :remove_avatar, icon: "user-xmark")
+    end
+
     if guardian.can_approve?(target)
       actions.add(:approve_user, bundle: nil) do |a|
         a.icon = "user-plus"
@@ -52,6 +56,12 @@ class ReviewableUser < Reviewable
   def build_actions(actions, guardian, args)
     return if approved?
     super
+  end
+
+  def perform_remove_avatar(performed_by, args)
+    target.remove_avatar!(performed_by)
+
+    create_result(:success)
   end
 
   def perform_approve_user(performed_by, args)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1304,6 +1304,17 @@ class User < ActiveRecord::Base
     end
   end
 
+  def remove_avatar!(actor)
+    return if uploaded_avatar_id.blank?
+
+    self.class.transaction do
+      update!(uploaded_avatar_id: nil)
+      user_avatar&.update!(custom_upload_id: nil, gravatar_upload_id: nil)
+    end
+
+    StaffActionLogger.new(actor).log_removed_avatar(self)
+  end
+
   # The following count methods are somewhat slow - definitely don't use them in a loop.
   # They might need to be denormalized
   def like_count

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -173,6 +173,7 @@ class UserHistory < ActiveRecord::Base
         admin_onboarding_step_completed: 128,
         admin_onboarding_completed: 129,
         admin_onboarding_dismissed: 130,
+        removed_avatar: 131,
       )
   end
 
@@ -307,6 +308,7 @@ class UserHistory < ActiveRecord::Base
       admin_onboarding_step_completed
       admin_onboarding_completed
       admin_onboarding_dismissed
+      removed_avatar
     ]
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -915,6 +915,13 @@ class StaffActionLogger
     )
   end
 
+  def log_removed_avatar(user, opts = {})
+    raise Discourse::InvalidParameters.new(:user) unless user
+    UserHistory.create!(
+      params(opts).merge(action: UserHistory.actions[:removed_avatar], target_user_id: user.id),
+    )
+  end
+
   def log_user_deactivate(user, reason, opts = {})
     raise Discourse::InvalidParameters.new(:user) unless user
     UserHistory.create!(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9146,6 +9146,7 @@ en:
             change_name: "change name"
             topic_timestamps_changed: "topic timestamps changed"
             approve_user: "approved user"
+            removed_avatar: "removed avatar"
             web_hook_create: "webhook create"
             web_hook_update: "webhook update"
             web_hook_destroy: "webhook destroy"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6300,6 +6300,10 @@ en:
       reject_post:
         title: "Reject Post"
         complete: "Post rejected."
+      remove_avatar:
+        title: "Remove avatar"
+        description: "Reset this user's profile picture to the system default"
+        complete: "Avatar removed."
       approve_user:
         title: "Yes"
         complete: "User approved."

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -193,6 +193,41 @@ RSpec.describe ReviewableUser, type: :model do
   describe "#perform" do
     fab!(:reviewable)
 
+    context "when removing an avatar" do
+      fab!(:avatar, :upload)
+
+      before do
+        reviewable.target.update!(uploaded_avatar_id: avatar.id)
+        reviewable.target.user_avatar.update!(custom_upload_id: avatar.id)
+      end
+
+      it "resets the avatar and leaves the reviewable pending" do
+        result = reviewable.perform(moderator, :remove_avatar)
+
+        expect(result.success?).to eq(true)
+        expect(reviewable.reload).to be_pending
+        expect(reviewable.target.reload.uploaded_avatar_id).to be_nil
+        expect(reviewable.target.user_avatar.reload.custom_upload_id).to be_nil
+      end
+
+      it "logs a staff action" do
+        expect { reviewable.perform(moderator, :remove_avatar) }.to change {
+          UserHistory.where(
+            action: UserHistory.actions[:removed_avatar],
+            target_user_id: reviewable.target_id,
+          ).count
+        }.by(1)
+      end
+
+      it "is offered only while the user still has an avatar" do
+        expect(reviewable.actions_for(Guardian.new(moderator)).has?(:remove_avatar)).to eq(true)
+
+        reviewable.target.remove_avatar!(moderator)
+
+        expect(reviewable.actions_for(Guardian.new(moderator)).has?(:remove_avatar)).to eq(false)
+      end
+    end
+
     context "when approving" do
       it "allows us to approve a user" do
         result = reviewable.perform(moderator, :approve_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1970,6 +1970,43 @@ RSpec.describe User do
     end
   end
 
+  describe "#remove_avatar!" do
+    fab!(:avatar, :upload)
+    fab!(:gravatar, :upload)
+    fab!(:actor, :admin)
+
+    it "drops the stored uploads so the image cannot be re-selected" do
+      user = Fabricate(:user, uploaded_avatar_id: avatar.id)
+      user.user_avatar.update!(custom_upload_id: avatar.id, gravatar_upload_id: gravatar.id)
+
+      user.remove_avatar!(actor)
+
+      expect(user.reload.uploaded_avatar_id).to be_nil
+      expect(user.user_avatar.reload.custom_upload_id).to be_nil
+      expect(user.user_avatar.gravatar_upload_id).to be_nil
+      expect(
+        UserHistory.exists?(action: UserHistory.actions[:removed_avatar], target_user_id: user.id),
+      ).to eq(true)
+    end
+
+    it "does nothing when there is no avatar to remove" do
+      user = Fabricate(:user)
+
+      expect { user.remove_avatar!(actor) }.not_to change {
+        UserHistory.where(action: UserHistory.actions[:removed_avatar]).count
+      }
+    end
+
+    it "works for a user that never had a user_avatar row" do
+      user = Fabricate(:user, uploaded_avatar_id: avatar.id)
+      user.user_avatar&.destroy
+      user.reload
+
+      expect { user.remove_avatar!(actor) }.not_to raise_error
+      expect(user.reload.uploaded_avatar_id).to be_nil
+    end
+  end
+
   describe "#avatar_template" do
     it "uses the small logo if the user is the system user" do
       logo_small_url = Discourse.store.cdn_url(SiteSetting.logo_small.url)


### PR DESCRIPTION
> Stacked on #42723.

Reviewing a user flagged for an inappropriate profile picture offered only **Approve** and **Delete user**. Deleting the account is the wrong remedy when the image is the only problem, so in practice the image could only be dealt with by editing the user out of band, and the reviewable stayed open meanwhile.

### Changes

- A **Remove avatar** action on pending user reviewables, shown only while the user still has one. It deliberately leaves the reviewable pending: removing the image is remediation, not a verdict on the account.
- `User#reset_avatar!`. Unlike picking the system avatar, this also drops `custom_upload_id` and `gravatar_upload_id`, so the removed image cannot simply be re-selected from the avatar picker. A gravatar can still be restored by its owner, since that image lives outside Discourse.
- A `removed_avatar` staff action, since the actor is not always the person reviewing.

The upload itself is kept, so the record of what was removed survives for whoever handles the account.

No frontend work: reviewable actions only need client code when they declare `client_action`, and this one is a plain server round-trip.