### PR TITLE
DEV: Record what workflow schemas and their payloads disagree on

### DIFF
--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_serializer_sync_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/schema_serializer_sync_spec.rb
@@ -2,28 +2,114 @@
 
 RSpec.describe DiscourseWorkflows::Schema do
   fab!(:user)
+  fab!(:group)
+  fab!(:post)
 
   let(:guardian) { Discourse.system_user.guardian }
+
+  let(:topic_undeclared) do
+    %w[
+      archetype
+      bookmarked
+      bumped
+      can_vote
+      excerpt
+      featured_link
+      has_accepted_answer
+      has_summary
+      highest_post_number
+      image_url
+      last_post_user_id
+      last_poster_username
+      like_count
+      liked
+      op_like_count
+      pinned
+      pinned_globally
+      posters
+      reply_count
+      tags_descriptions
+      unpinned
+      unseen
+      views
+      visible
+    ]
+  end
 
   def serialized_keys(serializer_class, object)
     MultiJson.load(serializer_class.new(object, scope: guardian, root: false).to_json).keys
   end
 
-  def expect_emitted(declared, emitted)
-    expect(declared.keys - emitted).to be_empty
+  def expect_ledger(declared, emitted, unemitted: [], undeclared: [])
+    aggregate_failures do
+      expect(declared.keys - emitted - unemitted).to be_empty
+      expect(emitted - declared.keys - undeclared).to be_empty
+    end
   end
 
-  it "emits every property USER_PROPERTIES declares" do
-    expect_emitted(
+  it "matches DiscourseWorkflows::UserSerializer" do
+    expect_ledger(
       described_class::USER_PROPERTIES,
       serialized_keys(DiscourseWorkflows::UserSerializer, user),
     )
   end
 
-  it "emits every property BASIC_USER_PROPERTIES declares" do
-    expect_emitted(
+  it "matches BasicUserSerializer" do
+    expect_ledger(
       described_class::BASIC_USER_PROPERTIES,
       serialized_keys(BasicUserSerializer, user),
     )
+  end
+
+  it "matches DiscourseWorkflows::PostSerializer" do
+    expect_ledger(
+      described_class::POST_PROPERTIES,
+      serialized_keys(DiscourseWorkflows::PostSerializer, post),
+      unemitted: %w[
+        cooked
+        cooked_truncated
+        cooked_original_length
+        raw_truncated
+        raw_original_length
+      ],
+    )
+  end
+
+  it "matches DiscourseWorkflows::TopicSerializer" do
+    expect_ledger(
+      described_class::TOPIC_PROPERTIES,
+      serialized_keys(DiscourseWorkflows::TopicSerializer, post.topic),
+      undeclared: topic_undeclared,
+    )
+  end
+
+  it "matches DiscourseWorkflows::TopicListItemSerializer" do
+    expect_ledger(
+      described_class::TOPIC_PROPERTIES,
+      serialized_keys(DiscourseWorkflows::TopicListItemSerializer, post.topic),
+      unemitted: %w[first_post_id],
+      undeclared: topic_undeclared,
+    )
+  end
+
+  it "matches WebHookGroupSerializer" do
+    expect_ledger(
+      described_class::GROUP_PROPERTIES,
+      serialized_keys(WebHookGroupSerializer, group),
+      undeclared: %w[
+        bio_raw
+        can_admin_group
+        can_edit_group
+        display_name
+        has_messages
+        incoming_email
+      ],
+    )
+  end
+
+  it "matches the group payload the membership triggers build" do
+    trigger = DiscourseWorkflows::Nodes::UserAddedToGroup::V1.new(user, group)
+
+    expect_ledger(described_class::BASIC_GROUP_PROPERTIES, trigger.output[:group].keys.map(&:to_s))
   end
 end


### PR DESCRIPTION
> Stacked on #42726.

#42723 added a spec pinning one direction of schema drift, for the user constants only. This extends it to the rest, and to the direction it deliberately skipped.

Two things drift, and the second is the interesting one:

- A property **declared but never emitted** becomes an expression the picker offers and that resolves to nil at runtime. `TOPIC_PROPERTIES` documents both topic serializers, but only the full one has `first_post_id`, so nodes backed by `TopicListItemSerializer` offer exactly that dead path today.
- A field **emitted but never declared** reaches item data without surfacing anywhere an admin can see it. `WebHookGroupSerializer` currently carries `incoming_email`, `bio_raw`, `can_admin_group`, `has_messages` and `display_name` into workflow items undeclared, all guardian-dependent. It is a core serializer this plugin does not own, so core can widen that surface without anyone here noticing.

Neither is automatically wrong — schemas are curated views, `TOPIC_PROPERTIES` hides around twenty fields on purpose — so this records the differences rather than forbidding them.

### Why subset checks rather than exact matching

Plenty of these fields are `include_*?`-gated and only appear under conditions the spec does not set up: `excerpt`, `display_name`, `can_edit_group`. Exact matching made the spec depend on whether a fabricated record happened to trigger them. Each check is now a subset test — a difference already recorded passes either way, anything new fails.

Payloads are built with the system user's guardian, so this pins the widest surface a workflow can see rather than what an anonymous scope happens to expose.

Also corrects one source attribution: `BASIC_GROUP_PROPERTIES` documents the hash the membership triggers build by hand, not `BasicGroupSerializer`. Comparing it against the serializer suggested 25 undeclared fields that were not real.

Mutation-tested by adding an attribute to `DiscourseWorkflows::UserSerializer` and confirming the new direction fails.