### PR TITLE
FEATURE: Show the avatar a user was flagged for in the review queue

### DIFF
--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -223,6 +223,13 @@
         width: auto;
       }
     }
+
+    .reviewable-user-avatar {
+      width: 6em;
+      height: 6em;
+      object-fit: cover;
+      border-radius: var(--d-border-radius);
+    }
   }
 }
 

--- a/app/jobs/regular/create_user_reviewable.rb
+++ b/app/jobs/regular/create_user_reviewable.rb
@@ -20,12 +20,7 @@ class Jobs::CreateUserReviewable < ::Jobs::Base
           target: user,
           created_by: Discourse.system_user,
           reviewable_by_moderator: true,
-          payload: {
-            username: user.username,
-            name: user.name,
-            email: user.email,
-            website: user.user_profile&.website,
-          },
+          payload: ReviewableUser.payload_for(user),
         )
 
       if @reviewable.created_new

--- a/app/jobs/scheduled/enqueue_suspect_users.rb
+++ b/app/jobs/scheduled/enqueue_suspect_users.rb
@@ -16,6 +16,7 @@ module Jobs
           .not_suspended
           .where(approved: false)
           .joins(:user_profile, :user_stat)
+          .includes(:user_profile, :uploaded_avatar)
           .where("users.created_at <= ? AND users.created_at >= ?", 1.day.ago, 6.months.ago)
           .where("LENGTH(COALESCE(user_profiles.bio_raw, user_profiles.website, '')) > 0")
           .where(
@@ -37,20 +38,12 @@ module Jobs
           .limit(10)
 
       users.each do |user|
-        user_profile = user.user_profile
-
         reviewable =
           ReviewableUser.needs_review!(
             target: user,
             created_by: Discourse.system_user,
             reviewable_by_moderator: true,
-            payload: {
-              username: user.username,
-              name: user.name,
-              email: user.email,
-              bio: user_profile.bio_raw,
-              website: user_profile.website,
-            },
+            payload: ReviewableUser.payload_for(user),
           )
 
         if reviewable.created_new

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -7,6 +7,23 @@ class ReviewableUser < Reviewable
     create(created_by_id: Discourse.system_user.id, target: user)
   end
 
+  after_create :retain_avatar_snapshot
+
+  def self.payload_for(user)
+    profile = user.user_profile
+    avatar = user.uploaded_avatar
+
+    {
+      username: user.username,
+      name: user.name,
+      email: user.email,
+      bio: profile&.bio_raw,
+      website: profile&.website,
+      avatar_upload_id: avatar&.id,
+      avatar_url: avatar && Discourse.store.cdn_url(avatar.url),
+    }
+  end
+
   def self.additional_args(params)
     { reject_reason: params[:reject_reason], send_email: params[:send_email] != "false" }
   end
@@ -173,6 +190,17 @@ class ReviewableUser < Reviewable
   end
 
   private
+
+  def retain_avatar_snapshot
+    upload_id = payload&.dig("avatar_upload_id")
+    return if upload_id.blank?
+
+    UploadReference.ensure_exist!(
+      upload_ids: [upload_id],
+      target_type: self.class.polymorphic_name,
+      target_id: id,
+    )
+  end
 
   def scrubbable?
     username = payload&.dig("username")

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1010,6 +1010,7 @@ en:
       deleted_post: "(post deleted)"
       deleted_user: "(user deleted)"
       user:
+        avatar: "Avatar when flagged"
         bio: "Bio"
         website: "Website"
         username: "Username"

--- a/frontend/discourse/app/components/reviewable/user.gjs
+++ b/frontend/discourse/app/components/reviewable/user.gjs
@@ -148,6 +148,20 @@ export default class ReviewableUser extends Component {
               />
             {{/if}}
 
+            {{#if this.reviewable.payload.avatar_url}}
+              <div class="reviewable-user-details avatar">
+                <div class="name">{{i18n "review.user.avatar"}}</div>
+                <div class="value">
+                  <img
+                    class="reviewable-user-avatar"
+                    src={{this.reviewable.payload.avatar_url}}
+                    alt={{i18n "review.user.avatar"}}
+                    loading="lazy"
+                  />
+                </div>
+              </div>
+            {{/if}}
+
             <ReviewableField
               @classes="reviewable-user-details name"
               @name={{i18n "review.user.name"}}

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/flag_user/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/flag_user/v1.rb
@@ -156,15 +156,7 @@ module DiscourseWorkflows
         end
 
         def reviewable_payload(user)
-          profile = user.user_profile
-
-          {
-            username: user.username,
-            name: user.name,
-            email: user.email,
-            bio: profile&.bio_raw,
-            website: profile&.website,
-          }
+          ::ReviewableUser.payload_for(user)
         end
 
         def add_review_score(reviewable, actor)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/flag_user_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/flag_user_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe DiscourseWorkflows::Nodes::FlagUser::V1 do
     end
 
     it "snapshots the same payload fields core's suspect user job does" do
+      avatar = Fabricate(:upload)
+      target.update!(uploaded_avatar_id: avatar.id)
       target.user_profile.update!(bio_raw: "Buy my links", website: "https://spam.example")
 
       flag
@@ -65,6 +67,7 @@ RSpec.describe DiscourseWorkflows::Nodes::FlagUser::V1 do
         "email" => target.email,
         "bio" => "Buy my links",
         "website" => "https://spam.example",
+        "avatar_url" => Discourse.store.cdn_url(avatar.url),
       )
     end
 

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -168,6 +168,56 @@ RSpec.describe ReviewableUser, type: :model do
     end
   end
 
+  describe ".payload_for" do
+    fab!(:avatar, :upload)
+
+    it "leaves the avatar blank when there is none" do
+      payload = ReviewableUser.payload_for(user)
+
+      expect(payload[:avatar_upload_id]).to be_nil
+      expect(payload[:avatar_url]).to be_nil
+    end
+
+    it "points at the upload rather than the avatar template" do
+      user.update!(uploaded_avatar_id: avatar.id)
+      user.user_profile.update!(bio_raw: "a bio", website: "https://example.com")
+
+      payload = ReviewableUser.payload_for(user)
+
+      expect(payload).to include(
+        username: user.username,
+        name: user.name,
+        email: user.email,
+        bio: "a bio",
+        website: "https://example.com",
+        avatar_upload_id: avatar.id,
+        avatar_url: Discourse.store.cdn_url(avatar.url),
+      )
+      expect(payload[:avatar_url]).not_to include("user_avatar")
+    end
+  end
+
+  describe "the avatar snapshot" do
+    fab!(:avatar, :upload)
+    fab!(:target) { Fabricate(:user, uploaded_avatar_id: avatar.id) }
+
+    it "is referenced on create, so upload cleanup spares it" do
+      reviewable =
+        ReviewableUser.needs_review!(
+          target: target,
+          created_by: Discourse.system_user,
+          payload: ReviewableUser.payload_for(target),
+        )
+
+      expect(UploadReference.exists?(upload_id: avatar.id, target: reviewable)).to eq(true)
+
+      target.remove_avatar!(admin)
+
+      expect(Jobs::CleanUpUploads.new.execute({})).to be_truthy
+      expect(Upload.exists?(id: avatar.id)).to eq(true)
+    end
+  end
+
   describe "#update_fields" do
     fab!(:moderator)
     fab!(:reviewable)
@@ -217,6 +267,15 @@ RSpec.describe ReviewableUser, type: :model do
             target_user_id: reviewable.target_id,
           ).count
         }.by(1)
+      end
+
+      it "leaves the snapshotted image in the payload" do
+        reviewable.update!(payload: ReviewableUser.payload_for(reviewable.target))
+
+        reviewable.perform(moderator, :remove_avatar)
+
+        expect(reviewable.reload.payload["avatar_url"]).to be_present
+        expect(Upload.exists?(id: avatar.id)).to eq(true)
       end
 
       it "is offered only while the user still has an avatar" do


### PR DESCRIPTION
> Stacked on #42729.

A moderator reviewing a flagged profile sees the account's *current* avatar, which is no longer the one anybody objected to once it has been removed. With #42724 giving staff a Remove avatar action and #42726 letting a workflow reset one automatically, a reviewable can now describe an image that exists nowhere on screen.

Snapshots the avatar into the reviewable payload, alongside the name, email, bio and website already captured there, and renders it.

### Notes

**One payload builder instead of three.** `Jobs::CreateUserReviewable`, `Jobs::EnqueueSuspectUsers` and the workflows flag node each built this hash independently, and had already drifted — the signup path omitted `bio`, which the review UI renders. Adding a field meant editing all three. They now share `ReviewableUser.payload_for`, so signup reviewables gain the `bio` the UI was already trying to show.

**The upload url, not the avatar template.** `avatar_template` resolves through `uploaded_avatar_id` at request time, so it would stop pointing at the flagged image the moment the avatar is removed — exactly when the snapshot has to work.

**The snapshot is referenced, not just recorded.** Once `uploaded_avatar_id` and `custom_upload_id` are nulled the upload has no `UploadReference` and no non-post relation, which makes it eligible for `Jobs::CleanUpUploads` after the grace period — the evidence would disappear an hour after remediation. An `after_create` on the reviewable references the upload, so cleanup spares it. Covered by a spec that removes the avatar and then runs the cleanup job.

**Scrubbing.** `ReviewableUser#scrub` already replaces the whole payload, so the url goes with it.