### PR TITLE
FIX: Keep profile backgrounds through unrelated user updates

### DIFF
--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -106,18 +106,22 @@ class UserUpdater
       user_profile.website = format_url(attributes.fetch(:website) { user_profile.website })
     end
 
-    if attributes[:profile_background_upload_url] == "" ||
-         !guardian.can_upload_profile_header?(user)
-      user_profile.profile_background_upload_id = nil
-    elsif upload = Upload.get_from_url(attributes[:profile_background_upload_url])
-      user_profile.profile_background_upload_id = upload.id
+    if attributes.key?(:profile_background_upload_url)
+      if attributes[:profile_background_upload_url] == "" ||
+           !guardian.can_upload_profile_header?(user)
+        user_profile.profile_background_upload_id = nil
+      elsif upload = Upload.get_from_url(attributes[:profile_background_upload_url])
+        user_profile.profile_background_upload_id = upload.id
+      end
     end
 
-    if attributes[:card_background_upload_url] == "" ||
-         !guardian.can_upload_user_card_background?(user)
-      user_profile.card_background_upload_id = nil
-    elsif upload = Upload.get_from_url(attributes[:card_background_upload_url])
-      user_profile.card_background_upload_id = upload.id
+    if attributes.key?(:card_background_upload_url)
+      if attributes[:card_background_upload_url] == "" ||
+           !guardian.can_upload_user_card_background?(user)
+        user_profile.card_background_upload_id = nil
+      elsif upload = Upload.get_from_url(attributes[:card_background_upload_url])
+        user_profile.card_background_upload_id = upload.id
+      end
     end
 
     if attributes[:user_notification_schedule]

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -278,6 +278,39 @@ RSpec.describe UserUpdater do
       expect(user.card_background_upload).to eq(nil)
     end
 
+    context "with profile and card backgrounds" do
+      fab!(:profile_background, :upload)
+      fab!(:card_background, :upload)
+      fab!(:target, :user)
+      fab!(:other, :user)
+
+      before do
+        target.user_profile.update!(
+          profile_background_upload_id: profile_background.id,
+          card_background_upload_id: card_background.id,
+        )
+      end
+
+      it "keeps them when the update does not mention them" do
+        UserUpdater.new(other, target).update(bio_raw: "edited by someone else")
+
+        target.user_profile.reload
+        expect(target.user_profile.profile_background_upload_id).to eq(profile_background.id)
+        expect(target.user_profile.card_background_upload_id).to eq(card_background.id)
+      end
+
+      it "still clears them when the update asks and the actor may not upload" do
+        UserUpdater.new(other, target).update(
+          profile_background_upload_url: profile_background.url,
+          card_background_upload_url: card_background.url,
+        )
+
+        target.user_profile.reload
+        expect(target.user_profile.profile_background_upload_id).to be_nil
+        expect(target.user_profile.card_background_upload_id).to be_nil
+      end
+    end
+
     it "disables email_digests when enabling mailing_list_mode" do
       updater = UserUpdater.new(acting_user, user)
       SiteSetting.disable_mailing_list_mode = false


### PR DESCRIPTION
The profile and card background uploads were reconsidered on **every** `UserUpdater` call, whether or not the caller mentioned them:

```ruby
if attributes[:profile_background_upload_url] == "" ||
     !guardian.can_upload_profile_header?(user)
  user_profile.profile_background_upload_id = nil
```

With the key absent the first test is false, so the permission check decides — and when it fails the upload is discarded. An update that only touched a bio could take the backgrounds with it.

### Reproduced

| scenario | before | after |
|---|---|---|
| permitted user updates their own bio | kept | kept |
| user has since dropped out of `profile_background_allowed_groups`, updates their bio | **cleared** | kept |
| non-staff actor updates another user's bio | **both cleared** | kept |

The third is the one that bites without any setting change: `can_upload_profile_header?` is `(is_me? && in allowed groups) || is_staff?`, so it is false for *any* other non-staff actor, and each background has its own independent guard.

### Fix

Both blocks are now entered only when the caller actually submitted the field. `permit` drops keys that were not sent, so the controller path is unaffected for real submissions.

Submitting a background the actor may not upload still clears it. That is the existing behaviour for a request that asks, and changing it is a separate judgement call.

Found while checking whether the workflows user node could clear a background unintentionally. It could not — that node defaults its actor to `system`, which is staff — so this is unrelated to that work and branches off `main`.