### PR TITLE
Example CSS variable rename

### DIFF
--- a/.skills/discourse-writing-html-css/references/color-and-theming.md
+++ b/.skills/discourse-writing-html-css/references/color-and-theming.md
@@ -46,7 +46,7 @@ intent and already handle light/dark via `light-dark()`:
 ## General-purpose `--d-*` design vars
 
 A family of app-wide design constants — `--d-border-radius` (and `--d-border-radius-large`,
-`--d-input-border-radius`), `--d-content-background`, `--d-link-color`, `--d-hover`,
+`--d-input-border-radius`), `--d-content-background`, `--fancy-new-link-color`, `--d-hover`,
 `--d-selected` — for conventions like the standard corner radius and link color. Prefer these
 over inventing your own constant so a component matches the rest of the UI (and a theme can
 retune them globally).

--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -134,7 +134,7 @@
   --gold: #{$gold};
   --silver: #{$silver};
   --bronze: #{$bronze};
-  --d-link-color: var(--tertiary);
+  --fancy-new-link-color: var(--tertiary);
   --title-color--read: var(--primary-medium);
   --content-border-color: var(--primary-low);
   --input-border-color: var(--primary-400);

--- a/app/assets/stylesheets/common/components/design-wizard.scss
+++ b/app/assets/stylesheets/common/components/design-wizard.scss
@@ -34,7 +34,7 @@ $dw-button-default-border: #d3d3d3;
   --primary-high: #{$dw-primary-high};
   --primary-very-high: #{$dw-primary-very-high};
   --d-hover: #{$dw-hover};
-  --d-link-color: #{$dw-tertiary};
+  --fancy-new-link-color: #{$dw-tertiary};
   --primary-100: #{$dw-hover};
   --primary-200: #{$dw-primary-low};
   --tertiary-300: #{$dw-selected};

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -65,7 +65,7 @@ a,
 a:visited,
 a:hover,
 a:active {
-  color: var(--d-link-color);
+  color: var(--fancy-new-link-color);
   text-decoration: var(--d-link-text-decoration);
   cursor: pointer;
 }

--- a/app/assets/stylesheets/variable-renames.json
+++ b/app/assets/stylesheets/variable-renames.json
@@ -1,1 +1,3 @@
-{}
+{
+  "--d-link-color": "--fancy-new-link-color"
+}


### PR DESCRIPTION
A demo of the variable rename system. Not intended for merge.

This was created by:

1. Adding the rename to the `.json` file
2. Running stylelint to automatically update all core occurences
3. Updating the `.md` docs manually

This change would be completely backwards-compatible for any themes/plugins which set or use `--d-link-color`. They would be able to adopt the new name at their leisure.