### PR TITLE
FIX: Honour any registered filter as a category `default_view`

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -9,6 +9,7 @@ class ListController < ApplicationController
   before_action :set_category,
                 only: [
                   :category_default,
+                  :category_none_default,
                   # filtered topics lists
                   Discourse.filters.map { |f| :"category_#{f}" },
                   Discourse.filters.map { |f| :"category_none_#{f}" },
@@ -30,6 +31,7 @@ class ListController < ApplicationController
                   Discourse.anonymous_filters.map { |f| "#{f}_feed" },
                   # anonymous categorized filters
                   :category_default,
+                  :category_none_default,
                   Discourse.anonymous_filters.map { |f| :"category_#{f}" },
                   Discourse.anonymous_filters.map { |f| :"category_none_#{f}" },
                   # category feeds
@@ -148,10 +150,11 @@ class ListController < ApplicationController
 
   def category_default
     canonical_url "#{Discourse.base_url_no_prefix}#{@category.url}"
-    view_method = @category.default_view
-    view_method = "latest" if %w[hot latest top].exclude?(view_method)
+    public_send(category_default_view, category: @category.id)
+  end
 
-    public_send(view_method, category: @category.id)
+  def category_none_default
+    public_send(category_default_view, category: @category.id, no_subcategories: true)
   end
 
   def topics_by
@@ -431,6 +434,16 @@ class ListController < ApplicationController
     end
 
     route_params
+  end
+
+  # `default_view` is free-form, so only ever dispatch to a filter this request
+  # could have reached directly at /c/<slug>/<id>/l/<filter>.
+  def category_default_view
+    filters = Discourse.filters
+    filters &= Discourse.anonymous_filters if current_user.nil?
+
+    view = @category.default_view
+    filters.include?(view&.to_sym) ? view : "latest"
   end
 
   def set_category

--- a/app/serializers/topic_list_serializer.rb
+++ b/app/serializers/topic_list_serializer.rb
@@ -2,6 +2,7 @@
 
 class TopicListSerializer < ApplicationSerializer
   attributes :can_create_topic,
+             :filter,
              :more_topics_url,
              :for_period,
              :per_page,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1406,7 +1406,7 @@ Discourse::Application.routes.draw do
 
     get "c/*category_slug_path_with_id.rss" => "list#category_feed", :format => :rss
     scope path: "c/*category_slug_path_with_id" do
-      get "/none" => "list#category_none_latest"
+      get "/none" => "list#category_none_default", :as => "category_none_default"
 
       TopTopic.periods.each do |period|
         get "/none/l/top/#{period}", to: redirect("/none/l/top?period=#{period}", status: 301)

--- a/plugins/discourse-topic-voting/spec/requests/category_default_view_spec.rb
+++ b/plugins/discourse-topic-voting/spec/requests/category_default_view_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "Category default view of votes" do
+  fab!(:category)
+  fab!(:most_voted) { Fabricate(:topic, category:, bumped_at: 2.days.ago) }
+  fab!(:recently_bumped) { Fabricate(:topic, category:, bumped_at: 1.minute.ago) }
+
+  before do
+    SiteSetting.topic_voting_enabled = true
+    DiscourseTopicVoting::CategorySetting.create!(category:)
+    Category.reset_voting_cache
+    category.update!(default_view: "votes")
+    DiscourseTopicVoting::TopicVoteCount.create!(topic: most_voted, votes_count: 5)
+  end
+
+  def topic_ids_for(url)
+    get url
+    expect(response.status).to eq(200)
+    response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] }
+  end
+
+  it "orders the category by votes" do
+    expect(topic_ids_for("/c/#{category.slug}/#{category.id}.json")).to eq(
+      [most_voted.id, recently_bumped.id],
+    )
+  end
+
+  it "orders the category by votes when excluding subcategories" do
+    expect(topic_ids_for("/c/#{category.slug}/#{category.id}/none.json")).to eq(
+      [most_voted.id, recently_bumped.id],
+    )
+  end
+
+  it "preloads the votes ordered list into the page" do
+    get "/c/#{category.slug}/#{category.id}"
+    expect(response.status).to eq(200)
+
+    preloaded = Nokogiri.HTML5(response.body).at_css("#data-preloaded").text
+    topic_list = JSON.parse(JSON.parse(preloaded)["topic_list"])["topic_list"]
+
+    expect(topic_list["topics"].map { |topic| topic["id"] }).to eq(
+      [most_voted.id, recently_bumped.id],
+    )
+  end
+end

--- a/spec/requests/api/schemas/json/category_topics_response.json
+++ b/spec/requests/api/schemas/json/category_topics_response.json
@@ -39,6 +39,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "filter": {
+          "type": "string"
+        },
         "can_create_topic": {
           "type": "boolean"
         },

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1193,6 +1193,29 @@ RSpec.describe ListController do
           json = response.parsed_body
           expect(json["topic_list"]["for_period"]).to be_blank
         end
+
+        def filter_for(default_view, path = "")
+          category.update!(default_view: default_view)
+          get "/c/#{category.slug}/#{category.id}#{path}.json"
+          expect(response.status).to eq(200)
+          response.parsed_body["topic_list"]["filter"]
+        end
+
+        it "falls back to latest when the default view is not a filter this request can reach" do
+          expect(filter_for("destroy")).to eq("latest")
+          expect(filter_for("categories")).to eq("latest")
+          expect(filter_for("unread")).to eq("latest")
+        end
+
+        it "honours a logged in only default view for logged in users" do
+          sign_in(user)
+
+          expect(filter_for("unread")).to eq("unread")
+        end
+
+        it "honours the default view when excluding subcategories" do
+          expect(filter_for("hot", "/none")).to eq("hot")
+        end
       end
 
       describe "renders canonical tag" do


### PR DESCRIPTION
Previously, `ListController#category_default` only honoured `hot`, `latest` and `top`, so a category whose `default_view` was any other registered filter — like `votes` from `discourse-topic-voting` — was served the `latest` list on a direct link, even though the client highlighted the matching tab.

This change resolves `default_view` against `Discourse.filters`, restricted to `Discourse.anonymous_filters` when logged out, and routes `/c/<slug>/<id>/none` through the same resolver instead of hardcoding `latest`.

---

### Why it only broke on a direct link

The client has always resolved `default_view` correctly, so an in-app transition requested `/c/<slug>/<id>/l/votes` and got the right list. On a full page load the server preloads its list under the fixed key `topic_list` (`TopicList#preload_key`), and `TopicListAdapter#find` consumes that key without checking it matches the filter it asked for — so the `latest` list was used and relabelled as `votes`. That is also why clicking "Latest" afterwards appeared to do nothing: the list was already `latest`.

Crawlers never recover from this, since there is no client-side correction for them.

### `/c/<slug>/<id>/none`

That route was hardcoded to `category_none_latest`, while the matching Ember route (`discovery.category-none`) has always resolved `default_view`. This is broken today for core views too — a category with `default_list_filter = "none"` and `default_view = "hot"` renders `latest` there, no plugin involved.

`:as => "category_none_default"` on the route is load-bearing: `construct_url_with` builds `"#{action_name}_path"` on every request.

### Behaviour change worth flagging

A logged-in member visiting a category whose `default_view` is a member-relative filter (`unread`, `new`, `bookmarks`, …) now gets that filter instead of `latest`, which may be an empty list. This matches what in-app navigation already does — making the two agree is the point of the fix. Anonymous visitors still fall back to `latest`, and none of these values are reachable from the category settings UI.

### `TopicListSerializer#filter`

Exposing the list's filter makes the ordering assertable in specs — the existing `category_default` examples only checked status and `for_period`, and passed either way. It also gives the client something to compare a preloaded list against, should we want to close the preload mismatch above properly. `category_topics_response.json` is `additionalProperties: false`, so the schema is updated to match.
