### PR TITLE
FIX: Discard a preloaded topic list built for a different filter

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -439,8 +439,7 @@ class ListController < ApplicationController
   # `default_view` is free-form, so only ever dispatch to a filter this request
   # could have reached directly at /c/<slug>/<id>/l/<filter>.
   def category_default_view
-    filters = Discourse.filters
-    filters &= Discourse.anonymous_filters if current_user.nil?
+    filters = current_user ? Discourse.filters : Discourse.anonymous_list_filters
 
     view = @category.default_view
     filters.include?(view&.to_sym) ? view : "latest"

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -247,6 +247,7 @@ class Site
         {
           periods: TopTopic.periods.map(&:to_s),
           filters: Discourse.filters.map(&:to_s),
+          anonymous_list_filters: Discourse.anonymous_list_filters.map(&:to_s),
           user_fields:
             UserField
               .includes(:user_field_options)

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -11,6 +11,7 @@ class SiteSerializer < ApplicationSerializer
     :trust_levels,
     :groups,
     :filters,
+    :anonymous_list_filters,
     :homepage_choices,
     :periods,
     :top_menu_items,
@@ -222,6 +223,10 @@ class SiteSerializer < ApplicationSerializer
 
   def filters
     Discourse.filters.map(&:to_s)
+  end
+
+  def anonymous_list_filters
+    Discourse.anonymous_list_filters.map(&:to_s)
   end
 
   def homepage_choices

--- a/frontend/discourse/app/adapters/topic-list.js
+++ b/frontend/discourse/app/adapters/topic-list.js
@@ -1,43 +1,67 @@
 import RestAdapter from "discourse/adapters/rest";
 import { ajax } from "discourse/lib/ajax";
+import { serverFilterForMode } from "discourse/lib/filter-mode";
 import PreloadStore from "discourse/lib/preload-store";
 import Topic from "discourse/models/topic";
 
 export default class TopicListAdapter extends RestAdapter {
-  find(store, type, { filter, params }) {
-    return PreloadStore.getAndRemove("topic_list", () => {
-      let url = `/${filter}.json`;
+  async find(store, type, { filter, params }) {
+    const result =
+      (await this.#preloadedList(filter)) ??
+      (await ajax(this.#url(filter, params)));
 
-      if (params) {
-        const urlSearchParams = new URLSearchParams();
+    result.filter = filter;
+    result.params = params;
+    return result;
+  }
 
-        for (const [key, value] of Object.entries(params)) {
-          if (typeof value === "undefined") {
-            continue;
-          }
+  // The server preloads whichever list it rendered under a single key, so it is
+  // only usable when it is the list we asked for. Falls through when either side
+  // cannot be identified.
+  async #preloadedList(filter) {
+    const preloaded = await PreloadStore.getAndRemove("topic_list");
+    if (!preloaded) {
+      return;
+    }
 
-          if (Array.isArray(value)) {
-            for (const arrayValue of value) {
-              urlSearchParams.append(`${key}[]`, arrayValue);
-            }
-          } else {
-            urlSearchParams.set(key, value);
-          }
+    const served = preloaded.topic_list?.filter;
+    const requested = serverFilterForMode(filter);
+
+    if (served && requested && served !== requested) {
+      return;
+    }
+
+    return preloaded;
+  }
+
+  #url(filter, params) {
+    let url = `/${filter}.json`;
+
+    if (params) {
+      const urlSearchParams = new URLSearchParams();
+
+      for (const [key, value] of Object.entries(params)) {
+        if (typeof value === "undefined") {
+          continue;
         }
 
-        const queryString = urlSearchParams.toString();
-
-        if (queryString) {
-          url += `?${queryString}`;
+        if (Array.isArray(value)) {
+          for (const arrayValue of value) {
+            urlSearchParams.append(`${key}[]`, arrayValue);
+          }
+        } else {
+          urlSearchParams.set(key, value);
         }
       }
 
-      return ajax(url);
-    }).then((result) => {
-      result.filter = filter;
-      result.params = params;
-      return result;
-    });
+      const queryString = urlSearchParams.toString();
+
+      if (queryString) {
+        url += `?${queryString}`;
+      }
+    }
+
+    return url;
   }
 
   async applyTransformations(results) {

--- a/frontend/discourse/app/lib/filter-mode.js
+++ b/frontend/discourse/app/lib/filter-mode.js
@@ -13,3 +13,28 @@ export function calculateFilterMode({ category, filterType, noSubcategories }) {
 export function filterTypeForMode(mode) {
   return mode?.split("/").pop();
 }
+
+/**
+ * The `filter` the server reports for a client-side filter mode, or `undefined`
+ * when it cannot be derived from the mode alone — user, group, private message
+ * and tag intersection lists end in a name rather than a filter.
+ *
+ * @param {string} mode a filter mode, e.g. `latest` or `c/bug/1/none/l/votes`
+ * @returns {string|undefined} the matching `TopicList#filter`
+ */
+export function serverFilterForMode(mode) {
+  if (!mode) {
+    return;
+  }
+
+  const segments = mode.split("/");
+  const listIndex = segments.lastIndexOf("l");
+
+  if (listIndex !== -1) {
+    return segments[listIndex + 1];
+  }
+
+  if (segments.length === 1) {
+    return mode;
+  }
+}

--- a/frontend/discourse/app/routes/build-category-route.js
+++ b/frontend/discourse/app/routes/build-category-route.js
@@ -76,9 +76,19 @@ class AbstractCategoryRoute extends DiscourseRoute {
   }
 
   filter(category) {
-    return this.routeConfig?.filter === "default"
-      ? category.get("default_view") || "latest"
-      : this.routeConfig?.filter;
+    if (this.routeConfig?.filter !== "default") {
+      return this.routeConfig?.filter;
+    }
+
+    // Mirrors `ListController#category_default_view`: `default_view` is free-form,
+    // so only honour it when this visitor could request `/l/<filter>` directly.
+    const allowed = this.currentUser
+      ? this.site.filters
+      : this.site.anonymous_list_filters;
+
+    return allowed.includes(category.default_view)
+      ? category.default_view
+      : "latest";
   }
 
   async _createSubcategoryList(category) {

--- a/frontend/discourse/tests/acceptance/category-default-view-test.js
+++ b/frontend/discourse/tests/acceptance/category-default-view-test.js
@@ -1,0 +1,57 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
+import pretender from "discourse/tests/helpers/create-pretender";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+const CATEGORY = {
+  id: 1,
+  name: "bug",
+  slug: "bug",
+  permission: 1,
+  default_view: "unread",
+};
+
+function requestedFilters() {
+  return pretender.handledRequests
+    .filter((request) => request.url.includes("/c/bug/1/l/"))
+    .map((request) => request.url.split("/l/")[1].split(".json")[0]);
+}
+
+// `latest` is stubbed by default, `unread` is not.
+function stubUnreadList(server, helper) {
+  server.get("/c/bug/1/l/unread.json", () =>
+    helper.response(discoveryFixtures["/c/bug/1/l/latest.json"])
+  );
+}
+
+acceptance("Category default view - anonymous", function (needs) {
+  needs.site({ categories: [CATEGORY] });
+  needs.pretender(stubUnreadList);
+
+  test("falls back to latest for a view it could not request", async function (assert) {
+    await visit("/c/bug/1");
+
+    assert.deepEqual(
+      requestedFilters(),
+      ["latest"],
+      "clamps a default view an anonymous visitor cannot reach"
+    );
+  });
+});
+
+acceptance("Category default view - logged in", function (needs) {
+  needs.user();
+  needs.site({ categories: [CATEGORY] });
+  needs.pretender(stubUnreadList);
+
+  test("honours a view it can request", async function (assert) {
+    await visit("/c/bug/1");
+
+    assert.deepEqual(
+      requestedFilters(),
+      ["unread"],
+      "keeps a default view this visitor can reach"
+    );
+  });
+});

--- a/frontend/discourse/tests/acceptance/topic-list-preload-test.js
+++ b/frontend/discourse/tests/acceptance/topic-list-preload-test.js
@@ -1,0 +1,60 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { cloneJSON } from "discourse/lib/object";
+import PreloadStore from "discourse/lib/preload-store";
+import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
+import pretender from "discourse/tests/helpers/create-pretender";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+function preloadTopicList(filter) {
+  const list = cloneJSON(discoveryFixtures["/c/bug/1/l/latest.json"]);
+  list.topic_list.filter = filter;
+  PreloadStore.store("topic_list", list);
+}
+
+function topicListRequests() {
+  return pretender.handledRequests
+    .filter((request) => request.url.includes("/l/"))
+    .map((request) => request.url.split("?")[0]);
+}
+
+acceptance("Topic list preload", function () {
+  test("uses a preloaded list built for the requested filter", async function (assert) {
+    preloadTopicList("latest");
+
+    await visit("/c/bug/1/l/latest");
+
+    assert.dom(".topic-list-item").exists();
+    assert.deepEqual(
+      topicListRequests(),
+      [],
+      "does not request a list it already has"
+    );
+  });
+
+  test("discards a preloaded list built for a different filter", async function (assert) {
+    preloadTopicList("top");
+
+    await visit("/c/bug/1/l/latest");
+
+    assert.dom(".topic-list-item").exists();
+    assert.deepEqual(
+      topicListRequests(),
+      ["/c/bug/1/l/latest.json"],
+      "requests the list it actually asked for"
+    );
+  });
+
+  test("uses a preloaded list that does not report a filter", async function (assert) {
+    preloadTopicList(undefined);
+
+    await visit("/c/bug/1/l/latest");
+
+    assert.dom(".topic-list-item").exists();
+    assert.deepEqual(
+      topicListRequests(),
+      [],
+      "an older server payload is still usable"
+    );
+  });
+});

--- a/frontend/discourse/tests/fixtures/site-fixtures.js
+++ b/frontend/discourse/tests/fixtures/site-fixtures.js
@@ -46,6 +46,11 @@ const siteFixtures = {
         "hot",
         "unseen"
       ],
+      anonymous_list_filters: [
+        "latest",
+        "top",
+        "hot"
+      ],
       homepage_choices: [
         "latest",
         "new",

--- a/frontend/discourse/tests/unit/lib/filter-mode-test.js
+++ b/frontend/discourse/tests/unit/lib/filter-mode-test.js
@@ -1,0 +1,50 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  filterTypeForMode,
+  serverFilterForMode,
+} from "discourse/lib/filter-mode";
+
+module("Unit | Lib | filter-mode", function (hooks) {
+  setupTest(hooks);
+
+  test("filterTypeForMode returns the last segment", function (assert) {
+    assert.strictEqual(filterTypeForMode("latest"), "latest");
+    assert.strictEqual(filterTypeForMode("c/bug/1/l/votes"), "votes");
+    assert.strictEqual(filterTypeForMode(undefined), undefined);
+  });
+
+  test("serverFilterForMode derives the filter the server reports", function (assert) {
+    const cases = {
+      latest: "latest",
+      hot: "hot",
+      filter: "filter",
+      "c/bug/1/l/latest": "latest",
+      "c/bug/1/l/votes": "votes",
+      "c/bug/1/none/l/votes": "votes",
+      // a category slug may itself be "l"
+      "c/l/1/l/latest": "latest",
+      "tag/5/l/latest": "latest",
+      "tags/c/bug/1/5/l/hot": "hot",
+    };
+
+    for (const [mode, expected] of Object.entries(cases)) {
+      assert.strictEqual(serverFilterForMode(mode), expected, mode);
+    }
+  });
+
+  test("serverFilterForMode gives up on modes that end in a name", function (assert) {
+    const undecidable = [
+      "tags/intersection/alpha/beta",
+      "topics/created-by/sam",
+      "topics/groups/staff",
+      "topics/private-messages/sam",
+      "",
+      undefined,
+    ];
+
+    for (const mode of undecidable) {
+      assert.strictEqual(serverFilterForMode(mode), undefined, `${mode}`);
+    }
+  });
+});

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -352,6 +352,12 @@ module Discourse
     @anonymous_filters ||= %i[latest top categories hot]
   end
 
+  # `anonymous_filters` also holds menu items such as `categories`, which have no
+  # `/l/<filter>` route. Not memoized: plugins push onto both lists at load time.
+  def self.anonymous_list_filters
+    Discourse.filters & Discourse.anonymous_filters
+  end
+
   def self.top_menu_items
     @top_menu_items ||= Discourse.filters + [:categories]
   end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -290,6 +290,15 @@ RSpec.describe Site do
     expect(data["auth_providers"].map { |a| a["name"] }).to contain_exactly("facebook", "twitter")
   end
 
+  it "includes anonymous_list_filters for anon when login_required" do
+    SiteSetting.login_required = true
+
+    data = JSON.parse(Site.json_for(Guardian.new))
+
+    expect(data["anonymous_list_filters"]).to include("latest")
+    expect(data["anonymous_list_filters"]).not_to include("unread")
+  end
+
   it "includes tos_url and privacy_policy_url when login_required" do
     SiteSetting.login_required = true
     SiteSetting.tos_url = "https://discourse.org"

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -332,6 +332,10 @@
       "type": "array",
       "items": {}
     },
+    "anonymous_list_filters": {
+      "type": "array",
+      "items": {}
+    },
     "homepage_choices": {
       "type": "array",
       "items": {}
@@ -1032,6 +1036,7 @@
     "trust_levels",
     "groups",
     "filters",
+    "anonymous_list_filters",
     "homepage_choices",
     "periods",
     "top_menu_items",

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe SiteSerializer do
     end
   end
 
+  describe "#anonymous_list_filters" do
+    it "exposes the filters an anonymous visitor can request" do
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+
+      expect(serialized[:anonymous_list_filters]).to include("latest", "top", "hot")
+      expect(serialized[:anonymous_list_filters]).not_to include("unread")
+      # an anonymous menu item, but not a list filter
+      expect(serialized[:anonymous_list_filters]).not_to include("categories")
+    end
+  end
+
   describe "#user_tips" do
     it "is included if enable_user_tips" do
       SiteSetting.enable_user_tips = true


### PR DESCRIPTION
Previously, the client used whatever topic list the server had preloaded without checking it was the list it asked for, so any server/client disagreement about the filter silently rendered the wrong list on a full page load — and only on a full page load.

This change compares the preloaded list's `filter` against the requested one and refetches when they differ, and clamps a category's `default_view` on the client to the filters the visitor could actually request.

---

Follow-up to #42736, which fixed the one instance of this we knew about. This closes the underlying seam so the next one self-heals.

### Why the check is needed

`TopicList#preload_key` has been the constant `"topic_list"` since e7a84948b97, and `TopicListAdapter#find` consumes that key regardless of the filter it requested, then stamps the requested filter onto the payload. Before that commit the key included the filter, so a mismatch missed the store and triggered a real request — that was the safety net.

Since then the same failure mode has come up twice: `default_list_filter = "none"` (patched narrowly in b5721b7b4f4, whose message notes *"it was still using the preloaded data for the old route. This has been happening since e7a84948"*) and `default_view` (#42736). Both were diagnosed from scratch. With #42736's `topic_list.filter` on the wire, the client can now just notice.

The check fails open when either side can't be identified, so an older server payload without `filter` is still used.

### Why `filterTypeForMode` isn't reused

`serverFilterForMode` looks like a duplicate of `filterTypeForMode` (`split("/").pop()`) but isn't a substitute for it: for `tags/intersection/<a>/<b>`, `topics/created-by/<user>` and private message lists the last segment is a *name*, not a filter, so comparing it would discard a perfectly good preload and issue a needless request on every load. The new helper only answers when the mode is a bare filter or contains `/l/<filter>`, and returns `undefined` otherwise. It also handles a category whose slug is itself `l` (`c/l/1/l/latest`).

### The client-side `default_view` clamp

This is not optional polish. `build-category-route.js` resolved `default_view` with no allow-list at all, so an anonymous visitor to a category with `default_view = "unread"` requested `/l/unread` and got a **403 and a blank page** on in-app navigation. That is reproducible on `main` today; the preload was masking it on direct loads. Adding the filter check without the clamp would have turned a working (if mislabelled) direct load into a blank one too.

The clamp mirrors `ListController#category_default_view` and reads a new `Site#anonymous_list_filters`. Both now go through `Discourse.anonymous_list_filters`, so the rule has one owner.

### Testing

New unit tests cover the normaliser, including every shape that must fail open. New acceptance tests cover match / mismatch / payload-without-filter, and the clamp in both directions (anonymous falls back to `latest`, logged in keeps `unread`).

Manually, on a dev instance: forcing `category_default_view` to return `"latest"` makes a direct load of a `default_view = "votes"` category refetch `/l/votes.json` and render correctly, where it previously rendered activity order with no request at all. With the server behaving, a cold load of every list route — homepage, latest, top, hot, categories, category, category `/none`, tag, tag intersection, tag-in-category, filter, unread, new, bookmarks — issues no extra request.

`site_response.json` is updated because it is `additionalProperties: false`.

