### PR TITLE
FIX: Skip new posts from ignored users when loading new posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -237,7 +237,10 @@ class Post < ActiveRecord::Base
       last_editor_id: last_editor_id,
       type: type,
       version: version,
-    }.merge(opts)
+    }
+
+    message[:username] = user&.username if type == :created
+    message.merge!(opts)
 
     publish_message!("/topic/#{topic_id}", message)
     Topic.publish_stats_to_clients!(topic.id, type) unless skip_topic_stats

--- a/frontend/discourse/app/controllers/topic.js
+++ b/frontend/discourse/app/controllers/topic.js
@@ -2115,6 +2115,12 @@ export default class TopicController extends Controller {
         break;
       }
       case "created": {
+        // The topic view filters out ignored users server-side, do the same
+        // for live updates so the stream stays consistent with a reload
+        if (this.currentUser?.ignored_users?.includes(data.username)) {
+          break;
+        }
+
         this._newPostsInStream.push(data.id);
 
         this.retryOnRateLimit(RETRIES_ON_RATE_LIMIT, () => {

--- a/frontend/discourse/tests/unit/controllers/topic-test.js
+++ b/frontend/discourse/tests/unit/controllers/topic-test.js
@@ -711,4 +711,79 @@ module("Unit | Controller | topic", function (hooks) {
       "transformer allowed finishedEditingTopic"
     );
   });
+
+  test("onMessage skips new posts from ignored users", async function (assert) {
+    const topic = topicWithStream.call(this, {
+      posts: [{ id: 1, post_number: 1 }],
+      stream: [1],
+    });
+    const controller = getOwner(this).lookup("controller:topic");
+    controller.setProperties({ model: topic });
+
+    const user = this.store.createRecord("user", {
+      username: "eviltrout",
+      id: 321,
+      ignored_users: ["ignored-user"],
+    });
+    getOwner(this).unregister("service:current-user");
+    getOwner(this).register("service:current-user", user, {
+      instantiate: false,
+    });
+
+    const stub = sinon
+      .stub(topic.postStream, "triggerNewPostsInStream")
+      .resolves();
+
+    controller.onMessage({
+      type: "created",
+      id: 101,
+      username: "ignored-user",
+      user_id: 321,
+    });
+    await settled();
+
+    assert.false(
+      topic.postStream.stream.includes(101),
+      "ignored user's post is not added to the stream"
+    );
+    assert.false(
+      stub.called,
+      "ignored user's post is not fetched into the stream"
+    );
+  });
+
+  test("onMessage live-inserts new posts from regular users", async function (assert) {
+    const topic = topicWithStream.call(this, {
+      posts: [{ id: 1, post_number: 1 }],
+      stream: [1],
+    });
+    const controller = getOwner(this).lookup("controller:topic");
+    controller.setProperties({ model: topic });
+
+    const user = this.store.createRecord("user", {
+      username: "eviltrout",
+      id: 321,
+    });
+    getOwner(this).unregister("service:current-user");
+    getOwner(this).register("service:current-user", user, {
+      instantiate: false,
+    });
+
+    const stub = sinon
+      .stub(topic.postStream, "triggerNewPostsInStream")
+      .resolves();
+
+    controller.onMessage({
+      type: "created",
+      id: 101,
+      username: "regular-user",
+      user_id: 321,
+    });
+    await settled();
+
+    assert.true(
+      stub.calledOnce,
+      "regular user's post is fetched into the stream"
+    );
+  });
 });

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2389,6 +2389,7 @@ RSpec.describe Post do
         post_number: post.post_number,
         updated_at: Time.now,
         user_id: post.user_id,
+        username: post.user.username,
         last_editor_id: post.last_editor_id,
         type: :created,
         version: post.version,


### PR DESCRIPTION
Currently if an ignored user makes a new post while you're in a topic without all posts loaded, when you scroll and load new posts, you see the ignored user's full post. On page refresh it is correctly hidden. 

This change includes the poster's `username` in the payload so we can skip their posts when new posts are loaded, keeping the ignored user's content hidden. 