### PR TITLE
FEAT: Add a system section to the redesigned admin dashboar

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -137,6 +137,19 @@ $db-bar-height: var(--space-2);
   }
 }
 
+.db-bar-track {
+  height: $db-bar-height;
+  border-radius: 1em;
+  background: var(--primary-low);
+}
+
+.db-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 4px;
+  background: var(--tertiary);
+}
+
 .db-configure {
   padding: var(--space-4);
   max-width: 100%;
@@ -491,5 +504,15 @@ $db-bar-height: var(--space-2);
         padding-bottom: 0;
       }
     }
+  }
+}
+
+.db-system {
+  &__breakdown {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    color: var(--primary-medium);
+    font-size: var(--font-down-1-rem);
   }
 }

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -138,9 +138,11 @@ $db-bar-height: var(--space-2);
 }
 
 .db-bar-track {
+  display: flex;
   height: $db-bar-height;
   border-radius: 1em;
   background: var(--primary-low);
+  overflow: hidden;
 }
 
 .db-bar-fill {
@@ -148,6 +150,14 @@ $db-bar-height: var(--space-2);
   height: 100%;
   border-radius: 4px;
   background: var(--tertiary);
+  flex: 0 0 auto;
+
+  // a real but tiny segment would otherwise round away to nothing
+  min-width: 2px;
+
+  &.--alt {
+    background: var(--tertiary-medium);
+  }
 }
 
 .db-configure {
@@ -598,5 +608,21 @@ $db-bar-height: var(--space-2);
 .db-bar-track {
   .--system & {
     margin-block: var(--space-2);
+  }
+}
+
+.db-bar-fill {
+  &:first-child {
+    .--system & {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  &:nth-child(2) {
+    .--system & {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
   }
 }

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -507,12 +507,96 @@ $db-bar-height: var(--space-2);
   }
 }
 
+.db-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .db-system {
+  &__block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+
+    &:first-of-type {
+      border-top-left-radius: var(--d-border-radius-large);
+      border-bottom-left-radius: var(--d-border-radius-large);
+    }
+
+    &:last-of-type {
+      border-top-right-radius: var(--d-border-radius-large);
+      border-bottom-right-radius: var(--d-border-radius-large);
+    }
+  }
+
+  &__value {
+    font-size: var(--font-up-3-rem);
+    font-weight: 500;
+    color: var(--primary);
+  }
+
+  &__label {
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-medium);
+  }
+
   &__breakdown {
     display: flex;
     align-items: center;
     gap: var(--space-1);
     color: var(--primary-medium);
     font-size: var(--font-down-1-rem);
+  }
+
+  &__link {
+    font-size: var(--font-down-1-rem);
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    margin-top: auto;
+
+    &.--critical {
+      .db-system__label {
+        color: var(--danger);
+      }
+    }
+
+    .--storage & {
+      justify-content: space-between;
+    }
+
+    .--status & {
+      justify-content: flex-end;
+    }
+  }
+
+  &__status-icon {
+    .--ok & {
+      color: var(--success);
+    }
+
+    .--warning &,
+    .--critical & {
+      color: var(--danger);
+    }
+  }
+}
+
+.--system {
+  @include viewport.until(sm) {
+    .db-section__row-block {
+      border-radius: var(--d-border-radius-large);
+      flex-basis: calc(50% - var(--space-1));
+      border: 1px solid var(--content-border-color);
+    }
+  }
+}
+
+.db-bar-track {
+  .--system & {
+    margin-block: var(--space-2);
   }
 }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -355,6 +355,7 @@ $hpad: 0.65em;
 }
 
 @mixin dot-separator($size: 0.35em) {
+  display: inline-block;
   width: $size;
   height: $size;
   margin-inline: var(--space-1);

--- a/app/services/admin_dashboard_section_configuration.rb
+++ b/app/services/admin_dashboard_section_configuration.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AdminDashboardSectionConfiguration
-  KNOWN_SECTIONS = %w[highlights reports traffic engagement search].freeze
+  KNOWN_SECTIONS = %w[highlights reports traffic engagement search system].freeze
+  DEFAULT_HIDDEN_SECTIONS = %w[system].freeze
 
   ACTIVITY_BY_CATEGORY_MAX = 10
   WHOS_POSTING_MAX = 10
@@ -51,6 +52,10 @@ class AdminDashboardSectionConfiguration
     },
   }.freeze
 
+  def self.default_visible?(section_id)
+    DEFAULT_HIDDEN_SECTIONS.exclude?(section_id.to_s)
+  end
+
   def self.available_plugin_section_ids
     DiscoursePluginRegistry
       .admin_dashboard_sections
@@ -71,7 +76,8 @@ class AdminDashboardSectionConfiguration
         .order(:position)
         .pluck(:section_id, :visible)
         .map { |id, visible| { id:, visible: } }
-    not_persisted = (known - persisted.map { |s| s[:id] }).map { |id| { id:, visible: true } }
+    not_persisted =
+      (known - persisted.map { |s| s[:id] }).map { |id| { id:, visible: default_visible?(id) } }
 
     persisted + not_persisted
   end
@@ -114,7 +120,7 @@ class AdminDashboardSectionConfiguration
     record =
       AdminDashboardSection.find_or_create_by!(section_id:) do |r|
         r.position = (AdminDashboardSection.maximum(:position) || -1) + 1
-        r.visible = true
+        r.visible = default_visible?(section_id)
       end
 
     record.with_lock { record.update!(settings: record.settings.to_h.deep_merge(key => value)) }

--- a/app/services/admin_dashboard_section_configuration.rb
+++ b/app/services/admin_dashboard_section_configuration.rb
@@ -59,7 +59,13 @@ class AdminDashboardSectionConfiguration
   end
 
   def self.all_known_section_ids
-    KNOWN_SECTIONS + available_plugin_section_ids
+    builtin_section_ids + available_plugin_section_ids
+  end
+
+  def self.builtin_section_ids
+    return KNOWN_SECTIONS if SiteSetting.version_checks?
+
+    KNOWN_SECTIONS - ["system"]
   end
 
   def self.sections

--- a/app/services/admin_dashboard_section_configuration.rb
+++ b/app/services/admin_dashboard_section_configuration.rb
@@ -2,7 +2,6 @@
 
 class AdminDashboardSectionConfiguration
   KNOWN_SECTIONS = %w[highlights reports traffic engagement search system].freeze
-  DEFAULT_HIDDEN_SECTIONS = %w[system].freeze
 
   ACTIVITY_BY_CATEGORY_MAX = 10
   WHOS_POSTING_MAX = 10
@@ -52,10 +51,6 @@ class AdminDashboardSectionConfiguration
     },
   }.freeze
 
-  def self.default_visible?(section_id)
-    DEFAULT_HIDDEN_SECTIONS.exclude?(section_id.to_s)
-  end
-
   def self.available_plugin_section_ids
     DiscoursePluginRegistry
       .admin_dashboard_sections
@@ -76,8 +71,7 @@ class AdminDashboardSectionConfiguration
         .order(:position)
         .pluck(:section_id, :visible)
         .map { |id, visible| { id:, visible: } }
-    not_persisted =
-      (known - persisted.map { |s| s[:id] }).map { |id| { id:, visible: default_visible?(id) } }
+    not_persisted = (known - persisted.map { |s| s[:id] }).map { |id| { id:, visible: true } }
 
     persisted + not_persisted
   end
@@ -120,7 +114,7 @@ class AdminDashboardSectionConfiguration
     record =
       AdminDashboardSection.find_or_create_by!(section_id:) do |r|
         r.position = (AdminDashboardSection.maximum(:position) || -1) + 1
-        r.visible = default_visible?(section_id)
+        r.visible = true
       end
 
     record.with_lock { record.update!(settings: record.settings.to_h.deep_merge(key => value)) }

--- a/app/services/admin_dashboard_section_loader.rb
+++ b/app/services/admin_dashboard_section_loader.rb
@@ -103,6 +103,8 @@ class AdminDashboardSectionLoader
       AdminDashboard::Reports::Section.build(guardian: user.guardian)
     when "search"
       AdminDashboardSearch.build(start_date: start_date, end_date: end_date)
+    when "system"
+      AdminDashboardSystem.build(guardian: user.guardian)
     else
       section = DiscoursePluginRegistry.admin_dashboard_sections.find { |s| s[:id] == id }
       section&.dig(:loader)&.call(start_date: start_date, end_date: end_date, current_user: user)

--- a/app/services/admin_dashboard_system.rb
+++ b/app/services/admin_dashboard_system.rb
@@ -35,7 +35,24 @@ class AdminDashboardSystem
     stats = storage_stats
     return nil if stats.blank?
 
-    guardian.is_admin? ? stats : stats.except(:backups)
+    stats = stats.except(:backups) if !guardian.is_admin?
+
+    # Only a local store has a bounded amount of space, so the client needs to
+    # know which of these live on this machine before it can chart them.
+    stats.each_with_object({}) do |(store, values), result|
+      result[store] = values.nil? ? nil : values.merge(remote: remote?(store))
+    end
+  end
+
+  def remote?(store)
+    case store.to_s
+    when "backups"
+      SiteSetting.backup_location == BackupLocationSiteSetting::S3
+    when "uploads"
+      Discourse.store.external?
+    else
+      false
+    end
   end
 
   def storage_stats

--- a/app/services/admin_dashboard_system.rb
+++ b/app/services/admin_dashboard_system.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class AdminDashboardSystem
+  STORAGE_REPORT = "storage_stats"
+  private_constant :STORAGE_REPORT
+
+  def self.build(guardian:)
+    new(guardian: guardian).build
+  end
+
+  def initialize(guardian:)
+    @guardian = guardian
+  end
+
+  def build
+    {
+      version: version,
+      storage: storage,
+      discourse_updated_at: Discourse.last_commit_date,
+      dashboard_updated_at: AdminDashboardIndexData.fetch_cached_stats["updated_at"],
+    }
+  end
+
+  private
+
+  attr_reader :guardian
+
+  def version
+    return nil if !SiteSetting.version_checks?
+
+    DiscourseUpdates.check_version.as_json
+  end
+
+  def storage
+    stats = storage_stats
+    return nil if stats.blank?
+
+    guardian.is_admin? ? stats : stats.except(:backups)
+  end
+
+  def storage_stats
+    cached = Report.find_cached(STORAGE_REPORT)
+    return cached[:data] if cached.present?
+
+    report = Report.find(STORAGE_REPORT)
+    return nil if report.nil? || report.error.present?
+
+    Report.cache(report)
+    report.data
+  end
+end

--- a/app/services/admin_dashboard_system.rb
+++ b/app/services/admin_dashboard_system.rb
@@ -26,8 +26,6 @@ class AdminDashboardSystem
   attr_reader :guardian
 
   def version
-    return nil if !SiteSetting.version_checks?
-
     DiscourseUpdates.check_version.as_json
   end
 
@@ -37,8 +35,6 @@ class AdminDashboardSystem
 
     stats = stats.except(:backups) if !guardian.is_admin?
 
-    # Only a local store has a bounded amount of space, so the client needs to
-    # know which of these live on this machine before it can chart them.
     stats.each_with_object({}) do |(store, values), result|
       result[store] = values.nil? ? nil : values.merge(remote: remote?(store))
     end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7615,6 +7615,26 @@ en:
                 no_match_tooltip: "Search terms with a 0% click-through rate (CTR)."
                 poor_match: "Poor match"
                 poor_match_tooltip: "Search terms with a click-through rate (CTR) between 1-20%."
+          system:
+            title: "System"
+            storage: "Storage"
+            status: "Status"
+            fetch_error: "Couldn't load system information. Try refreshing the page."
+            commits:
+              one: "+%{count} commit"
+              other: "+%{count} commits"
+            view_on_github: "View on GitHub"
+            update_check_failed: "Update check failed — ensure Sidekiq is running."
+            update_available: "Update available: %{version}"
+            space_free: "%{size} free"
+            backups_size:
+              one: "%{size} backup (%{count})"
+              other: "%{size} backups (%{count})"
+            uploads_size: "%{size} uploads"
+            latest_backup: "Latest backup %{date}"
+            manage_backups: "Manage backups"
+            discourse_updated: "Discourse updated"
+            dashboard_updated: "Dashboard updated"
         reports_section:
           header_action: "Manage"
           description: "Pin standard reports or Data Explorer queries to track what matters to your community."

--- a/frontend/discourse/admin/components/dashboard/system.gjs
+++ b/frontend/discourse/admin/components/dashboard/system.gjs
@@ -146,55 +146,63 @@ export default class DashboardSystem extends Component {
               </h3>
             </div>
 
-            <div class="db-kpi__value">
-              {{dashIfEmpty this.versionCheck.installed_version}}
+            <div class="db-system__headline">
+
+              <div class="db-group">
+                <div class="db-system__value">
+                  {{dashIfEmpty this.versionCheck.installed_version}}
+                </div>
+
+                {{#if this.versionCheck.installedCommitsAhead}}
+                  <span
+                    class="db-pill"
+                    title={{i18n
+                      "admin.dashboard.commits_ahead"
+                      count=this.versionCheck.installedCommitsAhead
+                    }}
+                  >
+                    {{i18n
+                      "admin.dashboard.sections.system.commits"
+                      count=this.versionCheck.installedCommitsAhead
+                    }}
+                  </span>
+                {{/if}}
+              </div>
+
+              {{#if this.versionCheck.gitLink}}
+                <a
+                  class="db-system__link"
+                  href={{this.versionCheck.gitLink}}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  title={{i18n
+                    "admin.dashboard.commit_on_github"
+                    sha=this.versionCheck.shortSha
+                  }}
+                >
+                  {{i18n "admin.dashboard.sections.system.view_on_github"}}
+                  {{dIcon "up-right-from-square"}}
+                </a>
+              {{/if}}
+
             </div>
-
-            {{#if this.versionCheck.installedCommitsAhead}}
-              <span
-                class="db-pill"
-                title={{i18n
-                  "admin.dashboard.commits_ahead"
-                  count=this.versionCheck.installedCommitsAhead
-                }}
-              >
-                {{i18n
-                  "admin.dashboard.sections.system.commits"
-                  count=this.versionCheck.installedCommitsAhead
-                }}
-              </span>
-            {{/if}}
-
-            {{#if this.versionCheck.gitLink}}
-              <a
-                class="db-kpi__label"
-                href={{this.versionCheck.gitLink}}
-                rel="noopener noreferrer"
-                target="_blank"
-                title={{i18n
-                  "admin.dashboard.commit_on_github"
-                  sha=this.versionCheck.shortSha
-                }}
-              >
-                {{i18n "admin.dashboard.sections.system.view_on_github"}}
-                {{dIcon "up-right-from-square"}}
-              </a>
-            {{/if}}
 
             <div
               class={{dConcatClass
-                "db-system__status"
+                "db-system__footer"
                 this.versionStatus.className
               }}
             >
-              {{dIcon this.versionStatus.icon class="db-system__status-icon"}}
-              {{this.versionStatus.message}}
+              <span class="db-system__label">
+                {{dIcon this.versionStatus.icon class="db-system__status-icon"}}
+                {{this.versionStatus.message}}
+              </span>
             </div>
           </div>
         {{/if}}
 
         {{#if @data.storage}}
-          <div class="db-section__row-block db-system__block">
+          <div class="db-section__row-block db-system__block --storage">
             <div class="db-section__row-block-header">
               <h3 class="db-section__header">
                 {{dIcon "database" class="db-system__block-icon"}}
@@ -202,12 +210,12 @@ export default class DashboardSystem extends Component {
               </h3>
             </div>
 
-            <div class="db-system__storage-headline">
-              <div class="db-kpi__value">
+            <div class="db-system__headline">
+              <div class="db-system__value">
                 {{i18n "admin.dashboard.space_used" usedSize=this.usedSpace}}
               </div>
               {{#if this.freeSpace}}
-                <div class="db-kpi__label">
+                <div class="db-system__label">
                   {{i18n
                     "admin.dashboard.sections.system.space_free"
                     size=this.freeSpace
@@ -216,36 +224,43 @@ export default class DashboardSystem extends Component {
               {{/if}}
             </div>
 
-            {{#if this.barStyle}}
-              <div class="db-bar-track" role="img" aria-label={{this.barLabel}}>
-                <span class="db-bar-fill" style={{this.barStyle}}></span>
-              </div>
-            {{/if}}
-
-            <div class="db-system__breakdown">
-              {{#if this.backups}}
-                <span class="db-system__breakdown-item">
-                  {{this.backupsSummary}}
-                </span>
-                <span class="dot-separator"></span>
+            <div>
+              {{#if this.barStyle}}
+                <div
+                  class="db-bar-track"
+                  role="img"
+                  aria-label={{this.barLabel}}
+                >
+                  <span class="db-bar-fill" style={{this.barStyle}}></span>
+                </div>
               {{/if}}
-              <span class="db-system__breakdown-item">
-                {{this.uploadsSummary}}
-              </span>
+
+              <div class="db-system__breakdown">
+                {{#if this.backups}}
+                  <span class="db-system__breakdown-item">
+                    {{this.backupsSummary}}
+                  </span>
+                  <span class="dot-separator"></span>
+                {{/if}}
+                <span class="db-system__breakdown-item">
+                  {{this.uploadsSummary}}
+                </span>
+              </div>
             </div>
 
             {{#if this.backups}}
-              <div class="db-system__block-footer">
+              <div class="db-system__footer">
                 {{#if this.backups.last_backup_taken_at}}
-                  {{trustHTML
-                    (i18n
-                      "admin.dashboard.sections.system.latest_backup"
-                      date=(dFormatDate
-                        this.backups.last_backup_taken_at leaveAgo="true"
-                      )
-                    )
-                  }}
-                  <span class="dot-separator"></span>
+                  <div class="db-system__label">
+                    <span>{{trustHTML
+                        (i18n
+                          "admin.dashboard.sections.system.latest_backup"
+                          date=(dFormatDate
+                            this.backups.last_backup_taken_at leaveAgo="true"
+                          )
+                        )
+                      }}</span>
+                  </div>
                 {{/if}}
                 <a class="db-system__link" href={{getUrl "/admin/backups"}}>
                   {{i18n "admin.dashboard.sections.system.manage_backups"}}
@@ -256,7 +271,7 @@ export default class DashboardSystem extends Component {
         {{/if}}
 
         {{#if this.hasStatus}}
-          <div class="db-section__row-block db-system__block">
+          <div class="db-section__row-block db-system__block --status">
             <div class="db-section__row-block-header">
               <h3 class="db-section__header">
                 {{dIcon "clock" class="db-system__block-icon"}}
@@ -265,28 +280,28 @@ export default class DashboardSystem extends Component {
             </div>
 
             {{#if @data.discourse_updated_at}}
-              <div class="db-section__status-type">
-                <div class="db-kpi__value">
+              <div class="db-system__headline">
+                <div class="db-system__value">
                   {{dFormatDate @data.discourse_updated_at leaveAgo="true"}}
                 </div>
-                <div class="db-kpi__label">
+                <div class="db-system__label">
                   {{i18n "admin.dashboard.sections.system.discourse_updated"}}
                 </div>
               </div>
             {{/if}}
 
             {{#if @data.dashboard_updated_at}}
-              <div class="db-section__status-type">
-                <div class="db-kpi__value">
+              <div class="db-system__headline">
+                <div class="db-system__value">
                   {{dFormatDate @data.dashboard_updated_at leaveAgo="true"}}
                 </div>
-                <div class="db-kpi__label">
+                <div class="db-system__label">
                   {{i18n "admin.dashboard.sections.system.dashboard_updated"}}
                 </div>
               </div>
             {{/if}}
 
-            <div class="db-system__block-footer">
+            <div class="db-system__footer">
               <LinkTo @route="admin.whatsNew" class="db-system__link">
                 {{i18n "admin.dashboard.whats_new_in_discourse"}}
               </LinkTo>

--- a/frontend/discourse/admin/components/dashboard/system.gjs
+++ b/frontend/discourse/admin/components/dashboard/system.gjs
@@ -69,12 +69,31 @@ export default class DashboardSystem extends Component {
     return this.args.data?.storage?.uploads;
   }
 
+  get #storeEntries() {
+    return [
+      { key: "backups", stats: this.backups, className: "" },
+      { key: "uploads", stats: this.uploads, className: "--alt" },
+    ].filter((entry) => entry.stats);
+  }
+
+  // Only a local store is bounded, so only local stores can be charted against
+  // free space. An external store has no ceiling to report at all.
+  get #localEntries() {
+    return this.#storeEntries.filter((entry) => !entry.stats.remote);
+  }
+
   get #usedBytes() {
-    return (this.backups?.used_bytes ?? 0) + (this.uploads?.used_bytes ?? 0);
+    return this.#storeEntries.reduce(
+      (sum, entry) => sum + (entry.stats.used_bytes ?? 0),
+      0
+    );
   }
 
   get #freeBytes() {
-    return this.uploads?.free_bytes ?? this.backups?.free_bytes ?? null;
+    return (
+      this.#localEntries.find((entry) => entry.stats.free_bytes)?.stats
+        .free_bytes ?? null
+    );
   }
 
   get usedSpace() {
@@ -86,17 +105,26 @@ export default class DashboardSystem extends Component {
     return free == null ? null : I18n.toHumanSize(free);
   }
 
-  get barStyle() {
+  // Segments plus the remaining free space add up to the whole track, so the
+  // denominator is the local disk rather than the total across every store.
+  get barSegments() {
     const free = this.#freeBytes;
 
     if (free == null) {
-      return null;
+      return [];
     }
 
-    const total = this.#usedBytes + free;
-    const percent = total === 0 ? 0 : (this.#usedBytes / total) * 100;
+    const local = this.#localEntries.filter((entry) => entry.stats.used_bytes);
+    const total = local.reduce((sum, e) => sum + e.stats.used_bytes, 0) + free;
 
-    return trustHTML(`width: ${Math.min(100, percent).toFixed(1)}%`);
+    return local.map((entry) => ({
+      key: entry.key,
+      className: entry.className,
+      title: i18n(`admin.dashboard.${entry.key}`),
+      style: trustHTML(
+        `width: ${Math.min(100, (entry.stats.used_bytes / total) * 100).toFixed(1)}%`
+      ),
+    }));
   }
 
   get barLabel() {
@@ -225,13 +253,19 @@ export default class DashboardSystem extends Component {
             </div>
 
             <div>
-              {{#if this.barStyle}}
+              {{#if this.barSegments}}
                 <div
                   class="db-bar-track"
                   role="img"
                   aria-label={{this.barLabel}}
                 >
-                  <span class="db-bar-fill" style={{this.barStyle}}></span>
+                  {{#each this.barSegments key="key" as |segment|}}
+                    <span
+                      class={{dConcatClass "db-bar-fill" segment.className}}
+                      style={{segment.style}}
+                      title={{segment.title}}
+                    ></span>
+                  {{/each}}
                 </div>
               {{/if}}
 

--- a/frontend/discourse/admin/components/dashboard/system.gjs
+++ b/frontend/discourse/admin/components/dashboard/system.gjs
@@ -83,7 +83,7 @@ export default class DashboardSystem extends Component {
   }
 
   get #usedBytes() {
-    return this.#storeEntries.reduce(
+    return this.#localEntries.reduce(
       (sum, entry) => sum + (entry.stats.used_bytes ?? 0),
       0
     );
@@ -91,7 +91,7 @@ export default class DashboardSystem extends Component {
 
   get #freeBytes() {
     return (
-      this.#localEntries.find((entry) => entry.stats.free_bytes)?.stats
+      this.#localEntries.find((entry) => entry.stats.free_bytes != null)?.stats
         .free_bytes ?? null
     );
   }
@@ -165,69 +165,67 @@ export default class DashboardSystem extends Component {
           {{i18n "admin.dashboard.sections.system.fetch_error"}}
         </div>
       {{else if @data}}
-        {{#if this.versionCheck}}
-          <div class="db-section__row-block db-system__block">
-            <div class="db-section__row-block-header">
-              <h3 class="db-section__header">
-                {{dIcon "tag" class="db-system__block-icon"}}
-                {{i18n "admin.dashboard.version"}}
-              </h3>
-            </div>
+        <div class="db-section__row-block db-system__block">
+          <div class="db-section__row-block-header">
+            <h3 class="db-section__header">
+              {{dIcon "tag" class="db-system__block-icon"}}
+              {{i18n "admin.dashboard.version"}}
+            </h3>
+          </div>
 
-            <div class="db-system__headline">
+          <div class="db-system__headline">
 
-              <div class="db-group">
-                <div class="db-system__value">
-                  {{dashIfEmpty this.versionCheck.installed_version}}
-                </div>
-
-                {{#if this.versionCheck.installedCommitsAhead}}
-                  <span
-                    class="db-pill"
-                    title={{i18n
-                      "admin.dashboard.commits_ahead"
-                      count=this.versionCheck.installedCommitsAhead
-                    }}
-                  >
-                    {{i18n
-                      "admin.dashboard.sections.system.commits"
-                      count=this.versionCheck.installedCommitsAhead
-                    }}
-                  </span>
-                {{/if}}
+            <div class="db-group">
+              <div class="db-system__value">
+                {{dashIfEmpty this.versionCheck.installed_version}}
               </div>
 
-              {{#if this.versionCheck.gitLink}}
-                <a
-                  class="db-system__link"
-                  href={{this.versionCheck.gitLink}}
-                  rel="noopener noreferrer"
-                  target="_blank"
+              {{#if this.versionCheck.installedCommitsAhead}}
+                <span
+                  class="db-pill"
                   title={{i18n
-                    "admin.dashboard.commit_on_github"
-                    sha=this.versionCheck.shortSha
+                    "admin.dashboard.commits_ahead"
+                    count=this.versionCheck.installedCommitsAhead
                   }}
                 >
-                  {{i18n "admin.dashboard.sections.system.view_on_github"}}
-                  {{dIcon "up-right-from-square"}}
-                </a>
+                  {{i18n
+                    "admin.dashboard.sections.system.commits"
+                    count=this.versionCheck.installedCommitsAhead
+                  }}
+                </span>
               {{/if}}
-
             </div>
 
-            <div
-              class={{dConcatClass
-                "db-system__footer"
-                this.versionStatus.className
-              }}
-            >
-              <span class="db-system__label">
-                {{dIcon this.versionStatus.icon class="db-system__status-icon"}}
-                {{this.versionStatus.message}}
-              </span>
-            </div>
+            {{#if this.versionCheck.gitLink}}
+              <a
+                class="db-system__link"
+                href={{this.versionCheck.gitLink}}
+                rel="noopener noreferrer"
+                target="_blank"
+                title={{i18n
+                  "admin.dashboard.commit_on_github"
+                  sha=this.versionCheck.shortSha
+                }}
+              >
+                {{i18n "admin.dashboard.sections.system.view_on_github"}}
+                {{dIcon "up-right-from-square"}}
+              </a>
+            {{/if}}
+
           </div>
-        {{/if}}
+
+          <div
+            class={{dConcatClass
+              "db-system__footer"
+              this.versionStatus.className
+            }}
+          >
+            <span class="db-system__label">
+              {{dIcon this.versionStatus.icon class="db-system__status-icon"}}
+              {{this.versionStatus.message}}
+            </span>
+          </div>
+        </div>
 
         {{#if @data.storage}}
           <div class="db-section__row-block db-system__block --storage">

--- a/frontend/discourse/admin/components/dashboard/system.gjs
+++ b/frontend/discourse/admin/components/dashboard/system.gjs
@@ -1,0 +1,299 @@
+import Component from "@glimmer/component";
+import { LinkTo } from "@ember/routing";
+import { trustHTML } from "@ember/template";
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import VersionCheck from "discourse/admin/models/version-check";
+import dashIfEmpty from "discourse/helpers/dash-if-empty";
+import getUrl from "discourse/lib/get-url";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dFormatDate from "discourse/ui-kit/helpers/d-format-date";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import I18n, { i18n } from "discourse-i18n";
+
+const PREFIX = "admin.dashboard.sections.system";
+
+export default class DashboardSystem extends Component {
+  get versionCheck() {
+    const version = this.args.data?.version;
+    return version ? new VersionCheck(version) : null;
+  }
+
+  get versionStatus() {
+    const check = this.versionCheck;
+
+    if (
+      check.noCheckPerformed ||
+      (check.stale_data && !check.version_check_pending)
+    ) {
+      return {
+        icon: "triangle-exclamation",
+        className: "--critical",
+        message: i18n(`${PREFIX}.update_check_failed`),
+      };
+    }
+
+    if (check.stale_data) {
+      return {
+        icon: "circle-check",
+        className: "--ok",
+        message: i18n("admin.dashboard.version_check_pending"),
+      };
+    }
+
+    if (check.upToDate) {
+      return {
+        icon: "circle-check",
+        className: "--ok",
+        message: check.newerCommitsAvailable
+          ? i18n("admin.dashboard.up_to_date_newer_commits", {
+              count: check.newChangesCount,
+            })
+          : i18n("admin.dashboard.up_to_date"),
+      };
+    }
+
+    return {
+      icon: "triangle-exclamation",
+      className: "--warning",
+      message: check.latest_version
+        ? i18n(`${PREFIX}.update_available`, { version: check.latest_version })
+        : i18n("admin.dashboard.updates_available"),
+    };
+  }
+
+  get backups() {
+    return this.args.data?.storage?.backups;
+  }
+
+  get uploads() {
+    return this.args.data?.storage?.uploads;
+  }
+
+  get #usedBytes() {
+    return (this.backups?.used_bytes ?? 0) + (this.uploads?.used_bytes ?? 0);
+  }
+
+  get #freeBytes() {
+    return this.uploads?.free_bytes ?? this.backups?.free_bytes ?? null;
+  }
+
+  get usedSpace() {
+    return I18n.toHumanSize(this.#usedBytes);
+  }
+
+  get freeSpace() {
+    const free = this.#freeBytes;
+    return free == null ? null : I18n.toHumanSize(free);
+  }
+
+  get barStyle() {
+    const free = this.#freeBytes;
+
+    if (free == null) {
+      return null;
+    }
+
+    const total = this.#usedBytes + free;
+    const percent = total === 0 ? 0 : (this.#usedBytes / total) * 100;
+
+    return trustHTML(`width: ${Math.min(100, percent).toFixed(1)}%`);
+  }
+
+  get barLabel() {
+    return i18n("admin.dashboard.space_used_and_free", {
+      usedSize: this.usedSpace,
+      freeSize: this.freeSpace,
+    });
+  }
+
+  get hasStatus() {
+    return !!(
+      this.args.data?.discourse_updated_at ||
+      this.args.data?.dashboard_updated_at
+    );
+  }
+
+  get backupsSummary() {
+    return i18n(`${PREFIX}.backups_size`, {
+      count: this.backups.count,
+      size: I18n.toHumanSize(this.backups.used_bytes),
+    });
+  }
+
+  get uploadsSummary() {
+    return i18n(`${PREFIX}.uploads_size`, {
+      size: I18n.toHumanSize(this.uploads?.used_bytes ?? 0),
+    });
+  }
+
+  <template>
+    <DashboardSection
+      @title={{i18n "admin.dashboard.sections.system.title"}}
+      @layout="row"
+      ...attributes
+    >
+      {{#if @fetchError}}
+        <div class="db-section__error" role="alert">
+          {{i18n "admin.dashboard.sections.system.fetch_error"}}
+        </div>
+      {{else if @data}}
+        {{#if this.versionCheck}}
+          <div class="db-section__row-block db-system__block">
+            <div class="db-section__row-block-header">
+              <h3 class="db-section__header">
+                {{dIcon "tag" class="db-system__block-icon"}}
+                {{i18n "admin.dashboard.version"}}
+              </h3>
+            </div>
+
+            <div class="db-kpi__value">
+              {{dashIfEmpty this.versionCheck.installed_version}}
+            </div>
+
+            {{#if this.versionCheck.installedCommitsAhead}}
+              <span
+                class="db-pill"
+                title={{i18n
+                  "admin.dashboard.commits_ahead"
+                  count=this.versionCheck.installedCommitsAhead
+                }}
+              >
+                {{i18n
+                  "admin.dashboard.sections.system.commits"
+                  count=this.versionCheck.installedCommitsAhead
+                }}
+              </span>
+            {{/if}}
+
+            {{#if this.versionCheck.gitLink}}
+              <a
+                class="db-kpi__label"
+                href={{this.versionCheck.gitLink}}
+                rel="noopener noreferrer"
+                target="_blank"
+                title={{i18n
+                  "admin.dashboard.commit_on_github"
+                  sha=this.versionCheck.shortSha
+                }}
+              >
+                {{i18n "admin.dashboard.sections.system.view_on_github"}}
+                {{dIcon "up-right-from-square"}}
+              </a>
+            {{/if}}
+
+            <div
+              class={{dConcatClass
+                "db-system__status"
+                this.versionStatus.className
+              }}
+            >
+              {{dIcon this.versionStatus.icon class="db-system__status-icon"}}
+              {{this.versionStatus.message}}
+            </div>
+          </div>
+        {{/if}}
+
+        {{#if @data.storage}}
+          <div class="db-section__row-block db-system__block">
+            <div class="db-section__row-block-header">
+              <h3 class="db-section__header">
+                {{dIcon "database" class="db-system__block-icon"}}
+                {{i18n "admin.dashboard.sections.system.storage"}}
+              </h3>
+            </div>
+
+            <div class="db-system__storage-headline">
+              <div class="db-kpi__value">
+                {{i18n "admin.dashboard.space_used" usedSize=this.usedSpace}}
+              </div>
+              {{#if this.freeSpace}}
+                <div class="db-kpi__label">
+                  {{i18n
+                    "admin.dashboard.sections.system.space_free"
+                    size=this.freeSpace
+                  }}
+                </div>
+              {{/if}}
+            </div>
+
+            {{#if this.barStyle}}
+              <div class="db-bar-track" role="img" aria-label={{this.barLabel}}>
+                <span class="db-bar-fill" style={{this.barStyle}}></span>
+              </div>
+            {{/if}}
+
+            <div class="db-system__breakdown">
+              {{#if this.backups}}
+                <span class="db-system__breakdown-item">
+                  {{this.backupsSummary}}
+                </span>
+                <span class="dot-separator"></span>
+              {{/if}}
+              <span class="db-system__breakdown-item">
+                {{this.uploadsSummary}}
+              </span>
+            </div>
+
+            {{#if this.backups}}
+              <div class="db-system__block-footer">
+                {{#if this.backups.last_backup_taken_at}}
+                  {{trustHTML
+                    (i18n
+                      "admin.dashboard.sections.system.latest_backup"
+                      date=(dFormatDate
+                        this.backups.last_backup_taken_at leaveAgo="true"
+                      )
+                    )
+                  }}
+                  <span class="dot-separator"></span>
+                {{/if}}
+                <a class="db-system__link" href={{getUrl "/admin/backups"}}>
+                  {{i18n "admin.dashboard.sections.system.manage_backups"}}
+                </a>
+              </div>
+            {{/if}}
+          </div>
+        {{/if}}
+
+        {{#if this.hasStatus}}
+          <div class="db-section__row-block db-system__block">
+            <div class="db-section__row-block-header">
+              <h3 class="db-section__header">
+                {{dIcon "clock" class="db-system__block-icon"}}
+                {{i18n "admin.dashboard.sections.system.status"}}
+              </h3>
+            </div>
+
+            {{#if @data.discourse_updated_at}}
+              <div class="db-section__status-type">
+                <div class="db-kpi__value">
+                  {{dFormatDate @data.discourse_updated_at leaveAgo="true"}}
+                </div>
+                <div class="db-kpi__label">
+                  {{i18n "admin.dashboard.sections.system.discourse_updated"}}
+                </div>
+              </div>
+            {{/if}}
+
+            {{#if @data.dashboard_updated_at}}
+              <div class="db-section__status-type">
+                <div class="db-kpi__value">
+                  {{dFormatDate @data.dashboard_updated_at leaveAgo="true"}}
+                </div>
+                <div class="db-kpi__label">
+                  {{i18n "admin.dashboard.sections.system.dashboard_updated"}}
+                </div>
+              </div>
+            {{/if}}
+
+            <div class="db-system__block-footer">
+              <LinkTo @route="admin.whatsNew" class="db-system__link">
+                {{i18n "admin.dashboard.whats_new_in_discourse"}}
+              </LinkTo>
+            </div>
+          </div>
+        {{/if}}
+      {{/if}}
+    </DashboardSection>
+  </template>
+}

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -9,6 +9,7 @@ import DashboardReports from "discourse/admin/components/dashboard/reports";
 import DashboardSearch from "discourse/admin/components/dashboard/search";
 import DashboardSiteAdvice from "discourse/admin/components/dashboard/site-advice";
 import DashboardSkeleton from "discourse/admin/components/dashboard/skeleton";
+import DashboardSystem from "discourse/admin/components/dashboard/system";
 import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
 import { lookupAdminDashboardSection } from "discourse/admin/lib/admin-dashboard-sections";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -131,6 +132,14 @@ export default class RedesignedAdminDashboard extends Component {
               @fetchError={{section.error}}
               @startDate={{@loadedSections.startDate}}
               @endDate={{@loadedSections.endDate}}
+            />
+          {{else if (eq section.id "system")}}
+            <DashboardSystem
+              class={{concat "--" section.id}}
+              data-section-id={{section.id}}
+              @data={{section.data}}
+              @loading={{@loadingSections}}
+              @fetchError={{section.error}}
             />
           {{else if (eq section.id "search")}}
             <DashboardSearch

--- a/frontend/discourse/tests/integration/components/dashboard/system-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/system-test.gjs
@@ -1,0 +1,44 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DashboardSystem from "discourse/admin/components/dashboard/system";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | Dashboard | System", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  test("uses local storage for capacity and renders a full disk bar", async function (assert) {
+    const data = {
+      version: {
+        installed_version: "3.6.0",
+        missing_versions_count: 0,
+      },
+      storage: {
+        backups: {
+          count: 1,
+          remote: true,
+          used_bytes: 1024,
+        },
+        uploads: {
+          free_bytes: 0,
+          remote: false,
+          used_bytes: 2048,
+        },
+      },
+    };
+
+    await render(<template><DashboardSystem @data={{data}} /></template>);
+
+    assert
+      .dom(".db-system__block.--storage .db-system__value")
+      .hasText(
+        "2 KB used",
+        "excludes remote storage from the local disk total"
+      );
+    assert
+      .dom(".db-system__block.--storage .db-bar-track")
+      .exists("renders a capacity bar when no local space remains");
+    assert
+      .dom(".db-system__block.--storage .db-bar-fill")
+      .hasAttribute("style", /width:\s*100(?:\.0)?%/, "fills the storage bar");
+  });
+});

--- a/lib/disk_space.rb
+++ b/lib/disk_space.rb
@@ -5,12 +5,12 @@ class DiskSpace
     Upload.sum(:filesize).to_i + OptimizedImage.sum(:filesize).to_i
   end
 
+  # nil rather than 0 when the store is external: there is no local ceiling to
+  # report, which is not the same as having no room left.
   def self.uploads_free_bytes
-    if Discourse.store.external?
-      0
-    else
-      free(uploads_path)
-    end
+    return nil if Discourse.store.external?
+
+    free(uploads_path)
   end
 
   def self.free(path)

--- a/lib/disk_space.rb
+++ b/lib/disk_space.rb
@@ -5,8 +5,6 @@ class DiskSpace
     Upload.sum(:filesize).to_i + OptimizedImage.sum(:filesize).to_i
   end
 
-  # nil rather than 0 when the store is external: there is no local ceiling to
-  # report, which is not the same as having no room left.
   def self.uploads_free_bytes
     return nil if Discourse.store.external?
 

--- a/lib/seed_data/admin_dashboard_sections.rb
+++ b/lib/seed_data/admin_dashboard_sections.rb
@@ -7,7 +7,11 @@ module SeedData
         next if AdminDashboardSection.exists?(section_id:)
 
         next_position = (AdminDashboardSection.maximum(:position) || -1) + 1
-        AdminDashboardSection.create!(section_id:, position: next_position, visible: true)
+        AdminDashboardSection.create!(
+          section_id:,
+          position: next_position,
+          visible: AdminDashboardSectionConfiguration.default_visible?(section_id),
+        )
       end
     end
   end

--- a/lib/seed_data/admin_dashboard_sections.rb
+++ b/lib/seed_data/admin_dashboard_sections.rb
@@ -7,11 +7,7 @@ module SeedData
         next if AdminDashboardSection.exists?(section_id:)
 
         next_position = (AdminDashboardSection.maximum(:position) || -1) + 1
-        AdminDashboardSection.create!(
-          section_id:,
-          position: next_position,
-          visible: AdminDashboardSectionConfiguration.default_visible?(section_id),
-        )
+        AdminDashboardSection.create!(section_id:, position: next_position, visible: true)
       end
     end
   end

--- a/spec/lib/seed_data/admin_dashboard_sections_spec.rb
+++ b/spec/lib/seed_data/admin_dashboard_sections_spec.rb
@@ -5,7 +5,7 @@ require "seed_data/admin_dashboard_sections"
 describe SeedData::AdminDashboardSections do
   before { AdminDashboardSection.delete_all }
 
-  it "seeds every known section, visible, in canonical order" do
+  it "seeds every known section in canonical order, respecting default visibility" do
     described_class.create
 
     rows = AdminDashboardSection.order(:position).pluck(:section_id, :position, :visible)
@@ -16,6 +16,7 @@ describe SeedData::AdminDashboardSections do
         ["traffic", 2, true],
         ["engagement", 3, true],
         ["search", 4, true],
+        ["system", 5, false],
       ],
     )
   end

--- a/spec/lib/seed_data/admin_dashboard_sections_spec.rb
+++ b/spec/lib/seed_data/admin_dashboard_sections_spec.rb
@@ -5,7 +5,7 @@ require "seed_data/admin_dashboard_sections"
 describe SeedData::AdminDashboardSections do
   before { AdminDashboardSection.delete_all }
 
-  it "seeds every known section in canonical order, respecting default visibility" do
+  it "seeds every known section, visible, in canonical order" do
     described_class.create
 
     rows = AdminDashboardSection.order(:position).pluck(:section_id, :position, :visible)
@@ -16,7 +16,7 @@ describe SeedData::AdminDashboardSections do
         ["traffic", 2, true],
         ["engagement", 3, true],
         ["search", 4, true],
-        ["system", 5, false],
+        ["system", 5, true],
       ],
     )
   end

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -408,6 +408,7 @@ RSpec.describe Admin::DashboardController do
           "traffic",
           "engagement",
           "search",
+          "system",
         )
         expect(section_payloads.dig("highlights", "data")).to be_present
         expect(section_payloads.dig("traffic", "data")).to be_present
@@ -538,7 +539,6 @@ RSpec.describe Admin::DashboardController do
 
       it "omits version_check when enabled for the admin" do
         SiteSetting.version_checks = true
-        DiscourseUpdates.expects(:check_version).never
 
         get "/admin/dashboard.json"
 
@@ -682,7 +682,9 @@ RSpec.describe Admin::DashboardController do
           }
 
       expect(response.status).to eq(204)
-      expect(AdminDashboardSectionConfiguration.visible_section_ids).to eq(%w[reports highlights])
+      expect(AdminDashboardSectionConfiguration.visible_section_ids).to eq(
+        %w[reports highlights system],
+      )
     end
 
     it "keeps a section's position when it is toggled off" do
@@ -733,7 +735,7 @@ RSpec.describe Admin::DashboardController do
           }
 
       expect(AdminDashboardSectionConfiguration.visible_section_ids).to eq(
-        %w[highlights engagement],
+        %w[highlights engagement system],
       )
     end
 
@@ -776,7 +778,7 @@ RSpec.describe Admin::DashboardController do
       get "/admin/dashboard.json"
 
       ids = response.parsed_body["sections"].map { |s| s["id"] }
-      expect(ids).to eq(["highlights"])
+      expect(ids).to eq(%w[highlights system])
     end
   end
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe Admin::DashboardController do
         expect(configuration).to be_present
 
         ids = configuration["sections"].map { |s| s["id"] }
-        expect(ids).to match_array(%w[highlights reports traffic engagement search])
+        expect(ids).to match_array(%w[highlights reports traffic engagement search system])
 
         visible = configuration["sections"].select { |s| s["visible"] }.map { |s| s["id"] }
         expect(visible).to eq(%w[highlights reports])
@@ -714,7 +714,7 @@ RSpec.describe Admin::DashboardController do
 
       expect(response.status).to eq(204)
       expect(AdminDashboardSectionConfiguration.sections.map { |s| s[:id] }).to match_array(
-        %w[highlights reports traffic engagement search],
+        %w[highlights reports traffic engagement search system],
       )
     end
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -643,6 +643,32 @@ RSpec.describe Admin::DashboardController do
         expect(visible).to eq(%w[highlights reports])
       end
 
+      it "only exposes the system section when version checks are enabled" do
+        configure_dashboard_sections(["system"])
+        SiteSetting.version_checks = false
+        sign_in(admin)
+
+        get "/admin/dashboard.json"
+
+        expect(response.parsed_body["sections"].map { |section| section["id"] }).not_to include(
+          "system",
+        )
+        expect(
+          response.parsed_body.dig("configuration", "sections").map { |section| section["id"] },
+        ).not_to include("system")
+
+        SiteSetting.version_checks = true
+
+        get "/admin/dashboard.json"
+
+        expect(response.parsed_body["sections"].map { |section| section["id"] }).to include(
+          "system",
+        )
+        expect(
+          response.parsed_body.dig("configuration", "sections").map { |section| section["id"] },
+        ).to include("system")
+      end
+
       it "is omitted for moderators" do
         sign_in(moderator)
 

--- a/spec/services/admin_dashboard_section_configuration_spec.rb
+++ b/spec/services/admin_dashboard_section_configuration_spec.rb
@@ -6,7 +6,7 @@ describe AdminDashboardSectionConfiguration do
   fab!(:category_2, :category)
 
   describe ".sections" do
-    it "returns every seeded section, all visible, in canonical order by default" do
+    it "returns every seeded section in canonical order, respecting default visibility" do
       expect(described_class.sections).to eq(
         [
           { id: "highlights", visible: true },
@@ -14,6 +14,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "traffic", visible: true },
           { id: "engagement", visible: true },
           { id: "search", visible: true },
+          { id: "system", visible: false },
         ],
       )
     end
@@ -36,6 +37,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "traffic", visible: true },
           { id: "engagement", visible: true },
           { id: "search", visible: true },
+          { id: "system", visible: false },
         ],
       )
     end
@@ -77,6 +79,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "reports", visible: true },
           { id: "traffic", visible: true },
           { id: "search", visible: true },
+          { id: "system", visible: false },
         ],
       )
     end
@@ -95,6 +98,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "traffic", visible: true },
           { id: "engagement", visible: true },
           { id: "search", visible: true },
+          { id: "system", visible: false },
         ],
       )
     end

--- a/spec/services/admin_dashboard_section_configuration_spec.rb
+++ b/spec/services/admin_dashboard_section_configuration_spec.rb
@@ -6,7 +6,7 @@ describe AdminDashboardSectionConfiguration do
   fab!(:category_2, :category)
 
   describe ".sections" do
-    it "returns every seeded section in canonical order, respecting default visibility" do
+    it "returns every seeded section, all visible, in canonical order by default" do
       expect(described_class.sections).to eq(
         [
           { id: "highlights", visible: true },
@@ -14,7 +14,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "traffic", visible: true },
           { id: "engagement", visible: true },
           { id: "search", visible: true },
-          { id: "system", visible: false },
+          { id: "system", visible: true },
         ],
       )
     end
@@ -37,7 +37,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "traffic", visible: true },
           { id: "engagement", visible: true },
           { id: "search", visible: true },
-          { id: "system", visible: false },
+          { id: "system", visible: true },
         ],
       )
     end
@@ -56,7 +56,7 @@ describe AdminDashboardSectionConfiguration do
         actor: admin,
       )
 
-      expect(described_class.visible_section_ids).to eq(%w[reports engagement])
+      expect(described_class.visible_section_ids).to eq(%w[reports engagement system])
     end
   end
 
@@ -79,7 +79,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "reports", visible: true },
           { id: "traffic", visible: true },
           { id: "search", visible: true },
-          { id: "system", visible: false },
+          { id: "system", visible: true },
         ],
       )
     end
@@ -98,7 +98,7 @@ describe AdminDashboardSectionConfiguration do
           { id: "traffic", visible: true },
           { id: "engagement", visible: true },
           { id: "search", visible: true },
-          { id: "system", visible: false },
+          { id: "system", visible: true },
         ],
       )
     end
@@ -115,7 +115,7 @@ describe AdminDashboardSectionConfiguration do
         actor: admin,
       )
 
-      expect(described_class.visible_section_ids).to eq(%w[highlights engagement])
+      expect(described_class.visible_section_ids).to eq(%w[highlights engagement system])
     end
 
     it "drops unknown section ids" do

--- a/spec/system/admin_dashboard_configure_spec.rb
+++ b/spec/system/admin_dashboard_configure_spec.rb
@@ -14,7 +14,7 @@ describe "Admin Dashboard Configure menu" do
     it "applies toggles immediately, persists across reload, and shows an empty state when everything is hidden" do
       dashboard.visit
       expect(dashboard).to have_configure_button
-      %w[highlights reports traffic engagement search].each do |id|
+      %w[highlights reports traffic engagement search system].each do |id|
         expect(dashboard).to have_section(id)
       end
 
@@ -41,13 +41,16 @@ describe "Admin Dashboard Configure menu" do
         .toggle_section("highlights")
         .toggle_section("reports")
         .toggle_section("search")
+        .toggle_section("system")
 
       expect(dashboard).to have_empty_state
     end
 
     it "keeps a section's position when it is toggled off and back on" do
       dashboard.visit
-      expect(dashboard.section_ids_in_order).to eq(%w[highlights reports traffic engagement search])
+      expect(dashboard.section_ids_in_order).to eq(
+        %w[highlights reports traffic engagement search system],
+      )
 
       dashboard.open_configure_menu.toggle_section("highlights")
       expect(dashboard).to have_no_section("highlights")
@@ -56,7 +59,9 @@ describe "Admin Dashboard Configure menu" do
 
       # it reappears in its original slot, not pushed to the bottom
       expect(dashboard).to have_first_section("highlights")
-      expect(dashboard.section_ids_in_order).to eq(%w[highlights reports traffic engagement search])
+      expect(dashboard.section_ids_in_order).to eq(
+        %w[highlights reports traffic engagement search system],
+      )
     end
 
     it "reorders sections via the arrow buttons on mobile", mobile: true do


### PR DESCRIPTION
Previously, admins needed separate pages to check version status, storage usage, backups, and dashboard freshness.
This change adds an optional System section that consolidates this information and is available only when version checks are enabled.

<img width="1380" height="326" alt="image" src="https://github.com/user-attachments/assets/f37fbc40-3e43-40d2-8f35-39ea893e6ec7" />
