### PR TITLE
FEATURE: show typing time along with fast typing flags

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -81,7 +81,12 @@ class ReviewableScoreSerializer < ApplicationSerializer
         return @reason = PrettyText.sanitize("<p>#{watched_word_reason(link)}</p>")
       end
 
-      text = I18n.t("reviewables.reasons.#{object.reason}", link:, default: object.reason)
+      text =
+        if object.reason == "fast_typer"
+          fast_typer_reason(link)
+        else
+          I18n.t("reviewables.reasons.#{object.reason}", link:, default: object.reason)
+        end
     else
       text = I18n.t("reviewables.reasons.#{object.reason}", default: object.reason)
     end
@@ -115,6 +120,24 @@ class ReviewableScoreSerializer < ApplicationSerializer
   end
 
   private
+
+  def fast_typer_reason(link)
+    typing_time = fast_typer_typing_time
+    if typing_time.blank?
+      return I18n.t("reviewables.reasons.fast_typer", link:, default: object.reason)
+    end
+
+    I18n.t("reviewables.reasons.fast_typer_with_time", link:, typing_time:, default: object.reason)
+  end
+
+  def fast_typer_typing_time
+    msecs = object.reviewable.payload&.dig("typing_duration_msecs")
+    return if msecs.blank?
+
+    count = msecs.to_i.fdiv(1000).round(1)
+    count = count.to_i if count == count.to_i
+    I18n.t("reviewables.reasons.fast_typer_time", count:)
+  end
 
   def watched_word_reason(link)
     words = watched_words_found

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6175,6 +6175,10 @@ en:
       group: "Users not in the specified groups must have replies approved by staff. See %{link}."
       new_topics_unless_trust_level: "Users at low trust levels must have topics approved by staff. See %{link}."
       fast_typer: "New user typed their first post suspiciously fast, suspected bot or spammer behavior. See %{link}."
+      fast_typer_with_time: "New user typed their first post suspiciously fast (%{typing_time}), suspected bot or spammer behavior. See %{link}."
+      fast_typer_time:
+        one: "%{count} second"
+        other: "%{count} seconds"
       auto_silence_regex: "New user whose first post matches the %{link} setting."
       watched_word:
         one: "This post included a Watched Word, the flagged word is: %{words}. Check the %{link} for more."

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -58,6 +58,32 @@ RSpec.describe ReviewableScoreSerializer do
         end
     end
 
+    context "with a fast_typer reason" do
+      it "includes the recorded typing duration" do
+        reviewable = Fabricate(:reviewable_queued_post, payload: { "typing_duration_msecs" => 500 })
+        score = ReviewableScore.new(reviewable:, reason: "fast_typer")
+        serialized = described_class.new(score, scope: Guardian.new(admin), root: nil)
+
+        expect(serialized.reason).to include("(0.5 seconds)")
+      end
+
+      it "drops trailing decimals when the duration is a whole number of seconds" do
+        reviewable =
+          Fabricate(:reviewable_queued_post, payload: { "typing_duration_msecs" => 3000 })
+        score = ReviewableScore.new(reviewable:, reason: "fast_typer")
+        serialized = described_class.new(score, scope: Guardian.new(admin), root: nil)
+
+        expect(serialized.reason).to include("(3 seconds)")
+      end
+
+      it "falls back to a message without a typing duration when none was recorded" do
+        serialized = serialized_score("fast_typer")
+
+        expect(serialized.reason).to include("typed their first post suspiciously fast,")
+        expect(serialized.reason).not_to include("second")
+      end
+    end
+
     context "with custom reasons" do
       it "serializes it without doing any translation" do
         custom = "completely custom flag reason"


### PR DESCRIPTION
Showing the typing time might provide a little useful information for mods... 0.1 second typing time could certainly be more suspicious than 3 seconds

before
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/6ef64eff-6f1f-405e-8b44-93532cb00ed0" />

after
<img width="800" alt="image" src="https://github.com/user-attachments/assets/86bd0aed-cb4e-488c-b8a0-e3404ee160e6" />
