### PR TITLE
FEATURE: distinguish assign/unassign in workflow trigger output

### DIFF
--- a/plugins/discourse-assign/lib/discourse_assign/workflows/schema.rb
+++ b/plugins/discourse-assign/lib/discourse_assign/workflows/schema.rb
@@ -46,6 +46,9 @@ module DiscourseAssign
           "assignment" => {
             "type" => "object",
             "properties" => {
+              "action" => {
+                "type" => "string",
+              },
               "id" => {
                 "type" => "integer",
               },

--- a/plugins/discourse-assign/lib/discourse_workflows/nodes/assigned/v1.rb
+++ b/plugins/discourse-assign/lib/discourse_workflows/nodes/assigned/v1.rb
@@ -56,6 +56,7 @@ if defined?(DiscourseWorkflows)
 
           def assignment_data
             {
+              action: "assigned",
               id: @assignment.id,
               target_type: @assignment.target_type,
               target_id: @assignment.target_id,

--- a/plugins/discourse-assign/lib/discourse_workflows/nodes/unassigned/v1.rb
+++ b/plugins/discourse-assign/lib/discourse_workflows/nodes/unassigned/v1.rb
@@ -56,6 +56,7 @@ if defined?(DiscourseWorkflows)
 
           def assignment_data
             {
+              action: "unassigned",
               id: @assignment.id,
               target_type: @assignment.target_type,
               target_id: @assignment.target_id,

--- a/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/assigned/v1_spec.rb
+++ b/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/assigned/v1_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Assigned::V1 do
       output = described_class.new(assignment).output
 
       expect(output[:assignment]).to include(
+        action: "assigned",
         id: assignment.id,
         target_type: "Post",
         target_id: post.id,
@@ -71,6 +72,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Assigned::V1 do
       output = described_class.new(assignment).output
 
       expect(output[:assignment]).to include(
+        action: "assigned",
         target_type: "Topic",
         target_id: topic.id,
         topic_assignment: true,

--- a/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/unassigned/v1_spec.rb
+++ b/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/unassigned/v1_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Unassigned::V1 do
       output = described_class.new(assignment).output
 
       expect(output[:assignment]).to include(
+        action: "unassigned",
         id: assignment.id,
         target_type: "Post",
         target_id: post.id,
@@ -71,6 +72,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Unassigned::V1 do
       output = described_class.new(assignment).output
 
       expect(output[:assignment]).to include(
+        action: "unassigned",
         target_type: "Topic",
         target_id: topic.id,
         topic_assignment: true,


### PR DESCRIPTION
The assigned and unassigned workflow triggers produced identical data, so a workflow reacting to both couldn't tell them apart. Their output now includes which of the two just happened.