### PR TITLE
FEATURE: Add API scope for Discourse Assign

### DIFF
--- a/plugins/discourse-assign/config/locales/client.en.yml
+++ b/plugins/discourse-assign/config/locales/client.en.yml
@@ -1,6 +1,11 @@
 en:
   admin_js:
     admin:
+      api:
+        scopes:
+          descriptions:
+            assign:
+              assign: "Assign/Unassign topics or posts."
       site_settings:
         categories:
           discourse_assign: "Discourse Assign"

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -882,6 +882,18 @@ after_initialize do
     MessageBus.publish("/private-messages/assigned", { topic_id: topic.id }, opts)
   end
 
+  add_api_key_scope(
+    :assign,
+    {
+      assign: {
+        actions: %w[
+          discourse_assign/assign#assign
+          discourse_assign/assign#unassign
+        ],
+      },
+    },
+  )
+
   # Event listeners
   on(:post_created) { |post| ::Assigner.auto_assign(post, force: true) }
 

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -884,14 +884,7 @@ after_initialize do
 
   add_api_key_scope(
     :assign,
-    {
-      assign: {
-        actions: %w[
-          discourse_assign/assign#assign
-          discourse_assign/assign#unassign
-        ],
-      },
-    },
+    { assign: { actions: %w[discourse_assign/assign#assign discourse_assign/assign#unassign] } },
   )
 
   # Event listeners

--- a/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
@@ -196,6 +196,31 @@ RSpec.describe DiscourseAssign::AssignController do
       expect(response.status).to eq(200)
       expect(allowed_topic.reload.assignment).to be_blank
     end
+
+    it "unassigns a topic with an API key scoped to assign -> assign" do
+      category = Fabricate(:category)
+      topic = Fabricate(:post).topic.tap { |topic| topic.update!(category: category) }
+      api_key = Fabricate(:api_key, user: admin)
+      Fabricate(:api_key_scope, resource: "assign", action: "assign", api_key_id: api_key.id)
+      Fabricate(
+        :topic_assignment,
+        target: topic,
+        assigned_to: admin,
+        assigned_by_user: admin,
+      )
+
+      put "/assign/unassign.json",
+          headers: {
+            "HTTP_API_KEY" => api_key.key,
+            "HTTP_API_USERNAME" => admin.username,
+          },
+          params: {
+            target_id: topic.id,
+            target_type: "Topic",
+          }
+
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#assign" do
@@ -523,6 +548,26 @@ RSpec.describe DiscourseAssign::AssignController do
           username: another_user.username,
         ),
       )
+    end
+
+    it "assigns a topic with an API key scoped to assign -> assign" do
+      category = Fabricate(:category)
+      topic = Fabricate(:post).topic.tap { |topic| topic.update!(category: category) }
+      api_key = Fabricate(:api_key, user: admin)
+      Fabricate(:api_key_scope, resource: "assign", action: "assign", api_key_id: api_key.id)
+
+      put "/assign/assign.json",
+          headers: {
+            "HTTP_API_KEY" => api_key.key,
+            "HTTP_API_USERNAME" => admin.username,
+          },
+          params: {
+            target_id: topic.id,
+            target_type: "Topic",
+            username: admin.username,
+          }
+
+      expect(response.status).to eq(200)
     end
   end
 

--- a/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
@@ -202,12 +202,7 @@ RSpec.describe DiscourseAssign::AssignController do
       topic = Fabricate(:post).topic.tap { |topic| topic.update!(category: category) }
       api_key = Fabricate(:api_key, user: admin)
       Fabricate(:api_key_scope, resource: "assign", action: "assign", api_key_id: api_key.id)
-      Fabricate(
-        :topic_assignment,
-        target: topic,
-        assigned_to: admin,
-        assigned_by_user: admin,
-      )
+      Fabricate(:topic_assignment, target: topic, assigned_to: admin, assigned_by_user: admin)
 
       put "/assign/unassign.json",
           headers: {


### PR DESCRIPTION
Adds a single API scope for assigning or unassigning a topic or post.

Scope listed on the API key creation page:

<img width="720" height="249" alt="Screenshot 2026-08-20 at 1 32 36 AM" src="https://github.com/user-attachments/assets/a8588b5d-0650-43ee-b9a9-6890739ec93f" />

Question mark tooltip hover:

<img width="735" height="243" alt="Screenshot 2026-08-20 at 1 33 10 AM" src="https://github.com/user-attachments/assets/ec85bd96-3703-4591-aee5-9bad0db3c55f" />

Modal from clicking on the link icon:

<img width="609" height="171" alt="Screenshot 2026-08-20 at 1 32 56 AM" src="https://github.com/user-attachments/assets/6a52dd41-2629-452f-9049-455b638e5e8a" />

Example API calls that are supported:

```
curl -X PUT "http://localhost:3000/assign/assign" \
-H "Api-Key: <API_KEY>" \
-H "Api-Username: system" \
-H "Content-Type: application/json" \
-d '{"target_id": 6, "target_type": "Topic", "username": "tshenry"}'
```

```
curl -X PUT "http://localhost:3000/assign/unassign" \
-H "Api-Key: <API_KEY>" \
-H "Api-Username: system" \
-H "Content-Type: application/json" \
-d '{"target_id": 6, "target_type": "Topic"}'
```