### PR TITLE
UX: Further followup of AI logs filtering

### DIFF
--- a/app/assets/stylesheets/common/components/d-filter-controls.scss
+++ b/app/assets/stylesheets/common/components/d-filter-controls.scss
@@ -30,6 +30,13 @@
     gap: var(--space-2);
   }
 
+  &__additional-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: var(--space-2);
+  }
+
   &__dropdown {
     flex: 1 1 auto;
 

--- a/frontend/discourse/app/ui-kit/d-filter-controls.gjs
+++ b/frontend/discourse/app/ui-kit/d-filter-controls.gjs
@@ -58,6 +58,7 @@ const ResetButton = <template>
  *                                              For multiple dropdowns: receives (key, value)
  * @param {Function} [onDropdownChange] - Callback for dropdown selection changes
  * @param {Function} [onResetFilters] - Callback for reset action (server-side mode)
+ * @param {Boolean} [additionalFiltersActive=false] - Whether filters rendered in the additionalFilters block are active
  * @param {String} [initialTextFilter] - Initial value to seed the text filter input on mount
  * @param {Boolean} [showCustomEmptyState] - Whether to show a custom empty state when no results found,
  *                                           if minItemsForFilter is set and the array is empty
@@ -176,8 +177,7 @@ export default class DFilterControls extends Component {
   get showFilterResetButton() {
     return (
       this.showResetButton &&
-      !this.hasMultipleDropdowns &&
-      !this.args.forceShowDropdownFilterToggle &&
+      !this.showDropdownFilterToggle &&
       this.hasActiveFilters
     );
   }
@@ -209,6 +209,10 @@ export default class DFilterControls extends Component {
   }
 
   get hasActiveFilters() {
+    if (this.args.additionalFiltersActive) {
+      return true;
+    }
+
     if (this.textFilter.length > 0) {
       return true;
     }
@@ -416,7 +420,7 @@ export default class DFilterControls extends Component {
   }
 
   @action
-  resetFilters() {
+  async resetFilters() {
     this.textFilter = "";
 
     if (this.hasMultipleDropdowns) {
@@ -441,9 +445,7 @@ export default class DFilterControls extends Component {
       );
     }
 
-    if (this.args.onResetFilters) {
-      this.args.onResetFilters();
-    }
+    await this.args.onResetFilters?.();
 
     schedule("afterRender", () => {
       (
@@ -559,6 +561,12 @@ export default class DFilterControls extends Component {
                 {{/each}}
               </DSelect>
             {{/if}}
+          </div>
+        {{/if}}
+
+        {{#if (has-block "additionalFilters")}}
+          <div class="d-filter-controls__additional-filters">
+            {{yield to="additionalFilters"}}
           </div>
         {{/if}}
 

--- a/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
@@ -146,6 +146,42 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
     assert.dom(".results").hasText("3", "still renders yielded content");
   });
 
+  test("supports additional filters and includes them in reset state", async function (assert) {
+    this.set("additionalFiltersActive", false);
+    this.set("resetCount", 0);
+    this.set("onReset", () => this.set("resetCount", this.resetCount + 1));
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{SAMPLE_DATA}}
+          @additionalFiltersActive={{this.additionalFiltersActive}}
+          @showTextFilter={{false}}
+          @onResetFilters={{this.onReset}}
+        >
+          <:additionalFilters>
+            <input class="custom-filter" aria-label="Custom filter" />
+          </:additionalFilters>
+        </DFilterControls>
+      </template>
+    );
+
+    assert.dom(".custom-filter").exists("renders the additional filter");
+    assert
+      .dom(".d-filter-controls__reset")
+      .doesNotExist("hides reset while the additional filter is inactive");
+
+    this.set("additionalFiltersActive", true);
+
+    assert
+      .dom(".d-filter-controls__reset")
+      .exists("shows reset while the additional filter is active");
+
+    await click(".d-filter-controls__reset");
+
+    assert.strictEqual(this.resetCount, 1, "calls the reset callback once");
+  });
+
   test("filters data by text (client-side)", async function (assert) {
     this.set("data", SAMPLE_DATA);
     this.set("searchableProps", ["name", "description"]);
@@ -267,6 +303,12 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
     assert
       .dom(".d-filter-controls__dropdown")
       .exists({ count: 2 }, "keeps the dropdowns expanded");
+
+    await select(".d-filter-controls__dropdown--category", "feature");
+
+    assert
+      .dom(".d-filter-controls__reset")
+      .exists({ count: 1 }, "shows reset when an expanded filter is active");
   });
 
   test("shows one reset button with a forced single-dropdown toggle", async function (assert) {

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
@@ -1,10 +1,11 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
-import { fn, hash } from "@ember/helper";
+import { hash } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
-import Form from "discourse/components/form";
+import withEventValue from "discourse/helpers/with-event-value";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import DiscourseURL from "discourse/lib/url";
@@ -16,12 +17,13 @@ import DDateTimeInputRange from "discourse/ui-kit/d-date-time-input-range";
 import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
+import DSelect from "discourse/ui-kit/d-select";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import { i18n } from "discourse-i18n";
 import AiLogRow from "discourse/plugins/discourse-ai/discourse/components/ai-log-row";
 import AiLogDetailModal from "./modal/ai-log-detail-modal";
 import AiLogRetentionModal from "./modal/ai-log-retention-modal";
 
-const ALL_FILTER_VALUE = "__all__";
 const MAX_SAFE_ID = Number.MAX_SAFE_INTEGER;
 const PERIODS = {
   hour: 1,
@@ -53,7 +55,6 @@ export default class AiLogs extends Component {
   @tracked startDate;
   @tracked endDate;
 
-  filterFormApi;
   _requestId = 0;
   _openRequestId = 0;
   _openLogId;
@@ -66,7 +67,6 @@ export default class AiLogs extends Component {
     this.models = this.args.model.models || [];
     this.features = this.mergedFeatures(this.args.model.features, this.logs);
     this.initializeFilters(this.args.queryParams);
-    this.filterFormData = this.buildFilterFormData();
 
     if (this.args.queryParams.details) {
       next(() =>
@@ -123,33 +123,23 @@ export default class AiLogs extends Component {
       : new Date();
   }
 
-  // must stay referentially stable: a new object passed as Form @data
-  // recreates the form and drops input focus
-  buildFilterFormData() {
-    return {
-      period: this.selectedPeriod,
-      date_range: { from: this.startDate, to: this.endDate },
-      usernames: this.selectedUsernames,
-      has_retries: this.hasRetries,
-      unattributed: this.unattributed,
-      id_type: this.idType,
-      id_value: this.idValue,
-    };
-  }
-
   get periodOptions() {
     return [
-      { id: "hour", name: i18n("discourse_ai.logs.periods.hour") },
-      { id: "day", name: i18n("discourse_ai.logs.periods.day") },
-      { id: "week", name: i18n("discourse_ai.logs.periods.week") },
-      { id: "custom", name: i18n("discourse_ai.logs.periods.custom") },
+      {
+        value: "all",
+        label: i18n("discourse_ai.logs.all_periods"),
+      },
+      { value: "hour", label: i18n("discourse_ai.logs.periods.hour") },
+      { value: "day", label: i18n("discourse_ai.logs.periods.day") },
+      { value: "week", label: i18n("discourse_ai.logs.periods.week") },
+      { value: "custom", label: i18n("discourse_ai.logs.periods.custom") },
     ];
   }
 
   get outcomeOptions() {
     return [
       {
-        value: ALL_FILTER_VALUE,
+        value: "all",
         label: i18n("discourse_ai.logs.all_outcomes"),
       },
       {
@@ -183,7 +173,7 @@ export default class AiLogs extends Component {
     }
 
     return [
-      { value: ALL_FILTER_VALUE, label: i18n("discourse_ai.logs.all_models") },
+      { value: "all", label: i18n("discourse_ai.logs.all_models") },
       ...options,
     ];
   }
@@ -197,7 +187,7 @@ export default class AiLogs extends Component {
 
     return [
       {
-        value: ALL_FILTER_VALUE,
+        value: "all",
         label: i18n("discourse_ai.logs.all_features"),
       },
       ...features.map((feature) => ({ value: feature, label: feature })),
@@ -207,6 +197,7 @@ export default class AiLogs extends Component {
   @cached
   get dropdownOptions() {
     return {
+      period: this.periodOptions,
       outcome: this.outcomeOptions,
       model: this.modelOptions,
       feature: this.featureOptions,
@@ -216,18 +207,10 @@ export default class AiLogs extends Component {
   @cached
   get dropdownValues() {
     return {
-      outcome: this.selectedOutcome || ALL_FILTER_VALUE,
-      model: this.selectedModel || ALL_FILTER_VALUE,
-      feature: this.selectedFeature || ALL_FILTER_VALUE,
-    };
-  }
-
-  @cached
-  get defaultDropdownValues() {
-    return {
-      outcome: ALL_FILTER_VALUE,
-      model: ALL_FILTER_VALUE,
-      feature: ALL_FILTER_VALUE,
+      period: this.selectedPeriod || "all",
+      outcome: this.selectedOutcome || "all",
+      model: this.selectedModel || "all",
+      feature: this.selectedFeature || "all",
     };
   }
 
@@ -238,6 +221,15 @@ export default class AiLogs extends Component {
       this.hasRetries ||
       this.selectedModel ||
       this.selectedFeature ||
+      this.selectedUsernames.length ||
+      this.unattributed ||
+      this.idValue
+    );
+  }
+
+  get additionalFiltersActive() {
+    return Boolean(
+      this.hasRetries ||
       this.selectedUsernames.length ||
       this.unattributed ||
       this.idValue
@@ -315,7 +307,7 @@ export default class AiLogs extends Component {
   }
 
   @action
-  async refresh({ focusFilters = false } = {}) {
+  async refresh() {
     const requestId = ++this._requestId;
     this.loading = true;
     this.loadingMore = false;
@@ -339,15 +331,6 @@ export default class AiLogs extends Component {
         result.logs
       );
       await this.updateUrl();
-      if (focusFilters) {
-        next(() =>
-          document
-            .querySelector(
-              ".ai-logs .d-filter-controls__toggle-filters, .ai-logs .d-filter-controls__dropdown"
-            )
-            ?.focus()
-        );
-      }
     } catch (error) {
       if (
         requestId === this._requestId &&
@@ -412,52 +395,24 @@ export default class AiLogs extends Component {
   }
 
   @action
-  registerFilterFormApi(api) {
-    this.filterFormApi = api;
-  }
-
-  @action
-  applyFilterForm(data) {
-    this.selectedPeriod = data.period || undefined;
-    this.startDate = data.date_range?.from || this.startDate;
-    this.endDate = data.date_range?.to || this.endDate;
-    this.hasRetries = Boolean(data.has_retries);
-    this.unattributed = Boolean(data.unattributed);
-    this.selectedUsernames = this.unattributed ? [] : data.usernames || [];
-    this.idType = data.id_type || "id";
-    this.idValue = data.id_value || undefined;
-    this.refresh();
-  }
-
-  @action
-  selectPeriod(period) {
-    this.selectedPeriod = this.selectedPeriod === period ? undefined : period;
-    this.filterFormApi?.set("period", this.selectedPeriod);
-    if (this.selectedPeriod && this.selectedPeriod !== "custom") {
-      this.endDate = new Date();
-      this.startDate = moment()
-        .subtract(PERIODS[this.selectedPeriod], "hours")
-        .toDate();
-      this.filterFormApi?.set("date_range", {
-        from: this.startDate,
-        to: this.endDate,
-      });
-    }
-    this.refresh();
-  }
-
-  @action
   changeDateRange(value) {
-    this.filterFormApi?.set("date_range", value);
     this.startDate = value.from;
     this.endDate = value.to;
   }
 
   @action
   changeDropdown(key, value) {
-    const selectedValue = value === ALL_FILTER_VALUE ? undefined : value;
+    const selectedValue = value === "all" ? undefined : value;
 
-    if (key === "outcome") {
+    if (key === "period") {
+      this.selectedPeriod = selectedValue;
+      if (this.selectedPeriod && this.selectedPeriod !== "custom") {
+        this.endDate = new Date();
+        this.startDate = moment()
+          .subtract(PERIODS[this.selectedPeriod], "hours")
+          .toDate();
+      }
+    } else if (key === "outcome") {
       this.selectedOutcome = selectedValue;
     } else if (key === "model") {
       this.selectedModel = selectedValue;
@@ -471,40 +426,33 @@ export default class AiLogs extends Component {
   @action
   changeUser(usernames) {
     const selectedUsernames = usernames || [];
-    this.filterFormApi?.set("usernames", selectedUsernames);
-    this.filterFormApi?.set("unattributed", false);
     this.selectedUsernames = selectedUsernames;
     this.unattributed = false;
     this.refresh();
   }
 
   @action
-  toggleRetries(value, { set }) {
-    set("has_retries", value);
-    this.hasRetries = Boolean(value);
+  toggleRetries() {
+    this.hasRetries = !this.hasRetries;
     this.refresh();
   }
 
   @action
-  toggleUnattributed(value, { set }) {
-    set("unattributed", value);
-    this.unattributed = Boolean(value);
+  toggleUnattributed() {
+    this.unattributed = !this.unattributed;
     if (this.unattributed) {
-      set("usernames", []);
       this.selectedUsernames = [];
     }
     this.refresh();
   }
 
   @action
-  setIdValue(value, { set }) {
-    set("id_value", value);
+  setIdValue(value) {
     this.idValue = value || undefined;
   }
 
   @action
-  changeIdType(value, { set }) {
-    set("id_type", value);
+  changeIdType(value) {
     this.idType = value;
     if (this.idValue) {
       this.refresh();
@@ -512,23 +460,16 @@ export default class AiLogs extends Component {
   }
 
   @action
+  findById(event) {
+    event.preventDefault();
+    this.refresh();
+  }
+
+  @action
   clearFilters() {
-    const cleared = {
-      period: undefined,
-      date_range: {
-        from: moment().subtract(24, "hours").toDate(),
-        to: new Date(),
-      },
-      usernames: [],
-      has_retries: false,
-      unattributed: false,
-      id_type: "id",
-      id_value: undefined,
-    };
-    this.filterFormApi?.setProperties(cleared);
     this.selectedPeriod = undefined;
-    this.startDate = cleared.date_range.from;
-    this.endDate = cleared.date_range.to;
+    this.startDate = moment().subtract(24, "hours").toDate();
+    this.endDate = new Date();
     this.selectedOutcome = undefined;
     this.hasRetries = false;
     this.selectedModel = undefined;
@@ -537,7 +478,7 @@ export default class AiLogs extends Component {
     this.unattributed = false;
     this.idType = "id";
     this.idValue = undefined;
-    this.refresh({ focusFilters: true });
+    return this.refresh();
   }
 
   @action
@@ -601,41 +542,29 @@ export default class AiLogs extends Component {
         </:actions>
       </DPageSubheader>
 
-      <Form
-        class="ai-logs__filters"
-        @data={{this.filterFormData}}
-        @onRegisterApi={{this.registerFilterFormApi}}
-        @onSubmit={{this.applyFilterForm}}
-        as |form|
+      <DFilterControls
+        @array={{this.logs}}
+        @dropdownOptions={{this.dropdownOptions}}
+        @dropdownValue={{this.dropdownValues}}
+        @additionalFiltersActive={{this.additionalFiltersActive}}
+        @filterDropdownsExpanded={{true}}
+        @showDropdownFilterToggle={{false}}
+        @showTextFilter={{false}}
+        @showNoResults={{false}}
+        @loading={{this.loading}}
+        @onDropdownFilterChange={{this.changeDropdown}}
+        @onResetFilters={{this.clearFilters}}
       >
-        <form.Fieldset
-          class="ai-logs__period-field"
-          @name="period-filter"
-          @title={{i18n "discourse_ai.logs.filters.period"}}
-        >
-          <div class="ai-logs__periods">
-            {{#each this.periodOptions as |period|}}
-              <DButton
-                class={{if
-                  (eq this.selectedPeriod period.id)
-                  "btn-primary"
-                  "btn-default"
-                }}
-                @action={{fn this.selectPeriod period.id}}
-                @ariaPressed={{eq this.selectedPeriod period.id}}
-                @translatedLabel={{period.name}}
-              />
-            {{/each}}
-          </div>
-        </form.Fieldset>
+        <:aboveFilters>
+          <h2 class="ai-logs__filters-title">
+            {{i18n "discourse_ai.logs.filters.title"}}
+          </h2>
+        </:aboveFilters>
 
-        {{#if (eq this.selectedPeriod "custom")}}
-          <form.Fieldset
-            class="ai-logs__date-range-field"
-            @name="date-range-filter"
-            @title={{i18n "discourse_ai.logs.filters.date_range"}}
-          >
-            <div class="ai-logs__date-range">
+        <:additionalFilters>
+          {{#if (eq this.selectedPeriod "custom")}}
+            <fieldset class="ai-logs__date-range-filter">
+              <legend>{{i18n "discourse_ai.logs.filters.date_range"}}</legend>
               <DDateTimeInputRange
                 @from={{this.startDate}}
                 @to={{this.endDate}}
@@ -643,120 +572,81 @@ export default class AiLogs extends Component {
                 @showToTime={{false}}
                 @onChange={{this.changeDateRange}}
               />
-              <form.Submit
+              <DButton
                 class="btn-default"
+                @action={{this.refresh}}
                 @label="discourse_ai.logs.apply"
               />
-            </div>
-          </form.Fieldset>
-        {{/if}}
+            </fieldset>
+          {{/if}}
 
-        <form.Fieldset
-          class="ai-logs__filter-panel"
-          @name="log-filters"
-          @title={{i18n "discourse_ai.logs.filters.title"}}
-        >
-          <DFilterControls
-            @array={{this.logs}}
-            @dropdownOptions={{this.dropdownOptions}}
-            @dropdownValue={{this.dropdownValues}}
-            @defaultDropdownValue={{this.defaultDropdownValues}}
-            @filterDropdownsExpanded={{true}}
-            @showDropdownFilterToggle={{false}}
-            @showTextFilter={{false}}
-            @showResetButton={{false}}
-            @showNoResults={{false}}
-            @loading={{this.loading}}
-            @onDropdownFilterChange={{this.changeDropdown}}
-          />
+          <fieldset class="ai-logs__user-filter">
+            <legend>{{i18n "discourse_ai.logs.user"}}</legend>
+            <UserChooser
+              @value={{this.selectedUsernames}}
+              @onChange={{this.changeUser}}
+              @options={{hash
+                maximum=1
+                none="discourse_ai.logs.user_placeholder"
+                filterPlaceholder="discourse_ai.logs.user_placeholder"
+                headerAriaLabel=(i18n "discourse_ai.logs.user_placeholder")
+              }}
+            />
+          </fieldset>
 
-          <div class="ai-logs__specialized-filters">
-            <form.Fieldset
-              class="ai-logs__user-filter"
-              @name="user-filter"
-              @title={{i18n "discourse_ai.logs.user"}}
-            >
-              <UserChooser
-                @value={{this.selectedUsernames}}
-                @onChange={{this.changeUser}}
-                @options={{hash
-                  maximum=1
-                  none="discourse_ai.logs.user_placeholder"
-                  filterPlaceholder="discourse_ai.logs.user_placeholder"
-                  headerAriaLabel=(i18n "discourse_ai.logs.user_placeholder")
-                }}
-              />
-            </form.Fieldset>
-
-            <form.Field
-              class="ai-logs__toggle"
-              @name="has_retries"
-              @title={{i18n "discourse_ai.logs.has_retries"}}
-              @type="checkbox"
-              @onSet={{this.toggleRetries}}
-              as |field|
-            >
-              <field.Control />
-            </form.Field>
-
-            <form.Field
-              class="ai-logs__toggle"
-              @name="unattributed"
-              @title={{i18n "discourse_ai.logs.unattributed"}}
-              @type="checkbox"
-              @onSet={{this.toggleUnattributed}}
-              as |field|
-            >
-              <field.Control />
-            </form.Field>
-          </div>
-
-          <div class="ai-logs__id-filter">
-            <form.Field
-              @name="id_type"
-              @title={{i18n "discourse_ai.logs.filters.id_type"}}
-              @type="select"
-              @onSet={{this.changeIdType}}
-              as |field|
-            >
-              <field.Control @includeNone={{false}} as |select|>
+          <form class="ai-logs__id-filter" {{on "submit" this.findById}}>
+            <label class="ai-logs__id-type">
+              <span>{{i18n "discourse_ai.logs.filters.id_type"}}</span>
+              <DSelect
+                @value={{this.idType}}
+                @includeNone={{false}}
+                @onChange={{this.changeIdType}}
+                as |select|
+              >
                 {{#each this.idTypeOptions as |idType|}}
                   <select.Option @value={{idType.id}}>
                     {{idType.name}}
                   </select.Option>
                 {{/each}}
-              </field.Control>
-            </form.Field>
+              </DSelect>
+            </label>
 
-            <form.Field
-              @name="id_value"
-              @title={{i18n "discourse_ai.logs.filters.id_value"}}
-              @type="input-number"
-              @onSet={{this.setIdValue}}
-              as |field|
-            >
-              <field.Control
+            <label class="ai-logs__id-value">
+              <span>{{i18n "discourse_ai.logs.filters.id_value"}}</span>
+              <input
+                type="number"
                 min="1"
                 max={{MAX_SAFE_ID}}
                 placeholder={{i18n "discourse_ai.logs.id_placeholder"}}
+                value={{this.idValue}}
+                {{on "input" (withEventValue this.setIdValue)}}
               />
-            </form.Field>
+            </label>
 
-            <form.Submit
+            <DButton
+              type="submit"
               class="btn-default ai-logs__find"
               @label="discourse_ai.logs.find"
             />
-            {{#if this.hasFilters}}
-              <DButton
-                class="btn-transparent ai-logs__clear"
-                @action={{this.clearFilters}}
-                @label="discourse_ai.logs.clear_filters"
-              />
-            {{/if}}
-          </div>
-        </form.Fieldset>
+          </form>
 
-      </Form>
+          <div class="ai-logs__toggles">
+            <DToggleSwitch
+              @state={{this.hasRetries}}
+              @label="discourse_ai.logs.has_retries"
+              aria-label={{i18n "discourse_ai.logs.has_retries"}}
+              {{on "click" this.toggleRetries}}
+            />
+
+            <DToggleSwitch
+              @state={{this.unattributed}}
+              @label="discourse_ai.logs.unattributed"
+              aria-label={{i18n "discourse_ai.logs.unattributed"}}
+              {{on "click" this.toggleUnattributed}}
+            />
+          </div>
+        </:additionalFilters>
+      </DFilterControls>
 
       <DConditionalLoadingSpinner @condition={{this.loading}}>
         {{#if this.logs.length}}
@@ -818,13 +708,6 @@ export default class AiLogs extends Component {
                 (i18n "discourse_ai.logs.no_results")
                 (i18n "discourse_ai.logs.no_logs")
               }}</p>
-            {{#if this.hasFilters}}
-              <DButton
-                class="btn-default"
-                @action={{this.clearFilters}}
-                @label="discourse_ai.logs.clear_filters"
-              />
-            {{/if}}
           </div>
         {{/if}}
       </DConditionalLoadingSpinner>

--- a/plugins/discourse-ai/assets/stylesheets/admin/ai-logs.scss
+++ b/plugins/discourse-ai/assets/stylesheets/admin/ai-logs.scss
@@ -3,78 +3,106 @@
 .ai-logs {
   padding: var(--space-4);
 
-  &__filters {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
+  > .d-filter-controls {
     margin-bottom: var(--space-4);
-
-    .d-filter-controls {
-      align-self: stretch;
-      margin-block: 0;
-    }
-
-    .d-filter-controls__dropdowns {
-      grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));
-    }
   }
 
-  &__filter-panel {
-    align-self: stretch;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
-    padding: var(--space-3);
-    border: 1px solid var(--content-border-color);
+  &__filters-title {
+    margin-block: var(--space-4) var(--space-2);
+    font-size: var(--font-up-1);
   }
 
-  &__periods,
-  &__date-range {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: var(--space-2);
+  .d-filter-controls__dropdowns {
+    grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));
   }
 
-  &__specialized-filters {
+  .d-filter-controls__additional-filters {
     display: grid;
-    grid-template-columns: minmax(15rem, 1fr) repeat(2, auto);
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+
+    @include viewport.from(md) {
+      grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+    }
+  }
+
+  &__date-range-filter,
+  &__user-filter {
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  &__date-range-filter {
+    display: flex;
+    grid-column: 1 / -1;
+    flex-wrap: wrap;
     align-items: end;
     gap: var(--space-2);
 
-    > * {
-      min-width: 0;
+    legend {
+      flex-basis: 100%;
     }
   }
 
-  &__user-filter .select-kit {
-    width: 100%;
-    max-width: var(--form-kit-medium-input);
-  }
+  &__user-filter {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
 
-  &__toggle {
-    align-self: end;
-    padding-bottom: var(--space-2);
+    // a rendered legend sits outside flex layout, so gap does not apply to it
+    legend {
+      margin-bottom: var(--space-1);
+    }
+
+    .select-kit {
+      width: 100%;
+    }
   }
 
   &__id-filter {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
     align-items: end;
     gap: var(--space-2);
+    margin: 0;
+  }
 
-    > .form-kit__field {
-      min-width: min(10rem, 100%);
+  &__id-type,
+  &__id-value {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+    margin: 0;
+
+    select,
+    input {
+      width: 100%;
+      min-height: 2.375rem;
+      margin: 0;
     }
   }
 
+  &__toggles {
+    display: flex;
+    grid-column: 1 / -1;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
   @include viewport.until(sm) {
-    &__specialized-filters {
-      grid-template-columns: 1fr;
+    &__date-range-filter .d-date-time-input-range {
+      flex-basis: 100%;
     }
 
-    &__user-filter .select-kit {
-      max-width: 100%;
+    &__id-filter {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    &__find {
+      justify-self: start;
     }
   }
 
@@ -122,12 +150,16 @@
   }
 
   &__col-outcome {
-    width: 5rem;
+    width: 2rem;
     text-align: center;
   }
 
   &__col-user {
-    width: 10rem;
+    width: 7rem;
+  }
+
+  &__col-request {
+    width: 15rem;
   }
 
   &__col-duration {

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -676,6 +676,7 @@ en:
         apply: "Apply"
         find: "Find"
         clear_filters: "Clear all filters"
+        all_periods: "All time periods"
         all_outcomes: "All outcomes"
         all_models: "All models"
         all_features: "All features"

--- a/plugins/discourse-ai/spec/system/ai_logs_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_logs_spec.rb
@@ -140,16 +140,16 @@ RSpec.describe "AI logs admin page" do
     ai_logs_page.visit
 
     ai_logs_page.select_model(llm_model.display_name)
-    click_button I18n.t("js.discourse_ai.logs.periods.day")
+    ai_logs_page.select_period(I18n.t("js.discourse_ai.logs.periods.day"))
     expect(page).to have_current_path(/model=#{llm_model.id}/, url: true)
     expect(page).to have_current_path(/period=day/, url: true)
 
     ai_logs_page.clear_filters
     expect(page).to have_current_path(%r{/ai-logs$}, url: true)
-    expect(page).to have_css(".d-filter-controls__dropdown--outcome:focus")
+    expect(page).to have_css(".d-filter-controls__dropdown--period:focus")
     expect(ai_logs_page).to have_log(log)
 
-    click_button I18n.t("js.discourse_ai.logs.periods.day")
+    ai_logs_page.select_period(I18n.t("js.discourse_ai.logs.periods.day"))
     ai_logs_page.clear_filters
     expect(page).to have_current_path(%r{/ai-logs$}, url: true)
   end
@@ -161,7 +161,7 @@ RSpec.describe "AI logs admin page" do
     expect(page).to have_no_css(".d-filter-controls__toggle-filters")
     expect(page).to have_no_css(".d-filter-controls__reset")
     expect(page).to have_css(
-      ".ai-logs__filter-panel",
+      ".ai-logs__filters-title",
       text: I18n.t("js.discourse_ai.logs.filters.title"),
     )
     expect(ai_logs_page).to have_expanded_filter_dropdowns

--- a/plugins/discourse-ai/spec/system/page_objects/pages/ai_logs.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/ai_logs.rb
@@ -21,8 +21,12 @@ module PageObjects
         select_filter(:feature, label)
       end
 
+      def select_period(label)
+        select_filter(:period, label)
+      end
+
       def clear_filters
-        find(".ai-logs__clear").click
+        find(".d-filter-controls__reset").click
         self
       end
 
@@ -31,7 +35,7 @@ module PageObjects
       end
 
       def has_expanded_filter_dropdowns?
-        page.has_css?(".d-filter-controls__dropdown", count: 3)
+        page.has_css?(".d-filter-controls__dropdown", count: 4)
       end
 
       def open_log(log)


### PR DESCRIPTION
Followup 4b550140c8d8a7379c44a966cf15e1ee25e5b739

Make some more changes to DFilterControls to support additional
filters needed by the AI logs page, and remove more bespoke
form/filter code from that page.

<img width="1015" height="619" alt="image" src="https://github.com/user-attachments/assets/6cc9c081-346b-4534-9b22-0bc8c65024d9" />
