### PR TITLE
SECURITY: Scope localized topic notifications [backport 2026.1]

### DIFF
--- a/app/jobs/regular/process_localized_cooked.rb
+++ b/app/jobs/regular/process_localized_cooked.rb
@@ -24,7 +24,11 @@ module Jobs
           topic_localization.update_excerpt(cooked:) if topic_localization
         end
 
-        MessageBus.publish("/topic/#{post.topic_id}", type: :localized, id: post.id)
+        MessageBus.publish(
+          "/topic/#{post.topic_id}",
+          { type: :localized, id: post.id },
+          post.topic.secure_audience_publish_messages,
+        )
       end
     end
   end

--- a/plugins/discourse-ai/app/jobs/regular/detect_translate_post.rb
+++ b/plugins/discourse-ai/app/jobs/regular/detect_translate_post.rb
@@ -60,7 +60,11 @@ module Jobs
         localize(post, locale)
       end
 
-      MessageBus.publish("/topic/#{post.topic_id}", type: :localized, id: post.id)
+      MessageBus.publish(
+        "/topic/#{post.topic_id}",
+        { type: :localized, id: post.id },
+        post.topic.secure_audience_publish_messages,
+      )
     end
 
     private

--- a/plugins/discourse-ai/spec/jobs/regular/detect_translate_post_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/detect_translate_post_spec.rb
@@ -128,6 +128,26 @@ describe Jobs::DetectTranslatePost do
     expect { job.execute({ post_id: post.id }) }.not_to raise_error
   end
 
+  it "restricts private message notifications to the topic audience" do
+    recipient_group = Fabricate(:group)
+    Fabricate(:group_user, group: recipient_group)
+    private_message_post =
+      Fabricate(:group_private_message_post, recipients: recipient_group, locale: "en")
+    SiteSetting.ai_translation_backfill_limit_to_public_content = false
+
+    messages =
+      MessageBus.track_publish("/topic/#{private_message_post.topic_id}") do
+        job.execute(post_id: private_message_post.id)
+      end
+
+    expect(messages.length).to eq(1)
+    message = messages.first
+    expect(message.data).to eq(type: :localized, id: private_message_post.id)
+    expect(message.user_ids).to contain_exactly(
+      *private_message_post.topic.secure_audience_publish_messages[:user_ids],
+    )
+  end
+
   describe "with public content and PM limitations" do
     fab!(:private_category) { Fabricate(:private_category, group: Group[:staff]) }
     fab!(:private_topic) { Fabricate(:topic, category: private_category) }

--- a/spec/jobs/process_localized_cooked_spec.rb
+++ b/spec/jobs/process_localized_cooked_spec.rb
@@ -70,6 +70,31 @@ describe Jobs::ProcessLocalizedCooked do
     expect(messages.first.data[:id]).to eq(post.id)
   end
 
+  it "restricts private message notifications to the topic audience" do
+    recipient = Fabricate(:user)
+    private_message_post = Fabricate(:private_message_post, recipient: recipient)
+    private_message_localization =
+      Fabricate(
+        :post_localization,
+        post: private_message_post,
+        locale: "ja",
+        raw: "これはテスト投稿です。",
+        cooked: "<p>これはテスト投稿です。</p>",
+      )
+
+    messages =
+      MessageBus.track_publish("/topic/#{private_message_post.topic_id}") do
+        job.execute(post_localization_id: private_message_localization.id)
+      end
+
+    expect(messages.length).to eq(1)
+    message = messages.first
+    expect(message.data).to eq(type: :localized, id: private_message_post.id)
+    expect(message.user_ids).to contain_exactly(
+      *private_message_post.topic.secure_audience_publish_messages[:user_ids],
+    )
+  end
+
   it "processes oneboxes and images" do
     stub_image_size
     onebox_html = <<~HTML


### PR DESCRIPTION
Backport of https://github.com/discourse/discourse/pull/42756

____

Localized post updates were published without the topic's MessageBus audience restrictions.