### PR TITLE
DEV: Render category, group, tag and icon site settings with FormKit

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -15,7 +15,8 @@
 # locale_default        - A hash which overrides according to `SiteSetting.default_locale`.
 #                         The key should be as the same as possible value of default_locale.
 # mandatory_values      - A list of mandatory values that must be included in the setting, these cannot be changed or removed
-#                         in the UI.
+#                         in the UI. Only applies to pipe-separated list type settings (e.g. group_list), as the values
+#                         are merged into the setting's value on both read and write.
 # disallowed_groups     - A list of group IDs (pipe-separated) that should be hidden from the group selector.
 #                         These groups cannot be selected and will be stripped if set via API.
 #                         Only applies to group_list type settings.

--- a/frontend/discourse/app/components/setting-field/category.gjs
+++ b/frontend/discourse/app/components/setting-field/category.gjs
@@ -1,0 +1,30 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import CategoryChooser from "discourse/select-kit/components/category-chooser";
+
+export default class SettingFieldCategory extends Component {
+  get categoryId() {
+    const id = parseInt(this.args.field.value, 10);
+    return isNaN(id) ? null : id;
+  }
+
+  @action
+  onChange(categoryId) {
+    this.args.field.set(String(categoryId ?? ""));
+  }
+
+  <template>
+    <@field.Control>
+      <CategoryChooser
+        @value={{this.categoryId}}
+        @onChange={{this.onChange}}
+        @options={{hash
+          allowUncategorized=true
+          none=true
+          disabled=@field.disabled
+        }}
+      />
+    </@field.Control>
+  </template>
+}

--- a/frontend/discourse/app/components/setting-field/group.gjs
+++ b/frontend/discourse/app/components/setting-field/group.gjs
@@ -1,0 +1,38 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import { splitString } from "discourse/lib/utilities";
+import ComboBox from "discourse/select-kit/components/combo-box";
+
+export default class SettingFieldGroup extends Component {
+  @service site;
+
+  get groupChoices() {
+    const disallowed = splitString(this.args.definition.disallowed_groups, "|");
+
+    return (this.site.groups || [])
+      .filter((group) => !disallowed.includes(group.id.toString()))
+      .map((group) => ({ name: group.name, id: group.id.toString() }));
+  }
+
+  get groupId() {
+    return this.args.field.value?.toString();
+  }
+
+  @action
+  onChange(groupId) {
+    this.args.field.set(groupId ?? "");
+  }
+
+  <template>
+    <@field.Control>
+      <ComboBox
+        @value={{this.groupId}}
+        @content={{this.groupChoices}}
+        @onChange={{this.onChange}}
+        @options={{hash clearable=true disabled=@field.disabled}}
+      />
+    </@field.Control>
+  </template>
+}

--- a/frontend/discourse/app/components/setting-field/icon.gjs
+++ b/frontend/discourse/app/components/setting-field/icon.gjs
@@ -1,0 +1,1 @@
+export default <template><@field.Control @onlyAvailable={{false}} /></template>

--- a/frontend/discourse/app/components/setting-field/tag-group-list.gjs
+++ b/frontend/discourse/app/components/setting-field/tag-group-list.gjs
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { splitString } from "discourse/lib/utilities";
+import TagGroupChooser from "discourse/select-kit/components/tag-group-chooser";
+
+const TOKEN_SEPARATOR = "|";
+
+export default class SettingFieldTagGroupList extends Component {
+  get selectedTagGroups() {
+    return splitString(this.args.field.value, TOKEN_SEPARATOR);
+  }
+
+  @action
+  onChange(tagGroups) {
+    this.args.field.set(tagGroups.join(TOKEN_SEPARATOR));
+  }
+
+  <template>
+    <@field.Control>
+      <TagGroupChooser
+        @tagGroups={{this.selectedTagGroups}}
+        @onChange={{this.onChange}}
+        @options={{hash
+          filterPlaceholder="category.required_tag_group.placeholder"
+          disabled=@field.disabled
+        }}
+      />
+    </@field.Control>
+  </template>
+}

--- a/frontend/discourse/app/components/setting-field/tag-list.gjs
+++ b/frontend/discourse/app/components/setting-field/tag-list.gjs
@@ -1,0 +1,30 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { splitString } from "discourse/lib/utilities";
+import TagChooser from "discourse/select-kit/components/tag-chooser";
+
+const TOKEN_SEPARATOR = "|";
+
+export default class SettingFieldTagList extends Component {
+  get selectedTags() {
+    return splitString(this.args.field.value, TOKEN_SEPARATOR);
+  }
+
+  @action
+  onChange(tags) {
+    this.args.field.set(tags.map((tag) => tag.name).join(TOKEN_SEPARATOR));
+  }
+
+  <template>
+    <@field.Control>
+      <TagChooser
+        @tags={{this.selectedTags}}
+        @onChange={{this.onChange}}
+        @everyTag={{true}}
+        @unlimitedTagCount={{true}}
+        @options={{hash allowAny=false disabled=@field.disabled}}
+      />
+    </@field.Control>
+  </template>
+}

--- a/frontend/discourse/app/lib/setting-field-registry.js
+++ b/frontend/discourse/app/lib/setting-field-registry.js
@@ -1,12 +1,17 @@
 import BoolControl from "discourse/components/setting-field/bool";
+import CategoryControl from "discourse/components/setting-field/category";
 import CategoryListControl from "discourse/components/setting-field/category-list";
 import CompactListControl from "discourse/components/setting-field/compact-list";
 import DurationControl from "discourse/components/setting-field/duration";
 import EnumControl from "discourse/components/setting-field/enum";
+import GroupControl from "discourse/components/setting-field/group";
 import GroupListControl from "discourse/components/setting-field/group-list";
+import IconControl from "discourse/components/setting-field/icon";
 import IntegerControl from "discourse/components/setting-field/integer";
 import LocaleEnumControl from "discourse/components/setting-field/locale-enum";
 import RadioGroupControl from "discourse/components/setting-field/radio-group";
+import TagGroupListControl from "discourse/components/setting-field/tag-group-list";
+import TagListControl from "discourse/components/setting-field/tag-list";
 
 const REGISTRY = {};
 
@@ -53,6 +58,7 @@ function typeKeyFor({ type, subtype, list_type }) {
 }
 
 const TEXT_INPUT = { ...ROW, type: "input", adminReady: true };
+const CUSTOM_CONTROL = { ...ROW, type: "custom", adminReady: true };
 
 registerSettingFieldType("default", { ...ROW, type: "input" });
 registerSettingFieldType("string", TEXT_INPUT);
@@ -90,6 +96,28 @@ registerSettingFieldType("locale_enum", {
   type: "select",
   adminReady: true,
   renderer: LocaleEnumControl,
+});
+registerSettingFieldType("icon", {
+  ...ROW,
+  type: "icon",
+  adminReady: true,
+  renderer: IconControl,
+});
+registerSettingFieldType("category", {
+  ...CUSTOM_CONTROL,
+  renderer: CategoryControl,
+});
+registerSettingFieldType("group", {
+  ...CUSTOM_CONTROL,
+  renderer: GroupControl,
+});
+registerSettingFieldType("tag_list", {
+  ...CUSTOM_CONTROL,
+  renderer: TagListControl,
+});
+registerSettingFieldType("tag_group_list", {
+  ...CUSTOM_CONTROL,
+  renderer: TagGroupListControl,
 });
 registerSettingFieldType("group_list", {
   ...ROW,

--- a/frontend/discourse/select-kit/components/select-kit/select-kit-filter.gjs
+++ b/frontend/discourse/select-kit/components/select-kit/select-kit-filter.gjs
@@ -141,8 +141,8 @@ export default class SelectKitFilter extends Component {
       (!this.selectKit.highlighted || this.selectKit.enterDisabled)
     ) {
       this.element.querySelector("input").focus();
+      event.preventDefault();
       if (this.selectKit.enterDisabled) {
-        event.preventDefault();
         event.stopImmediatePropagation();
       }
       return false;

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -1,10 +1,11 @@
 import { array, concat, hash } from "@ember/helper";
-import { render } from "@ember/test-helpers";
+import { click, render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import SettingDefinitionField from "discourse/components/setting-definition-field";
 import Site from "discourse/models/site";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
@@ -616,6 +617,143 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
     assert
       .dom(".value-probe")
       .hasText("", "removing the last category clears the value");
+  });
+
+  test("category serializes the selection as an id string", async function (assert) {
+    const [category, otherCategory] = Site.current().categories;
+
+    await render(
+      <template>
+        <Form @data={{hash my_category=(concat category.id)}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_category"
+              type="category"
+              label="My category"
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_category}}</span>
+        </Form>
+      </template>
+    );
+
+    const categories = selectKit("[data-name='my_category'] .category-chooser");
+    await categories.expand();
+    await categories.selectRowByValue(otherCategory.id);
+
+    assert.dom(".value-probe").hasText(String(otherCategory.id));
+  });
+
+  test("group filters out disallowed groups from the choices", async function (assert) {
+    this.site.groups = [
+      { id: 0, name: "everyone" },
+      { id: 1, name: "Donuts" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash my_group="1"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_group"
+              type="group"
+              label="My group"
+              disallowed_groups="0"
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_group}}</span>
+        </Form>
+      </template>
+    );
+
+    const groups = selectKit("[data-name='my_group'] .combo-box");
+    assert.strictEqual(groups.header().value(), "1");
+
+    await groups.expand();
+    assert.false(groups.rowByValue("0").exists(), "everyone is not offered");
+    assert.true(groups.rowByValue("1").exists());
+  });
+
+  test("tag_list round-trips a pipe-joined list of tag names", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_tags="dog|cat"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash key="my_tags" type="tag_list" label="My tags"}}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_tags}}</span>
+        </Form>
+      </template>
+    );
+
+    const tags = selectKit("[data-name='my_tags'] .tag-chooser");
+    assert.strictEqual(tags.header().value(), "dog,cat");
+
+    await tags.expand();
+    await tags.selectRowByName("monkey");
+
+    assert.dom(".value-probe").hasText("dog|cat|monkey");
+  });
+
+  test("tag_group_list round-trips a pipe-joined list of tag group names", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_tag_groups="TagGroup1"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_tag_groups"
+              type="tag_group_list"
+              label="My tag groups"
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_tag_groups}}</span>
+        </Form>
+      </template>
+    );
+
+    const tagGroups = selectKit(
+      "[data-name='my_tag_groups'] .tag-group-chooser"
+    );
+    await tagGroups.expand();
+    await tagGroups.selectRowByName("TagGroup2");
+
+    assert.dom(".value-probe").hasText("TagGroup1|TagGroup2");
+  });
+
+  test("icon offers icons that are not in the sprite yet", async function (assert) {
+    let onlyAvailable;
+    pretender.get("/svg-sprite/picker-search", (request) => {
+      onlyAvailable = request.queryParams.only_available;
+      return response(200, { icons: [{ id: "pencil" }], has_more: false });
+    });
+
+    await render(
+      <template>
+        <Form @data={{hash my_icon="heart"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash key="my_icon" type="icon" label="My icon"}}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_icon'] .d-icon-grid-picker")
+      .hasAttribute("data-value", "heart");
+
+    await click(".d-icon-grid-picker-trigger");
+    await waitFor("[data-icon-id='pencil']");
+
+    assert.strictEqual(
+      onlyAvailable,
+      "false",
+      "an icon can be picked before it is rendered anywhere on the site"
+    );
   });
 
   test("list + list_type collapses to the compact_list control", async function (assert) {

--- a/frontend/discourse/tests/integration/components/site-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-setting-test.gjs
@@ -13,6 +13,7 @@ import ThemeTranslation from "discourse/admin/components/theme-translation";
 import SiteSetting from "discourse/admin/models/site-setting";
 import ThemeSettings from "discourse/admin/models/theme-settings";
 import ThemeSiteSettings from "discourse/admin/models/theme-site-settings";
+import Site from "discourse/models/site";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, {
   parsePostData,
@@ -324,6 +325,59 @@ module("Integration | Component | SiteSetting", function (hooks) {
     await fillIn(".form-kit__control-select", "box");
 
     assert.dom(".preview .tag-preview").hasText("box");
+  });
+
+  test("a category setting selects the stored category", async function (assert) {
+    const category = Site.current().categories[0];
+
+    await renderSetting({
+      setting: "shared_drafts_category",
+      value: String(category.id),
+      default: "",
+      type: "category",
+    });
+
+    assert
+      .dom(".category-chooser .selected-name")
+      .hasAttribute(
+        "data-name",
+        category.name,
+        "the header names the stored category instead of its id"
+      );
+
+    await selectKit(".category-chooser").expand();
+
+    assert
+      .dom(`.category-row[data-value="${category.id}"]`)
+      .hasClass("is-selected", "the stored category is highlighted");
+  });
+
+  test("an unset category setting offers a none option", async function (assert) {
+    await renderSetting({
+      setting: "shared_drafts_category",
+      value: "",
+      default: "",
+      type: "category",
+    });
+
+    assert
+      .dom(".category-chooser .selected-name")
+      .hasText(
+        i18n("category.none"),
+        "an unset category setting offers a none option rather than uncategorized"
+      );
+  });
+
+  test("a disabled tag list setting cannot be edited", async function (assert) {
+    await renderSetting({
+      setting: "digest_suppress_tags",
+      value: "dog",
+      default: "",
+      type: "tag_list",
+      disabled: true,
+    });
+
+    assert.dom(".tag-chooser").hasClass("is-disabled");
   });
 
   test("a secret setting that is also a textarea stays readable", async function (assert) {

--- a/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
+++ b/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
@@ -1,7 +1,9 @@
 import { module, test } from "qunit";
+import CategoryControl from "discourse/components/setting-field/category";
 import CategoryListControl from "discourse/components/setting-field/category-list";
 import CompactListControl from "discourse/components/setting-field/compact-list";
 import DurationControl from "discourse/components/setting-field/duration";
+import GroupControl from "discourse/components/setting-field/group";
 import GroupListControl from "discourse/components/setting-field/group-list";
 import {
   resolveSettingFieldType,
@@ -76,7 +78,18 @@ module("Unit | Lib | setting-field-registry", function () {
       );
     });
 
-    test("the text field family is admin-ready, the fallback never is", function (assert) {
+    test("a single-value type does not shadow its list counterpart", function (assert) {
+      assert.strictEqual(
+        resolveSettingFieldType({ type: "category" }).renderer,
+        CategoryControl
+      );
+      assert.strictEqual(
+        resolveSettingFieldType({ type: "group" }).renderer,
+        GroupControl
+      );
+    });
+
+    test("the converted types are admin-ready, the fallback never is", function (assert) {
       for (const type of [
         "string",
         "float",
@@ -86,6 +99,11 @@ module("Unit | Lib | setting-field-registry", function () {
         "password",
         "enum",
         "locale_enum",
+        "category",
+        "group",
+        "tag_list",
+        "tag_group_list",
+        "icon",
       ]) {
         assert.true(
           resolveSettingFieldType({ type }).adminReady,

--- a/spec/system/admin_site_setting_category_spec.rb
+++ b/spec/system/admin_site_setting_category_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe "Admin site setting category" do
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  fab!(:admin)
+  fab!(:category)
+
+  before { sign_in(admin) }
+
+  it "saves the picked category and names it back" do
+    settings_page.visit("shared_drafts_category")
+
+    chooser = settings_page.category_setting("shared_drafts_category")
+    chooser.expand
+    chooser.select_row_by_value(category.id)
+
+    settings_page.save_setting("shared_drafts_category")
+    page.refresh
+
+    expect(SiteSetting.shared_drafts_category).to eq(category.id.to_s)
+    expect(settings_page.category_setting("shared_drafts_category")).to have_selected_name(
+      category.name,
+    )
+  end
+end

--- a/spec/system/admin_site_setting_group_spec.rb
+++ b/spec/system/admin_site_setting_group_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe "Admin site setting group" do
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  fab!(:admin)
+  fab!(:group)
+
+  before { sign_in(admin) }
+
+  it "saves the picked group and names it back" do
+    settings_page.visit("site_contact_group_name")
+
+    chooser = settings_page.group_setting("site_contact_group_name")
+    chooser.expand
+    chooser.select_row_by_value(group.id)
+
+    settings_page.save_setting("site_contact_group_name")
+    page.refresh
+
+    expect(SiteSetting.site_contact_group_name).to eq(group.id.to_s)
+    expect(settings_page.group_setting("site_contact_group_name")).to have_selected_name(group.name)
+  end
+end

--- a/spec/system/admin_site_setting_tag_list_spec.rb
+++ b/spec/system/admin_site_setting_tag_list_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe "Admin tag list site setting" do
 
     expect(settings_page).to have_tags_in_setting("digest_suppress_tags", [tag_1, tag_2])
   end
+
+  it "does not save while the admin is still filtering" do
+    settings_page.visit("digest_suppress_tags")
+
+    tag_chooser = settings_page.tag_list_setting("digest_suppress_tags")
+    tag_chooser.expand
+    tag_chooser.search(tag_1.name)
+    tag_chooser.select_row_by_name(tag_1.name)
+    tag_chooser.search("no-such-tag")
+    tag_chooser.press_enter_in_filter
+
+    tag_chooser.search(tag_2.name)
+    tag_chooser.select_row_by_name(tag_2.name)
+
+    expect(tag_chooser).to have_selected_names(tag_1.name, tag_2.name)
+    expect(settings_page.find_setting("digest_suppress_tags")).to have_css(".setting-controls__ok")
+    expect(SiteSetting.digest_suppress_tags).to eq("")
+  end
 end

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -113,6 +113,10 @@ module PageObjects
         has_no_css?("#{@context}.is-expanded .select-kit-filter .filter-input")
       end
 
+      def press_enter_in_filter
+        expanded_component.locator(".select-kit-filter .filter-input").press("Enter")
+      end
+
       def search(value = nil)
         expanded_component.locator(".select-kit-filter .filter-input").fill(value.to_s)
         wait_for_loaded

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -205,6 +205,16 @@ module PageObjects
           has_css?("#{setting_row_selector(setting_name)} .shift-down-value-btn", visible: :hidden)
       end
 
+      def category_setting(setting_name)
+        PageObjects::Components::SelectKit.new(
+          "#{setting_row_selector(setting_name)} .category-chooser",
+        )
+      end
+
+      def group_setting(setting_name)
+        PageObjects::Components::SelectKit.new("#{setting_row_selector(setting_name)} .combo-box")
+      end
+
       def tag_list_setting(setting_name)
         PageObjects::Components::SelectKit.new("#{setting_row_selector(setting_name)} .tag-chooser")
       end


### PR DESCRIPTION
Previously, the `category`, `group`, `tag_list`, `tag_group_list` and
`icon` site settings were the last choosers on the admin site settings
page still rendered by a bespoke control, separate from the shared
FormKit field infrastructure the text, number, boolean and enum
families already go through.

This change adds a shared renderer for each of them under
`app/components/setting-field/` and marks the five types admin-ready,
continuing the per-type rollout. They wrap the same select-kit
components the legacy controls did instead of resolving to a native
FormKit control, because the built-in tag chooser hands its callback
raw select-kit items — which the row would serialize as
`[object Object]` — and cannot express `allowAny=false`, and there is
no built-in control for a category or a single group at all. Each
renderer owns its own pipe-delimited wire format, so no type ever hands
an array to the row's serializer.

`icon` does use the native control, but through a renderer rather than
the bare fallback so that it can pass `@onlyAvailable={{false}}`. The
control otherwise offers only icons already in the site's sprite,
whereas picking an icon is precisely what adds it there — without it an
admin could never choose an icon the site does not already render.

Two things a category setting got wrong now work. The chooser was
handed the raw wire value, a string, while select-kit compares category
ids strictly, so the stored category was never highlighted in the
dropdown and the header's tooltip and accessible name were the raw id
rather than the category name. On sites with lazy category loading it
also warned and re-fetched the category on every render.

Pressing Enter in a select-kit filter no longer submits the surrounding
form. Each settings row is its own form and the chooser's filter is its
only text field, so as soon as nothing matched what an admin was typing
the browser's implicit submission saved the setting out from under
them.

Finally, the renderers forward the field's disabled state, which the
category and group controls never did. As with every earlier step of
this rollout the legacy controls are left in place for a single cleanup
at the end: theme rows opt out of change tracking, and both `icon` and
the list variants of the tag types are reachable as theme settings, so
they still resolve them.

