### PR TITLE
SECURITY: Require topic-edit permission for changed first-post titles in PostsControlle... [backport 2026.1]

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -266,7 +266,10 @@ class PostsController < ApplicationController
 
     # to stay consistent with the create api, we allow for title & category changes here
     if post.is_first_post?
-      changes[:title] = params[:title] if params[:title]
+      if params[:title]
+        guardian.ensure_can_edit_topic!(post.topic) if params[:title] != post.topic.title
+        changes[:title] = params[:title]
+      end
       changes[:category_id] = params[:post][:category_id] if params[:post][:category_id]
 
       if changes[:category_id] && changes[:category_id].to_i != post.topic.category_id.to_i

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -617,6 +617,45 @@ RSpec.describe PostsController do
       }
     end
 
+    context "when a wiki editor changes another user's topic title" do
+      fab!(:author) { Fabricate(:user, trust_level: TrustLevel[3], refresh_auto_groups: true) }
+      fab!(:editor) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
+      fab!(:wiki_post) do
+        create_post(
+          user: author,
+          title: "Original topic title",
+          raw: "Original wiki body",
+        ).tap { |post| post.update!(wiki: true) }
+      end
+
+      before do
+        Group[:trust_level_1].add(editor)
+        SiteSetting.edit_wiki_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
+        sign_in(editor)
+      end
+
+      it "prevents title changes while allowing wiki body edits" do
+        put "/posts/#{wiki_post.id}.json",
+            params: {
+              title: "Unauthorized topic title",
+              post: {
+                raw: "Unauthorized wiki body",
+              },
+            }
+
+        expect(response).to be_forbidden
+        expect(response.parsed_body["errors"]).to be_present
+        expect(wiki_post.reload.topic.title).to eq("Original topic title")
+        expect(wiki_post.raw).to eq("Original wiki body")
+
+        put "/posts/#{wiki_post.id}.json", params: { post: { raw: "Authorized wiki body" } }
+
+        expect(response.status).to eq(200), response.body
+        expect(response.parsed_body.dig("post", "raw")).to eq("Authorized wiki body")
+        expect(wiki_post.reload.topic.title).to eq("Original topic title")
+      end
+    end
+
     describe "when logged in as a regular user" do
       before { sign_in(user) }
 


### PR DESCRIPTION
Backport of #42748 to release/2026.1.

---

## Summary

A user authorized only to edit wiki post bodies could rename another user's topic by including a title parameter in a PUT /posts/:id.json request when the wiki post was the topic's first post. The patch now requires topic-edit permission before forwarding a changed title to PostRevisor, while still allowing authorized wiki body edits.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/2416

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
