### PR TITLE
FIX: Bulk delete topics is recoverable, not permanent

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4291,7 +4291,7 @@ en:
           missing_to: "A replacement tag is required"
       delete_topics:
         name: "Delete"
-        description: "Permanently delete the selected topics. This action cannot be undone."
+        description: "Delete the selected topics. Deleted topics can be restored."
       update_category:
         name: "Update Category"
         description: "Move all selected topics to the following category:"

--- a/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import BulkSelectTopicsDropdown from "discourse/components/bulk-select-topics-dropdown";
+import BulkTopicActions from "discourse/components/modal/bulk-topic-actions";
 import { addUniqueValueToArray } from "discourse/lib/array-tools";
 import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { TOPIC_VISIBILITY_REASONS } from "discourse/lib/constants";
@@ -257,7 +258,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert.verifySteps(["custom-action"]);
   });
 
-  test("allows overriding built-in delete label with extra buttons", async function (assert) {
+  test("an extra button reusing a built-in id overrides the label, not the action", async function (assert) {
     this.currentUser.admin = true;
     this.bulkSelectHelper = createBulkSelectHelper(this);
     this.extraButtons = [
@@ -284,5 +285,39 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert
       .dom(".fk-d-menu__inner-content .dropdown-menu__item .delete-topics")
       .hasTextContaining("Delete Topics (override)");
+
+    await click(
+      ".fk-d-menu__inner-content .dropdown-menu__item .delete-topics"
+    );
+    assert.strictEqual(
+      getOwner(this).lookup("service:modal").activeModal.component,
+      BulkTopicActions,
+      "the built-in delete action still runs"
+    );
+  });
+
+  test("the delete description does not claim the deletion is permanent", async function (assert) {
+    this.currentUser.admin = true;
+    this.bulkSelectHelper = createBulkSelectHelper(this);
+
+    await render(
+      <template>
+        <BulkSelectTopicsDropdown @bulkSelectHelper={{this.bulkSelectHelper}} />
+      </template>
+    );
+
+    await click(".bulk-select-topics-dropdown-trigger");
+    await click(
+      ".fk-d-menu__inner-content .dropdown-menu__item .delete-topics"
+    );
+
+    const { description } =
+      getOwner(this).lookup("service:modal").activeModal.opts.model;
+
+    assert.strictEqual(typeof description, "string", "a description is shown");
+    assert.false(
+      /permanent|cannot be undone/i.test(description),
+      `bulk delete is recoverable, but the copy reads "${description}"`
+    );
   });
 });

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -308,10 +308,13 @@ class TopicsBulkAction
 
   def delete
     topics.each do |t|
-      if guardian.can_delete?(t)
-        post = t.ordered_posts.first
-        PostDestroyer.new(@user, post).destroy if post
-      end
+      next if !guardian.can_delete?(t)
+
+      post = t.ordered_posts.with_deleted.first
+      next if !post
+
+      PostDestroyer.new(@user, post).destroy
+      @changed_ids << t.id
     end
   end
 

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -473,11 +473,29 @@ RSpec.describe TopicsBulkAction do
     fab!(:topic) { Fabricate(:post).topic }
     fab!(:moderator)
 
-    it "deletes the topic" do
+    it "deletes the topic and returns its id" do
       tba = TopicsBulkAction.new(moderator, [topic.id], type: "delete")
-      tba.perform!
-      topic.reload
-      expect(topic).to be_trashed
+
+      expect(tba.perform!).to contain_exactly(topic.id)
+      expect(topic.reload).to be_trashed
+    end
+
+    it "skips topics the user can't delete" do
+      tba = TopicsBulkAction.new(user, [topic.id], type: "delete")
+
+      expect(tba.perform!).to be_empty
+      expect(topic.reload).not_to be_trashed
+    end
+
+    it "deletes the topic when its first post was already deleted" do
+      reply = Fabricate(:post, topic: topic)
+      topic.first_post.trash!(moderator)
+
+      tba = TopicsBulkAction.new(moderator, [topic.id], type: "delete")
+
+      expect(tba.perform!).to contain_exactly(topic.id)
+      expect(topic.reload).to be_trashed
+      expect(reply.reload).not_to be_trashed
     end
   end
 

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -20,6 +20,12 @@ module PageObjects
         PageObjects::Components::SelectKit.new("#search-sort-by")
       end
 
+      def bulk_select_result_and_open_dropdown(topic)
+        find(".search-info .bulk-select").click
+        find(".fps-result .fps-topic[data-topic-id='#{topic.id}'] .bulk-select input").click
+        find(".search-info .bulk-select-topics-dropdown-trigger").click
+      end
+
       def click_search_menu_link
         find(".search-menu .results .search-link").click
       end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -9,6 +9,8 @@ describe "Search" do
   fab!(:post2) { Fabricate(:post, topic: topic2, raw: "This is another test post in a test topic") }
 
   let(:topic_bulk_actions_modal) { PageObjects::Modals::TopicBulkActions.new }
+  let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
 
   describe "when using full page search on mobile" do
     before do
@@ -253,10 +255,9 @@ describe "Search" do
     it "allows the user to perform bulk actions on the topic search results" do
       visit("/search?q=test")
       expect(page).to have_content(topic.title)
-      find(".search-info .bulk-select").click
-      find(".fps-result .fps-topic[data-topic-id=\"#{topic.id}\"] .bulk-select input").click
-      find(".search-info .bulk-select-topics-dropdown-trigger").click
-      PageObjects::Components::TopicListHeader.new.click_bulk_button("manage-tags")
+
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("manage-tags")
       manage_tags_modal = PageObjects::Modals::ManageTags.new
       manage_tags_modal.add_tags(tag1.name)
       manage_tags_modal.click_confirm
@@ -269,17 +270,24 @@ describe "Search" do
       visit("/search?q=This%20is%20a%20test%20post")
       expect(page).to have_content(post.raw)
 
-      find(".search-info .bulk-select").click
-      find(".fps-result .fps-topic[data-topic-id=\"#{topic.id}\"] .bulk-select input").click
-      find(".search-info .bulk-select-topics-dropdown-trigger").click
-
-      find(".bulk-select-topics-dropdown-content .delete-posts").click
-
-      find(".dialog-content")
-      click_button "OK"
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("delete-posts")
+      dialog.click_ok
 
       expect(page).to have_no_content(post.raw)
       expect(Post.with_deleted.find_by(id: post.id).deleted_at).to be_present
+    end
+
+    it "lets the user bulk delete the whole topic from a reply search result" do
+      visit("/search?q=This%20is%20a%20test%20post")
+      expect(page).to have_content(post.raw)
+
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("delete-topics")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+
+      expect(page).to have_no_content(post.raw)
+      expect(topic.reload).to be_trashed
     end
   end
 

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -450,6 +450,19 @@ describe "Topic bulk select" do
     end
   end
 
+  context "when deleting" do
+    it "removes the deleted topics from the list" do
+      sign_in(admin)
+      visit("/latest")
+
+      open_bulk_actions_modal([topics.first, topics.second], "delete-topics")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+
+      expect(topic_list).to have_no_topic(topics.first)
+      expect(topic_list).to have_no_topic(topics.second)
+    end
+  end
+
   context "when working with private messages" do
     fab!(:private_message_1) do
       Fabricate(:private_message_topic, user: admin, recipient: user, participant_count: 2)


### PR DESCRIPTION
Reported in [Bulk actions confusion - Delete Topics](https://meta.discourse.org/t/410444).

Selecting topics and choosing **Delete** asks you to confirm:

> Permanently delete the selected topics. This action cannot be undone.

…and then soft deletes them, so they can be recovered. Not search-specific — the same modal is used by every topic list.

There is no configuration where the copy is true. `TopicsBulkAction#delete` builds `PostDestroyer` with an empty options hash, so `permanent?` is never satisfied, and `PUT /topics/bulk` doesn't permit `force_destroy` in the first place. `can_permanently_delete` has no bearing on this path. The description was added with the copy pass in 4b6169028f and never matched the behaviour.

### Also fixed

Two long-standing bugs in the same six lines:

- `delete` was the only operation in `TopicsBulkAction` that never appended to `@changed_ids`, so the endpoint always answered `{"topic_ids":[]}`. A bulk delete where the guardian skipped every topic looked exactly like a successful one, toast included.

- `ordered_posts` is scoped by `Trashable`, so for a topic whose first post was already deleted it returned post 2. `is_first_post?` was then false, `@topic.trash!` never ran, and an unrelated reply was deleted while the topic stayed alive — reported as a success. `TopicsController#destroy` already gets this right with `ordered_posts.with_deleted.first`.

### Follow-ups, not in this PR

- `ordered_posts.first` feeding `PostDestroyer` carries the same latent bug at five other call sites: `Jobs::DeleteTopic`, three in `DestroyTask`, and `TopicGuardian#can_recover_topic?`. Worth a `Topic` accessor rather than a sixth hand-rolled copy.
- Search results give no hint whether a hit is a topic or a reply, which is the other half of the report. `post_number` is already serialized and `search.post_format` already exists, but is gated to the in-topic dropdown.
- Translations of this key still assert permanence until the pipeline catches up.
