### PR TITLE
UX: Fix filtering by ID types in AI logs

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
@@ -256,7 +256,6 @@ export default class AiLogs extends Component {
 
     if (this.idValue) {
       params[this.idType] = this.idValue;
-      return params;
     }
 
     if (this.selectedPeriod === "custom") {

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_logs_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_logs_controller.rb
@@ -183,7 +183,7 @@ module DiscourseAi
 
         if id_filters.one?
           name = id_filters.first
-          return scope.where(name => positive_integer!(name))
+          scope = scope.where(name => positive_integer!(name))
         end
 
         scope = apply_date_filters(scope)

--- a/plugins/discourse-ai/spec/requests/admin/ai_logs_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_logs_controller_spec.rb
@@ -223,12 +223,27 @@ RSpec.describe DiscourseAi::Admin::AiLogsController do
             topic_id: matching_log.topic_id,
             start_date: 50.years.from_now.to_date,
           }
+      expect(response.parsed_body["logs"]).to be_empty
+
+      get index_path,
+          params: {
+            topic_id: matching_log.topic_id,
+            start_date: 1.day.ago.iso8601,
+            outcome: "failed",
+            has_retries: true,
+            llm_id: llm_model.id,
+            feature: matching_log.feature_name,
+            user_id: user.id,
+          }
       expect(response.parsed_body["logs"].map { |log| log["id"] }).to eq([matching_log.id])
 
       get index_path, params: { post_id: matching_log.post_id }
       expect(response.parsed_body["logs"].map { |log| log["id"] }).to eq([matching_log.id])
 
-      get index_path, params: { id: matching_log.id, cursor: matching_log.id }
+      get index_path, params: { id: matching_log.id, outcome: "successful" }
+      expect(response.parsed_body["logs"]).to be_empty
+
+      get index_path, params: { id: matching_log.id, cursor: matching_log.id, outcome: "failed" }
       expect(response.parsed_body["logs"].map { |log| log["id"] }).to eq([matching_log.id])
     end
 

--- a/plugins/discourse-ai/spec/system/ai_logs_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_logs_spec.rb
@@ -92,12 +92,7 @@ RSpec.describe "AI logs admin page" do
     expect(ai_logs_page).to have_no_log(log)
     expect(page).to have_css('button[aria-pressed="true"]', text: day_period)
 
-    find("input[placeholder='#{I18n.t("js.discourse_ai.logs.feature_placeholder")}']").fill_in(
-      with: log.feature_name,
-    )
-    find("input[placeholder='#{I18n.t("js.discourse_ai.logs.feature_placeholder")}']").send_keys(
-      :enter,
-    )
+    ai_logs_page.select_feature(log.feature_name)
     expect(ai_logs_page).to have_log(log)
   end
 

--- a/plugins/discourse-ai/spec/system/ai_logs_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_logs_spec.rb
@@ -81,10 +81,23 @@ RSpec.describe "AI logs admin page" do
     ai_logs_page.select_feature("other-feature")
     expect(ai_logs_page).to have_no_log(log)
 
+    day_period = I18n.t("js.discourse_ai.logs.periods.day")
+    click_button day_period
+    expect(page).to have_css('button[aria-pressed="true"]', text: day_period)
+
     find("input[placeholder='#{I18n.t("js.discourse_ai.logs.id_placeholder")}']").fill_in(
       with: log.id,
     )
     find(".ai-logs__id-filter .btn", text: I18n.t("js.discourse_ai.logs.find")).click
+    expect(ai_logs_page).to have_no_log(log)
+    expect(page).to have_css('button[aria-pressed="true"]', text: day_period)
+
+    find("input[placeholder='#{I18n.t("js.discourse_ai.logs.feature_placeholder")}']").fill_in(
+      with: log.feature_name,
+    )
+    find("input[placeholder='#{I18n.t("js.discourse_ai.logs.feature_placeholder")}']").send_keys(
+      :enter,
+    )
     expect(ai_logs_page).to have_log(log)
   end
 


### PR DESCRIPTION
Previously, filtering by ID type would override all other filters. Now it is additive.

/t/190244