### PR TITLE
DEV: Stabilize `DFilterControls` system test typing

### DIFF
--- a/spec/system/page_objects/components/d_filter_controls.rb
+++ b/spec/system/page_objects/components/d_filter_controls.rb
@@ -13,7 +13,7 @@ module PageObjects
       end
 
       def type_in_search(input)
-        component.find(".d-filter-controls__input").send_keys(input)
+        component.find(".d-filter-controls__input").set(input)
       end
 
       def clear_search


### PR DESCRIPTION
Previously, `DFilterControls#type_in_search` sent one key at a time while each input event could rerender filtered results, which allowed system tests to lose characters and wait for a row that never appeared.

Observed in this [flaky system-test run](https://github.com/discourse/discourse/actions/runs/32333201741/job/96317650782).

This commit fills the search field atomically so each test applies its intended filter in one input update. It changes only system-test page-object behavior.