### PR TITLE
FIX: Honor `delete_all_posts_and_topics_allowed_groups` in `PostDestroyer`

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -214,7 +214,7 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def can_delete_all_posts_and_topics
-    object.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+    scope.can_delete_all_posts_and_topics?
   end
 
   def can_upload_avatar

--- a/app/services/post_owner_changer.rb
+++ b/app/services/post_owner_changer.rb
@@ -23,7 +23,12 @@ class PostOwnerChanger
 
       if post.is_first_post?
         @topic.user = @new_owner
-        @topic.recover! if post.user.nil?
+        if post.user.nil?
+          topic_was_deleted = @topic.deleted_at.present?
+          @topic.recover!
+          # only resurrect an OP trashed alongside its topic, not one moderated individually
+          post.recover! if topic_was_deleted && post.deleted_at.present?
+        end
       end
 
       post.topic = @topic

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4291,7 +4291,7 @@ en:
           missing_to: "A replacement tag is required"
       delete_topics:
         name: "Delete"
-        description: "Permanently delete the selected topics. This action cannot be undone."
+        description: "Delete the selected topics. Deleted topics can be restored."
       update_category:
         name: "Update Category"
         description: "Move all selected topics to the following category:"

--- a/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import BulkSelectTopicsDropdown from "discourse/components/bulk-select-topics-dropdown";
+import BulkTopicActions from "discourse/components/modal/bulk-topic-actions";
 import { addUniqueValueToArray } from "discourse/lib/array-tools";
 import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { TOPIC_VISIBILITY_REASONS } from "discourse/lib/constants";
@@ -257,7 +258,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert.verifySteps(["custom-action"]);
   });
 
-  test("allows overriding built-in delete label with extra buttons", async function (assert) {
+  test("an extra button reusing a built-in id overrides the label, not the action", async function (assert) {
     this.currentUser.admin = true;
     this.bulkSelectHelper = createBulkSelectHelper(this);
     this.extraButtons = [
@@ -284,5 +285,39 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert
       .dom(".fk-d-menu__inner-content .dropdown-menu__item .delete-topics")
       .hasTextContaining("Delete Topics (override)");
+
+    await click(
+      ".fk-d-menu__inner-content .dropdown-menu__item .delete-topics"
+    );
+    assert.strictEqual(
+      getOwner(this).lookup("service:modal").activeModal.component,
+      BulkTopicActions,
+      "the built-in delete action still runs"
+    );
+  });
+
+  test("the delete description does not claim the deletion is permanent", async function (assert) {
+    this.currentUser.admin = true;
+    this.bulkSelectHelper = createBulkSelectHelper(this);
+
+    await render(
+      <template>
+        <BulkSelectTopicsDropdown @bulkSelectHelper={{this.bulkSelectHelper}} />
+      </template>
+    );
+
+    await click(".bulk-select-topics-dropdown-trigger");
+    await click(
+      ".fk-d-menu__inner-content .dropdown-menu__item .delete-topics"
+    );
+
+    const { description } =
+      getOwner(this).lookup("service:modal").activeModal.opts.model;
+
+    assert.strictEqual(typeof description, "string", "a description is shown");
+    assert.false(
+      /permanent|cannot be undone/i.test(description),
+      `bulk delete is recoverable, but the copy reads "${description}"`
+    );
   });
 });

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -256,6 +256,10 @@ class Guardian
   end
   alias can_see_flags? can_moderate?
 
+  def can_delete_all_posts_and_topics?
+    @user.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+  end
+
   def can_tag?(topic)
     return false if topic.blank?
 

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -228,7 +228,7 @@ module PostGuardian
 
     return true if is_category_group_moderator?(post.topic&.category)
 
-    return true if user.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+    return true if can_delete_all_posts_and_topics?
 
     # Can't delete posts in archived topics unless you are staff
     return false if post.topic&.archived?
@@ -404,8 +404,7 @@ module PostGuardian
   end
 
   def can_see_deleted_posts?(category = nil)
-    is_category_group_moderator?(category) ||
-      @user.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+    is_category_group_moderator?(category) || can_delete_all_posts_and_topics?
   end
 
   def can_see_deleted_posts_for_user?

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -148,8 +148,7 @@ module TopicGuardian
     return false if topic.blank?
     return false if !is_staff? && !can_see_topic?(topic, false)
 
-    if is_category_group_moderator?(topic.category) ||
-         user&.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+    if is_category_group_moderator?(topic.category) || can_delete_all_posts_and_topics?
       topic.deleted_at?
     else
       can_recover_post?(topic.ordered_posts.first)
@@ -161,7 +160,7 @@ module TopicGuardian
     return false if topic.is_category_topic?
     return false if Discourse.static_doc_topic_ids.include?(topic.id)
     return true if is_category_group_moderator?(topic.category) && can_see_topic?(topic)
-    return true if user&.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+    return true if can_delete_all_posts_and_topics?
 
     is_my_own?(topic) && can_delete_own_topic?(topic)
   end
@@ -209,8 +208,7 @@ module TopicGuardian
   end
 
   def can_see_deleted_topics?(category)
-    is_category_group_moderator?(category) ||
-      user&.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+    is_category_group_moderator?(category) || can_delete_all_posts_and_topics?
   end
 
   # Accepts an array of `Topic#id` and returns an array of `Topic#id` which the user can see.

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -77,8 +77,8 @@ class PostDestroyer
 
     should_reset_bumped_at = @post.is_last_reply? && !@post.whisper?
 
-    if delete_removed_posts_after < 1 || post_is_reviewable? ||
-         Guardian.new(@user).can_moderate_topic?(@topic) || permanent?
+    if delete_removed_posts_after < 1 || post_is_reviewable? || can_moderate_this_topic? ||
+         permanent?
       perform_delete
     elsif @user.id == @post.user_id
       mark_for_deletion(delete_removed_posts_after)
@@ -114,15 +114,14 @@ class PostDestroyer
   end
 
   def recover
-    if (post_is_reviewable? || Guardian.new(@user).can_moderate_topic?(@post.topic)) &&
-         @post.deleted_at
-      staff_recovered
-    elsif @user.staff? || @user.id == @post.user_id
-      user_recovered
-    end
+    staff_recovery = (post_is_reviewable? || can_moderate_this_topic?) && @post.deleted_at.present?
+    user_recovery = !staff_recovery && (@user.staff? || @user.id == @post.user_id)
+
+    staff_recovered if staff_recovery
+    user_recovered if user_recovery
 
     @topic.update_column(:user_id, Discourse::SYSTEM_USER_ID) if !@topic.user_id
-    @topic.recover!(@user) if @post.is_first_post?
+    @topic.recover!(@user) if (staff_recovery || user_recovery) && @post.is_first_post?
     @topic.update_statistics!
     Topic.publish_stats_to_clients!(@topic.id, :recovered)
 
@@ -310,10 +309,18 @@ class PostDestroyer
 
   private
 
+  def guardian
+    @guardian ||= Guardian.new(@user)
+  end
+
+  def can_moderate_this_topic?
+    guardian.can_moderate_topic?(@topic) || guardian.can_delete_all_posts_and_topics?
+  end
+
   def post_is_reviewable?
     return true if @user.staff?
 
-    Guardian.new(@user).can_review_topic?(@topic) && Reviewable.exists?(target: @post)
+    guardian.can_review_topic?(@topic) && Reviewable.exists?(target: @post)
   end
 
   # we need topics to change if ever a post in them is deleted or created

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -308,10 +308,13 @@ class TopicsBulkAction
 
   def delete
     topics.each do |t|
-      if guardian.can_delete?(t)
-        post = t.ordered_posts.first
-        PostDestroyer.new(@user, post).destroy if post
-      end
+      next if !guardian.can_delete?(t)
+
+      post = t.ordered_posts.with_deleted.first
+      next if !post
+
+      PostDestroyer.new(@user, post).destroy
+      @changed_ids << t.id
     end
   end
 

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -1580,4 +1580,57 @@ RSpec.describe PostDestroyer do
       end
     end
   end
+
+  describe "members of delete_all_posts_and_topics_allowed_groups" do
+    fab!(:group)
+    fab!(:group_member, :user)
+
+    before do
+      group.add(group_member)
+      SiteSetting.delete_all_posts_and_topics_allowed_groups = "1|2|#{group.id}"
+    end
+
+    it "deletes another user's reply" do
+      reply = create_post(topic: post.topic, user: coding_horror)
+
+      PostDestroyer.new(group_member, reply).destroy
+
+      expect(reply.reload.deleted_at).to be_present
+      expect(reply.user_deleted).to eq(false)
+    end
+
+    it "deletes the topic along with the first post" do
+      PostDestroyer.new(group_member, post).destroy
+
+      expect(post.reload.deleted_at).to be_present
+      expect(Topic.with_deleted.find(post.topic_id).deleted_at).to be_present
+    end
+
+    it "recovers another user's deleted reply" do
+      reply = create_post(topic: post.topic, user: coding_horror)
+      PostDestroyer.new(moderator, reply).destroy
+
+      PostDestroyer.new(group_member, reply.reload).recover
+
+      expect(reply.reload.deleted_at).to eq(nil)
+    end
+
+    it "recovers the topic along with the first post" do
+      PostDestroyer.new(moderator, post).destroy
+
+      PostDestroyer.new(group_member, post.reload).recover
+
+      expect(post.reload.deleted_at).to eq(nil)
+      expect(post.topic.deleted_at).to eq(nil)
+    end
+  end
+
+  it "leaves the topic deleted when recovering a first post the user cannot recover" do
+    PostDestroyer.new(moderator, post).destroy
+
+    PostDestroyer.new(coding_horror, post.reload).recover
+
+    expect(post.reload.deleted_at).to be_present
+    expect(Topic.with_deleted.find(post.topic_id).deleted_at).to be_present
+  end
 end

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -473,11 +473,29 @@ RSpec.describe TopicsBulkAction do
     fab!(:topic) { Fabricate(:post).topic }
     fab!(:moderator)
 
-    it "deletes the topic" do
+    it "deletes the topic and returns its id" do
       tba = TopicsBulkAction.new(moderator, [topic.id], type: "delete")
-      tba.perform!
-      topic.reload
-      expect(topic).to be_trashed
+
+      expect(tba.perform!).to contain_exactly(topic.id)
+      expect(topic.reload).to be_trashed
+    end
+
+    it "skips topics the user can't delete" do
+      tba = TopicsBulkAction.new(user, [topic.id], type: "delete")
+
+      expect(tba.perform!).to be_empty
+      expect(topic.reload).not_to be_trashed
+    end
+
+    it "deletes the topic when its first post was already deleted" do
+      reply = Fabricate(:post, topic: topic)
+      topic.first_post.trash!(moderator)
+
+      tba = TopicsBulkAction.new(moderator, [topic.id], type: "delete")
+
+      expect(tba.perform!).to contain_exactly(topic.id)
+      expect(topic.reload).to be_trashed
+      expect(reply.reload).not_to be_trashed
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -416,6 +416,19 @@ RSpec.describe PostsController do
         expect(response).to be_forbidden
       end
 
+      it "deletes another user's post for a member of delete_all_posts_and_topics_allowed_groups" do
+        group = Fabricate(:group)
+        group.add(user)
+        SiteSetting.delete_all_posts_and_topics_allowed_groups = "1|2|#{group.id}"
+        post = Fabricate(:post, topic: topic, post_number: 3)
+        sign_in(user)
+
+        delete "/posts/#{post.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(post.reload.deleted_at).to be_present
+      end
+
       it "uses a PostDestroyer" do
         post = Fabricate(:post, topic_id: topic.id, post_number: 3)
         sign_in(moderator)
@@ -553,6 +566,19 @@ RSpec.describe PostsController do
         PostDestroyer.any_instance.expects(:destroy).twice
         delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
         expect(response.status).to eq(200)
+      end
+
+      it "deletes the posts for a member of delete_all_posts_and_topics_allowed_groups" do
+        group = Fabricate(:group)
+        group.add(user)
+        SiteSetting.delete_all_posts_and_topics_allowed_groups = "1|2|#{group.id}"
+        sign_in(user)
+
+        delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
+
+        expect(response.status).to eq(200)
+        expect(post1.reload.deleted_at).to be_present
+        expect(post2.reload.deleted_at).to be_present
       end
 
       # bookmark

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2104,6 +2104,24 @@ RSpec.describe TopicsController do
         end
       end
 
+      describe "with a member of delete_all_posts_and_topics_allowed_groups" do
+        fab!(:group)
+        fab!(:group_member, :user)
+
+        before do
+          group.add(group_member)
+          SiteSetting.delete_all_posts_and_topics_allowed_groups = "1|2|#{group.id}"
+          sign_in(group_member)
+        end
+
+        it "deletes the topic" do
+          delete "/t/#{topic.id}.json"
+
+          expect(response.status).to eq(200)
+          expect(topic.reload.trashed?).to eq(true)
+        end
+      end
+
       context "when logged in as a category group moderator who cannot see the topic" do
         fab!(:mod_group, :group)
         fab!(:cat_mod_user, :user)
@@ -5206,6 +5224,25 @@ RSpec.describe TopicsController do
 
         expect(response.status).to eq(400)
         expect(response.parsed_body["errors"]).to be_present
+      end
+
+      it "deletes topics for a member of delete_all_posts_and_topics_allowed_groups" do
+        group = Fabricate(:group)
+        group.add(user)
+        SiteSetting.delete_all_posts_and_topics_allowed_groups = "1|2|#{group.id}"
+        target_topic = Fabricate(:post).topic
+
+        put "/topics/bulk.json",
+            params: {
+              topic_ids: [target_topic.id],
+              operation: {
+                type: "delete",
+              },
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_ids"]).to contain_exactly(target_topic.id)
+        expect(target_topic.reload.trashed?).to eq(true)
       end
 
       it "can dismiss sub-categories posts as read" do

--- a/spec/services/post_owner_changer_spec.rb
+++ b/spec/services/post_owner_changer_spec.rb
@@ -134,6 +134,39 @@ RSpec.describe PostOwnerChanger do
       expect(p4.reload.user).to eq(user_a)
     end
 
+    it "recovers the first post along with a topic deleted when its author was removed" do
+      topic # memoize before the topic is trashed and scoped out of p1.topic
+      PostDestroyer.new(editor, p1).destroy
+      p1.reload.update_columns(user_id: nil)
+
+      PostOwnerChanger.new(
+        post_ids: [p1.id],
+        topic_id: topic.id,
+        new_owner: user_a,
+        acting_user: editor,
+      ).change_owner!
+
+      expect(topic.reload.deleted_at).to eq(nil)
+      expect(p1.reload.deleted_at).to eq(nil)
+      expect(p1.user).to eq(user_a)
+    end
+
+    it "leaves an individually deleted first post deleted when the topic is live" do
+      p1.trash!(editor)
+      p1.reload.update_columns(user_id: nil)
+
+      PostOwnerChanger.new(
+        post_ids: [p1.id],
+        topic_id: topic.id,
+        new_owner: user_a,
+        acting_user: editor,
+      ).change_owner!
+
+      expect(topic.reload.deleted_at).to eq(nil)
+      expect(p1.reload.deleted_at).to be_present
+      expect(p1.user).to eq(user_a)
+    end
+
     it "sets 'posted' for TopicUser to true" do
       PostOwnerChanger.new(
         post_ids: [p1.id],

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -20,6 +20,12 @@ module PageObjects
         PageObjects::Components::SelectKit.new("#search-sort-by")
       end
 
+      def bulk_select_result_and_open_dropdown(topic)
+        find(".search-info .bulk-select").click
+        find(".fps-result .fps-topic[data-topic-id='#{topic.id}'] .bulk-select input").click
+        find(".search-info .bulk-select-topics-dropdown-trigger").click
+      end
+
       def click_search_menu_link
         find(".search-menu .results .search-link").click
       end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -9,6 +9,8 @@ describe "Search" do
   fab!(:post2) { Fabricate(:post, topic: topic2, raw: "This is another test post in a test topic") }
 
   let(:topic_bulk_actions_modal) { PageObjects::Modals::TopicBulkActions.new }
+  let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
 
   describe "when using full page search on mobile" do
     before do
@@ -253,10 +255,9 @@ describe "Search" do
     it "allows the user to perform bulk actions on the topic search results" do
       visit("/search?q=test")
       expect(page).to have_content(topic.title)
-      find(".search-info .bulk-select").click
-      find(".fps-result .fps-topic[data-topic-id=\"#{topic.id}\"] .bulk-select input").click
-      find(".search-info .bulk-select-topics-dropdown-trigger").click
-      PageObjects::Components::TopicListHeader.new.click_bulk_button("manage-tags")
+
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("manage-tags")
       manage_tags_modal = PageObjects::Modals::ManageTags.new
       manage_tags_modal.add_tags(tag1.name)
       manage_tags_modal.click_confirm
@@ -269,17 +270,24 @@ describe "Search" do
       visit("/search?q=This%20is%20a%20test%20post")
       expect(page).to have_content(post.raw)
 
-      find(".search-info .bulk-select").click
-      find(".fps-result .fps-topic[data-topic-id=\"#{topic.id}\"] .bulk-select input").click
-      find(".search-info .bulk-select-topics-dropdown-trigger").click
-
-      find(".bulk-select-topics-dropdown-content .delete-posts").click
-
-      find(".dialog-content")
-      click_button "OK"
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("delete-posts")
+      dialog.click_ok
 
       expect(page).to have_no_content(post.raw)
       expect(Post.with_deleted.find_by(id: post.id).deleted_at).to be_present
+    end
+
+    it "lets the user bulk delete the whole topic from a reply search result" do
+      visit("/search?q=This%20is%20a%20test%20post")
+      expect(page).to have_content(post.raw)
+
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("delete-topics")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+
+      expect(page).to have_no_content(post.raw)
+      expect(topic.reload).to be_trashed
     end
   end
 

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -450,6 +450,19 @@ describe "Topic bulk select" do
     end
   end
 
+  context "when deleting" do
+    it "removes the deleted topics from the list" do
+      sign_in(admin)
+      visit("/latest")
+
+      open_bulk_actions_modal([topics.first, topics.second], "delete-topics")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+
+      expect(topic_list).to have_no_topic(topics.first)
+      expect(topic_list).to have_no_topic(topics.second)
+    end
+  end
+
   context "when working with private messages" do
     fab!(:private_message_1) do
       Fabricate(:private_message_topic, user: admin, recipient: user, participant_count: 2)


### PR DESCRIPTION
Stacked on #42776. Follow-up 1 of 2 from the bulk-actions investigation ([meta t/410444](https://meta.discourse.org/t/bulk-actions-confusion-delete-topics/410444)).

The guardians grant delete and recover on membership of `delete_all_posts_and_topics_allowed_groups`, but `PostDestroyer` only ever consulted the staff / TL4 / category-moderator checks. For a non-staff member of the group — exactly who the setting advertises ("Groups allowed to delete posts and topics created by other users") — every delete endpoint returned 200 with nothing deleted, while irreversible side effects (activity stream removal, webhooks, events) fired anyway.

A refused recover was worse: it still resurrected the topic, leaving a live topic whose first post is trashed — a corrupt state many downstream consumers choke on, and one `PostOwnerChanger` could also produce by recovering a topic without its first post.

Two deliberate consequences for these group members: their deletions of other users' content now appear in the staff action log, and they remain subject to `max_post_deletions_per_minute`/`_per_day` since the rate-limiter exemption still keys on `can_moderate_topic?`.
