### PR TITLE
FIX: Bulk tag, category, and read-state ops no longer lie or overreach

### DIFF
--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -78,19 +78,22 @@ class PostTiming < ActiveRecord::Base
     last_read = post_number - 1
 
     PostTiming.transaction do
-      PostTiming.where(
-        "topic_id = ? AND user_id = ? AND post_number > ?",
-        topic.id,
-        user.id,
-        last_read,
-      ).delete_all
+      destroyed_count =
+        PostTiming.where(
+          "topic_id = ? AND user_id = ? AND post_number > ?",
+          topic.id,
+          user.id,
+          last_read,
+        ).delete_all
       last_read = nil if last_read < 1
 
+      # the TopicUser reset below must still run without timing rows;
+      # only the read count must not go negative
       TopicUser.where(user_id: user.id, topic_id: topic.id).update_all(
         last_read_post_number: last_read,
       )
 
-      topic.posts.find_by(post_number: post_number).decrement!(:reads)
+      topic.posts.find_by(post_number: post_number)&.decrement!(:reads) if destroyed_count > 0
 
       if topic.private_message?
         set_minimum_first_unread_pm!(topic: topic, user_id: user.id, date: topic.updated_at)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4291,7 +4291,7 @@ en:
           missing_to: "A replacement tag is required"
       delete_topics:
         name: "Delete"
-        description: "Permanently delete the selected topics. This action cannot be undone."
+        description: "Delete the selected topics. Deleted topics can be restored."
       update_category:
         name: "Update Category"
         description: "Move all selected topics to the following category:"

--- a/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -46,6 +46,7 @@ export default class BulkSelectTopicsDropdown extends Component {
   @service router;
   @service modal;
   @service currentUser;
+  @service site;
   @service siteSettings;
   @service toasts;
 
@@ -95,8 +96,10 @@ export default class BulkSelectTopicsDropdown extends Component {
         id: "manage-tags",
         icon: "tag",
         name: i18n("topic_bulk_actions.manage_tags.name"),
-        visible: ({ currentUser, siteSettings }) =>
-          siteSettings.tagging_enabled && currentUser.canManageTopic,
+        visible: ({ currentUser, siteSettings, site }) =>
+          siteSettings.tagging_enabled &&
+          site.can_tag_topics &&
+          currentUser.canManageTopic,
       },
       {
         id: "pin-topics",
@@ -201,6 +204,7 @@ export default class BulkSelectTopicsDropdown extends Component {
         return visible({
           topics: this.args.bulkSelectHelper.selected,
           currentUser: this.currentUser,
+          site: this.site,
           siteSettings: this.siteSettings,
           router: this.router,
         });

--- a/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
@@ -48,6 +48,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
 
   test("actions all topics can perform", async function (assert) {
     this.currentUser.admin = true;
+    this.site.set("can_tag_topics", true);
     this.bulkSelectHelper = createBulkSelectHelper(this);
 
     await render(
@@ -114,6 +115,23 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
   test("does not allow tagging actions if tagging_enabled is false", async function (assert) {
     this.currentUser.admin = true;
     this.siteSettings.tagging_enabled = false;
+    this.bulkSelectHelper = createBulkSelectHelper(this);
+
+    await render(
+      <template>
+        <BulkSelectTopicsDropdown @bulkSelectHelper={{this.bulkSelectHelper}} />
+      </template>
+    );
+
+    await click(".bulk-select-topics-dropdown-trigger");
+    assert
+      .dom(".fk-d-menu__inner-content .dropdown-menu__item .manage-tags")
+      .doesNotExist();
+  });
+
+  test("does not allow tagging actions if the user cannot tag topics", async function (assert) {
+    this.currentUser.admin = true;
+    this.site.set("can_tag_topics", false);
     this.bulkSelectHelper = createBulkSelectHelper(this);
 
     await render(

--- a/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import BulkSelectTopicsDropdown from "discourse/components/bulk-select-topics-dropdown";
+import BulkTopicActions from "discourse/components/modal/bulk-topic-actions";
 import { addUniqueValueToArray } from "discourse/lib/array-tools";
 import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { TOPIC_VISIBILITY_REASONS } from "discourse/lib/constants";
@@ -257,7 +258,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert.verifySteps(["custom-action"]);
   });
 
-  test("allows overriding built-in delete label with extra buttons", async function (assert) {
+  test("an extra button reusing a built-in id overrides the label, not the action", async function (assert) {
     this.currentUser.admin = true;
     this.bulkSelectHelper = createBulkSelectHelper(this);
     this.extraButtons = [
@@ -284,5 +285,39 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert
       .dom(".fk-d-menu__inner-content .dropdown-menu__item .delete-topics")
       .hasTextContaining("Delete Topics (override)");
+
+    await click(
+      ".fk-d-menu__inner-content .dropdown-menu__item .delete-topics"
+    );
+    assert.strictEqual(
+      getOwner(this).lookup("service:modal").activeModal.component,
+      BulkTopicActions,
+      "the built-in delete action still runs"
+    );
+  });
+
+  test("the delete description does not claim the deletion is permanent", async function (assert) {
+    this.currentUser.admin = true;
+    this.bulkSelectHelper = createBulkSelectHelper(this);
+
+    await render(
+      <template>
+        <BulkSelectTopicsDropdown @bulkSelectHelper={{this.bulkSelectHelper}} />
+      </template>
+    );
+
+    await click(".bulk-select-topics-dropdown-trigger");
+    await click(
+      ".fk-d-menu__inner-content .dropdown-menu__item .delete-topics"
+    );
+
+    const { description } =
+      getOwner(this).lookup("service:modal").activeModal.opts.model;
+
+    assert.strictEqual(typeof description, "string", "a description is shown");
+    assert.false(
+      /permanent|cannot be undone/i.test(description),
+      `bulk delete is recoverable, but the copy reads "${description}"`
+    );
   });
 });

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -308,10 +308,13 @@ class TopicsBulkAction
 
   def delete
     topics.each do |t|
-      if guardian.can_delete?(t)
-        post = t.ordered_posts.first
-        PostDestroyer.new(@user, post).destroy if post
-      end
+      next if !guardian.can_delete?(t)
+
+      post = t.ordered_posts.with_deleted.first
+      next if !post
+
+      PostDestroyer.new(@user, post).destroy
+      @changed_ids << t.id
     end
   end
 

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -168,18 +168,27 @@ class TopicsBulkAction
 
   def destroy_post_timing
     topics.each do |t|
+      next unless guardian.can_see?(t)
+
       PostTiming.destroy_last_for(@user, topic: t)
       @changed_ids << t.id
     end
   end
 
   def change_category
-    updatable_topics = topics.where.not(category_id: @operation[:category_id])
+    category_id = @operation[:category_id]
+    updatable_topics = topics.where.not(category_id: category_id)
+
+    # mirrors the PostRevisor gate, which skips the check when moving to uncategorized
+    if category_id.to_i > 0 && !guardian.can_move_topic_to_category?(category_id)
+      @errors[I18n.t("category.errors.move_topic_to_category_disallowed")] += updatable_topics.count
+      return
+    end
 
     updatable_topics.each do |t|
       next unless guardian.can_edit?(t) && t.first_post
 
-      changes = { category_id: @operation[:category_id] }
+      changes = { category_id: category_id }
       if t.first_post.revise(@user, changes, bulk_revision_opts)
         @changed_ids << t.id
       else
@@ -271,6 +280,8 @@ class TopicsBulkAction
   def reset_bump_dates
     if guardian.can_update_bumped_at?
       topics.each do |t|
+        next unless guardian.can_see?(t)
+
         t.reset_bumped_at
         @changed_ids << t.id
       end
@@ -383,7 +394,10 @@ class TopicsBulkAction
   end
 
   def apply_tag_revision(topic, tag_names)
-    return false unless guardian.can_edit?(topic)
+    unless guardian.can_edit_tags?(topic)
+      @errors[I18n.t("tags.user_not_permitted")] += 1
+      return false
+    end
     return false unless topic.first_post
 
     if topic.first_post.revise(@user, { tags: tag_names }, bulk_revision_opts)
@@ -442,7 +456,7 @@ class TopicsBulkAction
   end
 
   def topics
-    @topics ||= Topic.where(id: @topic_ids)
+    @topics ||= Topic.where(id: @topic_ids).includes(:category)
   end
 
   def topics_with_tags

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -275,6 +275,30 @@ RSpec.describe TopicsBulkAction do
       end
     end
 
+    context "when the user can't move topics to the destination category" do
+      it "records an error and creates no revision" do
+        restricted_category = Fabricate(:private_category, group: Fabricate(:group))
+        original_category = topic.category
+
+        bulk_action =
+          TopicsBulkAction.new(
+            topic.user,
+            [topic.id],
+            type: "change_category",
+            category_id: restricted_category.id,
+          )
+        topic_ids = bulk_action.perform!
+
+        expect(topic_ids).to eq([])
+        expect(topic.reload.category).to eq(original_category)
+        expect(first_post.reload.version).to eq(1)
+        expect(PostRevision.where(post: first_post)).to be_empty
+        expect(bulk_action.errors).to eq(
+          I18n.t("category.errors.move_topic_to_category_disallowed") => 1,
+        )
+      end
+    end
+
     context "when destination category does not allow the topic's tags" do
       fab!(:destination_category, :category)
       fab!(:other_tag) { Fabricate(:tag, name: "other-tag") }
@@ -467,6 +491,19 @@ RSpec.describe TopicsBulkAction do
       expect { topic_ids = tba.perform! }.to change { PostTiming.count }.by(-1)
       expect(topic_ids).to contain_exactly(topic.id)
     end
+
+    it "skips topics the user can't see" do
+      pm = Fabricate(:private_message_topic)
+      pm_post = Fabricate(:post, topic: pm)
+      stranger = Fabricate(:user)
+
+      topic_ids = nil
+      expect {
+        topic_ids = TopicsBulkAction.new(stranger, [pm.id], type: "destroy_post_timing").perform!
+      }.not_to change { pm_post.reload.reads }
+
+      expect(topic_ids).to eq([])
+    end
   end
 
   describe "delete" do
@@ -602,6 +639,29 @@ RSpec.describe TopicsBulkAction do
 
       expect(topic_ids).to eq([])
       expect(topic.reload.bumped_at).to eq_time(bumped_at)
+    end
+
+    it "skips topics the user can't see" do
+      trust_level_4 = Fabricate(:trust_level_4)
+      private_topic =
+        Fabricate(:topic, category: Fabricate(:private_category, group: Fabricate(:group)))
+      pm = Fabricate(:private_message_topic)
+      bumped_at = 1.hour.ago
+      [private_topic, pm].each do |restricted_topic|
+        Fabricate(:post, topic: restricted_topic, created_at: 1.day.ago)
+        restricted_topic.update!(bumped_at: bumped_at)
+      end
+
+      topic_ids =
+        TopicsBulkAction.new(
+          trust_level_4,
+          [private_topic.id, pm.id],
+          type: "reset_bump_dates",
+        ).perform!
+
+      expect(topic_ids).to eq([])
+      expect(private_topic.reload.bumped_at).to eq_time(bumped_at)
+      expect(pm.reload.bumped_at).to eq_time(bumped_at)
     end
   end
 
@@ -757,7 +817,7 @@ RSpec.describe TopicsBulkAction do
       fab!(:tag3, :tag)
 
       it "doesn't change the tags" do
-        Guardian.any_instance.expects(:can_edit?).returns(false)
+        Guardian.any_instance.expects(:can_edit_topic?).returns(false)
 
         topic_ids =
           TopicsBulkAction.new(
@@ -769,6 +829,24 @@ RSpec.describe TopicsBulkAction do
 
         expect(topic_ids).to eq([])
         expect(topic.reload.tags).to contain_exactly(tag1, tag2)
+      end
+    end
+
+    context "when the user can't tag topics" do
+      fab!(:tag3, :tag)
+
+      it "records an error and creates no revision" do
+        SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:staff]
+
+        bulk_action =
+          TopicsBulkAction.new(topic.user, [topic.id], type: "change_tags", tag_ids: [tag3.id])
+        topic_ids = bulk_action.perform!
+
+        expect(topic_ids).to eq([])
+        expect(topic.reload.tags).to contain_exactly(tag1, tag2)
+        expect(first_post.reload.version).to eq(1)
+        expect(PostRevision.where(post: first_post)).to be_empty
+        expect(bulk_action.errors).to eq(I18n.t("tags.user_not_permitted") => 1)
       end
     end
 
@@ -853,7 +931,7 @@ RSpec.describe TopicsBulkAction do
 
     context "when the user can't edit the topic" do
       it "doesn't change the tags" do
-        Guardian.any_instance.expects(:can_edit?).returns(false)
+        Guardian.any_instance.expects(:can_edit_topic?).returns(false)
 
         topic_ids =
           TopicsBulkAction.new(
@@ -914,7 +992,7 @@ RSpec.describe TopicsBulkAction do
 
     context "when the user can't edit the topic" do
       it "doesn't remove the tags" do
-        Guardian.any_instance.expects(:can_edit?).returns(false)
+        Guardian.any_instance.expects(:can_edit_topic?).returns(false)
 
         topic_ids = TopicsBulkAction.new(topic.user, [topic.id], type: "remove_tags").perform!
 

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -473,11 +473,29 @@ RSpec.describe TopicsBulkAction do
     fab!(:topic) { Fabricate(:post).topic }
     fab!(:moderator)
 
-    it "deletes the topic" do
+    it "deletes the topic and returns its id" do
       tba = TopicsBulkAction.new(moderator, [topic.id], type: "delete")
-      tba.perform!
-      topic.reload
-      expect(topic).to be_trashed
+
+      expect(tba.perform!).to contain_exactly(topic.id)
+      expect(topic.reload).to be_trashed
+    end
+
+    it "skips topics the user can't delete" do
+      tba = TopicsBulkAction.new(user, [topic.id], type: "delete")
+
+      expect(tba.perform!).to be_empty
+      expect(topic.reload).not_to be_trashed
+    end
+
+    it "deletes the topic when its first post was already deleted" do
+      reply = Fabricate(:post, topic: topic)
+      topic.first_post.trash!(moderator)
+
+      tba = TopicsBulkAction.new(moderator, [topic.id], type: "delete")
+
+      expect(tba.perform!).to contain_exactly(topic.id)
+      expect(topic.reload).to be_trashed
+      expect(reply.reload).not_to be_trashed
     end
   end
 

--- a/spec/models/post_timing_spec.rb
+++ b/spec/models/post_timing_spec.rb
@@ -179,6 +179,14 @@ RSpec.describe PostTiming do
   end
 
   describe ".destroy_last_for" do
+    it "does not decrement reads when the user had no timing on the last post" do
+      post = Fabricate(:post, reads: 5)
+
+      expect {
+        PostTiming.destroy_last_for(Fabricate(:user), topic_id: post.topic_id)
+      }.not_to change { post.reload.reads }
+    end
+
     it "updates first unread for a user correctly when topic is public" do
       post.topic.update!(updated_at: 10.minutes.ago)
       PostTiming.process_timings(post.user, post.topic_id, 1, [[post.post_number, 100]])

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -20,6 +20,12 @@ module PageObjects
         PageObjects::Components::SelectKit.new("#search-sort-by")
       end
 
+      def bulk_select_result_and_open_dropdown(topic)
+        find(".search-info .bulk-select").click
+        find(".fps-result .fps-topic[data-topic-id='#{topic.id}'] .bulk-select input").click
+        find(".search-info .bulk-select-topics-dropdown-trigger").click
+      end
+
       def click_search_menu_link
         find(".search-menu .results .search-link").click
       end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -9,6 +9,8 @@ describe "Search" do
   fab!(:post2) { Fabricate(:post, topic: topic2, raw: "This is another test post in a test topic") }
 
   let(:topic_bulk_actions_modal) { PageObjects::Modals::TopicBulkActions.new }
+  let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
 
   describe "when using full page search on mobile" do
     before do
@@ -253,10 +255,9 @@ describe "Search" do
     it "allows the user to perform bulk actions on the topic search results" do
       visit("/search?q=test")
       expect(page).to have_content(topic.title)
-      find(".search-info .bulk-select").click
-      find(".fps-result .fps-topic[data-topic-id=\"#{topic.id}\"] .bulk-select input").click
-      find(".search-info .bulk-select-topics-dropdown-trigger").click
-      PageObjects::Components::TopicListHeader.new.click_bulk_button("manage-tags")
+
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("manage-tags")
       manage_tags_modal = PageObjects::Modals::ManageTags.new
       manage_tags_modal.add_tags(tag1.name)
       manage_tags_modal.click_confirm
@@ -269,17 +270,24 @@ describe "Search" do
       visit("/search?q=This%20is%20a%20test%20post")
       expect(page).to have_content(post.raw)
 
-      find(".search-info .bulk-select").click
-      find(".fps-result .fps-topic[data-topic-id=\"#{topic.id}\"] .bulk-select input").click
-      find(".search-info .bulk-select-topics-dropdown-trigger").click
-
-      find(".bulk-select-topics-dropdown-content .delete-posts").click
-
-      find(".dialog-content")
-      click_button "OK"
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("delete-posts")
+      dialog.click_ok
 
       expect(page).to have_no_content(post.raw)
       expect(Post.with_deleted.find_by(id: post.id).deleted_at).to be_present
+    end
+
+    it "lets the user bulk delete the whole topic from a reply search result" do
+      visit("/search?q=This%20is%20a%20test%20post")
+      expect(page).to have_content(post.raw)
+
+      search_page.bulk_select_result_and_open_dropdown(topic)
+      topic_list_header.click_bulk_button("delete-topics")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+
+      expect(page).to have_no_content(post.raw)
+      expect(topic.reload).to be_trashed
     end
   end
 

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -450,6 +450,19 @@ describe "Topic bulk select" do
     end
   end
 
+  context "when deleting" do
+    it "removes the deleted topics from the list" do
+      sign_in(admin)
+      visit("/latest")
+
+      open_bulk_actions_modal([topics.first, topics.second], "delete-topics")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+
+      expect(topic_list).to have_no_topic(topics.first)
+      expect(topic_list).to have_no_topic(topics.second)
+    end
+  end
+
   context "when working with private messages" do
     fab!(:private_message_1) do
       Fabricate(:private_message_topic, user: admin, recipient: user, participant_count: 2)


### PR DESCRIPTION
Stacked on #42776. Follow-up 2 of 2 from the bulk-actions investigation ([meta t/410444](https://meta.discourse.org/t/bulk-actions-confusion-delete-topics/410444)).

`PostRevisor` silently refuses tag and category changes the user lacks permission for, yet the bulk layer gated only on `can_edit?` and counted every topic as changed: a green "Completed" toast, zero changes applied — and each refused revise still bumped `post.version` and wrote an empty `PostRevision`, permanently stamping a bogus "1 edit" indicator on up to 1000 topics per click. The UI also offered "Manage tags" to users the server would then refuse.

`reset_bump_dates` checked permissions once, globally, so a TL4 user could reset bump dates on topics in restricted categories they cannot see — the single-topic route fixed this exact hole in aac9494fb3c (#37798), but the bulk path was missed. `destroy_post_timing` had no permission check at all, and could drive `posts.reads` negative on topics where the caller had no timings to destroy.
