### PR TITLE
UX: Gate bulk "Delete Topics" on the delete capability, not staff

### DIFF
--- a/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -189,7 +189,8 @@ export default class BulkSelectTopicsDropdown extends Component {
         id: "delete-topics",
         icon: "trash-can",
         name: i18n("topic_bulk_actions.delete_topics.name"),
-        visible: ({ currentUser }) => currentUser.staff,
+        visible: ({ currentUser }) =>
+          currentUser.can_delete_all_posts_and_topics,
       },
     ];
 

--- a/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
@@ -49,6 +49,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
   test("actions all topics can perform", async function (assert) {
     this.currentUser.admin = true;
     this.site.set("can_tag_topics", true);
+    this.currentUser.can_delete_all_posts_and_topics = true;
     this.bulkSelectHelper = createBulkSelectHelper(this);
 
     await render(
@@ -161,7 +162,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
       .doesNotExist();
   });
 
-  test("does not allow deleting topics if user is not staff", async function (assert) {
+  test("does not allow deleting topics if the user cannot delete all posts and topics", async function (assert) {
     this.bulkSelectHelper = createBulkSelectHelper(this);
 
     await render(
@@ -174,6 +175,22 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert
       .dom(".fk-d-menu__inner-content .dropdown-menu__item .delete-topics")
       .doesNotExist();
+  });
+
+  test("allows deleting topics for a non-staff user who can delete all posts and topics", async function (assert) {
+    this.currentUser.can_delete_all_posts_and_topics = true;
+    this.bulkSelectHelper = createBulkSelectHelper(this);
+
+    await render(
+      <template>
+        <BulkSelectTopicsDropdown @bulkSelectHelper={{this.bulkSelectHelper}} />
+      </template>
+    );
+
+    await click(".bulk-select-topics-dropdown-trigger");
+    assert
+      .dom(".fk-d-menu__inner-content .dropdown-menu__item .delete-topics")
+      .exists();
   });
 
   test("does not allow unlisting or relisting PM topics", async function (assert) {
@@ -316,6 +333,7 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
 
   test("the delete description does not claim the deletion is permanent", async function (assert) {
     this.currentUser.admin = true;
+    this.currentUser.can_delete_all_posts_and_topics = true;
     this.bulkSelectHelper = createBulkSelectHelper(this);
 
     await render(


### PR DESCRIPTION
Stacked on #42783 — without it, showing the action would offer group members a delete the server silently no-ops.

The server grants bulk delete to members of `delete_all_posts_and_topics_allowed_groups`, but the menu item was offered to staff only, so a TL4 member of the group could bulk select topics and never see a delete action the server would honor. Staff lose nothing: the setting's `mandatory_values: "1|2"` keep them in the capability.

Deliberately out of scope: non-staff, non-TL4 group members still cannot enter bulk-select mode at all (`canBulkSelect` is staff/TL4-gated in the discovery, user-topics, and search controllers). Widening that gate would surface other menu items whose visibility still assumes staff — the same "UI offers what the server refuses" class this stack fixes — so it deserves its own pass.
