### PR TITLE
PERF: Batch category type site setting override lookups

### DIFF
--- a/app/services/categories/type_registry.rb
+++ b/app/services/categories/type_registry.rb
@@ -32,10 +32,19 @@ module Categories
       end
 
       def list(only_visible: false, guardian: nil)
-        types
-          .values
-          .select { |type| only_visible ? type.visible? : true }
-          .map { |type| type.metadata(guardian:) }
+        type_list = types.values.select { |type| only_visible ? type.visible? : true }
+
+        overridden_site_settings =
+          if type_list.any? { |type| type.configuration_schema[:site_settings].present? }
+            SiteSetting
+              .provider
+              .all
+              .each_with_object({}) { |setting, result| result[setting.name.to_sym] = true }
+          else
+            {}
+          end
+
+        type_list.map { |type| type.metadata(guardian:, overridden_site_settings:) }
       end
 
       def valid?(id)

--- a/app/services/categories/types/base.rb
+++ b/app/services/categories/types/base.rb
@@ -392,7 +392,7 @@ module Categories
         end
 
         # Used when serializing the category configuration schema to the client.
-        def metadata(guardian: nil)
+        def metadata(guardian: nil, overridden_site_settings: nil)
           name = I18n.t("category_types.#{type_id}.name", default: type_id.to_s.titleize)
           result = {
             id: type_id,
@@ -402,7 +402,7 @@ module Categories
             icon:,
             available: available?,
             visible: visible?,
-            configuration_schema: resolved_configuration_schema,
+            configuration_schema: resolved_configuration_schema(overridden_site_settings:),
           }
           if enables_plugin?
             result[:required_plugin] = Categories::TypeRegistry.plugin_display_name(type_id)
@@ -420,13 +420,18 @@ module Categories
 
         private
 
-        def site_setting_overridden?(setting_name)
-          SiteSetting.provider.find(setting_name.to_sym).present?
-        end
-
-        def resolved_configuration_schema
+        def resolved_configuration_schema(overridden_site_settings: nil)
           schema = configuration_schema
           return {} if schema.blank?
+          overridden_site_settings ||=
+            if schema[:site_settings].present?
+              SiteSetting
+                .provider
+                .all
+                .each_with_object({}) { |setting, result| result[setting.name.to_sym] = true }
+            else
+              {}
+            end
 
           entries = {
             general_category_settings: [],
@@ -456,7 +461,7 @@ module Categories
               key: setting_name.to_s,
               default: config[:default],
               current: SiteSetting.public_send(setting_name),
-              overridden: site_setting_overridden?(setting_name),
+              overridden: overridden_site_settings.key?(setting_name.to_sym),
               type: config[:type] || meta[:type],
               label: config[:label] || meta[:humanized_name],
               choices: config[:choices] || meta[:choices],

--- a/spec/services/categories/type_registry_spec.rb
+++ b/spec/services/categories/type_registry_spec.rb
@@ -55,6 +55,38 @@ RSpec.describe Categories::TypeRegistry do
       expect(discussion).to include(available: true)
     end
 
+    it "loads site setting overrides once across category types" do
+      first_type =
+        Class.new(Categories::Types::Base) do
+          type_id :test_site_settings_one
+
+          def self.configuration_schema
+            { site_settings: { title: "Forum One" } }
+          end
+        end
+
+      second_type =
+        Class.new(Categories::Types::Base) do
+          type_id :test_site_settings_two
+
+          def self.configuration_schema
+            { site_settings: { allow_user_locale: false } }
+          end
+        end
+
+      described_class.register(first_type)
+      described_class.register(second_type)
+
+      provider = SiteSetting.provider
+
+      provider.expects(:all).once.returns([])
+
+      described_class.list
+    ensure
+      described_class.all.delete(:test_site_settings_one)
+      described_class.all.delete(:test_site_settings_two)
+    end
+
     context "with a plugin-enabling type" do
       let(:test_type) do
         Class.new(Categories::Types::Base) do

--- a/spec/services/categories/types/base_spec.rb
+++ b/spec/services/categories/types/base_spec.rb
@@ -368,6 +368,27 @@ RSpec.describe Categories::Types::Base do
       expect(entry[:overridden]).to eq(true)
     end
 
+    it "loads site setting overrides once" do
+      test_type =
+        build_test_type(
+          :test_batched_overrides,
+          configuration_schema: {
+            site_settings: {
+              title: "My Forum",
+              allow_user_locale: false,
+              suggested_topics: 5,
+            },
+          },
+        )
+
+      provider = SiteSetting.provider
+
+      provider.expects(:all).once.returns([])
+      provider.expects(:find).never
+
+      test_type.send(:resolved_configuration_schema)
+    end
+
     it "passes through category settings" do
       test_type =
         build_test_type(


### PR DESCRIPTION
This avoids performing a separate SiteSetting provider lookup for each SiteSetting represented in category type configuration schemas.

Previously, `resolved_configuration_schema` called `SiteSetting.provider.find` for each configured site setting. When `Categories::TypeRegistry.list` serialized multiple category types, this resulted in multiple individual `site_settings WHERE name = ?` queries.

This change:

- loads persisted SiteSetting overrides once in `TypeRegistry.list`
- reuses that override information across all serialized category types
- retains a single bulk-provider fallback for direct metadata/schema resolution
- preserves the existing `overridden` behavior

While profiling a staff site payload, I observed 16 individual SiteSetting lookup queries originating from this path.

Tests cover both multiple SiteSettings within one category type and multiple category types sharing the same bulk lookup.

Local verification:

- RuboCop: no offenses
- Syntax Tree: expected format
- relevant category/serializer specs: 149 examples, 0 failures