### PR TITLE
DEV: Convert JSON:API parameters in the contract

### DIFF
--- a/lib/json_api_kit/document.rb
+++ b/lib/json_api_kit/document.rb
@@ -13,7 +13,7 @@ module JsonApiKit
         )
         .then do |contract|
           next Errors.new(*Request::Contract::Mapper.new(contract.errors).to_a) if contract.invalid?
-          new(yield, urls:).tap(&:to_h)
+          new(yield(contract.to_hash), urls:).tap(&:to_h)
         end
     rescue Error => error
       Errors.new(error)

--- a/lib/json_api_kit/document/collection.rb
+++ b/lib/json_api_kit/document/collection.rb
@@ -7,7 +7,7 @@ module JsonApiKit
         def contract_class = Request::Contract::Collection
 
         def for(parameters, resource:, guardian:, urls:, scoped_to: nil)
-          build(parameters, resource:, urls:) { resource.all(parameters, guardian:, scoped_to:) }
+          build(parameters, resource:, urls:) { resource.all(it, guardian:, scoped_to:) }
         end
       end
 

--- a/lib/json_api_kit/document/individual.rb
+++ b/lib/json_api_kit/document/individual.rb
@@ -7,7 +7,7 @@ module JsonApiKit
         def contract_class = Request::Contract::Individual
 
         def for(id, parameters, resource:, guardian:, urls:)
-          build(parameters, resource:, urls:) { resource.find(id, parameters, guardian:) }
+          build(parameters, resource:, urls:) { resource.find(id, it, guardian:) }
         end
       end
 

--- a/lib/json_api_kit/pagination/direction.rb
+++ b/lib/json_api_kit/pagination/direction.rb
@@ -4,10 +4,10 @@ module JsonApiKit
   module Pagination
     class Direction
       def self.for(direction)
-        case direction.to_s
-        when "asc"
+        case direction
+        when :asc
           Ascending.new
-        when "desc"
+        when :desc
           Descending.new
         else
           raise ArgumentError, "unknown direction: #{direction}"

--- a/lib/json_api_kit/request.rb
+++ b/lib/json_api_kit/request.rb
@@ -10,11 +10,11 @@ module JsonApiKit
       @guardian = guardian
     end
 
-    def ordering = @ordering ||= params[:sort].to_h.transform_values(&:to_sym)
+    def ordering = @ordering ||= params[:sort].to_h
 
     def filtering = @filtering ||= params[:filter].to_h
 
-    def fields = @fields ||= params[:fields].to_h.transform_values { it.map(&:to_s) }
+    def fields = @fields ||= params[:fields].to_h
 
     def including = @including ||= Paths.new(params[:include])
 

--- a/lib/json_api_kit/request/contract/fields.rb
+++ b/lib/json_api_kit/request/contract/fields.rb
@@ -6,8 +6,27 @@ module JsonApiKit
       module Fields
         extend ActiveSupport::Concern
 
+        class FieldsType < IndifferentHashType
+          def cast_value(value)
+            super&.transform_values { fields(it) }
+          end
+
+          private
+
+          def fields(value)
+            case value
+            when String
+              value.split(",")
+            when Array
+              value.map(&:to_s)
+            else
+              value
+            end
+          end
+        end
+
         included do
-          attribute :fields, INDIFFERENT_HASH
+          attribute :fields, FieldsType.new
 
           validate :check_fields, if: -> { fields.present? }
         end

--- a/lib/json_api_kit/request/contract/including.rb
+++ b/lib/json_api_kit/request/contract/including.rb
@@ -6,8 +6,19 @@ module JsonApiKit
       module Including
         extend ActiveSupport::Concern
 
+        class IncludeType < ActiveModel::Type::Value
+          def cast_value(value)
+            case value
+            when String
+              value.split(",")
+            else
+              value
+            end
+          end
+        end
+
         included do
-          attribute :include, default: -> { [] }
+          attribute :include, IncludeType.new, default: -> { [] }
 
           validate :check_include_paths, if: -> { include.present? }
         end

--- a/lib/json_api_kit/request/contract/mapper.rb
+++ b/lib/json_api_kit/request/contract/mapper.rb
@@ -92,7 +92,7 @@ module JsonApiKit
           },
           %i[sort bad_shape] => {
             title: "Invalid sort parameter",
-            detail: ->(_) { "sort must name a direction for each sort." },
+            detail: ->(_) { "sort must be a comma-separated list, as in sort=-created_at." },
           },
           %i[filter bad_shape] => {
             title: "Invalid filter parameter",

--- a/lib/json_api_kit/request/contract/paging.rb
+++ b/lib/json_api_kit/request/contract/paging.rb
@@ -57,12 +57,10 @@ module JsonApiKit
             validates :anchor, presence: true, if: -> { window? }
 
             validate :check_cursors, if: -> { raw_cursors.present? }
-            validate :check_cursor_ordering,
-                     if: -> { cursors.present? && ordering && resource.sortable_by?(ordering:) }
+            validate :check_cursor_ordering, if: -> { cursors.present? && sortable? }
             validate :check_anchor_name, if: -> { anchor.present? }
             validate :check_anchor_value, if: -> { anchor.present? }
-            validate :check_anchor_ordering,
-                     if: -> { anchor.present? && resource.sortable_by?(ordering:) }
+            validate :check_anchor_ordering, if: -> { anchor.present? && sortable? }
 
             def cursor? = after.present? || before.present?
 
@@ -86,7 +84,13 @@ module JsonApiKit
 
             def raw_sort = options[:raw_parameters][:sort]
 
-            def ordering = raw_sort.nil? ? {} : INDIFFERENT_HASH.cast(raw_sort)
+            def ordering = raw_sort.nil? ? {} : Sorting::SORT.cast(raw_sort)
+
+            def sortable?
+              return false unless ordering
+              ordering.values.all? { it.in?(Sorting::DIRECTIONS.values) } &&
+                resource.sortable_by?(ordering:)
+            end
 
             def window_size
               return unless before_size || after_size

--- a/lib/json_api_kit/request/contract/sorting.rb
+++ b/lib/json_api_kit/request/contract/sorting.rb
@@ -6,10 +6,30 @@ module JsonApiKit
       module Sorting
         extend ActiveSupport::Concern
 
-        DIRECTIONS = %w[asc desc].freeze
+        DIRECTIONS = { "-" => :desc, "" => :asc }.freeze
+
+        class SortType < IndifferentHashType
+          def cast_value(value)
+            super(value.is_a?(String) ? sorts(value) : value)
+          end
+
+          private
+
+          def sorts(value)
+            value
+              .split(",")
+              .to_h do |raw_sort|
+                raw_sort
+                  .partition(/\A-/)
+                  .then { |head, match, tail| [head.presence || tail, DIRECTIONS[match]] }
+              end
+          end
+        end
+
+        SORT = SortType.new
 
         included do
-          attribute :sort, INDIFFERENT_HASH
+          attribute :sort, SORT
 
           validate :check_sort_names, if: -> { sort.present? }
           validate :check_sort_directions, if: -> { sort.present? }
@@ -21,7 +41,7 @@ module JsonApiKit
 
         def check_sort_directions
           sort.each_value do |direction|
-            next if direction.to_s.in?(DIRECTIONS)
+            next if direction.in?(DIRECTIONS.values)
             errors.add(:sort, :unknown_direction, direction:, message: "unknown direction")
           end
         end

--- a/spec/integration/json_api_kit/anchors_spec.rb
+++ b/spec/integration/json_api_kit/anchors_spec.rb
@@ -46,6 +46,32 @@ RSpec.describe "a listing entered at an anchor" do
     )
   end
 
+  describe "the links either side of the window" do
+    let(:query) do
+      {
+        "sort" => "created_at",
+        "page" => {
+          "anchor" => {
+            "id" => middle.id.to_s,
+          },
+          "before_size" => "1",
+          "after_size" => "1",
+        },
+      }
+    end
+
+    let(:next_listing) { listing_of(parameters_of(document.dig(:links, :next))) }
+    let(:previous_listing) { listing_of(parameters_of(document.dig(:links, :prev))) }
+
+    it "returns the rows after the window" do
+      expect(listed_ids(next_listing)).to eq([latest.id.to_s])
+    end
+
+    it "returns the rows before the window" do
+      expect(listed_ids(previous_listing)).to eq([earliest.id.to_s])
+    end
+  end
+
   context "when the page has a size alone" do
     let(:params) do
       {

--- a/spec/integration/json_api_kit/documents_spec.rb
+++ b/spec/integration/json_api_kit/documents_spec.rb
@@ -19,19 +19,37 @@ RSpec.describe "a rendered document" do
 
     context "when all parameters are strings" do
       let(:params) do
-        { "sort" => { "created_at" => "asc" }, "fields" => { "topics" => %w[title] } }
+        {
+          "sort" => "created_at",
+          "include" => "user",
+          "fields" => {
+            "topics" => "title,user",
+          },
+          "page" => {
+            "size" => "1",
+          },
+        }
       end
-      let(:query) { {} }
 
-      it "renders the same listing" do
+      it "renders the same page" do
         expect(document).to eq(
           data: [
-            topic_object(oldest, fields: %w[title]),
-            topic_object(middle, fields: %w[title]),
-            topic_object(newest, fields: %w[title]),
+            topic_object(
+              oldest,
+              fields: %w[title],
+              relationships: {
+                "user" =>
+                  relationship_object(
+                    "topics",
+                    oldest,
+                    "user",
+                    data: identifier_of("users", oldest.user),
+                  ),
+              },
+            ),
           ],
-          included: [],
-          links: links_of,
+          included: [user_object(oldest.user)],
+          links: links_of(next: page_url(after: cursor_of_record(oldest), size: 1)),
         )
       end
     end

--- a/spec/integration/json_api_kit/errors_spec.rb
+++ b/spec/integration/json_api_kit/errors_spec.rb
@@ -8,15 +8,31 @@ RSpec.describe "a refused request" do
   let(:cursor) { cursor_of_record(middle) }
 
   describe "the sort parameter" do
-    context "when the sort is a string" do
-      let(:params) { { sort: "created_at" } }
+    context "when the sort is a list" do
+      let(:params) { { sort: %w[created_at] } }
 
       it "refuses the sort" do
         expect(document).to eq(
           errors: [
             refusal(
               title: "Invalid sort parameter",
-              detail: "sort must name a direction for each sort.",
+              detail: "sort must be a comma-separated list, as in sort=-created_at.",
+              parameter: "sort",
+            ),
+          ],
+        )
+      end
+    end
+
+    context "when the sort is a string the resource does not declare" do
+      let(:params) { { sort: "secrets" } }
+
+      it "refuses the sort" do
+        expect(document).to eq(
+          errors: [
+            refusal(
+              title: "No such sort",
+              detail: "There is no sort named secrets.",
               parameter: "sort",
             ),
           ],
@@ -55,6 +71,54 @@ RSpec.describe "a refused request" do
             refusal(
               title: "No such sort direction",
               detail: "Sort direction sideways is not asc or desc.",
+              parameter: "sort",
+            ),
+          ],
+        )
+      end
+    end
+
+    context "when an unknown sort direction comes with an anchor" do
+      let(:params) { { sort: { created_at: :sideways }, page: { anchor: { id: middle.id } } } }
+
+      it "refuses the sort alone" do
+        expect(document).to eq(
+          errors: [
+            refusal(
+              title: "No such sort direction",
+              detail: "Sort direction sideways is not asc or desc.",
+              parameter: "sort",
+            ),
+          ],
+        )
+      end
+    end
+
+    context "when an unknown sort direction comes with a cursor" do
+      let(:params) { { sort: { created_at: :sideways }, page: { after: cursor } } }
+
+      it "refuses the sort alone" do
+        expect(document).to eq(
+          errors: [
+            refusal(
+              title: "No such sort direction",
+              detail: "Sort direction sideways is not asc or desc.",
+              parameter: "sort",
+            ),
+          ],
+        )
+      end
+    end
+
+    context "when a sort sent as a list comes with an anchor" do
+      let(:params) { { sort: %w[created_at], page: { anchor: { id: middle.id } } } }
+
+      it "refuses the sort alone" do
+        expect(document).to eq(
+          errors: [
+            refusal(
+              title: "Invalid sort parameter",
+              detail: "sort must be a comma-separated list, as in sort=-created_at.",
               parameter: "sort",
             ),
           ],
@@ -194,8 +258,8 @@ RSpec.describe "a refused request" do
       end
     end
 
-    context "when the fieldset of a type is a string" do
-      let(:params) { { fields: { topics: "title" } } }
+    context "when the fieldset of a type is a number" do
+      let(:params) { { fields: { topics: 42 } } }
 
       it "refuses the fieldset" do
         expect(document).to eq(

--- a/spec/integration/json_api_kit/relationships_spec.rb
+++ b/spec/integration/json_api_kit/relationships_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe "a document with related records" do
   describe "a record two paths reach" do
     fab!(:post) { Fabricate(:post, topic:, user: author) }
 
-    let(:params) { { include: %w[user posts.user.groups] } }
+    let(:params) { { include: "user,posts.user.groups" } }
 
     it "renders it one time with its relationships" do
       expect(document).to eq(

--- a/spec/integration/json_api_kit/support.rb
+++ b/spec/integration/json_api_kit/support.rb
@@ -192,6 +192,8 @@ RSpec.shared_context "with a listing of topics" do
 
   def cursor_at(index, rendered = document) = cursor_of(rendered[:data][index])
 
+  def parameters_of(url) = Rack::Utils.parse_nested_query(URI.parse(url).query)
+
   def cursor_of_record(record, of: resource, sort: {})
     order = of.order(sort.transform_keys(&:to_s))
     order.locate(of.model.where(id: record.id)).cursor.to_s

--- a/spec/lib/json_api_kit/pagination/direction_spec.rb
+++ b/spec/lib/json_api_kit/pagination/direction_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe JsonApiKit::Pagination::Direction do
         expect { direction }.to raise_error(ArgumentError)
       end
     end
+
+    context "when the declaration is a string" do
+      let(:declaration) { "asc" }
+
+      it "refuses the direction" do
+        expect { direction }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe "#to_sym" do

--- a/spec/lib/json_api_kit/query/collection_spec.rb
+++ b/spec/lib/json_api_kit/query/collection_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe JsonApiKit::Query::Collection do
     end
 
     context "when the fields hold a column attribute" do
-      let(:params) { { fields: { topics: [:title] } } }
+      let(:params) { { fields: { topics: %w[title] } } }
 
       it "renders only those fields" do
         expect(fields.first.keys).to contain_exactly("title")
@@ -143,7 +143,7 @@ RSpec.describe JsonApiKit::Query::Collection do
           attribute(:slug) { |record| record.title.parameterize }
         end
       end
-      let(:params) { { fields: { topics: %i[title slug] } } }
+      let(:params) { { fields: { topics: %w[title slug] } } }
 
       it "reads the whole row" do
         expect(query.records.first.record.attributes.keys).to include("closed", "views")

--- a/spec/lib/json_api_kit/request/contract/collection_spec.rb
+++ b/spec/lib/json_api_kit/request/contract/collection_spec.rb
@@ -58,9 +58,47 @@ RSpec.describe JsonApiKit::Request::Contract::Collection, type: :model do
   describe "Sorting" do
     it { is_expected.to allow_value(nil, {}, { created_at: :asc }).for(:sort) }
     it { is_expected.to allow_value({ created_at: :desc, title: :asc }).for(:sort) }
+    it { is_expected.to allow_value("", "created_at", "-created_at").for(:sort) }
+    it { is_expected.to allow_value("created_at,-title").for(:sort) }
     it { is_expected.not_to allow_value({ secrets: :asc }).for(:sort) }
-    it { is_expected.not_to allow_value({ created_at: :sideways }).for(:sort) }
-    it { is_expected.not_to allow_value("created_at", %w[created_at], 5, "").for(:sort) }
+    it do
+      is_expected.not_to allow_value({ created_at: :sideways }, { created_at: "asc" }).for(:sort)
+    end
+    it { is_expected.not_to allow_value("secrets", "created_at,secrets").for(:sort) }
+    it { is_expected.not_to allow_value(%w[created_at], 5).for(:sort) }
+
+    context "when sort is a string" do
+      let(:params) { { sort: "-created_at,title" } }
+
+      it "converts it as a hash" do
+        expect(contract.sort).to eq("created_at" => :desc, "title" => :asc)
+      end
+
+      context "when there’s a hyphen in the sort name" do
+        let(:params) { { sort: "last-posted-at" } }
+
+        it "converts it as a hash" do
+          expect(contract.sort).to eq("last-posted-at" => :asc)
+        end
+      end
+
+      context "when there’s also a cursor" do
+        let(:params) { { sort: "title", page: { after: cursor } } }
+
+        it "checks the cursor against that sort" do
+          expect(contract).to be_invalid
+          expect(contract.errors).to be_of_kind(:"page.after", :unreadable_cursor)
+        end
+      end
+    end
+
+    context "when sort is a hash" do
+      let(:params) { { sort: { created_at: :desc } } }
+
+      it "returns it as a hash" do
+        expect(contract.sort).to eq("created_at" => :desc)
+      end
+    end
   end
 
   describe "Filtering" do
@@ -72,14 +110,47 @@ RSpec.describe JsonApiKit::Request::Contract::Collection, type: :model do
 
   describe "Including" do
     it { is_expected.to allow_value(nil, [], %w[user]).for(:include) }
-    it { is_expected.to allow_value("", [""]).for(:include) }
+    it { is_expected.to allow_value("", [""], "user").for(:include) }
     it { is_expected.not_to allow_value(%w[secrets], %w[user.groups]).for(:include) }
+    it { is_expected.not_to allow_value("secrets", "user,secrets").for(:include) }
+
+    context "when include is a string" do
+      let(:params) { { include: "user,posts.user" } }
+
+      it "converts it as a list of paths" do
+        expect(contract.include).to eq(%w[user posts.user])
+      end
+    end
   end
 
   describe "Fieldsets" do
     it { is_expected.to allow_value(nil, {}, { topics: %w[title created_at] }).for(:fields) }
+    it { is_expected.to allow_value({ topics: "title" }, { topics: "" }).for(:fields) }
     it { is_expected.not_to allow_value("title", [1], { topics: 42 }).for(:fields) }
-    it { is_expected.not_to allow_value({ topics: "title" }).for(:fields) }
+
+    context "when fieldset is a string" do
+      let(:params) { { fields: { topics: "title,created_at" } } }
+
+      it "converts it as a list of fields" do
+        expect(contract.fields).to eq("topics" => %w[title created_at])
+      end
+    end
+
+    context "when fieldset is empty" do
+      let(:params) { { fields: { topics: "" } } }
+
+      it "converts it as an empty list" do
+        expect(contract.fields).to eq("topics" => [])
+      end
+    end
+
+    context "when  fieldset is a list of symbols" do
+      let(:params) { { fields: { topics: %i[title] } } }
+
+      it "converts it as a list of fields" do
+        expect(contract.fields).to eq("topics" => %w[title])
+      end
+    end
   end
 
   describe "Anchoring" do

--- a/spec/lib/json_api_kit/request/contract/individual_spec.rb
+++ b/spec/lib/json_api_kit/request/contract/individual_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe JsonApiKit::Request::Contract::Individual, type: :model do
 
   describe "Fieldsets" do
     it { is_expected.to allow_value(nil, {}, { topics: %w[title created_at] }).for(:fields) }
+    it { is_expected.to allow_value({ topics: "title" }, { topics: "" }).for(:fields) }
     it { is_expected.not_to allow_value("title", [1], { topics: 42 }).for(:fields) }
-    it { is_expected.not_to allow_value({ topics: "title" }).for(:fields) }
   end
 end

--- a/spec/lib/json_api_kit/request_spec.rb
+++ b/spec/lib/json_api_kit/request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe JsonApiKit::Request do
     let(:params) do
       {
         fields: {
-          users: %i[username],
+          users: %w[username],
         },
         include: %w[user.groups],
         sort: {
@@ -62,7 +62,7 @@ RSpec.describe JsonApiKit::Request do
     context "when a caller asks for one record" do
       subject(:request) { described_class::Individual.new(params, guardian:) }
 
-      let(:params) { { id: 12, fields: { users: %i[username] } } }
+      let(:params) { { id: 12, fields: { users: %w[username] } } }
 
       it "leaves the id out" do
         expect(for_sideload.keys).to contain_exactly(:fields, :include)
@@ -112,14 +112,6 @@ RSpec.describe JsonApiKit::Request do
         expect(ordering).to be_empty
       end
     end
-
-    context "when a caller spells the parameters as strings" do
-      let(:params) { { "sort" => { "created_at" => "desc" } } }
-
-      it "returns the same ordering" do
-        expect(ordering).to eq("created_at" => :desc)
-      end
-    end
   end
 
   describe "#filtering" do
@@ -143,7 +135,7 @@ RSpec.describe JsonApiKit::Request do
   describe "#fields" do
     subject(:fields) { request.fields }
 
-    let(:params) { { fields: { topics: [:title] } } }
+    let(:params) { { fields: { topics: %w[title] } } }
 
     it "returns the fields of each type" do
       expect(fields).to eq("topics" => %w[title])

--- a/spec/lib/json_api_kit/sideload_spec.rb
+++ b/spec/lib/json_api_kit/sideload_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe JsonApiKit::Sideload do
     end
 
     context "when a request asks for fields of the related type" do
-      let(:params) { { fields: { users: [:username] } } }
+      let(:params) { { fields: { users: %w[username] } } }
 
       it "renders the related record as those fields" do
         expect(linkage.records.map(&:attributes)).to eq([{ "username" => author.username }])


### PR DESCRIPTION
A client sends `sort=-created_at` but `Resource` takes `sort: { created_at: :desc }`. The contract already validates everything, so it’s logical for it to also convert values. That’s necessary for wiring the kit in a controller.

A caller that already passes the kit's own parameters gets them back unchanged, so nothing below the contract had to move.