### PR TITLE
FIX: Stop placeholder usernames sticking after email code signup

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -977,7 +977,7 @@ class SessionController < ApplicationController
       render json: login_not_approved
     elsif payload = login_error_check(user)
       render json: payload
-    elsif created_account && !cookies[:sso_payload]
+    elsif created_account
       # Same tail as `login`, except the response tells the client a new
       # account was created so it can show the "account ready" step before
       # following the usual post-login redirect.
@@ -1001,10 +1001,25 @@ class SessionController < ApplicationController
                  # the avatar picker needs the upload permission passed through.
                  can_upload_avatar:
                    user.in_any_groups?(SiteSetting.uploaded_avatars_allowed_groups_map),
+                 # Only set when a DiscourseConnect provider handoff is pending.
+                 redirect_url: deferred_sso_provider_url,
                )
     else
       login(user)
     end
+  end
+
+  # A pending provider handoff would redirect as soon as the session exists,
+  # skipping the account-ready step, so the URL is handed to the client to
+  # follow once signup is finished (as account activation does). Consumes the
+  # payload so a later login isn't sent through a handoff it didn't start.
+  def deferred_sso_provider_url
+    return if !SiteSetting.enable_discourse_connect_provider
+
+    payload = cookies.delete(:sso_payload)
+    return if payload.blank?
+
+    "#{session_sso_provider_url}?#{payload}"
   end
 
   def invalid_login_code

--- a/app/services/user/action/create_from_verified_email.rb
+++ b/app/services/user/action/create_from_verified_email.rb
@@ -16,7 +16,9 @@ class User::Action::CreateFromVerifiedEmail < Service::ActionBase
     user.attributes = {
       email: email,
       username: username,
-      name: name.presence || username,
+      # The generated username is a placeholder, so it must never become the
+      # full name. A staged account's existing name is real and survives.
+      name: name.presence || user.name,
       active: false,
       locale: I18n.locale,
       ip_address: ip_address,

--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -74,6 +74,7 @@ export default class CodeLoginForm extends Component {
     showValidationOnInit: false,
   });
   #cooldownTimer;
+  #postSignupRedirectUrl;
   #usernameCheckSeq = 0;
   @tracked _step = "email";
 
@@ -368,6 +369,10 @@ export default class CodeLoginForm extends Component {
     // Only prefill an email-derived suggestion; otherwise the user picks one.
     this.username = result.prefill_username ? user.username : "";
     this.avatarTemplate = user.avatar_template;
+    // Set when the server held back a DiscourseConnect provider handoff so this
+    // step could run; continuing resumes it.
+    this.#postSignupRedirectUrl = result.redirect_url;
+
     if (this.usernameEditable && this.username) {
       this.checkUsernameAvailability();
     }
@@ -481,7 +486,7 @@ export default class CodeLoginForm extends Component {
 
     // Leave the button disabled and spinning through the redirect so it doesn't
     // flash back to its idle state before the page navigates away.
-    this.redirectAfterLogin();
+    this.redirectAfterLogin(this.#postSignupRedirectUrl);
   }
 
   @action

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -693,6 +693,19 @@ RSpec.describe SessionController do
 
     before { SiteSetting.enable_local_logins_via_code = true }
 
+    def begin_discourse_connect_provider_handoff
+      sso = DiscourseConnectBase.new
+      sso.nonce = "handoffnonce"
+      sso.sso_secret = "topsecret"
+      sso.return_sso_url = "http://ask.example.com/sso"
+
+      SiteSetting.enable_discourse_connect_provider = true
+      SiteSetting.discourse_connect_provider_secrets = "ask.example.com|#{sso.sso_secret}"
+      cookies[:sso_payload] = sso.payload
+
+      sso.payload
+    end
+
     it "returns a 404 when login via code is disabled" do
       SiteSetting.enable_local_logins_via_code = false
 
@@ -776,6 +789,15 @@ RSpec.describe SessionController do
       expect(EmailLoginCode.active.for_email(user.email)).to be_empty
     end
 
+    it "follows a pending DiscourseConnect provider handoff for an existing user" do
+      begin_discourse_connect_provider_handoff
+
+      post "/session/login-code/verify.json", params: { email: user.email, code: }
+
+      expect(response.status).to eq(302)
+      expect(response.location).to start_with("http://ask.example.com/sso")
+    end
+
     it "does not log in with a code issued for a normalized email alias" do
       SiteSetting.normalize_emails = true
       user.update!(email: "foobar@example.com")
@@ -840,6 +862,18 @@ RSpec.describe SessionController do
         # Off by default, so the client makes the user pick rather than
         # prefilling a generic username.
         expect(body["prefill_username"]).to eq(false)
+      end
+
+      it "defers a pending DiscourseConnect provider handoff to the account-ready step" do
+        payload = begin_discourse_connect_provider_handoff
+
+        post "/session/login-code/verify.json", params: { email: "newuser@example.com", code: }
+
+        body = response.parsed_body
+        expect(body["account_created"]).to eq(true)
+        expect(body["redirect_url"]).to end_with("/session/sso_provider?#{payload}")
+        # Consumed, so a later login isn't sent through this handoff.
+        expect(cookies[:sso_payload]).to be_blank
       end
 
       it "flags the username for prefill when email-based suggestions are on" do

--- a/spec/services/email_login_code/redeem_spec.rb
+++ b/spec/services/email_login_code/redeem_spec.rb
@@ -127,10 +127,8 @@ RSpec.describe EmailLoginCode::Redeem do
         expect(result[:user].username).to eq("jane")
       end
 
-      it "defaults the name to the generated username" do
-        user = result[:user]
-
-        expect(user.name).to eq(user.username)
+      it "leaves the name blank rather than reusing the generated username" do
+        expect(result[:user].name).to be_blank
       end
 
       context "when a name is provided" do
@@ -268,12 +266,13 @@ RSpec.describe EmailLoginCode::Redeem do
 
       it { is_expected.to run_successfully }
 
-      it "unstages and activates the existing user" do
+      it "unstages and activates the existing user, keeping its name" do
         user = result[:user]
 
         expect(user.id).to eq(staged_user.id)
         expect(user).not_to be_staged
         expect(user).to be_active
+        expect(user.name).to eq(staged_user.name)
         expect(login_code.reload.consumed_at).to be_present
       end
     end

--- a/spec/system/discourse_connect_provider_spec.rb
+++ b/spec/system/discourse_connect_provider_spec.rb
@@ -34,6 +34,40 @@ describe "Discourse Connect Provider" do
       ignore_query: false,
     )
   end
+
+  it "lets a new account pick a username before returning to the return_sso_url" do
+    SiteSetting.enable_local_logins_via_email = true
+    SiteSetting.enable_local_logins_via_code = true
+    new_email = "new.person@example.com"
+    sso, sig = build_discourse_connect_payload(return_url)
+
+    visit "/"
+    visit "/session/sso_provider?sso=#{CGI.escape(sso)}&sig=#{sig}"
+    expect(page).to have_current_path("/login")
+    expect(page).to have_css("#login-account-name")
+
+    find("#one-time-code-link").click
+    find(".code-login-form__email-step input[type='email']").fill_in(with: new_email)
+    find(".code-login-form__continue").click
+
+    wait_for(timeout: 10) { ActionMailer::Base.deliveries.present? }
+    find(".d-otp-input").fill_in(with: ActionMailer::Base.deliveries.last.subject[/(\d{6})/, 1])
+
+    # The handoff waits here rather than redirecting as soon as the session
+    # exists, so the generated placeholder username can be replaced.
+    expect(page).to have_css(".code-login-form__complete-step")
+    find("#code-login-username").fill_in(with: "janedoe")
+    expect(page).to have_no_css(".code-login-form__continue-to-site[disabled]")
+    find(".code-login-form__continue-to-site").click
+
+    expect(page).to have_current_path(
+      /#{Regexp.escape(return_url)}\?sso=.*&sig=[0-9a-f]+/,
+      url: true,
+      ignore_query: false,
+    )
+    expect(User.find_by_email(new_email).username).to eq("janedoe")
+  end
+
   context "with two-factor authentication" do
     let!(:user_second_factor) { Fabricate(:user_second_factor_totp, user: user) }
     let!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup, user: user) }


### PR DESCRIPTION
**Previously**, a DiscourseConnect provider handoff redirected away as soon as the account existed, so email code signups never saw the username step and kept a generated `userNNN` name.

**In this update**, the handoff waits for the account-ready step to finish, and the generated username is no longer copied into the full name.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-jg4e21.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-ofh8io.png) |