### PR TITLE
FIX: ensure user deletion confirmation in review queue names correct user

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -812,7 +812,7 @@ class Reviewable < ActiveRecord::Base
   def delete_user_actions(actions, bundle = nil, require_reject_reason: false)
     bundle ||=
       actions.add_bundle(
-        "reject_user",
+        "#{id}-reject_user",
         icon: "user-xmark",
         label: "reviewables.actions.reject_user.title",
       )

--- a/app/serializers/reviewable_action_serializer.rb
+++ b/app/serializers/reviewable_action_serializer.rb
@@ -2,6 +2,7 @@
 
 class ReviewableActionSerializer < ApplicationSerializer
   attributes :id,
+             :action_name,
              :icon,
              :button_class,
              :label,

--- a/frontend/discourse/app/components/modal/flag.gjs
+++ b/frontend/discourse/app/components/modal/flag.gjs
@@ -48,20 +48,20 @@ export default class Flag extends Component {
       label: i18n("flagging.take_action"),
       actions: [
         {
-          id: "agree_and_hide",
+          action_name: "agree_and_hide",
           icon: "thumbs-up",
           label: i18n("flagging.take_action_options.default.title"),
           description: i18n("flagging.take_action_options.default.details"),
         },
         {
-          id: "agree_and_suspend",
+          action_name: "agree_and_suspend",
           icon: "ban",
           label: i18n("flagging.take_action_options.suspend.title"),
           description: i18n("flagging.take_action_options.suspend.details"),
           client_action: "suspend",
         },
         {
-          id: "agree_and_silence",
+          action_name: "agree_and_silence",
           icon: "microphone-slash",
           label: i18n("flagging.take_action_options.silence.title"),
           description: i18n("flagging.take_action_options.silence.details"),

--- a/frontend/discourse/app/components/reviewable-bundled-action.gjs
+++ b/frontend/discourse/app/components/reviewable-bundled-action.gjs
@@ -27,9 +27,11 @@ export default class ReviewableBundledAction extends Component {
   }
 
   @action
-  perform(id) {
-    if (id) {
-      const _action = this.args.bundle.actions.find((a) => a.id === id);
+  perform(actionName) {
+    if (actionName) {
+      const _action = this.args.bundle.actions.find(
+        (a) => a.action_name === actionName
+      );
       this.args.performAction(_action);
     } else {
       this.args.performAction(this.first);
@@ -40,6 +42,7 @@ export default class ReviewableBundledAction extends Component {
     {{#if this.multiple}}
       <DropdownSelectBox
         @nameProperty="label"
+        @valueProperty="action_name"
         @content={{@bundle.actions}}
         @onChange={{this.perform}}
         @options={{hash
@@ -51,7 +54,7 @@ export default class ReviewableBundledAction extends Component {
         class={{dConcatClass
           "reviewable-action-dropdown"
           "btn-icon-text"
-          (dasherize this.first.id)
+          (dasherize this.first.action_name)
           this.first.button_class
         }}
       />
@@ -63,7 +66,7 @@ export default class ReviewableBundledAction extends Component {
         class={{dConcatClass
           "btn-default"
           "reviewable-action"
-          (dasherize this.first.id)
+          (dasherize this.first.action_name)
           this.first.button_class
         }}
       />

--- a/frontend/discourse/tests/helpers/review-pretender.js
+++ b/frontend/discourse/tests/helpers/review-pretender.js
@@ -1,5 +1,55 @@
 import { set } from "@ember/object";
 
+const BUNDLES = {
+  approve: { action_ids: ["approve"] },
+  reject: { action_ids: ["reject"] },
+  reject_user: {
+    icon: "user-xmark",
+    label: "Delete User...",
+    action_ids: ["reject_user_delete", "reject_user_block"],
+  },
+};
+
+const ACTIONS = {
+  approve: { label: "Approve", icon: "far-thumbs-up" },
+  reject: { label: "Reject", icon: "far-thumbs-down" },
+  reject_user_delete: {
+    icon: "user-xmark",
+    button_class: null,
+    label: "Delete User",
+    description: "The user will be deleted from the forum.",
+    require_reject_reason: true,
+  },
+  reject_user_block: {
+    icon: "ban",
+    button_class: null,
+    label: "Delete and Block User",
+    description:
+      "The user will be deleted, and we'll block their IP and email address.",
+    require_reject_reason: true,
+  },
+};
+
+function bundledActionsFor(reviewableId, bundleIds) {
+  return bundleIds.map((bundleId) => ({
+    ...BUNDLES[bundleId],
+    id: `${reviewableId}-${bundleId}`,
+    action_ids: BUNDLES[bundleId].action_ids.map(
+      (actionId) => `${reviewableId}-${actionId}`
+    ),
+  }));
+}
+
+function actionsFor(reviewableId, bundleIds) {
+  return bundleIds
+    .flatMap((bundleId) => BUNDLES[bundleId].action_ids)
+    .map((actionId) => ({
+      ...ACTIONS[actionId],
+      id: `${reviewableId}-${actionId}`,
+      action_name: actionId,
+    }));
+}
+
 export default function (helpers) {
   const { response } = helpers;
 
@@ -14,6 +64,9 @@ export default function (helpers) {
     reviewable_score_ids: [1, 2],
   };
 
+  const USER_BUNDLES = ["approve", "reject", "reject_user"];
+  const QUEUED_BUNDLES = ["approve", "reject"];
+
   this.get("/review", () => {
     return response(200, {
       reviewables: [
@@ -27,7 +80,7 @@ export default function (helpers) {
           created_at: "2019-01-14T19:49:53.571Z",
           username: "newbie",
           email: "newbie@example.com",
-          bundled_action_ids: ["approve", "reject", "reject_user"],
+          bundled_action_ids: USER_BUNDLES.map((b) => `1234-${b}`),
           reviewable_score_ids: [],
         },
         {
@@ -51,55 +104,18 @@ export default function (helpers) {
             { id: "payload.raw", type: "textarea" },
             { id: "payload.tags", type: "tags" },
           ],
-          bundled_action_ids: ["approve", "reject"],
+          bundled_action_ids: QUEUED_BUNDLES.map((b) => `4321-${b}`),
           reviewable_score_ids: [],
         },
         flag,
       ],
       bundled_actions: [
-        {
-          id: "approve",
-          action_ids: ["approve"],
-        },
-        {
-          id: "reject",
-          action_ids: ["reject"],
-        },
-        {
-          id: "reject_user",
-          icon: "user-xmark",
-          label: "Delete User...",
-          action_ids: ["reject_user_delete", "reject_user_block"],
-        },
+        ...bundledActionsFor(1234, USER_BUNDLES),
+        ...bundledActionsFor(4321, QUEUED_BUNDLES),
       ],
       actions: [
-        {
-          id: "approve",
-          label: "Approve",
-          icon: "far-thumbs-up",
-        },
-        {
-          id: "reject",
-          label: "Reject",
-          icon: "far-thumbs-down",
-        },
-        {
-          id: "reject_user_delete",
-          icon: "user-xmark",
-          button_class: null,
-          label: "Delete User",
-          description: "The user will be deleted from the forum.",
-          require_reject_reason: true,
-        },
-        {
-          id: "reject_user_block",
-          icon: "ban",
-          button_class: null,
-          label: "Delete and Block User",
-          description:
-            "The user will be deleted, and we'll block their IP and email address.",
-          require_reject_reason: true,
-        },
+        ...actionsFor(1234, USER_BUNDLES),
+        ...actionsFor(4321, QUEUED_BUNDLES),
       ],
       reviewable_scores: [
         {

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -58,6 +58,13 @@ class Reviewable < ActiveRecord::Base
         @icon, @button_class, @label = icon, button_class, label
       end
 
+      # The id without its reviewable prefix, e.g. "post-delete_user", so the
+      # client can key styling and selection on something stable. Must not end
+      # in `_id`: the client store reads such attributes as record references.
+      def action_name
+        id.split("-", 2).last
+      end
+
       def server_action
         id.split("-").last
       end
@@ -69,13 +76,18 @@ class Reviewable < ActiveRecord::Base
       bundle
     end
 
+    # Ids are scoped to the reviewable because actions serialize into one
+    # id-keyed collection for the whole queue. Two reviewables offering the same
+    # action would otherwise collapse into a single record, and every one of
+    # them would render the last copy. Bundle ids are scoped by their callers.
     def add(id, bundle: nil)
-      id = [reviewable.target_type&.underscore, id].compact_blank.join("-")
-      action = Actions.common_actions[id] || Action.new(id)
+      action_name = [reviewable.target_type&.underscore, id].compact_blank.join("-")
+      scoped_id = [reviewable.id, action_name].compact_blank.join("-")
+      action = Actions.common_actions[action_name] || Action.new(scoped_id)
       yield action if block_given?
       @content << action
 
-      bundle ||= add_bundle(id)
+      bundle ||= add_bundle(scoped_id)
       bundle.actions << action
     end
   end

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -444,13 +444,13 @@ RSpec.describe ReviewableQueuedPost, type: :model do
 
       it "includes actions" do
         actions = reviewable.actions_for(Guardian.new(admin))
-        action_ids = actions.to_a.map(&:id).map(&:to_s)
+        action_names = actions.to_a.map(&:action_name)
 
-        expect(action_ids).to include("approve_post")
-        expect(action_ids).to include("reject_post")
-        expect(action_ids).to include("revise_and_reject_post")
-        expect(action_ids).to include("delete_user")
-        expect(action_ids).to include("delete_user_block")
+        expect(action_names).to include("approve_post")
+        expect(action_names).to include("reject_post")
+        expect(action_names).to include("revise_and_reject_post")
+        expect(action_names).to include("delete_user")
+        expect(action_names).to include("delete_user_block")
       end
     end
   end

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -873,12 +873,14 @@ RSpec.describe Reviewable, type: :model do
 
     it "gets the bundles and actions for a reviewable" do
       actions = reviewable.actions_for(user.guardian)
-      expect(actions.bundles.map(&:id)).to eq(["approve_post", "#{reviewable.id}-reject-post"])
-      expect(actions.bundles.find { |b| b.id == "approve_post" }.actions.map(&:id)).to eq(
-        ["approve_post"],
+      expect(actions.bundles.map(&:id)).to eq(
+        ["#{reviewable.id}-approve_post", "#{reviewable.id}-reject-post"],
       )
       expect(
-        actions.bundles.find { |b| b.id == "#{reviewable.id}-reject-post" }.actions.map(&:id),
+        actions.bundles.find { |b| b.bundle_id == "approve_post" }.actions.map(&:action_name),
+      ).to eq(["approve_post"])
+      expect(
+        actions.bundles.find { |b| b.bundle_id == "reject-post" }.actions.map(&:action_name),
       ).to eq(%w[reject_post revise_and_reject_post])
     end
 

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -75,6 +75,34 @@ RSpec.describe ReviewablesController do
         expect(json["meta"]["status"]).to eq("pending")
       end
 
+      it "scopes action ids to their reviewable so confirmations name the right user" do
+        flagger = Fabricate(:user, trust_level: TrustLevel[3])
+        first = PostActionCreator.spam(flagger, Fabricate(:post)).reviewable
+        second = PostActionCreator.spam(flagger, Fabricate(:post)).reviewable
+
+        get "/review.json"
+        expect(response.code).to eq("200")
+        json = response.parsed_body
+
+        action_ids = json["actions"].map { |a| a["id"] }
+        expect(action_ids).to eq(action_ids.uniq)
+        expect(json["bundled_actions"].map { |b| b["id"] }).to eq(
+          json["bundled_actions"].map { |b| b["id"] }.uniq,
+        )
+
+        [first, second].each do |reviewable|
+          action = json["actions"].find { |a| a["id"] == "#{reviewable.id}-post-delete_user_block" }
+
+          expect(action["action_name"]).to eq("post-delete_user_block")
+          expect(action["confirm_message"]).to eq(
+            I18n.t(
+              "reviewables.actions.reject_user.block.confirm",
+              username: reviewable.target_created_by.username,
+            ),
+          )
+        end
+      end
+
       context "with trashed topics and posts" do
         fab!(:post1, :post)
         fab!(:reviewable) do

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -73,6 +73,38 @@ describe "Reviewables" do
     end
   end
 
+  describe "when there are several flagged posts in the queue" do
+    fab!(:flagger) { Fabricate(:user, trust_level: TrustLevel[3]) }
+    fab!(:spammer_one, :user)
+    fab!(:spammer_two, :user)
+
+    it "confirms deletion of the author of the reviewable that was acted on" do
+      reviewables = {
+        spammer_one =>
+          PostActionCreator.spam(flagger, Fabricate(:post, user: spammer_one)).reviewable,
+        spammer_two =>
+          PostActionCreator.spam(flagger, Fabricate(:post, user: spammer_two)).reviewable,
+      }
+
+      visit("/review")
+
+      reviewables.each do |spammer, reviewable|
+        review_page.delete_user_from_reviewable(
+          reviewable,
+          "post-delete_user_block",
+          confirm: false,
+        )
+
+        expect(dialog).to have_content(
+          I18n.t("reviewables.actions.reject_user.block.confirm", username: spammer.username),
+        )
+
+        dialog.click_no
+        expect(dialog).to be_closed
+      end
+    end
+  end
+
   describe "when there is a queued post reviewable with a short post" do
     fab!(:short_queued_reviewable, :reviewable_queued_post)
 


### PR DESCRIPTION
follow-up to https://github.com/discourse/discourse/pull/42605

The reviewable actions were using the same id, so they were collapsed (and the last one won). So in the case of multiple flags with a delete user option on the same page... they'd all have the same confirmation text. 
 
This prefixes action ids with the reviewable id and serializes the name separately as `action_name`, so each reviewable keeps its own copy. Doing this separately allows CSS classes and dropdown values to remain unchanged. 