### PR TITLE
DEV: Add the JSON:API cursor pagination profile

### DIFF
--- a/app/controllers/json_api_kit/base_controller.rb
+++ b/app/controllers/json_api_kit/base_controller.rb
@@ -43,7 +43,9 @@ module JsonApiKit
     end
 
     def render_document(document)
-      render json: document.to_h, status: document.status, content_type: MediaType::JSON_API
+      render json: document.to_h,
+             status: document.status,
+             content_type: Pagination::Profile::MEDIA_TYPE
     end
 
     def negotiate

--- a/lib/json_api_kit/document.rb
+++ b/lib/json_api_kit/document.rb
@@ -35,7 +35,7 @@ module JsonApiKit
 
     def contents = @contents ||= Contents.new(primary_records, query.included)
 
-    def links = { self: urls.current.to_s }
+    def links = { self: { href: urls.current.to_s, type: Pagination::Profile::MEDIA_TYPE } }
 
     def included = contents.related.map { ResourceObject.new(it, urls:).to_h }
   end

--- a/lib/json_api_kit/pagination/profile.rb
+++ b/lib/json_api_kit/pagination/profile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module JsonApiKit
+  module Pagination
+    module Profile
+      URL = "https://jsonapi.org/profiles/ethanresnick/cursor-pagination"
+      MAX_SIZE = "#{URL}/max-size-exceeded"
+      RANGE_UNSUPPORTED = "#{URL}/range-pagination-not-supported"
+      MEDIA_TYPE = %(#{MediaType::JSON_API};profile="#{URL}")
+    end
+  end
+end

--- a/lib/json_api_kit/request/contract/mapper.rb
+++ b/lib/json_api_kit/request/contract/mapper.rb
@@ -4,9 +4,6 @@ module JsonApiKit
   class Request
     class Contract
       class Mapper
-        MAX_SIZE = "https://jsonapi.org/profiles/ethanresnick/cursor-pagination/max-size-exceeded"
-        RANGE_UNSUPPORTED =
-          "https://jsonapi.org/profiles/ethanresnick/cursor-pagination/range-pagination-not-supported"
         NOT_AN_INTEGER = {
           title: "Page size is not an integer",
           detail: ->(_) { "Page size must be an integer." },
@@ -14,7 +11,7 @@ module JsonApiKit
         RANGE = {
           title: "Range pagination is not supported",
           detail: ->(_) { "Use page[after] or page[before], not both." },
-          type: RANGE_UNSUPPORTED,
+          type: Pagination::Profile::RANGE_UNSUPPORTED,
         }.freeze
         INVALID_CURSOR = {
           title: "Invalid cursor",
@@ -125,7 +122,7 @@ module JsonApiKit
             detail: ->(error) do
               "Page size #{error.options[:value]} exceeds the maximum of #{error.options[:count]}."
             end,
-            type: MAX_SIZE,
+            type: Pagination::Profile::MAX_SIZE,
             meta: ->(error) { { page: { maxSize: error.options[:count] } } },
           },
           [:"page.before_size", :not_an_integer] => SIDE_NOT_AN_INTEGER,
@@ -146,7 +143,7 @@ module JsonApiKit
                 "the maximum of #{error.options[:count]}."
             end,
             source: WINDOW_PARAMETER,
-            type: MAX_SIZE,
+            type: Pagination::Profile::MAX_SIZE,
             meta: ->(error) { { page: { maxSize: error.options[:count] } } },
           },
           [:"page.after", :present] => RANGE,

--- a/spec/integration/json_api_kit/endpoint_spec.rb
+++ b/spec/integration/json_api_kit/endpoint_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "a JSON:API endpoint", type: :request do
   let(:base) { "http://test.localhost/api" }
   let(:current) { "#{base}/topics" }
   let(:media_type) { "application/vnd.api+json" }
+  let(:profile_media_type) { JsonApiKit::Pagination::Profile::MEDIA_TYPE }
   let(:profile) { "https://jsonapi.org/profiles/ethanresnick/cursor-pagination" }
   let(:path) { "/api/topics" }
   let(:headers) { {} }
@@ -68,7 +69,7 @@ RSpec.describe "a JSON:API endpoint", type: :request do
 
   describe "the response" do
     it "sends the JSON:API media type" do
-      expect(response.media_type).to eq(media_type)
+      expect(response.media_type).to eq(profile_media_type)
     end
 
     it "varies on the accept header" do
@@ -79,7 +80,7 @@ RSpec.describe "a JSON:API endpoint", type: :request do
       let(:path) { "/api/topics.json" }
 
       it "sends the JSON:API media type" do
-        expect(response.media_type).to eq(media_type)
+        expect(response.media_type).to eq(profile_media_type)
       end
 
       it "varies on the accept header" do
@@ -186,7 +187,7 @@ RSpec.describe "a JSON:API endpoint", type: :request do
     it { expect(response).to have_http_status(:internal_server_error) }
 
     it "sends the JSON:API media type" do
-      expect(response.media_type).to eq(media_type)
+      expect(response.media_type).to eq(profile_media_type)
     end
 
     it "sends the reason" do
@@ -214,7 +215,7 @@ RSpec.describe "a JSON:API endpoint", type: :request do
     it { expect(response).to have_http_status(:forbidden) }
 
     it "sends the JSON:API media type" do
-      expect(response.media_type).to eq(media_type)
+      expect(response.media_type).to eq(profile_media_type)
     end
 
     it "sends the reason" do

--- a/spec/integration/json_api_kit/support.rb
+++ b/spec/integration/json_api_kit/support.rb
@@ -184,7 +184,10 @@ RSpec.shared_context "with a listing of topics" do
 
   def profile_link(name) = "https://jsonapi.org/profiles/ethanresnick/cursor-pagination/#{name}"
 
-  def self_link = query.blank? ? current : "#{current}?#{query.to_query}"
+  def self_link
+    href = query.blank? ? current : "#{current}?#{query.to_query}"
+    { href:, type: JsonApiKit::Pagination::Profile::MEDIA_TYPE }
+  end
 
   def links_of(**pages) = { self: self_link, **{ prev: nil, next: nil }.merge(pages) }
 

--- a/spec/lib/json_api_kit/document/collection_spec.rb
+++ b/spec/lib/json_api_kit/document/collection_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe JsonApiKit::Document::Collection do
     end
   end
   let(:guardian) { Guardian.new }
-  let(:urls) do
-    JsonApiKit::Urls.new(base: "https://example.com/api", current: "https://example.com/api/topics")
-  end
+  let(:urls) { JsonApiKit::Urls.new(base: "https://example.com/api", current:) }
+  let(:current) { "https://example.com/api/topics" }
+  let(:self_link) { { href: current, type: JsonApiKit::Pagination::Profile::MEDIA_TYPE } }
   let(:params) { {} }
   let(:listing) { resource.all(params, guardian:) }
   let(:primary_data) { document.to_h[:data] }
@@ -88,7 +88,7 @@ RSpec.describe JsonApiKit::Document::Collection do
           data: [],
           included: [],
           links: {
-            self: "https://example.com/api/topics",
+            self: self_link,
             prev: nil,
             next: nil,
           },
@@ -109,7 +109,7 @@ RSpec.describe JsonApiKit::Document::Collection do
 
       it "renders a link to the page at each end" do
         expect(document.to_h[:links]).to eq(
-          self: "https://example.com/api/topics",
+          self: self_link,
           prev: "https://example.com/api/topics?page%5Bbefore%5D=#{page_cursor}",
           next: "https://example.com/api/topics?page%5Bafter%5D=#{page_cursor}",
         )

--- a/spec/lib/json_api_kit/document/individual_spec.rb
+++ b/spec/lib/json_api_kit/document/individual_spec.rb
@@ -13,12 +13,9 @@ RSpec.describe JsonApiKit::Document::Individual do
     end
   end
   let(:guardian) { Guardian.new }
-  let(:urls) do
-    JsonApiKit::Urls.new(
-      base: "https://example.com/api",
-      current: "https://example.com/api/topics/1",
-    )
-  end
+  let(:urls) { JsonApiKit::Urls.new(base: "https://example.com/api", current:) }
+  let(:current) { "https://example.com/api/topics/1" }
+  let(:self_link) { { href: current, type: JsonApiKit::Pagination::Profile::MEDIA_TYPE } }
   let(:reading) { resource.find(topic.id, guardian:) }
 
   describe "#to_h" do
@@ -36,7 +33,7 @@ RSpec.describe JsonApiKit::Document::Individual do
         },
         included: [],
         links: {
-          self: "https://example.com/api/topics/1",
+          self: self_link,
         },
       )
     end


### PR DESCRIPTION
The JSON:API Kit pages by cursor and that’s a JSON:API profile.

The specification requires the profile in the `Content-Type` header. It also recommends it in the top-level `self` link. Every response now carries both.