### PR TITLE
FIX: close PM invite modal after generic email response

### DIFF
--- a/frontend/discourse/app/components/invite-panel.gjs
+++ b/frontend/discourse/app/components/invite-panel.gjs
@@ -382,12 +382,14 @@ export default class InvitePanel extends Component {
         .createInvite(this.invitee.trim(), groupIds, this.customMessage)
         .then((result) => {
           model.setProperties({ saving: false, finished: true });
-          if (this.isPM && result && result.user) {
-            this.get("inviteModel.details.allowed_users").push(
-              EmberObject.create(result.user)
-            );
+          if (this.isPM) {
+            if (result && result.user) {
+              this.get("inviteModel.details.allowed_users").push(
+                EmberObject.create(result.user)
+              );
+            }
             this.toasts.success({
-              data: { message: this.successMessage(result) },
+              data: { message: this.successMessage(this.invitee) },
             });
             this.closeModal();
           } else if (

--- a/frontend/discourse/tests/acceptance/personal-message-test.js
+++ b/frontend/discourse/tests/acceptance/personal-message-test.js
@@ -116,3 +116,29 @@ acceptance("Personal Message - invite", function (needs) {
     assert.dom(".d-modal.add-pm-participants .alert-error").exists();
   });
 });
+
+acceptance("Personal Message - email invite", function (needs) {
+  needs.user({ admin: true });
+  needs.pretender((server, helper) => {
+    server.get("/u/search/users", () => helper.response({ users: [] }));
+    server.post("/t/12/invite", () => helper.response({ success: "OK" }));
+  });
+
+  test("closes the modal after a generic email success response", async function (assert) {
+    await visit("/t/pm-for-testing/12");
+    getOwner(this)
+      .lookup("controller:topic")
+      .model.set("details.can_invite_via_email", true);
+    await click(".topic-map__private-message-map .add-participant-btn");
+
+    const input = selectKit(".invite-user-input");
+    await input.expand();
+    await input.fillInFilter("existing@example.com");
+    await input.selectRowByValue("existing@example.com");
+    await click(".send-invite");
+
+    assert
+      .dom(".d-modal.add-pm-participants")
+      .doesNotExist("the invite modal closes instead of showing an empty body");
+  });
+});

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7250,6 +7250,23 @@ RSpec.describe TopicsController do
         expect(pm.reload.topic_allowed_users.pluck(:user_id)).not_to include(user_2.id)
       end
 
+      it "returns generic success without side effects when an authorized email invite matches an existing user" do
+        sign_in(admin)
+        pm = Fabricate(:private_message_topic, user: admin)
+        small_actions =
+          pm.posts.where(post_type: Post.types[:small_action], action_code: "invited_user")
+
+        expect do
+          post "/t/#{pm.id}/invite.json", params: { email: user_2.email }
+        end.to not_change { pm.reload.topic_allowed_users.count }.and not_change {
+                small_actions.reload.count
+              }.and not_change { Invite.count }.and not_change { EmailLog.count }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+        expect(pm.topic_allowed_users.pluck(:user_id)).not_to include(user_2.id)
+      end
+
       context "when user does not have permission to invite to the topic" do
         fab!(:topic) { pm }
 


### PR DESCRIPTION
## What changed

Inviting an existing user to a personal message by email returns a generic success response without `user` data. This is intentional: exposing the matching account would allow account enumeration.

The invite panel still assumed every successful response contained `result.user`. It therefore stayed open after the generic response and rendered as an empty modal with only a close button. This change closes the modal and shows the existing non-identifying success message when no user payload is returned. Responses that include `result.user` retain the existing behavior.

The server-side operation remains a no-op for an email address belonging to an existing account: it does not add the user, create an `invited_user` action post, create an invite, or send an email.

## Tests

- Adds an acceptance test covering the generic PM email-invite response, closed modal, and success message.
- Adds a request spec documenting that the privacy-preserving response has no server-side side effects.

This fixes the UI regression while preserving the account-enumeration protection introduced by https://github.com/discourse/discourse/commit/5871b7c5a5c159b2e1a911aecb2457f9c4277dab.