### PR TITLE
UX: Add a preview button for the chat notification sound

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-notifications/chat-notifications.gjs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-notifications/chat-notifications.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";
 import ComboBox from "discourse/select-kit/components/combo-box";
+import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 import {
   HEADER_INDICATOR_PREFERENCE_ALL_NEW,
@@ -86,6 +87,11 @@ export default class ChatNotifications extends Component {
     this.model.set("user_option.chat_sound", sound ?? null);
   }
 
+  @action
+  previewChatSound() {
+    this.chatAudioManager?.play(this.chatSound, { throttle: false });
+  }
+
   <template>
     <div class="control-group chat-notifications">
       <label class="control-label">{{i18n
@@ -101,14 +107,24 @@ export default class ChatNotifications extends Component {
 
       <div class="controls controls-dropdown">
         <label>{{i18n "chat.sound.title"}}</label>
-        <ComboBox
-          @valueProperty="value"
-          @content={{this.chatSounds}}
-          @value={{this.chatSound}}
-          @options={{hash none="chat.sounds.none"}}
-          @onChange={{this.setChatSound}}
-          class="chat-sound"
-        />
+        <div class="chat-sound-controls">
+          <ComboBox
+            @valueProperty="value"
+            @content={{this.chatSounds}}
+            @value={{this.chatSound}}
+            @options={{hash none="chat.sounds.none"}}
+            @onChange={{this.setChatSound}}
+            class="chat-sound"
+          />
+          {{#if this.chatSound}}
+            <DButton
+              @icon="play"
+              @action={{this.previewChatSound}}
+              @title="chat.sound.preview"
+              class="btn-flat chat-sound-preview"
+            />
+          {{/if}}
+        </div>
       </div>
 
       <div class="controls controls-dropdown">

--- a/plugins/chat/assets/stylesheets/common/chat-preferences.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-preferences.scss
@@ -1,0 +1,7 @@
+.chat-notifications {
+  .chat-sound-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+  }
+}

--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -1,6 +1,7 @@
 @import "chat-unread-indicator";
 @import "chat-height-mixin";
 @import "base-common";
+@import "chat-preferences";
 @import "chat-drawer-routes";
 @import "chat-browse";
 @import "chat-disabled";

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -341,6 +341,7 @@ en:
         other: "%{count} new messages"
       sound:
         title: "Desktop chat notification sound"
+        preview: "Play a preview of the selected sound"
       sounds:
         none: "None"
         classic: "Classic and clean"

--- a/plugins/chat/spec/system/user_notification_preferences_spec.rb
+++ b/plugins/chat/spec/system/user_notification_preferences_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe "User notification preferences | Chat notifications" do
     expect(combo(".chat-sound").value).to eq("retro")
   end
 
+  it "shows a sound preview button only while a sound is selected" do
+    visit_notifications
+
+    expect(page).to have_no_css(".chat-sound-preview")
+
+    combo(".chat-sound").expand
+    combo(".chat-sound").select_row_by_value("retro")
+
+    expect(page).to have_css(".chat-sound-preview")
+
+    combo(".chat-sound").expand
+    combo(".chat-sound").select_row_by_name("None")
+
+    expect(page).to have_no_css(".chat-sound-preview")
+  end
+
   it "can toggle and persist ignore channel-wide mentions" do
     current_user.user_option.update!(ignore_channel_wide_mention: false)
     visit_notifications


### PR DESCRIPTION
Selecting a sound already plays it once, but replaying the current selection meant switching away and back. A play button next to the dropdown replays it on demand; it is hidden while no sound is selected.

<img width="361" height="176" alt="chat-sound-preview" src="https://github.com/user-attachments/assets/8a32a85e-4b49-4d50-95e7-de9cb05a86d1" />
