### PR TITLE
FEATURE: add $helpers.absoluteUrl expression helper to workflows

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-context.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-context.js
@@ -17,6 +17,13 @@ const WORKFLOW_METHOD_DOCS = Object.freeze({
       infoKey: "discourse_workflows.expression_docs.methods.input.last",
     }),
   }),
+  $helpers: Object.freeze({
+    absoluteUrl: Object.freeze({
+      detail: "(path)",
+      infoKey:
+        "discourse_workflows.expression_docs.methods.helpers.absolute_url",
+    }),
+  }),
 });
 
 export function resolveVariableId(variable, itemPrefix = "$json") {
@@ -320,6 +327,17 @@ function buildExecutionScope(nodes) {
   return scope;
 }
 
+function buildHelpersScope() {
+  return cleanObject({
+    absoluteUrl: (path) => {
+      if (typeof path !== "string" || !/^\/[^/]/.test(path)) {
+        return path;
+      }
+      return `${window.location.origin}${path}`;
+    },
+  });
+}
+
 function buildInputScope($json) {
   const currentItem = buildItem($json);
   const inputItems = [currentItem];
@@ -364,6 +382,7 @@ export function buildScope({
     $current_user: cleanObject({ id: 0, username: "" }),
     $vars: buildVarsScope(workflowVars),
     $execution: buildExecutionScope(nodes),
+    $helpers: buildHelpersScope(),
     $: (name) => nodeOutputs[name] || EMPTY_NODE_OUTPUT,
     JSON,
     Math,

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-extensions/dollar-vars.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-extensions/dollar-vars.js
@@ -33,6 +33,10 @@ const DOLLAR_VAR_DOCS = {
     detail: "object",
     infoKey: "discourse_workflows.expression_docs.vars.execution",
   },
+  $helpers: {
+    detail: "object",
+    infoKey: "discourse_workflows.expression_docs.vars.helpers",
+  },
 };
 
 export function lookupDollarVarDoc(name) {
@@ -51,7 +55,13 @@ export function buildDollarVars(scope, sections) {
       boost: (name) => (name === "$json" ? 10 : 5),
     },
     {
-      names: ["$site_settings", "$current_user", "$vars", "$execution"],
+      names: [
+        "$site_settings",
+        "$current_user",
+        "$vars",
+        "$execution",
+        "$helpers",
+      ],
       section: sections.metadata,
     },
   ];

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -682,11 +682,14 @@ en:
           workflow_vars: "Workflow variables defined in the admin panel."
           execution: "Execution metadata: id, workflow_id, workflow_name"
           node_ref: "Reference a previous node's output. Example: $('Node Name').item.json"
+          helpers: "Utility functions. Currently: $helpers.absoluteUrl(path)."
         methods:
           input:
             all: "Returns an array of the current node's input items."
             first: "Returns the current node's first input item."
             last: "Returns the current node's last input item."
+          helpers:
+            absolute_url: "Converts a relative path (e.g. a post or topic URL) into an absolute URL using the site's base URL. Already-absolute paths are returned unchanged."
       node_preview:
         title: "Preview"
         counts: "%{input} → %{output}"

--- a/plugins/discourse-workflows/lib/discourse_workflows/expression_context_schema.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/expression_context_schema.rb
@@ -3,6 +3,9 @@
 module DiscourseWorkflows
   class ExpressionContextSchema
     ENVIRONMENT_SYMBOLS = {
+      "$helpers" => {
+        type: :object,
+      },
       "$site_settings" => {
         type: :object,
       },

--- a/plugins/discourse-workflows/lib/discourse_workflows/js_sandbox.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/js_sandbox.rb
@@ -117,6 +117,7 @@ module DiscourseWorkflows
       @js_context.attach("__getNodeContext", method(:fetch_node_context))
       @js_context.attach("__getNodeParams", method(:fetch_node_params))
       @js_context.attach("__isNodeExecuted", method(:node_executed?))
+      @js_context.attach("__absoluteUrl", method(:absolute_url))
 
       execution = @workflow_context.fetch("__execution") { {} }
       declare_json("__vars", @vars)
@@ -216,6 +217,12 @@ module DiscourseWorkflows
           configurable: true,
           writable: false
         });
+
+        Object.defineProperty(this, '$helpers', {
+          value: Object.freeze({
+            absoluteUrl: function(path) { return __absoluteUrl(path); }
+          })
+        });
       JS
     end
 
@@ -223,6 +230,10 @@ module DiscourseWorkflows
       @site_setting_store.fetch(name)&.to_s
     rescue StandardError
       nil
+    end
+
+    def absolute_url(path)
+      UrlHelper.absolute_without_cdn(path.to_s)
     end
 
     def fetch_node_item(name, item_index = nil)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/code/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/code/v1.rb
@@ -14,6 +14,7 @@ module DiscourseWorkflows
           //   $site_settings.NAME    - site settings
           //   $execution             - execution metadata (id, workflow_name, ...)
           //   $current_user          - user running the workflow
+          //   $helpers.absoluteUrl(path) - convert a relative path to an absolute URL
           //   console.log/warn/error - logging
 
           // Example: add a new field called 'foo' to every input item

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/expression_context_schema_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/expression_context_schema_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe DiscourseWorkflows::ExpressionContextSchema do
       expect(schema).to have_key(:item_prefix)
     end
 
-    it "declares $site_settings, $vars, $current_user, $execution as environment symbols" do
+    it "declares $helpers, $site_settings, $vars, $current_user, $execution as environment symbols" do
       symbols = described_class.environment_symbols.keys
-      expect(symbols).to contain_exactly("$site_settings", "$vars", "$current_user", "$execution")
+      expect(symbols).to contain_exactly(
+        "$helpers",
+        "$site_settings",
+        "$vars",
+        "$current_user",
+        "$execution",
+      )
     end
 
     it "declares $current_user fields matching JsSandbox#build_current_user" do
@@ -81,7 +87,7 @@ RSpec.describe DiscourseWorkflows::ExpressionContextSchema do
       sandbox = DiscourseWorkflows::JsSandbox.new(context, user: user)
 
       # $execution is injected by ExpressionResolver, not JsSandbox directly
-      sandbox_symbols = %w[$site_settings $vars $current_user]
+      sandbox_symbols = %w[$site_settings $vars $current_user $helpers]
       sandbox_symbols.each do |symbol|
         result = sandbox.eval("typeof #{symbol}")
         expect(result).not_to eq("undefined"),

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/expression_resolver_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/expression_resolver_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe DiscourseWorkflows::ExpressionResolver do
       expect(resolver.resolve("={{ $site_settings.title }}")).to eq("My Forum")
     end
 
+    it "resolves $helpers.absoluteUrl expressions" do
+      expect(resolver.resolve("={{ $helpers.absoluteUrl('/t/some-slug/123/4') }}")).to eq(
+        "#{Discourse.base_url}/t/some-slug/123/4",
+      )
+    end
+
     it "handles mixed literal and expression" do
       expect(resolver.resolve("=topic-{{ $trigger.topic_id }}-closed")).to eq("topic-42-closed")
     end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/js_sandbox_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/js_sandbox_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe DiscourseWorkflows::JsSandbox do
     end
   end
 
+  describe "$helpers.absoluteUrl" do
+    it "prefixes a root-relative path with the site's base URL" do
+      result = sandbox.eval('$helpers.absoluteUrl("/t/some-slug/123/4")')
+      expect(result).to eq("#{Discourse.base_url}/t/some-slug/123/4")
+    end
+
+    it "returns an already-absolute URL unchanged" do
+      result = sandbox.eval('$helpers.absoluteUrl("https://example.com/foo")')
+      expect(result).to eq("https://example.com/foo")
+    end
+  end
+
   describe "private node names" do
     it "returns empty object for underscore-prefixed node names" do
       context = { "_internal" => [{ "json" => { "secret" => "data" } }] }

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/code_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/code_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe DiscourseWorkflows::Nodes::Code::V1 do
       expect(result.first["json"]["name"]).to eq("Alice")
     end
 
+    it "exposes $helpers.absoluteUrl for converting a relative path" do
+      result =
+        execute_code(
+          "return { url: $helpers.absoluteUrl($json.path) };",
+          items: [{ "json" => { "path" => "/t/some-slug/123/4" } }],
+        )
+
+      expect(result.first["json"]["url"]).to eq("#{Discourse.base_url}/t/some-slug/123/4")
+    end
+
     it "captures console.log output" do
       log = execute_code_with_log('console.log("debug message"); return {};')
 

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/expression-context-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/expression-context-test.js
@@ -85,6 +85,19 @@ module("Unit | lib | discourse-workflows | buildScope", function () {
     assert.deepEqual(scope.$input.context, Object.create(null));
   });
 
+  test("builds $helpers.absoluteUrl for converting a relative path", function (assert) {
+    const scope = buildScope({});
+
+    assert.strictEqual(
+      scope.$helpers.absoluteUrl("/t/some-slug/123/4"),
+      `${window.location.origin}/t/some-slug/123/4`
+    );
+    assert.strictEqual(
+      scope.$helpers.absoluteUrl("https://example.com/foo"),
+      "https://example.com/foo"
+    );
+  });
+
   test("exposes method docs for workflow-owned scope helpers", function (assert) {
     assert.deepEqual(lookupWorkflowMethodDoc("$input", "all"), {
       detail: "()",


### PR DESCRIPTION
Workflow authors can now convert a relative post/topic path into a full URL with `$helpers.absoluteUrl(path)`, usable in the Code node and in any node's expression fields. Useful for sending links in workflows that notify external systems.