### PR TITLE
DEV: document topic archetype in workflows output schema

### DIFF
--- a/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
@@ -45,6 +45,7 @@ module DiscourseWorkflows
         "title": { "type": "string" },
         "fancy_title": { "type": "string" },
         "slug": { "type": "string" },
+        "archetype": { "type": "string", "description": "regular for topics, private_message for PMs" },
         "posts_count": { "type": "integer" },
         "category_id": { "type": ["integer", "null"] },
         "user_id": { "type": "integer" },


### PR DESCRIPTION
Workflow authors can now discover and rely on the archetype field (regular vs private_message) on topic data, so they can tell PMs apart from regular topics in expressions and conditions.