### PR TITLE
UX: Improve mobile sidebar drawer gestures

### DIFF
--- a/frontend/discourse/app/components/glimmer-site-header.gjs
+++ b/frontend/discourse/app/components/glimmer-site-header.gjs
@@ -555,7 +555,6 @@ export default class GlimmerSiteHeader extends Component {
     const translation =
       this._swipeMenuOrigin === "right" ? dragPosition : -dragPosition;
 
-    // Avoid allocating an Animation per pointermove.
     drawerDrag.panel.style.transform = `translate3d(${translation}px, 0, 0)`;
     if (drawerDrag.cloak) {
       drawerDrag.cloak.style.opacity =
@@ -698,6 +697,7 @@ export default class GlimmerSiteHeader extends Component {
         onDragEnd: this.onDrawerDragEnd,
         onDragCancel: this.onDrawerDragCancel,
         threshold: DRAWER_DRAG_THRESHOLD,
+        // arbitration stops at .panel-body, which declares its own pan-y
         touchAction: "pan-y",
         preservePress: isPanel,
       }));

--- a/frontend/discourse/app/components/glimmer-site-header.gjs
+++ b/frontend/discourse/app/components/glimmer-site-header.gjs
@@ -31,7 +31,6 @@ const DRAWER_DRAG_THRESHOLD = 5;
 const HAMBURGER_BUTTON_ID = "toggle-hamburger-menu";
 const USER_BUTTON_ID = "toggle-current-user";
 const DRAWER_TAP_SLOP = 10;
-const DRAWER_VELOCITY_EXPIRY_MS = 100;
 
 export default class GlimmerSiteHeader extends Component {
   @service appEvents;
@@ -472,8 +471,6 @@ export default class GlimmerSiteHeader extends Component {
 
     this._drawerDrag = {
       axis: null,
-      lastTime: event.timeStamp,
-      lastX: event.clientX,
       panel,
       pointerId: event.pointerId,
       cloak: document.querySelector(".header-cloak"),
@@ -481,7 +478,6 @@ export default class GlimmerSiteHeader extends Component {
       scrollerLocked: false,
       startClosed,
       startedOnCloak: Boolean(cloakAtPointer),
-      velocityX: 0,
       width: this.#drawerWidth(panel),
     };
     this.pxClosed = startClosed;
@@ -546,8 +542,6 @@ export default class GlimmerSiteHeader extends Component {
       return;
     }
 
-    this.#updateDrawerVelocity(event);
-
     const closingDelta = this.#closingTravel(dragInfo.delta.x);
     this.pxClosed = Math.min(drawerDrag.width, Math.max(0, closingDelta));
     const dragPosition =
@@ -571,7 +565,7 @@ export default class GlimmerSiteHeader extends Component {
 
     const animationEvent = {
       deltaX: dragInfo.delta.x,
-      velocityX: this.#releaseVelocity(event),
+      velocityX: dragInfo.velocity.x,
     };
 
     if (this.#shouldCloseDrawer(animationEvent)) {
@@ -611,21 +605,6 @@ export default class GlimmerSiteHeader extends Component {
     }
 
     this.#resetDrawerDrag();
-  }
-
-  #updateDrawerVelocity(event) {
-    const drawerDrag = this._drawerDrag;
-    const elapsed = event.timeStamp - drawerDrag.lastTime;
-    drawerDrag.velocityX =
-      elapsed > 0 ? (event.clientX - drawerDrag.lastX) / elapsed : 0;
-    drawerDrag.lastX = event.clientX;
-    drawerDrag.lastTime = event.timeStamp;
-  }
-
-  #releaseVelocity(event) {
-    const drawerDrag = this._drawerDrag;
-    const idleMs = event.timeStamp - drawerDrag.lastTime;
-    return idleMs > DRAWER_VELOCITY_EXPIRY_MS ? 0 : drawerDrag.velocityX;
   }
 
   #isLeftMenu(panel) {

--- a/frontend/discourse/app/components/glimmer-site-header.gjs
+++ b/frontend/discourse/app/components/glimmer-site-header.gjs
@@ -288,14 +288,15 @@ export default class GlimmerSiteHeader extends Component {
 
       if (this._animate) {
         let animationFinished;
-        let finalPosition = PANEL_WIDTH;
+        let finalPosition = this.#drawerWidth(panel);
         this._swipeMenuOrigin = "right";
         if (this.slideInMode && this.#isLeftMenu(panel)) {
           this._swipeMenuOrigin = "left";
-          finalPosition = -PANEL_WIDTH;
+          finalPosition = -finalPosition;
         }
         animationFinished = this.#driveDrawer(
           panel,
+          "transform",
           [{ transform: `translate3d(${finalPosition}px, 0, 0)` }],
           { fill: "forwards" }
         ).finished;
@@ -303,7 +304,7 @@ export default class GlimmerSiteHeader extends Component {
         waitForPromise(animationFinished.catch(() => {}));
 
         if (cloakElement) {
-          this.#driveDrawer(cloakElement, [{ opacity: 0 }], {
+          this.#driveDrawer(cloakElement, "opacity", [{ opacity: 0 }], {
             fill: "forwards",
           });
           cloakElement.style.display = "block";
@@ -339,13 +340,18 @@ export default class GlimmerSiteHeader extends Component {
       easing: DRAWER_SETTLE_EASING,
     };
     const animations = [
-      this.#driveDrawer(panel, [{ transform: `translate3d(0, 0, 0)` }], timing)
-        .finished,
+      this.#driveDrawer(
+        panel,
+        "transform",
+        [{ transform: `translate3d(0, 0, 0)` }],
+        timing
+      ).finished,
     ];
     if (cloakElement) {
       cloakElement.style.display = "block";
       animations.push(
-        this.#driveDrawer(cloakElement, [{ opacity: 1 }], timing).finished
+        this.#driveDrawer(cloakElement, "opacity", [{ opacity: 1 }], timing)
+          .finished
       );
     }
 
@@ -378,13 +384,15 @@ export default class GlimmerSiteHeader extends Component {
     const animations = [
       this.#driveDrawer(
         panel,
+        "transform",
         [{ transform: `translate3d(${endPosition}px, 0, 0)` }],
         timing
       ).finished,
     ];
     if (cloakElement) {
       animations.push(
-        this.#driveDrawer(cloakElement, [{ opacity: 0 }], timing).finished
+        this.#driveDrawer(cloakElement, "opacity", [{ opacity: 0 }], timing)
+          .finished
       );
     }
 
@@ -479,9 +487,9 @@ export default class GlimmerSiteHeader extends Component {
     this.pxClosed = startClosed;
   }
 
-  #driveDrawer(element, keyframes, timing) {
+  #driveDrawer(element, property, keyframes, timing) {
     const animation = element.animate(keyframes, timing);
-    this._drawerAnimations.push(animation);
+    this._drawerAnimations.push({ animation, property });
     return animation;
   }
 
@@ -501,11 +509,10 @@ export default class GlimmerSiteHeader extends Component {
   // a cancelled fill-forwards animation reverts its element, so pin what is
   // on screen first
   #stopDrawerAnimations() {
-    for (const animation of this._drawerAnimations) {
+    for (const { animation, property } of this._drawerAnimations) {
       const target = animation.effect?.target;
       if (target?.isConnected) {
-        const { transform, opacity } = window.getComputedStyle(target);
-        Object.assign(target.style, { transform, opacity });
+        target.style[property] = window.getComputedStyle(target)[property];
       }
       animation.cancel();
     }

--- a/frontend/discourse/app/components/glimmer-site-header.gjs
+++ b/frontend/discourse/app/components/glimmer-site-header.gjs
@@ -12,18 +12,26 @@ import { isTesting } from "discourse/lib/environment";
 import discourseLater from "discourse/lib/later";
 import scrollLock from "discourse/lib/scroll-lock";
 import {
+  dampenedOverdrag,
   getMaxAnimationTimeMs,
-  shouldCloseMenu,
 } from "discourse/lib/swipe-events";
 import { isDocumentRTL } from "discourse/lib/text-direction";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
-import dSwipe from "discourse/ui-kit/modifiers/d-swipe";
+import { registerPointerDrag } from "discourse/ui-kit/modifiers/d-pointer-drag";
 import Header from "./header";
 import ImpersonationNotice from "./impersonation-notice";
 
 let _menuPanelClassesToForceDropdown = [];
 const PANEL_WIDTH = 340;
 const DEBOUNCE_HEADER_DELAY = 10;
+const DRAWER_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+const DRAWER_CLOSE_DISTANCE_RATIO = 0.25;
+const DRAWER_CLOSE_VELOCITY_THRESHOLD = 0.4;
+const DRAWER_DRAG_THRESHOLD = 5;
+const HAMBURGER_BUTTON_ID = "toggle-hamburger-menu";
+const USER_BUTTON_ID = "toggle-current-user";
+const DRAWER_TAP_SLOP = 10;
+const DRAWER_VELOCITY_EXPIRY_MS = 100;
 
 export default class GlimmerSiteHeader extends Component {
   @service appEvents;
@@ -38,6 +46,10 @@ export default class GlimmerSiteHeader extends Component {
   _headerWrap;
   _mainOutletWrapper;
   _swipeMenuOrigin;
+  _drawerDrag;
+  _drawerAnimations = [];
+  _drawerCloseGeneration = 0;
+  _drawerGestureCleanups = new Map();
   _applicationElement;
   _resizeObserver;
 
@@ -69,6 +81,7 @@ export default class GlimmerSiteHeader extends Component {
     window.removeEventListener("scroll", this.debouncedRecalculateHeaderOffset);
     this._resizeObserver.disconnect();
     cancel(this.recalculationTimer);
+    this.#clearDrawerGestures();
   }
 
   get dropDownHeaderEnabled() {
@@ -245,6 +258,7 @@ export default class GlimmerSiteHeader extends Component {
     const menuPanels = document.querySelectorAll(".menu-panel");
 
     if (menuPanels.length === 0) {
+      this.#clearDrawerGestures();
       this._animate = this.slideInMode;
       return;
     }
@@ -263,38 +277,47 @@ export default class GlimmerSiteHeader extends Component {
       panel.classList.remove("slide-in");
       panel.classList.add(viewMode);
 
+      if (
+        viewMode === "slide-in" &&
+        (this.header.hamburgerVisible || this.header.userVisible)
+      ) {
+        this.#syncDrawerGestures(panel, cloakElement);
+      } else {
+        this.#clearDrawerGestures();
+      }
+
       if (this._animate) {
         let animationFinished;
         let finalPosition = PANEL_WIDTH;
         this._swipeMenuOrigin = "right";
-        if (
-          this.slideInMode &&
-          panel.parentElement.classList.contains(this.leftMenuClass)
-        ) {
+        if (this.slideInMode && this.#isLeftMenu(panel)) {
           this._swipeMenuOrigin = "left";
           finalPosition = -PANEL_WIDTH;
         }
-        animationFinished = panel.animate(
+        animationFinished = this.#driveDrawer(
+          panel,
           [{ transform: `translate3d(${finalPosition}px, 0, 0)` }],
-          {
-            fill: "forwards",
-          }
+          { fill: "forwards" }
         ).finished;
 
-        waitForPromise(animationFinished);
+        waitForPromise(animationFinished.catch(() => {}));
 
         if (cloakElement) {
-          cloakElement.animate([{ opacity: 0 }], { fill: "forwards" });
+          this.#driveDrawer(cloakElement, [{ opacity: 0 }], {
+            fill: "forwards",
+          });
           cloakElement.style.display = "block";
         }
 
-        animationFinished.then(() => {
-          if (isTesting()) {
-            this._animateOpening(panel);
-          } else {
-            discourseLater(() => this._animateOpening(panel));
-          }
-        });
+        animationFinished
+          .then(() => {
+            if (isTesting()) {
+              this._animateOpening(panel);
+            } else {
+              discourseLater(() => this._animateOpening(panel));
+            }
+          })
+          .catch(() => {});
       }
 
       this._animate = false;
@@ -313,10 +336,20 @@ export default class GlimmerSiteHeader extends Component {
     const timing = {
       duration: durationMs > 0 ? durationMs : 0,
       fill: "forwards",
-      easing: "ease-out",
+      easing: DRAWER_SETTLE_EASING,
     };
-    panel.animate([{ transform: `translate3d(0, 0, 0)` }], timing);
-    cloakElement?.animate?.([{ opacity: 1 }], timing);
+    const animations = [
+      this.#driveDrawer(panel, [{ transform: `translate3d(0, 0, 0)` }], timing)
+        .finished,
+    ];
+    if (cloakElement) {
+      cloakElement.style.display = "block";
+      animations.push(
+        this.#driveDrawer(cloakElement, [{ opacity: 1 }], timing).finished
+      );
+    }
+
+    waitForPromise(Promise.all(animations).catch(() => {}));
     this.pxClosed = null;
   }
 
@@ -324,9 +357,10 @@ export default class GlimmerSiteHeader extends Component {
   _animateClosing(event, panel, menuOrigin) {
     this._animate = true;
     const cloakElement = document.querySelector(".header-cloak");
+    const panelWidth = this.#drawerWidth(panel);
     let durationMs = getMaxAnimationTimeMs();
     if (event && this.pxClosed > 0) {
-      const distancePx = PANEL_WIDTH - this.pxClosed;
+      const distancePx = panelWidth - this.pxClosed;
       durationMs = getMaxAnimationTimeMs(
         distancePx / Math.abs(event.velocityX)
       );
@@ -334,100 +368,345 @@ export default class GlimmerSiteHeader extends Component {
     const timing = {
       duration: durationMs > 0 ? durationMs : 0,
       fill: "forwards",
+      easing: DRAWER_SETTLE_EASING,
     };
 
-    let endPosition = -PANEL_WIDTH; //origin left
+    let endPosition = -panelWidth; //origin left
     if (menuOrigin === "right") {
-      endPosition = PANEL_WIDTH;
+      endPosition = panelWidth;
     }
-    panel.animate(
-      [{ transform: `translate3d(${endPosition}px, 0, 0)` }],
-      timing
-    );
+    const animations = [
+      this.#driveDrawer(
+        panel,
+        [{ transform: `translate3d(${endPosition}px, 0, 0)` }],
+        timing
+      ).finished,
+    ];
     if (cloakElement) {
-      cloakElement.animate([{ opacity: 0 }], timing);
-      cloakElement.style.display = "none";
-
-      // to ensure that the cloak is cleared after animation we need to toggle any active menus
-      if (this.header.hamburgerVisible || this.header.userVisible) {
-        this.header.hamburgerVisible = false;
-        this.header.userVisible = false;
-      }
+      animations.push(
+        this.#driveDrawer(cloakElement, [{ opacity: 0 }], timing).finished
+      );
     }
+
+    const generation = ++this._drawerCloseGeneration;
+    const closingFinished = Promise.all(animations)
+      .catch(() => {})
+      .then(() => {
+        if (
+          generation !== this._drawerCloseGeneration ||
+          !panel.isConnected ||
+          this.isDestroying ||
+          this.isDestroyed
+        ) {
+          return;
+        }
+
+        this.#clearDrawerGestures();
+
+        if (cloakElement) {
+          cloakElement.style.display = "none";
+        }
+
+        scrollLock(false);
+
+        if (this.header.hamburgerVisible || this.header.userVisible) {
+          const toggleId = this.header.hamburgerVisible
+            ? HAMBURGER_BUTTON_ID
+            : USER_BUTTON_ID;
+
+          this.header.hamburgerVisible = false;
+          this.header.userVisible = false;
+          document.getElementById(toggleId)?.focus();
+        }
+      });
+
+    waitForPromise(closingFinished);
     this.pxClosed = null;
   }
 
   @bind
-  onSwipeStart(swipeEvent, fullEvent) {
-    const center = swipeEvent.center;
-    const swipeOverValidElement = document
-      .elementsFromPoint(center.x, center.y)
-      .some(
-        (ele) =>
-          ele.classList.contains("panel-body") ||
-          ele.classList.contains("header-cloak")
+  onDrawerDragStart(event) {
+    const target = event.target;
+    if (!this.slideInMode || !(target instanceof Element)) {
+      return false;
+    }
+
+    const panelAtPointer = target.closest(".menu-panel.slide-in");
+    const cloakAtPointer = target.closest(".header-cloak");
+    if (!panelAtPointer && !cloakAtPointer) {
+      return false;
+    }
+
+    if (target.closest("input, textarea, select, [contenteditable='true']")) {
+      return false;
+    }
+
+    const panel =
+      panelAtPointer ?? document.querySelector(".menu-panel.slide-in");
+    if (!panel) {
+      return false;
+    }
+
+    if (cloakAtPointer) {
+      event.stopPropagation();
+    }
+
+    // refusing before the stopPropagation above would let the outside-press
+    // handler dismiss the drawer mid-gesture
+    if (this._drawerDrag) {
+      return false;
+    }
+
+    this._drawerCloseGeneration++;
+    this._swipeMenuOrigin = this.#isLeftMenu(panel) ? "left" : "right";
+
+    const startClosed = this.#stopDrawerSettle(panel);
+
+    this._drawerDrag = {
+      axis: null,
+      lastTime: event.timeStamp,
+      lastX: event.clientX,
+      panel,
+      pointerId: event.pointerId,
+      cloak: document.querySelector(".header-cloak"),
+      scroller: panel.querySelector(".panel-body"),
+      scrollerLocked: false,
+      startClosed,
+      startedOnCloak: Boolean(cloakAtPointer),
+      velocityX: 0,
+      width: this.#drawerWidth(panel),
+    };
+    this.pxClosed = startClosed;
+  }
+
+  #driveDrawer(element, keyframes, timing) {
+    const animation = element.animate(keyframes, timing);
+    this._drawerAnimations.push(animation);
+    return animation;
+  }
+
+  #stopDrawerSettle(panel) {
+    this.#stopDrawerAnimations();
+
+    const { transform } = window.getComputedStyle(panel);
+    const translateX =
+      transform === "none" ? 0 : new DOMMatrixReadOnly(transform).m41;
+
+    return Math.max(
+      0,
+      Math.min(translateX * this.#closingDirection(), this.#drawerWidth(panel))
+    );
+  }
+
+  // a cancelled fill-forwards animation reverts its element, so pin what is
+  // on screen first
+  #stopDrawerAnimations() {
+    for (const animation of this._drawerAnimations) {
+      const target = animation.effect?.target;
+      if (target?.isConnected) {
+        const { transform, opacity } = window.getComputedStyle(target);
+        Object.assign(target.style, { transform, opacity });
+      }
+      animation.cancel();
+    }
+    this._drawerAnimations = [];
+  }
+
+  #drawerWidth(panel) {
+    return panel.getBoundingClientRect().width || PANEL_WIDTH;
+  }
+
+  @bind
+  onDrawerDrag(event, dragInfo) {
+    const drawerDrag = this._drawerDrag;
+    if (drawerDrag?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    if (!drawerDrag.axis) {
+      drawerDrag.axis =
+        Math.abs(dragInfo.delta.x) >= Math.abs(dragInfo.delta.y)
+          ? "horizontal"
+          : "vertical";
+
+      if (drawerDrag.axis === "horizontal" && drawerDrag.scroller) {
+        scrollLock(true, drawerDrag.scroller);
+        drawerDrag.scrollerLocked = true;
+      }
+    }
+
+    if (drawerDrag.axis !== "horizontal") {
+      return;
+    }
+
+    this.#updateDrawerVelocity(event);
+
+    const closingDelta = this.#closingTravel(dragInfo.delta.x);
+    this.pxClosed = Math.min(drawerDrag.width, Math.max(0, closingDelta));
+    const dragPosition =
+      closingDelta >= 0 ? this.pxClosed : -dampenedOverdrag(-closingDelta);
+    const translation =
+      this._swipeMenuOrigin === "right" ? dragPosition : -dragPosition;
+
+    // Avoid allocating an Animation per pointermove.
+    drawerDrag.panel.style.transform = `translate3d(${translation}px, 0, 0)`;
+    if (drawerDrag.cloak) {
+      drawerDrag.cloak.style.opacity =
+        (drawerDrag.width - this.pxClosed) / drawerDrag.width;
+    }
+  }
+
+  @bind
+  onDrawerDragEnd(event, dragInfo) {
+    const drawerDrag = this._drawerDrag;
+    if (drawerDrag?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const animationEvent = {
+      deltaX: dragInfo.delta.x,
+      velocityX: this.#releaseVelocity(event),
+    };
+
+    if (this.#shouldCloseDrawer(animationEvent)) {
+      this._animateClosing(
+        animationEvent,
+        drawerDrag.panel,
+        this._swipeMenuOrigin
       );
-
-    if (
-      swipeOverValidElement &&
-      (swipeEvent.direction === "left" || swipeEvent.direction === "right")
-    ) {
-      scrollLock(true, document.querySelector(".panel-body"));
     } else {
-      fullEvent.preventDefault();
+      this._animateOpening(drawerDrag.panel, animationEvent);
     }
+
+    this.#resetDrawerDrag();
   }
 
   @bind
-  onSwipeEnd(swipeEvent) {
-    const menuPanels = document.querySelectorAll(".menu-panel");
-    scrollLock(false, document.querySelector(".panel-body"));
-    menuPanels.forEach((panel) => {
-      if (shouldCloseMenu(swipeEvent, this._swipeMenuOrigin)) {
-        this._animateClosing(swipeEvent, panel, this._swipeMenuOrigin);
-        scrollLock(false);
+  onDrawerDragCancel(event, dragInfo) {
+    const drawerDrag = this._drawerDrag;
+    if (drawerDrag?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    if (drawerDrag.startedOnCloak) {
+      const cancelEvent = { deltaX: dragInfo.delta.x, velocityX: 0 };
+
+      if (this.#shouldCloseDrawer(cancelEvent)) {
+        this._animateClosing(
+          cancelEvent,
+          drawerDrag.panel,
+          this._swipeMenuOrigin
+        );
       } else {
-        this._animateOpening(panel, swipeEvent);
+        this._animateOpening(drawerDrag.panel);
       }
-    });
-  }
-
-  @bind
-  onSwipeCancel() {
-    const menuPanels = document.querySelectorAll(".menu-panel");
-    scrollLock(false, document.querySelector(".panel-body"));
-    menuPanels.forEach((panel) => {
-      this._animateOpening(panel);
-    });
-  }
-
-  @bind
-  onSwipe(swipeEvent) {
-    const movingElement = document.querySelector(".menu-panel");
-    const cloakElement = document.querySelector(".header-cloak");
-
-    //origin left
-    this.pxClosed = Math.max(0, -swipeEvent.deltaX);
-    let translation = -this.pxClosed;
-    if (this._swipeMenuOrigin === "right") {
-      this.pxClosed = Math.max(0, swipeEvent.deltaX);
-      translation = this.pxClosed;
+    } else if (drawerDrag.axis === "horizontal") {
+      this._animateOpening(drawerDrag.panel);
     }
 
-    movingElement.animate(
-      [{ transform: `translate3d(${translation}px, 0, 0)` }],
-      {
-        fill: "forwards",
+    this.#resetDrawerDrag();
+  }
+
+  #updateDrawerVelocity(event) {
+    const drawerDrag = this._drawerDrag;
+    const elapsed = event.timeStamp - drawerDrag.lastTime;
+    drawerDrag.velocityX =
+      elapsed > 0 ? (event.clientX - drawerDrag.lastX) / elapsed : 0;
+    drawerDrag.lastX = event.clientX;
+    drawerDrag.lastTime = event.timeStamp;
+  }
+
+  #releaseVelocity(event) {
+    const drawerDrag = this._drawerDrag;
+    const idleMs = event.timeStamp - drawerDrag.lastTime;
+    return idleMs > DRAWER_VELOCITY_EXPIRY_MS ? 0 : drawerDrag.velocityX;
+  }
+
+  #isLeftMenu(panel) {
+    return Boolean(panel.closest(`.${this.leftMenuClass}`));
+  }
+
+  #closingTravel(deltaX) {
+    return (
+      (this._drawerDrag?.startClosed ?? 0) + deltaX * this.#closingDirection()
+    );
+  }
+
+  #closingDirection() {
+    return this._swipeMenuOrigin === "right" ? 1 : -1;
+  }
+
+  #shouldCloseDrawer({ deltaX, velocityX }) {
+    const drawerDrag = this._drawerDrag;
+    const direction = this.#closingDirection();
+    const closingDistance = this.#closingTravel(deltaX);
+
+    if (drawerDrag.startedOnCloak) {
+      return closingDistance > -DRAWER_TAP_SLOP;
+    }
+
+    if (drawerDrag.axis !== "horizontal") {
+      return false;
+    }
+
+    const flickedClosed =
+      closingDistance > 0 &&
+      velocityX * direction >= DRAWER_CLOSE_VELOCITY_THRESHOLD;
+
+    return (
+      flickedClosed ||
+      closingDistance >= drawerDrag.width * DRAWER_CLOSE_DISTANCE_RATIO
+    );
+  }
+
+  #resetDrawerDrag() {
+    if (this._drawerDrag?.scrollerLocked) {
+      scrollLock(false, this._drawerDrag.scroller);
+    }
+    this._drawerDrag = null;
+  }
+
+  #syncDrawerGestures(panel, cloakElement) {
+    const surfaces = new Set(
+      this.slideInMode ? [panel, cloakElement].filter(Boolean) : []
+    );
+
+    for (const [surface, cleanup] of this._drawerGestureCleanups) {
+      if (!surfaces.has(surface)) {
+        cleanup();
+        this._drawerGestureCleanups.delete(surface);
       }
-    );
-    cloakElement?.animate?.(
-      [
-        {
-          opacity: (PANEL_WIDTH - this.pxClosed) / PANEL_WIDTH,
-        },
-      ],
-      { fill: "forwards" }
-    );
+    }
+
+    for (const surface of surfaces) {
+      if (this._drawerGestureCleanups.has(surface)) {
+        continue;
+      }
+
+      const isPanel = surface === panel;
+
+      const cleanup = registerPointerDrag(surface, () => ({
+        onDragStart: this.onDrawerDragStart,
+        onDrag: this.onDrawerDrag,
+        onDragEnd: this.onDrawerDragEnd,
+        onDragCancel: this.onDrawerDragCancel,
+        threshold: DRAWER_DRAG_THRESHOLD,
+        touchAction: "pan-y",
+        preservePress: isPanel,
+      }));
+      this._drawerGestureCleanups.set(surface, cleanup);
+    }
+  }
+
+  #clearDrawerGestures() {
+    // teardown fires no terminal callback, so the gesture state is dropped here
+    this.#resetDrawerDrag();
+    for (const cleanup of this._drawerGestureCleanups.values()) {
+      cleanup();
+    }
+    this._drawerGestureCleanups.clear();
+
+    this.#stopDrawerAnimations();
   }
 
   <template>
@@ -437,13 +716,6 @@ export default class GlimmerSiteHeader extends Component {
         "d-header-wrap"
       }}
       {{didInsert this.setupHeader}}
-      {{dSwipe
-        onDidStartSwipe=this.onSwipeStart
-        onDidEndSwipe=this.onSwipeEnd
-        onDidCancelSwipe=this.onSwipeCancel
-        onDidSwipe=this.onSwipe
-        lockBody=false
-      }}
     >
       {{#if this.showImpersonationNotice}}
         <ImpersonationNotice />

--- a/frontend/discourse/app/lib/swipe-events.js
+++ b/frontend/discourse/app/lib/swipe-events.js
@@ -1,6 +1,14 @@
 import { bind } from "discourse/lib/decorators";
 import { isTesting } from "discourse/lib/environment";
 
+let animationTimeOverride = null;
+
+// test-only: animations otherwise collapse to 0ms and finish before a gesture
+// could catch anything mid-flight
+export function overrideAnimationTimeForTesting(durationMs = null) {
+  animationTimeOverride = durationMs;
+}
+
 // common max animation time in ms for swipe events for swipe end
 // prefers reduced motion and tests return 0
 export function getMaxAnimationTimeMs(durationMs = MAX_ANIMATION_TIME) {
@@ -8,7 +16,7 @@ export function getMaxAnimationTimeMs(durationMs = MAX_ANIMATION_TIME) {
     isTesting() ||
     window.matchMedia("(prefers-reduced-motion: reduce)").matches
   ) {
-    return 0;
+    return animationTimeOverride ?? 0;
   }
   return Math.min(durationMs, MAX_ANIMATION_TIME);
 }

--- a/frontend/discourse/tests/acceptance/mobile-pan-test.js
+++ b/frontend/discourse/tests/acceptance/mobile-pan-test.js
@@ -385,6 +385,38 @@ acceptance("Mobile - menu drawer gestures", function (needs) {
     );
   });
 
+  test("a drawer wider than the 340px default starts fully offscreen", async function (assert) {
+    const style = document.createElement("style");
+    style.textContent =
+      ".menu-panel.slide-in { width: 450px !important; max-width: 450px !important; }";
+    document.head.appendChild(style);
+
+    try {
+      await visit("/");
+      overrideAnimationTimeForTesting(600_000);
+      // the raw click leaves the slide-in settle running for the press to
+      // catch; the click helper would wait on it
+      find(".hamburger-dropdown button").click();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      const drag = await startDrawerDrag(".panel-body");
+      overrideAnimationTimeForTesting();
+      const width = Math.round(drawerWidth());
+
+      assert.strictEqual(
+        drawerTranslateX(),
+        -width,
+        "the slide-in enters from the drawer's measured width, not from -340px"
+      );
+
+      // a press that never moves is a tap on the panel, which keeps it open
+      await endParkedDrawerDrag(drag);
+      assert.strictEqual(drawerTranslateX(), 0, "and the tap settles it open");
+    } finally {
+      style.remove();
+    }
+  });
+
   test("catching a settling drawer carries on from where it is", async function (assert) {
     await openHamburgerDrawer();
 

--- a/frontend/discourse/tests/acceptance/mobile-pan-test.js
+++ b/frontend/discourse/tests/acceptance/mobile-pan-test.js
@@ -427,7 +427,6 @@ acceptance("Mobile - menu drawer gestures", function (needs) {
     await moveDrawerDrag(drag, { by: -width / 5, afterMs: 400 });
     const pulledTo = drawerTranslateX();
 
-    // a real duration keeps the settle in flight for the press to catch
     overrideAnimationTimeForTesting(1_000);
     releaseDrawerDrag(drag, { afterMs: PARKED_RELEASE_MS });
     const caught = await startDrawerDrag(".panel-body");

--- a/frontend/discourse/tests/acceptance/mobile-pan-test.js
+++ b/frontend/discourse/tests/acceptance/mobile-pan-test.js
@@ -1,125 +1,541 @@
-import { click, triggerEvent, visit } from "@ember/test-helpers";
-import { acceptance, chromeTest } from "discourse/tests/helpers/qunit-helpers";
+import { click, find, settled, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { overrideAnimationTimeForTesting } from "discourse/lib/swipe-events";
+import { resetSiteDirForTesting } from "discourse/lib/text-direction";
+import Site from "discourse/models/site";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import {
+  stubPointerCapture,
+  stubSharedPointerCapture,
+} from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
 
-async function triggerSwipeStart(touchTarget) {
-  const emberTesting = document.querySelector("#ember-testing-container");
-  emberTesting.scrollTop = 0;
-  emberTesting.scrollLeft = 0;
+const PANEL_WIDTH_FALLBACK = 340;
+const JITTER_PX = 8;
+const PARKED_RELEASE_MS = 250;
 
-  // Other tests are shown in a transformed viewport, and this is a multiple for the offsets
-  let scale = parseFloat(
-    window
-      .getComputedStyle(document.querySelector("#ember-testing"))
-      .transform.replace("matrix(", "") || 1
+let nextPointerId = 1;
+
+function drawerWidth() {
+  return (
+    find(".menu-panel").getBoundingClientRect().width || PANEL_WIDTH_FALLBACK
   );
+}
 
-  const touchStart = {
-    touchTarget,
-    x:
-      touchTarget.getBoundingClientRect().x +
-      (scale * touchTarget.offsetWidth) / 2,
-    y:
-      touchTarget.getBoundingClientRect().y +
-      (scale * touchTarget.offsetHeight) / 2,
+function dispatchPointerEvent(target, type, drag) {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    pointerId: drag.pointerId,
+    clientX: drag.x,
+    clientY: drag.y,
+  });
+  Object.defineProperty(event, "timeStamp", { value: drag.time });
+  target.dispatchEvent(event);
+}
+
+async function startDrawerDrag(targetSelector) {
+  const target = find(targetSelector);
+  const gestureSurface = target.closest(".menu-panel.slide-in, .header-cloak");
+  const drag = {
+    gestureSurface,
+    pointerId: nextPointerId++,
+    x: 200,
+    y: 200,
+    time: 1000,
   };
-  const touch = new Touch({
-    identifier: "test",
-    target: touchTarget,
-    clientX: touchStart.x,
-    clientY: touchStart.y,
-  });
-  await triggerEvent(touchTarget, "touchstart", {
-    touches: [touch],
-    targetTouches: [touch],
-  });
-  return touchStart;
+
+  stubPointerCapture(gestureSurface);
+  if (target !== gestureSurface) {
+    stubPointerCapture(target);
+  }
+
+  dispatchPointerEvent(target, "pointerdown", drag);
+  await settled();
+
+  return drag;
 }
 
-async function triggerSwipeMove({ x, y, touchTarget }) {
-  const touch = new Touch({
-    identifier: "test",
-    target: touchTarget,
-    clientX: x,
-    clientY: y,
-  });
-  await triggerEvent(touchTarget, "touchmove", {
-    touches: [touch],
-    targetTouches: [touch],
-  });
+async function moveDrawerDrag(drag, { by, afterMs = 16 }) {
+  drag.x += by;
+  drag.time += afterMs;
+
+  dispatchPointerEvent(drag.gestureSurface, "pointermove", drag);
+  await settled();
 }
 
-async function triggerSwipeEnd({ x, y, touchTarget }) {
-  const touch = new Touch({
-    identifier: "test",
-    target: touchTarget,
-    clientX: x,
-    clientY: y,
-  });
-  await triggerEvent(touchTarget, "touchend", {
-    touches: [touch],
-    targetTouches: [touch],
-  });
+function releaseDrawerDrag(drag, { afterMs = 16 } = {}) {
+  drag.time += afterMs;
+  dispatchPointerEvent(drag.gestureSurface, "pointerup", drag);
 }
 
-// new Touch() isn't available in Firefox, so this is skipped there
-acceptance("Mobile - menu swipes", function (needs) {
+async function endDrawerDrag(drag, options) {
+  releaseDrawerDrag(drag, options);
+  await settled();
+}
+
+async function endParkedDrawerDrag(drag) {
+  await endDrawerDrag(drag, { afterMs: PARKED_RELEASE_MS });
+}
+
+function drawerTranslateX() {
+  const { transform } = window.getComputedStyle(find(".menu-panel"));
+  return transform === "none"
+    ? 0
+    : Math.round(new DOMMatrixReadOnly(transform).m41);
+}
+
+// without the gesture, the outside-press handler closes the drawer at the press
+// and every later assertion passes vacuously
+function assertPressAloneKeptDrawer(assert) {
+  assert
+    .dom(".panel-body")
+    .exists({ count: 1 }, "the press alone does not dismiss the drawer");
+}
+
+async function openHamburgerDrawer() {
+  await visit("/");
+  await click(".hamburger-dropdown button");
+}
+
+async function cancelDrawerDrag(drag, { afterMs = 16 } = {}) {
+  drag.time += afterMs;
+  dispatchPointerEvent(drag.gestureSurface, "pointercancel", drag);
+  await settled();
+}
+
+acceptance("Mobile - menu drawer gestures", function (needs) {
   needs.mobileView();
   needs.user();
 
-  chromeTest("swipe to close hamburger", async function (assert) {
-    await visit("/");
-    await click(".hamburger-dropdown button");
+  // a test dying mid-settle must not leave the override active for later tests
+  needs.hooks.afterEach(() => overrideAnimationTimeForTesting());
+
+  test("a drag past the distance threshold closes the hamburger drawer", async function (assert) {
+    await openHamburgerDrawer();
 
     assert.dom(document.documentElement).hasClass(/scroll-lock/);
 
-    const touchTarget = document.querySelector(".panel-body");
-    let swipe = await triggerSwipeStart(touchTarget);
-    swipe.x -= 20;
-    await triggerSwipeMove(swipe);
-    await triggerSwipeEnd(swipe);
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: -drawerWidth() / 2 });
+    await endParkedDrawerDrag(drag);
 
     assert
       .dom(".panel-body")
-      .doesNotExist("it closes hamburger on a left swipe");
+      .doesNotExist("half the drawer's width closes it on distance alone");
     assert.dom(document.documentElement).doesNotHaveClass(/scroll-lock/);
   });
 
-  chromeTest(
-    "swipe back and flick to re-open hamburger",
-    async function (assert) {
-      await visit("/");
-      await click(".hamburger-dropdown button");
+  test("a flick closes the hamburger drawer", async function (assert) {
+    await openHamburgerDrawer();
 
-      const touchTarget = document.querySelector(".panel-body");
-      let swipe = await triggerSwipeStart(touchTarget);
-      swipe.x -= 100;
-      await triggerSwipeMove(swipe);
-      swipe.x += 20;
-      await triggerSwipeMove(swipe);
-      await triggerSwipeEnd(swipe);
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: -drawerWidth() / 10, afterMs: 16 });
+    await endDrawerDrag(drag);
 
-      assert
-        .dom(".panel-body")
-        .exists({ count: 1 }, "it re-opens hamburger on a right swipe");
-    }
-  );
+    assert
+      .dom(".panel-body")
+      .doesNotExist("a short, fast movement closes it on velocity alone");
+  });
 
-  chromeTest("swipe to user menu", async function (assert) {
+  test("parking the pointer after a flick leaves the hamburger drawer open", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: -drawerWidth() / 10, afterMs: 16 });
+    await endParkedDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .exists(
+        { count: 1 },
+        "the flick's velocity expires while the pointer is held still, so the release is not read as a flick"
+      );
+    assert.strictEqual(
+      drawerTranslateX(),
+      0,
+      "and it settles rather than staying where the pointer left it"
+    );
+    assert.dom(document.documentElement).hasClass(/scroll-lock/);
+  });
+
+  test("dragging the hamburger drawer back open", async function (assert) {
+    await openHamburgerDrawer();
+
+    const width = drawerWidth();
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: -width / 2, afterMs: 400 });
+
+    assert
+      .dom(".panel-body")
+      .hasClass(/scroll-lock/, "the panel's content is locked while it drags");
+
+    await moveDrawerDrag(drag, { by: width / 2 - JITTER_PX, afterMs: 400 });
+    await endParkedDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .exists({ count: 1 }, "it restores the hamburger drawer");
+    assert.dom(document.documentElement).hasClass(/scroll-lock/);
+    assert.strictEqual(
+      drawerTranslateX(),
+      0,
+      "and it settles rather than staying where the pointer left it"
+    );
+    assert
+      .dom(".panel-body")
+      .doesNotHaveClass(
+        /scroll-lock/,
+        "the panel's own scroll lock is released with the gesture"
+      );
+  });
+
+  test("tapping the cloak closes the hamburger drawer", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".header-cloak");
+    assertPressAloneKeptDrawer(assert);
+    await endDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .doesNotExist("the ordinary tap-to-dismiss behavior is preserved");
+    assert.dom(document.documentElement).doesNotHaveClass(/scroll-lock/);
+  });
+
+  test("a jittery tap on the cloak still closes the hamburger drawer", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".header-cloak");
+    assertPressAloneKeptDrawer(assert);
+    await moveDrawerDrag(drag, { by: -JITTER_PX, afterMs: 400 });
+    await endParkedDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .doesNotExist(
+        "finger jitter engages the drag but must not strand the drawer open"
+      );
+    assert.dom(document.documentElement).doesNotHaveClass(/scroll-lock/);
+  });
+
+  test("dragging the drawer open from the cloak keeps it open", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".header-cloak");
+    assertPressAloneKeptDrawer(assert);
+    await moveDrawerDrag(drag, { by: drawerWidth() / 4, afterMs: 400 });
+    await endParkedDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .exists(
+        { count: 1 },
+        "a deliberate pull in the opening direction is the one cloak gesture that does not dismiss"
+      );
+    assert.strictEqual(drawerTranslateX(), 0, "and the overdrag is settled");
+  });
+
+  test("catching the drawer while it settles closed keeps it open", async function (assert) {
+    await openHamburgerDrawer();
+
+    const width = drawerWidth();
+    const closing = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(closing, { by: -width / 2, afterMs: 400 });
+
+    releaseDrawerDrag(closing, { afterMs: 400 });
+
+    const caught = await startDrawerDrag(".panel-body");
+    // zero-duration settles land instantly, so the drawer is caught fully closed
+    await moveDrawerDrag(caught, { by: width, afterMs: 400 });
+    await endParkedDrawerDrag(caught);
+
+    assert
+      .dom(".panel-body")
+      .exists(
+        { count: 1 },
+        "the settling close does not commit over the gesture that caught the drawer"
+      );
+    assert.strictEqual(
+      drawerTranslateX(),
+      0,
+      "and it settles rather than staying where the pointer left it"
+    );
+    assert.dom(document.documentElement).hasClass(/scroll-lock/);
+  });
+
+  test("dragging the user drawer closed", async function (assert) {
     await visit("/");
     await click("#current-user button");
 
     assert.dom(document.documentElement).hasClass(/scroll-lock/);
 
-    const touchTarget = document.querySelector(".panel-body");
-    let swipe = await triggerSwipeStart(touchTarget);
-    swipe.x += 20;
-    await triggerSwipeMove(swipe);
-    await triggerSwipeEnd(swipe);
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: drawerWidth() / 2 });
+    await endParkedDrawerDrag(drag);
 
     assert
       .dom(".panel-body")
-      .doesNotExist("it closes user menu on a left swipe");
-
+      .doesNotExist("it closes the user drawer on a right drag");
     assert.dom(document.documentElement).doesNotHaveClass(/scroll-lock/);
+  });
+
+  test("a cloak gesture the browser claims still closes the drawer", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".header-cloak");
+    assertPressAloneKeptDrawer(assert);
+    await moveDrawerDrag(drag, { by: -JITTER_PX, afterMs: 400 });
+    await cancelDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .doesNotExist(
+        "a press outside the drawer dismisses it however the gesture ends, since the outside-press handler it displaced will not fire"
+      );
+    assert.dom(document.documentElement).doesNotHaveClass(/scroll-lock/);
+  });
+
+  test("a cloak gesture pulling the drawer open survives a claim", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".header-cloak");
+    assertPressAloneKeptDrawer(assert);
+    await moveDrawerDrag(drag, { by: drawerWidth() / 4, afterMs: 400 });
+    await cancelDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .exists(
+        { count: 1 },
+        "a deliberate pull the other way is still not a dismissal"
+      );
+    assert.strictEqual(
+      drawerTranslateX(),
+      0,
+      "and it settles back rather than staying where the overdrag left it"
+    );
+  });
+
+  test("a reversal sharing a timestamp does not close the drawer", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: -drawerWidth() / 10, afterMs: 16 });
+    await moveDrawerDrag(drag, { by: JITTER_PX * 2, afterMs: 0 });
+    await endDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .exists(
+        { count: 1 },
+        "an untimeable sample leaves the decision to distance, which this drag never covers"
+      );
+    assert.strictEqual(
+      drawerTranslateX(),
+      0,
+      "and it settles rather than staying where the pointer left it"
+    );
+    assert.dom(document.documentElement).hasClass(/scroll-lock/);
+  });
+
+  test("the user drawer closes toward its own edge under RTL", async function (assert) {
+    await visit("/");
+    await click("#current-user button");
+
+    // rtlcss flips the anchoring at build time only, so this covers just the
+    // direction logic; siteDir memoizes off the class
+    document.documentElement.classList.add("rtl");
+    resetSiteDirForTesting();
+
+    try {
+      const drag = await startDrawerDrag(".panel-body");
+      await moveDrawerDrag(drag, { by: -drawerWidth() / 2, afterMs: 400 });
+      await endParkedDrawerDrag(drag);
+
+      assert
+        .dom(".panel-body")
+        .doesNotExist(
+          "under RTL the user drawer is the left menu, so dragging left dismisses it"
+        );
+    } finally {
+      document.documentElement.classList.remove("rtl");
+      resetSiteDirForTesting();
+    }
+  });
+
+  test("a correction after overdragging does not dismiss the drawer", async function (assert) {
+    await openHamburgerDrawer();
+
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: drawerWidth() * 0.6, afterMs: 400 });
+    await moveDrawerDrag(drag, { by: -JITTER_PX, afterMs: 16 });
+    await endDrawerDrag(drag);
+
+    assert
+      .dom(".panel-body")
+      .exists(
+        { count: 1 },
+        "a flick's velocity cannot close a drawer the gesture has net pulled open"
+      );
+    assert.strictEqual(
+      drawerTranslateX(),
+      0,
+      "and the rubber-banding settles back"
+    );
+  });
+
+  test("catching a settling drawer carries on from where it is", async function (assert) {
+    await openHamburgerDrawer();
+
+    const width = drawerWidth();
+    const panel = find(".menu-panel");
+    const cloak = find(".header-cloak");
+    const drag = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(drag, { by: -width / 5, afterMs: 400 });
+    const pulledTo = drawerTranslateX();
+
+    // a real duration keeps the settle in flight for the press to catch
+    overrideAnimationTimeForTesting(1_000);
+    releaseDrawerDrag(drag, { afterMs: PARKED_RELEASE_MS });
+    const caught = await startDrawerDrag(".panel-body");
+    overrideAnimationTimeForTesting();
+
+    assert.strictEqual(
+      panel.getAnimations().length + cloak.getAnimations().length,
+      0,
+      "the press cancels the settle animations the drawer was running"
+    );
+    assert.strictEqual(
+      drawerTranslateX(),
+      pulledTo,
+      "the drawer is caught where the settle had it, not snapped to open"
+    );
+
+    await moveDrawerDrag(caught, { by: -JITTER_PX, afterMs: 400 });
+
+    assert.strictEqual(
+      drawerTranslateX(),
+      pulledTo - JITTER_PX,
+      "the drag moves the drawer on from there"
+    );
+    assert.strictEqual(
+      panel.getAnimations().length,
+      0,
+      "previews write styles rather than stacking animations per move"
+    );
+
+    await endParkedDrawerDrag(caught);
+  });
+
+  test("a second pointer does not take the drawer from the first", async function (assert) {
+    await openHamburgerDrawer();
+
+    const width = drawerWidth();
+    const held = await startDrawerDrag(".panel-body");
+    await moveDrawerDrag(held, { by: -width / 4, afterMs: 400 });
+    const caughtAt = drawerTranslateX();
+
+    const second = await startDrawerDrag(".header-cloak");
+    await moveDrawerDrag(second, { by: width / 4, afterMs: 400 });
+
+    assert.strictEqual(
+      drawerTranslateX(),
+      caughtAt,
+      "the second pointer is refused rather than overwriting the gesture in flight"
+    );
+
+    await endDrawerDrag(second);
+    await endParkedDrawerDrag(held);
+  });
+
+  test("a press inside the panel hands the capture to the pressed control", async function (assert) {
+    await openHamburgerDrawer();
+
+    const { ownerOf } = stubSharedPointerCapture([
+      ".menu-panel",
+      ".panel-body",
+    ]);
+    const drag = {
+      gestureSurface: find(".menu-panel"),
+      pointerId: nextPointerId++,
+      x: 200,
+      y: 200,
+      time: 1000,
+    };
+
+    dispatchPointerEvent(find(".panel-body"), "pointerdown", drag);
+    await settled();
+
+    assert
+      .dom(ownerOf(drag.pointerId))
+      .hasClass(
+        "panel-body",
+        "the pressed node keeps the capture, not the panel"
+      );
+
+    await endDrawerDrag(drag);
+  });
+
+  test("a press inside the panel is left uncancelled, a press on the cloak is not", async function (assert) {
+    await openHamburgerDrawer();
+
+    const prevented = {};
+    const record = (surface) => (event) =>
+      (prevented[surface] = event.defaultPrevented);
+    const panel = find(".menu-panel");
+    const cloak = find(".header-cloak");
+    const recordPanel = record("panel");
+    const recordCloak = record("cloak");
+    panel.addEventListener("pointerdown", recordPanel);
+    cloak.addEventListener("pointerdown", recordCloak);
+
+    let panelDragEngaged;
+    try {
+      const panelDrag = await startDrawerDrag(".panel-body");
+      await moveDrawerDrag(panelDrag, { by: -JITTER_PX * 3, afterMs: 400 });
+      panelDragEngaged = drawerTranslateX() !== 0;
+      await endParkedDrawerDrag(panelDrag);
+      await endDrawerDrag(await startDrawerDrag(".header-cloak"));
+    } finally {
+      panel.removeEventListener("pointerdown", recordPanel);
+      cloak.removeEventListener("pointerdown", recordCloak);
+    }
+
+    assert.true(
+      panelDragEngaged,
+      "the panel gesture exists, so the uncancelled press below is its doing rather than its absence"
+    );
+    assert.false(
+      prevented.panel,
+      "the panel keeps the compatibility mousedown its controls need for focus and text selection"
+    );
+    assert.true(
+      prevented.cloak,
+      "the cloak carries nothing to press, so its gesture still suppresses one"
+    );
+  });
+});
+
+acceptance("Narrow desktop - menu drawer gestures", function (needs) {
+  needs.user();
+
+  test("dragging the hamburger drawer closed", async function (assert) {
+    await visit("/");
+    Site.current().set("narrowDesktopView", true);
+
+    try {
+      await click(".btn-sidebar-toggle");
+
+      const drag = await startDrawerDrag(".panel-body");
+      await moveDrawerDrag(drag, { by: -drawerWidth() / 2 });
+      await endParkedDrawerDrag(drag);
+
+      assert
+        .dom(".panel-body")
+        .doesNotExist("every slide-in drawer drags, not only the mobile one");
+    } finally {
+      Site.current().set("narrowDesktopView", false);
+    }
   });
 });


### PR DESCRIPTION
Previously, the mobile drawer only responded to touch swipes, judged against a hardcoded 340px width and fixed thresholds: mouse and pen drags did nothing, narrower drawers faded out of step with the finger, a sideways swipe on the dim cloak left the drawer open where a tap would have dismissed it, the RTL user menu swiped as if anchored on the wrong side, and a drawer animating closed could not be caught.

This change drives the drawers with the shared pointer-drag gesture (`preservePress`, #42857): any pointer drags them on mobile and narrow desktop, taps inside still focus and click, a settling drawer is caught where it is, dragging past open rubber-bands, and release dismisses on real distance or a flick measured against the drawer's own width, in both text directions.
