### PR TITLE
DEV: Add JSON:API restricted fields

### DIFF
--- a/lib/json_api_kit/declarations/attribute.rb
+++ b/lib/json_api_kit/declarations/attribute.rb
@@ -5,8 +5,11 @@ module JsonApiKit
     class Attribute
       attr_reader :name
 
-      def initialize(name, &value)
+      delegate :readable_by?, :readable_for?, to: :readable
+
+      def initialize(name, readable: Readable::ALWAYS, &value)
         @name = name.to_s
+        @readable = Readable.for(readable)
         @value = value
       end
 
@@ -16,13 +19,13 @@ module JsonApiKit
       end
 
       def column_for(schema)
-        return if value
+        return if value || readable.per_record?
         schema.column(name)
       end
 
       private
 
-      attr_reader :value
+      attr_reader :readable, :value
     end
   end
 end

--- a/lib/json_api_kit/declarations/attributes.rb
+++ b/lib/json_api_kit/declarations/attributes.rb
@@ -3,18 +3,21 @@
 module JsonApiKit
   module Declarations
     class Attributes
-      def initialize(attributes, schema:)
+      def initialize(attributes, guardian:, schema:)
         @attributes = attributes
+        @guardian = guardian
         @schema = schema
       end
 
-      def values_for(record) = attributes.to_h { [it.name, it.value_for(record)] }
+      def values_for(record) = readable(record).to_h { [it.name, it.value_for(record)] }
 
       def columns = Columns.for(attributes.map { it.column_for(schema) })
 
       private
 
-      attr_reader :attributes, :schema
+      attr_reader :attributes, :guardian, :schema
+
+      def readable(record) = attributes.select { it.readable_for?(guardian, record) }
     end
   end
 end

--- a/lib/json_api_kit/declarations/fields.rb
+++ b/lib/json_api_kit/declarations/fields.rb
@@ -12,15 +12,16 @@ module JsonApiKit
         new(names, **declarations)
       end
 
-      def initialize(names, attributes:, relationships:, schema:)
+      def initialize(names, guardian:, attributes:, relationships:, schema:)
         @names = names
+        @guardian = guardian
         @declared_attributes = attributes
         @declared_relationships = relationships
         @schema = schema
         verify_field_names
       end
 
-      def attributes = @attributes ||= Attributes.new(pick(declared_attributes), schema:)
+      def attributes = @attributes ||= Attributes.new(pick(declared_attributes), guardian:, schema:)
 
       def relationships = Relationships.new(pick(declared_relationships))
 
@@ -28,9 +29,11 @@ module JsonApiKit
 
       private
 
-      attr_reader :names, :declared_attributes, :declared_relationships, :schema
+      attr_reader :names, :guardian, :declared_attributes, :declared_relationships, :schema
 
-      def pick(fields) = fields.select { names.include?(it.name) }
+      def pick(fields) = readable(fields).select { names.include?(it.name) }
+
+      def readable(fields) = fields.select { it.readable_by?(guardian) }
 
       def all_fields = declared_attributes + declared_relationships
 

--- a/lib/json_api_kit/declarations/fields/all.rb
+++ b/lib/json_api_kit/declarations/fields/all.rb
@@ -10,7 +10,7 @@ module JsonApiKit
 
         private
 
-        def pick(fields) = fields
+        def pick(fields) = readable(fields)
       end
     end
   end

--- a/lib/json_api_kit/declarations/readable.rb
+++ b/lib/json_api_kit/declarations/readable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module JsonApiKit
+  module Declarations
+    class Readable
+      ALWAYS = ->(_guardian) { true }
+
+      def self.for(rule) = (rule.arity == 2 ? PerRecord : PerUser).new(rule)
+
+      def initialize(rule)
+        @rule = rule
+      end
+
+      private
+
+      attr_reader :rule
+    end
+  end
+end

--- a/lib/json_api_kit/declarations/readable/per_record.rb
+++ b/lib/json_api_kit/declarations/readable/per_record.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module JsonApiKit
+  module Declarations
+    class Readable
+      class PerRecord < Readable
+        def per_record? = true
+
+        def readable_by?(_guardian) = true
+
+        def readable_for?(guardian, record) = rule.call(guardian, record)
+      end
+    end
+  end
+end

--- a/lib/json_api_kit/declarations/readable/per_user.rb
+++ b/lib/json_api_kit/declarations/readable/per_user.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module JsonApiKit
+  module Declarations
+    class Readable
+      class PerUser < Readable
+        def per_record? = false
+
+        def readable_by?(guardian) = rule.call(guardian)
+
+        def readable_for?(_guardian, _record) = true
+      end
+    end
+  end
+end

--- a/lib/json_api_kit/declarations/relationship.rb
+++ b/lib/json_api_kit/declarations/relationship.rb
@@ -3,16 +3,32 @@
 module JsonApiKit
   module Declarations
     class Relationship
+      UnsupportedRule = Class.new(StandardError)
+
       attr_reader :name, :resource
 
-      def initialize(name, resource:)
+      delegate :readable_by?, to: :readable
+
+      def initialize(name, resource:, readable: Readable::ALWAYS)
         @name = name.to_s
         @resource = resource
+        @readable = Readable.for(readable)
+        verify_readable_block
       end
 
       def listing(params, guardian:, scoped_to:) = resource.all(params, guardian:, scoped_to:)
 
       def resolves?(path) = resource.resolves?(path)
+
+      private
+
+      attr_reader :readable
+
+      def verify_readable_block
+        return unless readable.per_record?
+        raise UnsupportedRule,
+              "#{name}: having both a guardian and a record for a relationship isn’t supported"
+      end
     end
   end
 end

--- a/lib/json_api_kit/query.rb
+++ b/lib/json_api_kit/query.rb
@@ -49,7 +49,7 @@ module JsonApiKit
 
     def schema = @schema ||= resource.schema
 
-    def fields = @fields ||= resource.fields(request.fields[resource.type])
+    def fields = @fields ||= resource.fields(request.fields[resource.type], guardian:)
 
     def sideloads
       @sideloads ||= Sideloads.for(relationships, paths:, rows:, request:, schema:)

--- a/lib/json_api_kit/resource/fields.rb
+++ b/lib/json_api_kit/resource/fields.rb
@@ -23,22 +23,18 @@ module JsonApiKit
       class_methods do
         delegate :resolves?, to: :relationships
 
-        def attribute(name, &value)
-          self.declared_attributes =
-            declared_attributes + [Declarations::Attribute.new(name, &value)]
+        def attribute(...)
+          self.declared_attributes = declared_attributes + [Declarations::Attribute.new(...)]
         end
 
-        def has_one(name, resource:)
-          relate(Declarations::Relationship::ToOne.new(name, resource:))
-        end
+        def has_one(...) = relate(Declarations::Relationship::ToOne.new(...))
 
-        def has_many(name, resource:)
-          relate(Declarations::Relationship::ToMany.new(name, resource:))
-        end
+        def has_many(...) = relate(Declarations::Relationship::ToMany.new(...))
 
-        def fields(names = nil)
+        def fields(names = nil, guardian:)
           Declarations::Fields.for(
             names,
+            guardian:,
             attributes: declared_attributes,
             relationships: declared_relationships,
             schema:,

--- a/spec/integration/json_api_kit/restricted_fields_spec.rb
+++ b/spec/integration/json_api_kit/restricted_fields_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative "support"
+
+RSpec.describe "a restricted field" do
+  include_context "with a listing of topics"
+
+  describe "an attribute" do
+    context "when the rule only looks at the user" do
+      let(:resource) do
+        Class.new(JsonApiKit::Resource) do
+          model Topic
+          type :topics
+          attribute :title
+          attribute :created_at, readable: ->(guardian) { guardian.is_admin? }
+        end
+      end
+      let(:title_only) do
+        {
+          data: [
+            topic_object(oldest, fields: %w[title]),
+            topic_object(middle, fields: %w[title]),
+            topic_object(newest, fields: %w[title]),
+          ],
+          included: [],
+          links: links_of,
+        }
+      end
+
+      context "when it’s not readable by the user" do
+        it "does not render it" do
+          expect(document).to eq(title_only)
+        end
+
+        context "when the field is explicitly requested" do
+          let(:params) { { fields: { topics: %w[title created_at] } } }
+
+          it "does not render it" do
+            expect(document).to eq(title_only)
+          end
+        end
+      end
+
+      context "when it’s readable by the user" do
+        let(:guardian) { Fabricate(:admin).guardian }
+
+        it "renders it" do
+          expect(document).to eq(
+            data: [topic_object(oldest), topic_object(middle), topic_object(newest)],
+            included: [],
+            links: links_of,
+          )
+        end
+      end
+    end
+
+    context "when the rule looks both at the user and the record" do
+      let(:resource) do
+        Class.new(JsonApiKit::Resource) do
+          model Topic
+          type :topics
+          attribute :title
+          attribute :created_at,
+                    readable: ->(guardian, topic) { topic.user_id == guardian.user&.id }
+        end
+      end
+      let(:guardian) { middle.user.guardian }
+
+      context "when using sparse fieldsets excluding the one used in the rule" do
+        let(:params) { { fields: { topics: %w[title created_at] } } }
+
+        it "does not crash" do
+          expect(document[:data].map { it[:attributes].keys }).to eq(
+            [%w[title], %w[title created_at], %w[title]],
+          )
+        end
+      end
+
+      it "renders it on the user’s own record alone" do
+        expect(document).to eq(
+          data: [
+            topic_object(oldest, fields: %w[title]),
+            topic_object(middle),
+            topic_object(newest, fields: %w[title]),
+          ],
+          included: [],
+          links: links_of,
+        )
+      end
+    end
+  end
+
+  describe "a relationship" do
+    let(:resource) do
+      Class.new(JsonApiKit::Resource) do
+        model Topic
+        type :topics
+        attribute :title
+        has_one :user,
+                resource: JsonApiKitSpec::UserResource,
+                readable: ->(guardian) { guardian.is_admin? }
+      end
+    end
+    let(:scoped_to) { Topic.where(id: middle.id) }
+    let(:params) { { include: %w[user] } }
+
+    context "when it’s not readable by the user" do
+      it "does not render it" do
+        expect(document).to eq(
+          data: [topic_object(middle, fields: %w[title])],
+          included: [],
+          links: links_of,
+        )
+      end
+    end
+
+    context "when it’s readable by the user" do
+      let(:guardian) { Fabricate(:admin).guardian }
+
+      it "renders it" do
+        expect(document).to eq(
+          data: [
+            topic_object(
+              middle,
+              fields: %w[title],
+              relationships: {
+                "user" =>
+                  relationship_object(
+                    "topics",
+                    middle,
+                    "user",
+                    data: identifier_of("users", middle.user),
+                  ),
+              },
+            ),
+          ],
+          included: [user_object(middle.user)],
+          links: links_of,
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/json_api_kit/declarations/attributes_spec.rb
+++ b/spec/lib/json_api_kit/declarations/attributes_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiKit::Declarations::Attributes do
-  subject(:attributes) { described_class.new(declarations, schema:) }
+  subject(:attributes) { described_class.new(declarations, guardian:, schema:) }
 
   fab!(:topic) { Fabricate(:topic, title: "A field rendered from a record", closed: false) }
 
+  let(:guardian) { Guardian.new }
   let(:schema) { JsonApiKit::Schema.new(Topic) }
   let(:attribute) { JsonApiKit::Declarations::Attribute }
   let(:declarations) { [attribute.new(:title), attribute.new(:closed)] }

--- a/spec/lib/json_api_kit/declarations/fields_spec.rb
+++ b/spec/lib/json_api_kit/declarations/fields_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiKit::Declarations::Fields do
-  subject(:fields) { described_class.for(names, attributes:, relationships:, schema:) }
+  subject(:fields) { described_class.for(names, guardian:, attributes:, relationships:, schema:) }
+
+  let(:guardian) { Guardian.new }
 
   fab!(:topic) { Fabricate(:topic, title: "A record read as its fields", closed: false) }
 

--- a/spec/lib/json_api_kit/declarations/readable/per_record_spec.rb
+++ b/spec/lib/json_api_kit/declarations/readable/per_record_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiKit::Declarations::Readable::PerRecord do
+  subject(:readable) { described_class.new(rule) }
+
+  fab!(:topic)
+
+  let(:guardian) { Guardian.new }
+  let(:rule) { ->(_user, _record) { true } }
+
+  describe "#per_record?" do
+    it { is_expected.to be_per_record }
+  end
+
+  describe "#readable_by?" do
+    context "when the rule refuses the record" do
+      let(:rule) { ->(_user, _record) { false } }
+
+      it "allows the user" do
+        expect(readable).to be_readable_by(guardian)
+      end
+    end
+  end
+
+  describe "#readable_for?" do
+    context "when the rule allows the record" do
+      it "allows the record" do
+        expect(readable).to be_readable_for(guardian, topic)
+      end
+    end
+
+    context "when the rule refuses the record" do
+      let(:rule) { ->(_user, _record) { false } }
+
+      it "refuses the record" do
+        expect(readable).not_to be_readable_for(guardian, topic)
+      end
+    end
+  end
+end

--- a/spec/lib/json_api_kit/declarations/readable/per_user_spec.rb
+++ b/spec/lib/json_api_kit/declarations/readable/per_user_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiKit::Declarations::Readable::PerUser do
+  subject(:readable) { described_class.new(rule) }
+
+  fab!(:topic)
+
+  let(:guardian) { Guardian.new }
+  let(:rule) { ->(_user) { true } }
+
+  describe "#per_record?" do
+    it { is_expected.not_to be_per_record }
+  end
+
+  describe "#readable_by?" do
+    context "when the rule allows the user" do
+      it "allows the user" do
+        expect(readable).to be_readable_by(guardian)
+      end
+    end
+
+    context "when the rule refuses the user" do
+      let(:rule) { ->(_user) { false } }
+
+      it "refuses the user" do
+        expect(readable).not_to be_readable_by(guardian)
+      end
+    end
+  end
+
+  describe "#readable_for?" do
+    context "when the rule refuses the user" do
+      let(:rule) { ->(_user) { false } }
+
+      it "allows the record" do
+        expect(readable).to be_readable_for(guardian, topic)
+      end
+    end
+  end
+end

--- a/spec/lib/json_api_kit/declarations/readable_spec.rb
+++ b/spec/lib/json_api_kit/declarations/readable_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiKit::Declarations::Readable do
+  describe ".for" do
+    subject(:readable) { described_class.for(rule) }
+
+    context "when no rule is declared" do
+      let(:rule) { described_class::ALWAYS }
+
+      it { is_expected.to be_a(described_class::PerUser) }
+    end
+
+    context "when the rule only looks at the user" do
+      let(:rule) { ->(_user) { true } }
+
+      it { is_expected.to be_a(described_class::PerUser) }
+    end
+
+    context "when the rule looks both at the user and the record" do
+      let(:rule) { ->(_user, _record) { true } }
+
+      it { is_expected.to be_a(described_class::PerRecord) }
+    end
+  end
+end

--- a/spec/lib/json_api_kit/declarations/relationship_spec.rb
+++ b/spec/lib/json_api_kit/declarations/relationship_spec.rb
@@ -8,6 +8,23 @@ RSpec.describe JsonApiKit::Declarations::Relationship do
   fab!(:author, :user)
   fab!(:topic) { Fabricate(:topic, user: author, title: "A topic that relates to rows") }
 
+  let(:guardian) { Guardian.new }
+
+  describe ".new" do
+    context "when the readable block declares both a guardian and a record" do
+      subject(:relationship) do
+        described_class.new(
+          :user,
+          resource: users_resource,
+          readable: ->(guardian, record) { true },
+        )
+      end
+
+      it "raises an error" do
+        expect { relationship }.to raise_error(described_class::UnsupportedRule, /user/)
+      end
+    end
+  end
   let(:groups_resource) { Class.new(JsonApiKit::Resource) { type :groups } }
   let(:users_resource) do
     related = groups_resource
@@ -113,7 +130,7 @@ RSpec.describe JsonApiKit::Declarations::Relationship do
           [first_post, second_post, third_post].map do
             JsonApiKit::Record.new(
               JsonApiKit::Pagination::Row.new(record: it, segment: order.first),
-              posts_resource.fields,
+              posts_resource.fields(guardian:),
               type: "posts",
             )
           end,

--- a/spec/lib/json_api_kit/document/contents_spec.rb
+++ b/spec/lib/json_api_kit/document/contents_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe JsonApiKit::Document::Contents do
   let(:records) { [record_of(topic, "topics", "user" => linkage(author_record))] }
   let(:related_records) { [author_record] }
 
+  let(:guardian) { Guardian.new }
+
   def record_of(model, type, relationships = {})
     JsonApiKit::Record.new(
       JsonApiKit::Pagination::Row.new(record: model, segment: nil),
       JsonApiKit::Declarations::Fields.for(
         nil,
+        guardian:,
         attributes: [],
         relationships: [],
         schema: JsonApiKit::Schema.new(model.class),

--- a/spec/lib/json_api_kit/document/relationship_object_spec.rb
+++ b/spec/lib/json_api_kit/document/relationship_object_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe JsonApiKit::Document::RelationshipObject do
   fab!(:author, :user)
   fab!(:topic)
 
+  let(:guardian) { Guardian.new }
   let(:urls) do
     JsonApiKit::Urls.new(base: "https://example.com/api", current: "https://example.com/api/topics")
   end
@@ -25,14 +26,14 @@ RSpec.describe JsonApiKit::Document::RelationshipObject do
   let(:record) do
     JsonApiKit::Record.new(
       JsonApiKit::Pagination::Row.new(record: author, segment: nil),
-      users_resource.fields,
+      users_resource.fields(guardian:),
       type: "users",
     )
   end
   let(:owner) do
     JsonApiKit::Record.new(
       JsonApiKit::Pagination::Row.new(record: topic, segment: nil),
-      topics_resource.fields,
+      topics_resource.fields(guardian:),
       type: "topics",
     )
   end

--- a/spec/lib/json_api_kit/document/resource_object_spec.rb
+++ b/spec/lib/json_api_kit/document/resource_object_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe JsonApiKit::Document::ResourceObject do
 
   fab!(:topic) { Fabricate(:topic, title: "A row a document renders") }
 
+  let(:guardian) { Guardian.new }
   let(:resource) do
     Class.new(JsonApiKit::Resource) do
       model Topic
@@ -12,7 +13,7 @@ RSpec.describe JsonApiKit::Document::ResourceObject do
       attribute :title
     end
   end
-  let(:fields) { resource.fields }
+  let(:fields) { resource.fields(guardian:) }
   let(:row) { JsonApiKit::Pagination::Row.new(record: topic, segment: nil) }
   let(:record) { JsonApiKit::Record.new(row, fields, type: "topics") }
   let(:meta) { {} }
@@ -43,7 +44,7 @@ RSpec.describe JsonApiKit::Document::ResourceObject do
     end
 
     context "when the record holds no attribute" do
-      let(:fields) { resource.fields(["secrets"]) }
+      let(:fields) { resource.fields(["secrets"], guardian:) }
 
       it "renders no attributes" do
         expect(resource_object.to_h).not_to have_key(:attributes)
@@ -58,7 +59,7 @@ RSpec.describe JsonApiKit::Document::ResourceObject do
       let(:author_record) do
         JsonApiKit::Record.new(
           JsonApiKit::Pagination::Row.new(record: topic.user, segment: nil),
-          users_resource.fields,
+          users_resource.fields(guardian:),
           type: "users",
         )
       end
@@ -99,7 +100,7 @@ RSpec.describe JsonApiKit::Document::ResourceObject do
       let(:post_record) do
         JsonApiKit::Record.new(
           JsonApiKit::Pagination::Row.new(record: post, segment: nil),
-          posts_resource.fields,
+          posts_resource.fields(guardian:),
           type: "posts",
         )
       end

--- a/spec/lib/json_api_kit/included_spec.rb
+++ b/spec/lib/json_api_kit/included_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe JsonApiKit::Included do
   let(:author_record) { record_of(author, "users") }
   let(:records) { [record_of(topic, "topics", "user" => linkage(author_record))] }
 
+  let(:guardian) { Guardian.new }
+
   def record_of(model, type, relationships = {})
     JsonApiKit::Record.new(
       JsonApiKit::Pagination::Row.new(record: model, segment: nil),
       JsonApiKit::Declarations::Fields.for(
         nil,
+        guardian:,
         attributes: [],
         relationships: [],
         schema: JsonApiKit::Schema.new(model.class),

--- a/spec/lib/json_api_kit/linkage/to_many_spec.rb
+++ b/spec/lib/json_api_kit/linkage/to_many_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe JsonApiKit::Linkage::ToMany do
 
   fab!(:topic)
 
+  let(:guardian) { Guardian.new }
   let(:resource) do
     Class.new(JsonApiKit::Resource) do
       model Topic
@@ -14,7 +15,7 @@ RSpec.describe JsonApiKit::Linkage::ToMany do
   let(:record) do
     JsonApiKit::Record.new(
       JsonApiKit::Pagination::Row.new(record: topic, segment: nil),
-      resource.fields,
+      resource.fields(guardian:),
       type: "topics",
     )
   end

--- a/spec/lib/json_api_kit/linkage/to_one_spec.rb
+++ b/spec/lib/json_api_kit/linkage/to_one_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe JsonApiKit::Linkage::ToOne do
 
   fab!(:topic)
 
+  let(:guardian) { Guardian.new }
   let(:resource) do
     Class.new(JsonApiKit::Resource) do
       model Topic
@@ -14,7 +15,7 @@ RSpec.describe JsonApiKit::Linkage::ToOne do
   let(:record) do
     JsonApiKit::Record.new(
       JsonApiKit::Pagination::Row.new(record: topic, segment: nil),
-      resource.fields,
+      resource.fields(guardian:),
       type: "topics",
     )
   end

--- a/spec/lib/json_api_kit/record_spec.rb
+++ b/spec/lib/json_api_kit/record_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiKit::Record do
-  subject(:record) { described_class.new(row, resource.fields, type: "topics", relationships:) }
+  subject(:record) do
+    described_class.new(row, resource.fields(guardian:), type: "topics", relationships:)
+  end
 
   fab!(:author, :user)
   fab!(:topic) { Fabricate(:topic, user: author, title: "A row read as a record") }
 
+  let(:guardian) { Guardian.new }
   let(:resource) do
     Class.new(JsonApiKit::Resource) do
       model Topic
@@ -24,7 +27,7 @@ RSpec.describe JsonApiKit::Record do
   let(:author_record) do
     described_class.new(
       JsonApiKit::Pagination::Row.new(record: author, segment: nil),
-      users_resource.fields,
+      users_resource.fields(guardian:),
       type: "users",
     )
   end
@@ -51,7 +54,7 @@ RSpec.describe JsonApiKit::Record do
 
     it "matches another reading of the same row" do
       expect(record.identity).to eq(
-        described_class.new(row, resource.fields(["secrets"]), type: "topics").identity,
+        described_class.new(row, resource.fields(["secrets"], guardian:), type: "topics").identity,
       )
     end
   end
@@ -61,7 +64,12 @@ RSpec.describe JsonApiKit::Record do
 
     let(:relationships) { { "user" => JsonApiKit::Linkage::ToOne.new([author_record]) } }
     let(:other) do
-      described_class.new(row, resource.fields(["secrets"]), type: "topics", relationships: editors)
+      described_class.new(
+        row,
+        resource.fields(["secrets"], guardian:),
+        type: "topics",
+        relationships: editors,
+      )
     end
     let(:editors) do
       {

--- a/spec/lib/json_api_kit/resource_spec.rb
+++ b/spec/lib/json_api_kit/resource_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe JsonApiKit::Resource do
   end
 
   describe ".attribute" do
-    subject(:attribute_values) { topic_resource.fields.attributes.values_for(topic) }
+    subject(:attribute_values) { topic_resource.fields(guardian:).attributes.values_for(topic) }
 
     fab!(:topic) { Fabricate(:topic, title: "A field a resource renders") }
 
@@ -291,7 +291,7 @@ RSpec.describe JsonApiKit::Resource do
 
     context "when the resource declares one more after a reading" do
       before do
-        topic_resource.fields.attributes
+        topic_resource.fields(guardian:).attributes
         topic_resource.attribute(:closed)
       end
 
@@ -302,7 +302,7 @@ RSpec.describe JsonApiKit::Resource do
   end
 
   describe ".has_one" do
-    subject(:user_relationships) { topic_resource.fields.relationships.pick(%w[user]) }
+    subject(:user_relationships) { topic_resource.fields(guardian:).relationships.pick(%w[user]) }
 
     it "relates the resource to one record of another" do
       expect(user_relationships.first.resource).to eq(user_resource)
@@ -313,10 +313,12 @@ RSpec.describe JsonApiKit::Resource do
     end
 
     context "when the resource declares one more after a reading" do
-      subject(:category_relationships) { topic_resource.fields.relationships.pick(%w[category]) }
+      subject(:category_relationships) do
+        topic_resource.fields(guardian:).relationships.pick(%w[category])
+      end
 
       before do
-        topic_resource.fields
+        topic_resource.fields(guardian:)
         topic_resource.has_one(:category, resource: user_resource)
       end
 
@@ -327,7 +329,7 @@ RSpec.describe JsonApiKit::Resource do
   end
 
   describe ".has_many" do
-    subject(:posts_relationships) { topic_resource.fields.relationships.pick(%w[posts]) }
+    subject(:posts_relationships) { topic_resource.fields(guardian:).relationships.pick(%w[posts]) }
 
     it "relates the resource to many records of another" do
       expect(posts_relationships.first).to be_a(JsonApiKit::Declarations::Relationship::ToMany)


### PR DESCRIPTION
A resource used to show every field it declared to everyone, so there was no way to serve something like `sql` to admins only.

A field can now declare it:

```ruby
  attribute :sql, readable: ->(guardian) { guardian.is_admin? }
  attribute :notes, readable: ->(guardian, record) { guardian.can_edit?(record) }
```

When the rule only looks at the user, the answer is the same for the whole request, so the column is never selected. When it also looks at the record, the column has to be read and the decision happens row by row.

A field the user can’t see is left out, with no error (and requesting it by name does not change that).

Relationships take the same option, but only in the user form. A rule that looks at a record raises when the resource loads: there, "the record" could mean the owner row or each related row, and a related resource already scopes its own.