### PR TITLE
UX: Allow unpinning chat messages from the pinned messages panel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-pinned-messages-list.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-pinned-messages-list.gjs
@@ -3,13 +3,16 @@ import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { getOwner } from "@ember/owner";
 import { LinkTo } from "@ember/routing";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ChatMessage from "discourse/plugins/chat/discourse/components/chat-message";
+import ChatMessageInteractor from "discourse/plugins/chat/discourse/lib/chat-message-interactor";
 import {
   dismissPinsUpTo,
   hasPinsDismissal,
@@ -18,15 +21,18 @@ import {
 } from "discourse/plugins/chat/discourse/lib/chat-pinned-bar-dismissal";
 
 export default class ChatPinnedMessagesList extends Component {
+  @service a11y;
   @service messageBus;
   @service chatApi;
   @service currentUser;
   @service router;
+  @service siteSettings;
 
   @tracked pinnedMessages = this.args.pinnedMessages || [];
 
-  subscribe = modifierFn(() => {
+  subscribe = modifierFn((element) => {
     const channel = this.args.channel;
+    this.#element = element;
 
     this.messageBus.subscribe(
       `/chat/${channel.id}`,
@@ -34,6 +40,8 @@ export default class ChatPinnedMessagesList extends Component {
       channel.channelMessageBusLastId
     );
 
+    // @pinnedMessages can be stale (the drawer caches its route model)
+    this.#loadPins(channel);
     this.#markPinsAsRead(channel);
 
     return () => {
@@ -79,6 +87,10 @@ export default class ChatPinnedMessagesList extends Component {
   routeModels = (pin) => {
     return [...this.args.channel.routeModels, pin.message.id];
   };
+  #element = null;
+  #inFlightUnpins = new Set();
+  #loadSequence = 0;
+
   #lastViewedPinsAtSnapshot =
     this.args.channel.currentUserMembership?.lastViewedPinsAt;
 
@@ -88,6 +100,12 @@ export default class ChatPinnedMessagesList extends Component {
 
   get barDismissed() {
     return hasPinsDismissal(this.args.channel);
+  }
+
+  get canManagePins() {
+    return (
+      this.siteSettings.chat_pinned_messages && this.args.channel?.canManagePins
+    );
   }
 
   // mirror the visited pin in the bar (the jump's scroll wouldn't update it)
@@ -110,7 +128,96 @@ export default class ChatPinnedMessagesList extends Component {
     this.router.transitionTo("chat.channel", ...channel.routeModels);
   }
 
+  // the interactor owns channel-wide pin state, including the
+  // pendingOptimisticUnpins handshake that stops the message-bus handler from
+  // decrementing the count a second time; this panel owns only its own list
+  @action
+  async unpin(pin) {
+    const messageId = pin.message.id;
+
+    if (this.#inFlightUnpins.has(messageId)) {
+      return;
+    }
+    // kept on success until a pin event re-pins the message, so fetches
+    // started before the unpin can't restore the row
+    this.#inFlightUnpins.add(messageId);
+
+    const removedIndex = this.pinnedMessages.indexOf(pin);
+    this.pinnedMessages = this.pinnedMessages.filter(
+      (existingPin) => existingPin.message.id !== messageId
+    );
+    this.#focusAfterRemoval(removedIndex);
+
+    await new ChatMessageInteractor(
+      getOwner(this),
+      pin.message,
+      "channel"
+    ).unpin();
+
+    // the interactor re-pins its message when the request failed
+    if (pin.message.pinned) {
+      this.#inFlightUnpins.delete(messageId);
+      this.#restorePin(pin);
+      return;
+    }
+
+    // the row is gone and focus lands on a button with the same label, so
+    // say what happened
+    this.a11y.announce(i18n("chat.pinned_messages.message_unpinned"), "polite");
+  }
+
+  #restorePin(pin) {
+    if (this.isDestroying || this.pinnedMessages.includes(pin)) {
+      return;
+    }
+
+    // pins render in channel timeline order
+    this.pinnedMessages = [...this.pinnedMessages, pin].sort(
+      (a, b) => a.message.id - b.message.id
+    );
+  }
+
+  // a removed row must not drop focus to <body>
+  #focusAfterRemoval(removedIndex) {
+    schedule("afterRender", () => {
+      if (this.isDestroying || !this.#element) {
+        return;
+      }
+
+      const buttons = [
+        ...this.#element.querySelectorAll(".chat-pinned-message__unpin"),
+      ];
+
+      const target =
+        buttons[removedIndex] ??
+        buttons.at(-1) ??
+        this.#element.querySelector(".chat-pinned-messages-list__empty");
+
+      target?.focus();
+    });
+  }
+
+  async #loadPins(channel) {
+    const sequence = ++this.#loadSequence;
+
+    try {
+      const pinnedMessages = await this.chatApi.pinnedMessages(channel);
+
+      if (this.isDestroying || sequence !== this.#loadSequence) {
+        return;
+      }
+
+      this.pinnedMessages = pinnedMessages.filter(
+        (pin) => !this.#inFlightUnpins.has(pin.message.id)
+      );
+    } catch {
+      // best-effort refresh
+    }
+  }
+
   handlePinMessage(data) {
+    this.#inFlightUnpins.delete(data.chat_message_id);
+
     const existingPin = this.pinnedMessages.find(
       (pin) => pin.message.id === data.chat_message_id
     );
@@ -119,9 +226,7 @@ export default class ChatPinnedMessagesList extends Component {
       return;
     }
 
-    this.chatApi.pinnedMessages(this.args.channel).then((pinnedMessages) => {
-      this.pinnedMessages = pinnedMessages;
-
+    this.#loadPins(this.args.channel).then(() => {
       // If current user pinned this message, update timestamp so it doesn't show as unseen
       if (
         this.args.channel.currentUserMembership &&
@@ -153,33 +258,45 @@ export default class ChatPinnedMessagesList extends Component {
     >
       <div class="chat-pinned-messages-list__items">
         {{#each this.pinnedMessages as |pin|}}
-          <LinkTo
-            @route="chat.channel.near-message"
-            @models={{this.routeModels pin}}
-            class="chat-pinned-message"
-            {{on "click" (fn this.visitPin pin)}}
-          >
-            <ChatMessage
-              @message={{this.decorateMessage pin}}
-              @context="pinned"
-              @includeSeparator={{false}}
-              @interactive={{false}}
+          <div class="chat-pinned-message">
+            <LinkTo
+              @route="chat.channel.near-message"
+              @models={{this.routeModels pin}}
+              class="chat-pinned-message__link"
+              {{on "click" (fn this.visitPin pin)}}
             >
-              <:top>
-                <div class="chat-pinned-message__pinned-by">
-                  {{#if (this.isUnseen pin)}}
-                    {{dIcon
-                      "thumbtack"
-                      class="chat-pinned-message__pinned-by-icon"
-                    }}
-                  {{/if}}
-                  <span>{{this.pinnedByText pin}}</span>
-                </div>
-              </:top>
-            </ChatMessage>
-          </LinkTo>
+              <ChatMessage
+                @message={{this.decorateMessage pin}}
+                @context="pinned"
+                @includeSeparator={{false}}
+                @interactive={{false}}
+              >
+                <:top>
+                  <div class="chat-pinned-message__pinned-by">
+                    {{#if (this.isUnseen pin)}}
+                      {{dIcon
+                        "thumbtack"
+                        class="chat-pinned-message__pinned-by-icon"
+                      }}
+                    {{/if}}
+                    <span>{{this.pinnedByText pin}}</span>
+                  </div>
+                </:top>
+              </ChatMessage>
+            </LinkTo>
+
+            {{#if this.canManagePins}}
+              <DButton
+                @icon="thumbtack-slash"
+                @title="chat.unpin_message"
+                @ariaLabel="chat.unpin_message"
+                @action={{fn this.unpin pin}}
+                class="btn-transparent chat-pinned-message__unpin"
+              />
+            {{/if}}
+          </div>
         {{else}}
-          <div class="chat-pinned-messages-list__empty">
+          <div class="chat-pinned-messages-list__empty" tabindex="-1">
             {{i18n "chat.no_pinned_messages"}}
           </div>
         {{/each}}

--- a/plugins/chat/assets/stylesheets/common/chat-pinned-messages.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-pinned-messages.scss
@@ -48,16 +48,45 @@
 }
 
 .chat-pinned-message {
-  display: block;
+  position: relative;
+  display: flex;
+  align-items: flex-start;
   margin-inline: 1rem 0.75rem;
   border-bottom: 1px solid var(--content-border-color);
 
-  &,
-  &:hover,
-  &:visited,
-  &:active {
-    color: var(--primary);
-    text-decoration: none;
+  &__link {
+    flex: 1;
+    min-width: 0;
+
+    &,
+    &:hover,
+    &:visited,
+    &:active {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    // stretch the click target across the whole row, under the unpin button
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
+  }
+
+  &__unpin {
+    position: relative;
+    z-index: 1;
+    margin-block-start: 0.25em;
+
+    .discourse-no-touch & {
+      opacity: 0;
+    }
+
+    .discourse-no-touch .chat-pinned-message:hover &,
+    &:focus-visible {
+      opacity: 1;
+    }
   }
 
   .chat-message-container {

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -72,6 +72,7 @@ en:
         show: "Show pinned banner"
         pinned_by_you: "Pinned by you"
         pinned_by_user: "Pinned by %{username}"
+        message_unpinned: "Message unpinned"
       pinned_bar:
         title: "Pinned"
         jump_to_pinned: "Jump to pinned message"

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -29,6 +29,7 @@ register_svg_icon "circle-stop"
 register_svg_icon "filter"
 register_svg_icon "filter-circle-xmark"
 register_svg_icon "sort"
+register_svg_icon "thumbtack-slash"
 
 # route: /admin/plugins/chat
 add_admin_route "chat.admin.title", "chat", use_new_show_route: true

--- a/plugins/chat/spec/system/pinned_messages_spec.rb
+++ b/plugins/chat/spec/system/pinned_messages_spec.rb
@@ -245,6 +245,9 @@ RSpec.describe "Chat pinned messages" do
     expect(page).to have_css(".chat-pinned-bar")
 
     find(".chat-pinned-bar__see-all").click
+    expect(page).to have_css(".chat-pinned-message", text: "Important message")
+    expect(page).to have_no_css(".chat-pinned-message__unpin")
+
     find(".chat-pinned-messages-list__dismiss").click
 
     # the panel closes and the bar is dismissed (hidden) until a newer pin
@@ -300,6 +303,69 @@ RSpec.describe "Chat pinned messages" do
     expect(page).to have_no_css(".c-routes.--channel-pins")
     expect(page).to have_no_css(".chat-pinned-bar")
     expect(channel.pinned_messages.count).to eq(2)
+  end
+
+  context "when unpinning from the pinned messages panel" do
+    fab!(:pin) do
+      Fabricate(:chat_pinned_message, chat_message: message, chat_channel: channel, user: admin)
+    end
+    fab!(:second_message) do
+      Fabricate(:chat_message, chat_channel: channel, message: "Second message")
+    end
+    fab!(:second_pin) do
+      Fabricate(
+        :chat_pinned_message,
+        chat_message: second_message,
+        chat_channel: channel,
+        user: admin,
+      )
+    end
+
+    it "lets a pin manager unpin a message from the panel" do
+      chat_page.visit_channel(channel)
+      find(".chat-pinned-bar__see-all").click
+      expect(page).to have_css(".c-routes.--channel-pins")
+
+      row = find(".chat-pinned-message", text: "Important message")
+      row.hover
+      expect(row).to have_css(
+        ".chat-pinned-message__unpin[aria-label='#{I18n.t("js.chat.unpin_message")}']",
+      )
+      row.find(".chat-pinned-message__unpin").click
+
+      expect(page).to have_css(
+        "#a11y-announcements-polite",
+        text: I18n.t("js.chat.pinned_messages.message_unpinned"),
+        visible: :all,
+      )
+
+      expect(page).to have_no_css(".chat-pinned-message", text: "Important message")
+      expect(page).to have_css(".chat-pinned-message", text: "Second message")
+
+      # focus moves to the next row instead of falling back to <body>
+      expect(page).to have_css(".chat-pinned-message__unpin:focus")
+
+      find(".c-navbar__close-pins-button").click
+
+      expect(page).to have_no_css(
+        ".chat-message-container[data-id='#{message.id}'] .chat-message-info__pinned",
+      )
+
+      # the remaining pin still counts: the bar must not vanish
+      expect(page).to have_css(".chat-pinned-bar__excerpt", text: "Second message")
+    end
+
+    it "lets a pin manager unpin a message on mobile", mobile: true do
+      chat_page.visit_channel(channel)
+      find(".chat-pinned-bar__see-all").click
+      expect(page).to have_css(".c-routes.--channel-pins")
+
+      find(".chat-pinned-message", text: "Important message").find(
+        ".chat-pinned-message__unpin",
+      ).click
+
+      expect(page).to have_no_css(".chat-pinned-message", text: "Important message")
+    end
   end
 
   context "when viewing pinned messages attribution" do


### PR DESCRIPTION
Users who can manage pins previously had to locate the message in the channel and unpin it through the message actions menu. Each row in the pinned messages panel now has an unpin button, revealed on hover and always visible on touch devices.

Rows are laid out as a flex wrapper with the link and button as siblings, keeping interactive elements un-nested, reserving space for the button on touch, and working in RTL; a pseudo-element stretches the link across the whole row. The panel removes the row optimistically and resyncs from the server on failure — channel-wide pin state (`pinnedMessagesCount`, `message.pinned`) stays owned by the message-bus unpin event, and an in-flight guard prevents double-fired requests.