### PR TITLE
FIX: Let undo reach past an onebox in the rich editor

### DIFF
--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
@@ -271,9 +271,14 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
       dispatchTransaction: (tr) => {
         this.view.updateState(this.view.state.apply(tr));
 
-        // serializing rewrites the whole document, so only the user's own
-        // edits, the ones they can undo, may replace the value
-        if (tr.docChanged && tr.getMeta("addToHistory") !== false) {
+        // serializing rewrites the whole document, so a transaction that only
+        // renders resolved data may not replace the value, even when it stays
+        // undoable with the edit that introduced it
+        if (
+          tr.docChanged &&
+          tr.getMeta("addToHistory") !== false &&
+          !tr.getMeta("skipSerialization")
+        ) {
           // If this gets expensive, we can debounce it
           const value = this.convertToMarkdown(this.view.state.doc);
           this.#lastSerialized = value;

--- a/frontend/discourse/app/static/prosemirror/extensions/onebox.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/onebox.js
@@ -114,6 +114,7 @@ const extension = {
   plugins({
     pmState: { Plugin },
     pmView: { Decoration, DecorationSet },
+    pmHistory: { isHistoryTransaction, redoDepth, undoDepth },
     getContext,
   }) {
     const failedUrls = { full: new Set(), inline: new Set() };
@@ -182,10 +183,27 @@ const extension = {
       key: oneboxPluginKey,
       state: {
         init() {
-          return DecorationSet.empty;
+          // undo restores the link a preview replaced, which is exactly the
+          // shape the scan promotes, so it would render right back and
+          // re-record the step that was just undone. skipScanUntilEdit holds
+          // the scan off until the user edits again.
+          return { decorations: DecorationSet.empty, skipScanUntilEdit: false };
         },
-        apply(tr, set) {
+        apply(tr, { decorations: set, skipScanUntilEdit }) {
           const meta = tr.getMeta(plugin);
+
+          if (isHistoryTransaction(tr)) {
+            skipScanUntilEdit = true;
+          } else if (
+            tr.docChanged &&
+            tr.getMeta("addToHistory") !== false &&
+            !tr.getMeta("skipSerialization") &&
+            !tr.getMeta("appendedTransaction")
+          ) {
+            // only the user's own edits release the scan — not renders
+            // (skipSerialization) or other plugins' appended reactions
+            skipScanUntilEdit = false;
+          }
 
           if (meta?.removeDecorations) {
             set = set.remove(meta.removeDecorations);
@@ -249,8 +267,19 @@ const extension = {
             }
 
             if (!meta?.forceOneboxUrl) {
-              return set;
+              return { decorations: set, skipScanUntilEdit };
             }
+          }
+
+          if (!meta?.forceOneboxUrl && skipScanUntilEdit) {
+            // a preview whose data already arrived would render from its
+            // decoration alone, without the scan
+            return {
+              decorations: set.remove(
+                set.find(undefined, undefined, (spec) => spec.oneboxDataLoaded)
+              ),
+              skipScanUntilEdit,
+            };
           }
 
           const decorations = scanForOneboxLinks(
@@ -260,13 +289,16 @@ const extension = {
             meta?.forceOneboxUrl
           );
 
-          return set.add(tr.doc, decorations);
+          return {
+            decorations: set.add(tr.doc, decorations),
+            skipScanUntilEdit,
+          };
         },
       },
 
       props: {
         decorations(state) {
-          return plugin.getState(state);
+          return plugin.getState(state).decorations;
         },
       },
 
@@ -275,7 +307,7 @@ const extension = {
 
         return {
           update(view) {
-            const decorations = plugin.getState(view.state);
+            const { decorations } = plugin.getState(view.state);
 
             this.processNew(view, decorations);
             this.processLoaded(view, decorations);
@@ -452,7 +484,18 @@ const extension = {
 
             if (removeDecorations.length || tr.docChanged) {
               tr.setMeta(plugin, { removeDecorations });
-              view.dispatch(tr.setMeta("addToHistory", false));
+              // the preview replaces the link, so it has to undo along with it,
+              // or undoing the edit that introduced the URL leaves it stranded
+              tr.setMeta("skipSerialization", true);
+
+              // ...but only when that edit is in the history: with nothing to
+              // reach back to, recording only adds a phantom undo step, and a
+              // recorded step would wipe a live redo stack
+              if (undoDepth(view.state) === 0 || redoDepth(view.state) > 0) {
+                tr.setMeta("addToHistory", false);
+              }
+
+              view.dispatch(tr);
             }
           },
         };
@@ -519,8 +562,8 @@ const extension = {
 
     function removeLoadingDecorations(view, urls, type) {
       const urlSet = typeof urls === "string" ? new Set([urls]) : new Set(urls);
-      const decoState = plugin.getState(view.state);
-      const toRemove = decoState.find(
+      const { decorations } = plugin.getState(view.state);
+      const toRemove = decorations.find(
         undefined,
         undefined,
         (spec) => spec.oneboxType === type && urlSet.has(spec.oneboxUrl)

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/onebox-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/onebox-test.js
@@ -1,5 +1,12 @@
 import { settled } from "@ember/test-helpers";
 import { setLocalCache } from "pretty-text/oneboxer-cache";
+import {
+  closeHistory,
+  redo,
+  redoDepth,
+  undo,
+  undoDepth,
+} from "prosemirror-history";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import { module, test } from "qunit";
 import { buildEngine } from "discourse/static/markdown-it";
@@ -9,6 +16,9 @@ import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
 
 // Mocked by create-pretender for both /inline-onebox and /onebox.
 const URL = "http://www.example.com/has-title.html";
+const TOP_LEVEL_URL = "http://www.example.com";
+const ONEBOX_HTML =
+  '<aside class="onebox"><article class="onebox-body"><h3><a href="http://www.example.com">Example</a></h3></article></aside>';
 
 function lastParagraphStart(doc) {
   let pos = null;
@@ -18,6 +28,39 @@ function lastParagraphStart(doc) {
     }
   });
   return pos;
+}
+
+async function undoAll(view) {
+  for (let i = 0; i < 5 && undoDepth(view.state) > 0; i++) {
+    undo(view.state, view.dispatch);
+    await settled();
+  }
+}
+
+function posOfText(doc, text) {
+  let pos = null;
+  doc.descendants((node, nodePos) => {
+    if (node.isText && node.text === text) {
+      pos = nodePos;
+    }
+  });
+  return pos;
+}
+
+// With pretender in manual-resolution mode, waits for the next /onebox request
+// to fire, releases its response, and lets the resulting render dispatch.
+async function resolveOneboxRequest() {
+  let ref;
+  for (let i = 0; i < 200 && !ref; i++) {
+    ref = pretender.requestReferences?.find((reference) =>
+      reference.request.url.includes("/onebox")
+    );
+    if (!ref) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+  pretender.resolve(ref.request);
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function moveCursorTo(view, pos) {
@@ -166,6 +209,181 @@ module(
         view.state.selection instanceof NodeSelection,
         "the cursor lands after the onebox, not selecting the block"
       );
+    });
+
+    test("undo reaches back past a typed URL's onebox", async function (assert) {
+      pretender.get("/onebox", () => [
+        200,
+        { "Content-Type": "text/html" },
+        ONEBOX_HTML,
+      ]);
+
+      const [editor] = await setupRichEditor(assert, "x");
+      const { view } = editor;
+      const original = editor.value;
+
+      view.dispatch(view.state.tr.insertText(`${TOP_LEVEL_URL} `, 1, 2));
+      await settled();
+      view.dispatch(view.state.tr.split(view.state.selection.from));
+      await settled();
+      assert.dom(".onebox-wrapper").exists("the URL becomes a full onebox");
+
+      await undoAll(view);
+
+      assert.dom(".onebox-wrapper").doesNotExist("undo removes the onebox");
+      assert.strictEqual(editor.value, original, "undo restores the document");
+    });
+
+    // The cursor lands away from a dropped link, so the scan must stay held
+    // through other plugins' appended reactions to the undo.
+    test("undo reaches back past a dropped link's onebox", async function (assert) {
+      pretender.get("/onebox", () => [
+        200,
+        { "Content-Type": "text/html" },
+        ONEBOX_HTML,
+      ]);
+
+      const [editor] = await setupRichEditor(assert, "aaaaa\n\nx");
+      const { view } = editor;
+      const { schema } = view.state;
+      const original = editor.value;
+
+      const linkMark = schema.marks.link.create({
+        href: TOP_LEVEL_URL,
+        markup: "linkify",
+      });
+      const lastStart = lastParagraphStart(view.state.doc);
+      const tr = view.state.tr
+        .replaceWith(
+          lastStart,
+          lastStart + 1,
+          schema.text(TOP_LEVEL_URL, [linkMark])
+        )
+        .delete(1, 3);
+      tr.setSelection(TextSelection.create(tr.doc, 1));
+      view.dispatch(tr);
+      await settled();
+      assert.dom(".onebox-wrapper").exists("the dropped link becomes a onebox");
+
+      await undoAll(view);
+
+      assert.dom(".onebox-wrapper").doesNotExist("undo removes the onebox");
+      assert.strictEqual(editor.value, original, "undo restores the document");
+    });
+
+    test("a render arriving after an undo preserves the redo stack", async function (assert) {
+      pretender.get("/onebox", () => [
+        200,
+        { "Content-Type": "text/html" },
+        ONEBOX_HTML,
+      ]);
+
+      const [editor] = await setupRichEditor(assert, "x");
+      const { view } = editor;
+
+      view.dispatch(view.state.tr.insertText(`${TOP_LEVEL_URL} `, 1, 2));
+      await settled();
+
+      view.dispatch(
+        closeHistory(view.state.tr.split(view.state.selection.from))
+      );
+      view.dispatch(closeHistory(view.state.tr.insertText("abc")));
+
+      undo(view.state, view.dispatch);
+      assert.strictEqual(redoDepth(view.state), 1, "the undo is redoable");
+
+      await settled();
+      assert.dom(".onebox-wrapper").exists("the late render still shows");
+      assert.strictEqual(
+        redoDepth(view.state),
+        1,
+        "the late render does not wipe the redo stack"
+      );
+
+      redo(view.state, view.dispatch);
+      await settled();
+      assert.true(
+        view.state.doc.textContent.includes("abc"),
+        "redo restores the undone edit"
+      );
+    });
+
+    test("a pending render leaves an undone onebox's link alone", async function (assert) {
+      let manual = false;
+      pretender.get(
+        "/onebox",
+        () => [200, { "Content-Type": "text/html" }, ONEBOX_HTML],
+        () => manual
+      );
+
+      const [editor] = await setupRichEditor(assert, "x\n\nyyy\n\nzzz");
+      const { view } = editor;
+      const { schema } = view.state;
+      manual = true;
+
+      const linkText = (url) =>
+        schema.text(url, [
+          schema.marks.link.create({ href: url, markup: "linkify" }),
+        ]);
+
+      // Drop link A on the first line, with the cursor away on the last line.
+      const trA = view.state.tr.replaceWith(1, 2, linkText(TOP_LEVEL_URL));
+      trA.setSelection(TextSelection.create(trA.doc, trA.doc.content.size - 1));
+      view.dispatch(trA);
+
+      // Drop link B on the second line — its fetch queues behind A's.
+      const posB = posOfText(view.state.doc, "yyy");
+      const trB = view.state.tr.replaceWith(
+        posB,
+        posB + 3,
+        linkText(`${TOP_LEVEL_URL}/b`)
+      );
+      trB.setSelection(TextSelection.create(trB.doc, trB.doc.content.size - 1));
+      view.dispatch(closeHistory(trB));
+
+      await resolveOneboxRequest();
+      assert.dom(".onebox-wrapper").exists({ count: 1 }, "A renders first");
+
+      // Undo A's render while B's fetch is still in flight.
+      undo(view.state, view.dispatch);
+      assert.dom(".onebox-wrapper").doesNotExist("undo restores A's link");
+
+      await resolveOneboxRequest();
+      await settled();
+
+      assert
+        .dom(".onebox-wrapper")
+        .exists({ count: 1 }, "B's preview still renders");
+      assert.strictEqual(
+        view.state.doc.firstChild.textContent,
+        TOP_LEVEL_URL,
+        "A stays the link undo restored"
+      );
+      assert.strictEqual(redoDepth(view.state), 1, "the undo stays redoable");
+    });
+
+    test("opening content with a onebox URL leaves nothing extra to undo", async function (assert) {
+      pretender.get("/onebox", () => [
+        200,
+        { "Content-Type": "text/html" },
+        ONEBOX_HTML,
+      ]);
+
+      const markdown = `hello\n\n${TOP_LEVEL_URL}\n\nworld`;
+      const [editor] = await setupRichEditor(assert, markdown);
+      const { view } = editor;
+
+      assert.dom(".onebox-wrapper").exists("the URL renders as a onebox");
+      assert.strictEqual(
+        undoDepth(view.state),
+        1,
+        "only the helper's own serialization nudge is undoable — not the render"
+      );
+
+      await undoAll(view);
+
+      assert.dom(".onebox-wrapper").exists("undo does not degrade the preview");
+      assert.strictEqual(editor.value, markdown, "the value is unchanged");
     });
   }
 );


### PR DESCRIPTION
Rendering a URL as its onebox replaces the link that produced it. That render was dispatched outside the undo history, so undoing the edit that introduced the URL left the onebox behind, holding the text it had replaced, and no further undo removed it.

Record the render in history, skipping only its serialization so the composer value still tracks what the user typed. Recording stays off in the two cases where it only hurts: loading content, which must not create a phantom undo step, and a render arriving after an undo, which must not wipe the live redo stack. Those renders aren't individually undoable, and undo reaches the edit beneath instead. After an undo, the scan holds off until the user edits again, so it can't re-promote the link the undo just restored. Rendering previews without rewriting the document (a node view over the URL text) would remove these special cases entirely and is the natural follow-up.
