### PR TITLE
FIX: Use full set of feature names to filter ai logs

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-log-feature-filter.js
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-log-feature-filter.js
@@ -1,0 +1,21 @@
+import { classNames } from "@ember-decorators/component";
+import ComboBox from "discourse/select-kit/components/combo-box";
+import { selectKitOptions } from "discourse/select-kit/components/select-kit";
+
+@classNames("ai-log-feature-filter")
+@selectKitOptions({
+  allowAny: false,
+  clearable: true,
+  filterable: true,
+})
+export default class AiLogFeatureFilter extends ComboBox {
+  search(filter) {
+    const matches = super.search(filter);
+
+    if (!filter || matches.includes(filter)) {
+      return matches;
+    }
+
+    return [filter, ...matches];
+  }
+}

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
@@ -21,6 +21,7 @@ import DSelect from "discourse/ui-kit/d-select";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import { i18n } from "discourse-i18n";
 import AiLogRow from "discourse/plugins/discourse-ai/discourse/components/ai-log-row";
+import AiLogFeatureFilter from "./ai-log-feature-filter";
 import AiLogDetailModal from "./modal/ai-log-detail-modal";
 import AiLogRetentionModal from "./modal/ai-log-retention-modal";
 
@@ -123,6 +124,15 @@ export default class AiLogs extends Component {
       : new Date();
   }
 
+  @cached
+  get featureOptions() {
+    if (this.selectedFeature && !this.features.includes(this.selectedFeature)) {
+      return [...this.features, this.selectedFeature];
+    }
+
+    return this.features;
+  }
+
   get periodOptions() {
     return [
       {
@@ -179,28 +189,11 @@ export default class AiLogs extends Component {
   }
 
   @cached
-  get featureOptions() {
-    const features = [...this.features];
-    if (this.selectedFeature && !features.includes(this.selectedFeature)) {
-      features.push(this.selectedFeature);
-    }
-
-    return [
-      {
-        value: "all",
-        label: i18n("discourse_ai.logs.all_features"),
-      },
-      ...features.map((feature) => ({ value: feature, label: feature })),
-    ];
-  }
-
-  @cached
   get dropdownOptions() {
     return {
       period: this.periodOptions,
       outcome: this.outcomeOptions,
       model: this.modelOptions,
-      feature: this.featureOptions,
     };
   }
 
@@ -210,7 +203,6 @@ export default class AiLogs extends Component {
       period: this.selectedPeriod || "all",
       outcome: this.selectedOutcome || "all",
       model: this.selectedModel || "all",
-      feature: this.selectedFeature || "all",
     };
   }
 
@@ -230,6 +222,7 @@ export default class AiLogs extends Component {
   get additionalFiltersActive() {
     return Boolean(
       this.hasRetries ||
+      this.selectedFeature ||
       this.selectedUsernames.length ||
       this.unattributed ||
       this.idValue
@@ -415,10 +408,14 @@ export default class AiLogs extends Component {
       this.selectedOutcome = selectedValue;
     } else if (key === "model") {
       this.selectedModel = selectedValue;
-    } else if (key === "feature") {
-      this.selectedFeature = selectedValue;
     }
 
+    this.refresh();
+  }
+
+  @action
+  changeFeature(value) {
+    this.selectedFeature = value || undefined;
     this.refresh();
   }
 
@@ -561,6 +558,23 @@ export default class AiLogs extends Component {
         </:aboveFilters>
 
         <:additionalFilters>
+          <fieldset class="ai-logs__feature-filter">
+            <legend>{{i18n "discourse_ai.logs.feature"}}</legend>
+            <AiLogFeatureFilter
+              @valueProperty={{null}}
+              @nameProperty={{null}}
+              @value={{this.selectedFeature}}
+              @content={{this.featureOptions}}
+              @onChange={{this.changeFeature}}
+              @options={{hash
+                translatedNone=(i18n "discourse_ai.logs.all_features")
+                translatedFilterPlaceholder=(i18n
+                  "discourse_ai.logs.feature_placeholder"
+                )
+              }}
+            />
+          </fieldset>
+
           {{#if (eq this.selectedPeriod "custom")}}
             <fieldset class="ai-logs__date-range-filter">
               <legend>{{i18n "discourse_ai.logs.filters.date_range"}}</legend>

--- a/plugins/discourse-ai/assets/stylesheets/admin/ai-logs.scss
+++ b/plugins/discourse-ai/assets/stylesheets/admin/ai-logs.scss
@@ -27,6 +27,7 @@
   }
 
   &__date-range-filter,
+  &__feature-filter,
   &__user-filter {
     min-width: 0;
     margin: 0;
@@ -46,6 +47,7 @@
     }
   }
 
+  &__feature-filter,
   &__user-filter {
     display: flex;
     flex-direction: column;

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -686,6 +686,7 @@ en:
         has_retries: "Has retries"
         retried: "Retried"
         unattributed: "Unattributed"
+        feature_placeholder: "Feature name"
         user_placeholder: "Filter by user"
         id_placeholder: "Enter an ID"
         log_id: "Log ID"

--- a/plugins/discourse-ai/spec/system/ai_logs_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_logs_spec.rb
@@ -73,11 +73,6 @@ RSpec.describe "AI logs admin page" do
     ai_logs_page.select_outcome(I18n.t("js.discourse_ai.logs.all_outcomes"))
     expect(ai_logs_page).to have_log(log)
 
-    configured_feature = DiscourseAi::Configuration::Feature.all.first.name
-    feature_select = find(".d-filter-controls__dropdown--feature")
-    expect(feature_select).to have_selector("option", text: configured_feature)
-    expect(feature_select).to have_selector("option", text: "system-test")
-    expect(feature_select).to have_selector("option", text: "other-feature")
     ai_logs_page.select_feature("other-feature")
     expect(ai_logs_page).to have_no_log(log)
 
@@ -93,6 +88,15 @@ RSpec.describe "AI logs admin page" do
     expect(ai_logs_page).to have_filter_value(:period, "day")
 
     ai_logs_page.select_feature(log.feature_name)
+    expect(ai_logs_page).to have_log(log)
+  end
+
+  it "filters by a feature outside the initial page of logs" do
+    Fabricate.times(50, :ai_api_audit_log, feature_name: "recent-feature")
+    ai_logs_page.visit
+
+    ai_logs_page.select_feature(log.feature_name)
+
     expect(ai_logs_page).to have_log(log)
   end
 
@@ -116,13 +120,15 @@ RSpec.describe "AI logs admin page" do
         :ai_api_audit_log,
         llm_model: other_model,
         language_model: other_model.name,
+        feature_name: "url-feature",
         created_at: 10.minutes.ago,
       )
 
-    ai_logs_page.visit("model=#{other_model.id}&period=hour")
+    ai_logs_page.visit("model=#{other_model.id}&period=hour&feature=url-feature")
 
     expect(ai_logs_page).to have_log(other_log)
     expect(ai_logs_page).to have_no_log(log)
+    expect(ai_logs_page.feature_filter_value).to eq("url-feature")
   end
 
   it "filters by a seeded model from selection and a shareable URL" do
@@ -165,7 +171,7 @@ RSpec.describe "AI logs admin page" do
   it "lets an admin inspect a raw log and open retention configuration" do
     ai_logs_page.visit
     expect(ai_logs_page).to have_log(log)
-    expect(page).to have_no_css(".d-filter-controls__input")
+    expect(page).to have_css(".ai-logs__feature-filter .combo-box")
     expect(page).to have_no_css(".d-filter-controls__toggle-filters")
     expect(page).to have_no_css(".d-filter-controls__reset")
     expect(page).to have_css(

--- a/plugins/discourse-ai/spec/system/page_objects/pages/ai_logs.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/ai_logs.rb
@@ -18,7 +18,14 @@ module PageObjects
       end
 
       def select_feature(label)
-        select_filter(:feature, label)
+        feature_filter.expand
+        feature_filter.search(label)
+        feature_filter.select_row_by_value(label)
+        self
+      end
+
+      def feature_filter_value
+        feature_filter.value
       end
 
       def select_period(label)
@@ -39,7 +46,7 @@ module PageObjects
       end
 
       def has_expanded_filter_dropdowns?
-        page.has_css?(".d-filter-controls__dropdown", count: 4)
+        page.has_css?(".d-filter-controls__dropdown", count: 3)
       end
 
       def open_log(log)
@@ -72,6 +79,10 @@ module PageObjects
       end
 
       private
+
+      def feature_filter
+        PageObjects::Components::SelectKit.new(".ai-logs__feature-filter .combo-box")
+      end
 
       def select_filter(key, label)
         find(".d-filter-controls__dropdown--#{key}").select(label)


### PR DESCRIPTION
The feature dropdown only included registered features and features from the latest 50 logs, so older logged features disappeared from the filter. Related - https://github.com/discourse/discourse/pull/42759

https://github.com/user-attachments/assets/e66ec79e-4e66-48e9-8a23-b235cc415cbf


