### PR TITLE
FIX: only treat a fifth weekday as last in monthly recurrences

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/lib/event-recurrence.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/lib/event-recurrence.js
@@ -11,9 +11,10 @@ export function recurrenceRef(event) {
 
 export function recurrenceContext(ref) {
   const weekday = ref.format("dddd");
-  const dayOfMonth = ref.date();
-  const isLast = dayOfMonth + 7 > ref.daysInMonth();
-  const ordinalKey = isLast ? "last" : ORDINALS[Math.ceil(dayOfMonth / 7) - 1];
+  const nth = Math.ceil(ref.date() / 7);
+  // Mirrors RRuleConfigurator: a fifth occurrence is expressed as "last",
+  // since not every month has one.
+  const ordinalKey = nth === 5 ? "last" : ORDINALS[nth - 1];
   const ordinal = i18n(
     `discourse_post_event.builder_modal.recurrence.ordinals.${ordinalKey}`
   );

--- a/plugins/discourse-events/lib/discourse_post_event/email_renderer.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/email_renderer.rb
@@ -202,10 +202,10 @@ module DiscoursePostEvent
     end
 
     def recurrence_ordinal(ref)
-      day_of_month = ref.mday
-      days_in_month = Date.new(ref.year, ref.month, -1).day
-      is_last = day_of_month + 7 > days_in_month
-      key = is_last ? "last" : RECURRENCE_ORDINALS[(day_of_month / 7.0).ceil - 1]
+      # Mirrors RRuleConfigurator: a fifth occurrence is expressed as "last",
+      # since not every month has one.
+      nth = (ref.mday / 7.0).ceil
+      key = nth == 5 ? "last" : RECURRENCE_ORDINALS[nth - 1]
       card_t("builder_modal.recurrence.ordinals.#{key}")
     end
 

--- a/plugins/discourse-events/lib/discourse_post_event/rrule_configurator.rb
+++ b/plugins/discourse-events/lib/discourse_post_event/rrule_configurator.rb
@@ -7,21 +7,13 @@ class RRuleConfigurator
       when "every_day"
         "FREQ=DAILY"
       when "every_month"
-        start_date = starts_at.beginning_of_month.to_date
-        end_date = starts_at.end_of_month.to_date
         weekday = starts_at.strftime("%A")
+        nth = ((starts_at.day - 1) / 7) + 1
 
-        count = 0
-        (start_date..end_date).each do |date|
-          count += 1 if date.strftime("%A") == weekday
-          break if date.day == starts_at.day
-        end
-
-        # If this is the last occurrence of the weekday in the month, use -1
-        # ("last") so the rule fires every month, including months where this
-        # weekday only occurs four times.
-        is_last = starts_at.day + 7 > starts_at.end_of_month.day
-        byday_count = is_last ? -1 : count
+        # Every month has at least four of each weekday, so the first four
+        # positions are safe. A fifth only exists in some months, so anchor it
+        # to -1 ("last") instead, otherwise the rule would skip months.
+        byday_count = nth == 5 ? -1 : nth
 
         "FREQ=MONTHLY;BYDAY=#{byday_count}#{weekday.upcase[0, 2]}"
       when "every_weekday"

--- a/plugins/discourse-events/spec/lib/discourse_post_event/pretty_text_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_post_event/pretty_text_spec.rb
@@ -248,6 +248,16 @@ describe PrettyText do
 
           expect(result).to include("The first Tuesday of every month")
         end
+
+        it "displays a fourth weekday as fourth even when the month has no fifth" do
+          # 2026-02-26 is both the fourth and the final Thursday of February
+          post_3 =
+            create_post_with_event(user_1, 'recurrence="every_month"', Time.utc(2026, 2, 26, 17, 0))
+          cooked = PrettyText.cook(post_3.raw)
+          result = PrettyText.format_for_email(cooked, post_3)
+
+          expect(result).to include("The fourth Thursday of every month")
+        end
       end
 
       context "when the event is closed" do

--- a/plugins/discourse-events/spec/lib/discourse_post_event/rrule_configurator_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_post_event/rrule_configurator_spec.rb
@@ -32,12 +32,11 @@ describe RRuleConfigurator do
         expect(rule).to eq("FREQ=MONTHLY;BYDAY=-1MO")
       end
 
-      it "uses BYDAY=-1 when the fourth occurrence is also the last in the month" do
-        # September 2025 has only 4 Mondays (1, 8, 15, 22, 29 — 5 actually)
-        # Use February 2026 instead: only 4 Mondays (2, 9, 16, 23)
+      it "uses BYDAY=4 when the fourth occurrence is also the last in the month" do
+        # February 2026 has only 4 Mondays (2, 9, 16, 23)
         last_monday = Time.utc(2026, 2, 23, 12, 0)
         rule = RRuleConfigurator.rule(recurrence: "every_month", starts_at: last_monday)
-        expect(rule).to eq("FREQ=MONTHLY;BYDAY=-1MO")
+        expect(rule).to eq("FREQ=MONTHLY;BYDAY=4MO")
       end
 
       it "uses BYDAY=4 when there is also a fifth occurrence in the month" do
@@ -45,6 +44,18 @@ describe RRuleConfigurator do
         fourth_monday = Time.utc(2027, 3, 22, 12, 0)
         rule = RRuleConfigurator.rule(recurrence: "every_month", starts_at: fourth_monday)
         expect(rule).to eq("FREQ=MONTHLY;BYDAY=4MO")
+      end
+
+      it "keeps a fourth-weekday series on the fourth weekday in months with five" do
+        # Feb 26 2026 is both the 4th and the last Thursday of the month
+        fourth_thursday = Time.utc(2026, 2, 26, 17, 0)
+        rule = RRuleConfigurator.rule(recurrence: "every_month", starts_at: fourth_thursday)
+
+        occurrences = RRule::Rule.new(rule, dtstart: fourth_thursday).all(limit: 3).map(&:to_date)
+
+        expect(occurrences).to eq(
+          [Date.new(2026, 2, 26), Date.new(2026, 3, 26), Date.new(2026, 4, 23)],
+        )
       end
     end
 

--- a/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -137,6 +137,29 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
       .hasText("Every Thursday", "uses the date's weekday, not the prior day");
   });
 
+  test("labels a fourth weekday as fourth even when the month has no fifth", async function (assert) {
+    // 2026-02-26 is both the fourth and the final Thursday of February
+    stubApi.call(
+      this,
+      buildEvent({
+        recurrence: "every_month",
+        starts_at: "2026-02-26T14:00:00Z",
+        ends_at: "2026-02-26T15:00:00Z",
+      })
+    );
+
+    const event = { id: 1, startsAt: "2026-02-26T14:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "The fourth Thursday of every month",
+        "matches the fourth-weekday rule the server generates"
+      );
+  });
+
   test("renders location and url side by side when they differ", async function (assert) {
     stubApi.call(
       this,


### PR DESCRIPTION
Previously, a monthly event created on a fourth weekday that was also the last one (ie. short months like February) in its month generated `BYDAY=-1`, moving the series to the fifth weekday in every month that had one.

This change anchors `RRuleConfigurator` to the weekday's positional index and only falls back to `-1` for a genuine fifth occurrence, so a fourth Thursday stays the fourth Thursday while fifth-weekday events still recur every month.