### PR TITLE
FEATURE: Show graphviz diagrams in the rich editor

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -340,52 +340,77 @@
     }
   }
 
+  // A block showing a rendered result in place of its source. Both faces share
+  // one cell, so the block keeps its footprint when they are swapped and the
+  // document below it does not move.
   .composer-preview-node {
-    position: relative;
+    display: grid;
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-border-radius);
+    margin-block: var(--space-4);
+    overflow: hidden;
+
+    > * {
+      grid-area: 1 / 1;
+    }
 
     &.ProseMirror-selectednode {
       outline: 2px solid var(--tertiary);
       outline-offset: 2px;
-      border-radius: var(--d-border-radius);
     }
 
-    // clicking the rendered result selects the node rather than doing nothing
-    .composer-preview-node__preview {
-      cursor: pointer;
-    }
-
-    // the source is a code block of its own, shown in place of the preview
-    &:not(.--source) .composer-preview-node__source {
-      display: none;
+    // hidden, but still holding its space: swapping faces must not resize
+    &:not(.--source) .composer-preview-node__source,
+    &.--source .composer-preview-node__preview {
+      visibility: hidden;
     }
 
     .composer-preview-node__source pre {
       margin: 0;
-    }
-
-    // renderers mark the raw source hidden once they have replaced it; the
-    // editor's own display rules would otherwise override that
-    .composer-preview-node__preview [hidden] {
-      display: none;
-    }
-
-    .composer-preview-node__toggle {
-      position: absolute;
-      z-index: 1;
-      top: var(--space-1);
-      right: var(--space-1);
-      color: var(--primary-medium);
-      background-color: var(--secondary);
-      border: none;
-      cursor: pointer;
-
-      &:hover {
-        color: var(--primary);
-      }
+      height: 100%;
+      overflow: auto;
     }
 
     .composer-preview-node__preview {
       user-select: none;
+      cursor: pointer;
+
+      // renderers mark the raw source hidden once they have replaced it; the
+      // editor's own display rules would otherwise override that
+      [hidden] {
+        display: none;
+      }
+    }
+
+    .composer-preview-node__controls {
+      z-index: 1;
+      justify-self: end;
+      align-self: start;
+      display: flex;
+      gap: var(--space-half);
+      margin: var(--space-1);
+      border-radius: var(--d-border-radius);
+      background-color: var(--secondary);
+      box-shadow: var(--shadow-card);
+    }
+
+    html.no-touch & .composer-preview-node__controls {
+      opacity: 0;
+      transition: opacity 0.15s;
+    }
+
+    html.no-touch &:hover .composer-preview-node__controls,
+    html.no-touch &:focus-within .composer-preview-node__controls {
+      opacity: 1;
+    }
+
+    .composer-preview-node__control {
+      color: var(--primary-medium);
+
+      &:hover,
+      &:focus-visible {
+        color: var(--primary);
+      }
     }
   }
 

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -340,6 +340,55 @@
     }
   }
 
+  .composer-preview-node {
+    position: relative;
+
+    &.ProseMirror-selectednode {
+      outline: 2px solid var(--tertiary);
+      outline-offset: 2px;
+      border-radius: var(--d-border-radius);
+    }
+
+    // clicking the rendered result selects the node rather than doing nothing
+    .composer-preview-node__preview {
+      cursor: pointer;
+    }
+
+    // the source is a code block of its own, shown in place of the preview
+    &:not(.--source) .composer-preview-node__source {
+      display: none;
+    }
+
+    .composer-preview-node__source pre {
+      margin: 0;
+    }
+
+    // renderers mark the raw source hidden once they have replaced it; the
+    // editor's own display rules would otherwise override that
+    .composer-preview-node__preview [hidden] {
+      display: none;
+    }
+
+    .composer-preview-node__toggle {
+      position: absolute;
+      z-index: 1;
+      top: var(--space-1);
+      right: var(--space-1);
+      color: var(--primary-medium);
+      background-color: var(--secondary);
+      border: none;
+      cursor: pointer;
+
+      &:hover {
+        color: var(--primary);
+      }
+    }
+
+    .composer-preview-node__preview {
+      user-select: none;
+    }
+  }
+
   .onebox-loading {
     border-radius: var(--d-border-radius);
     padding: 0 0.125rem;

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -344,6 +344,7 @@
   // one cell, so the block keeps its footprint when they are swapped and the
   // document below it does not move.
   .composer-preview-node {
+    position: relative;
     display: grid;
     border: 1px solid var(--primary-low);
     border-radius: var(--d-border-radius);
@@ -369,6 +370,14 @@
       margin: 0;
       height: 100%;
       overflow: auto;
+
+      // the code element paints the source's backdrop, so it has to fill the row
+      // the taller face sized — overriding the cap code blocks carry elsewhere
+      code {
+        box-sizing: border-box;
+        min-height: 100%;
+        max-height: none;
+      }
     }
 
     .composer-preview-node__preview {
@@ -379,37 +388,6 @@
       // editor's own display rules would otherwise override that
       [hidden] {
         display: none;
-      }
-    }
-
-    .composer-preview-node__controls {
-      z-index: 1;
-      justify-self: end;
-      align-self: start;
-      display: flex;
-      gap: var(--space-half);
-      margin: var(--space-1);
-      border-radius: var(--d-border-radius);
-      background-color: var(--secondary);
-      box-shadow: var(--shadow-card);
-    }
-
-    html.no-touch & .composer-preview-node__controls {
-      opacity: 0;
-      transition: opacity 0.15s;
-    }
-
-    html.no-touch &:hover .composer-preview-node__controls,
-    html.no-touch &:focus-within .composer-preview-node__controls {
-      opacity: 1;
-    }
-
-    .composer-preview-node__control {
-      color: var(--primary-medium);
-
-      &:hover,
-      &:focus-visible {
-        color: var(--primary);
       }
     }
   }
@@ -441,6 +419,7 @@
 .fk-d-menu[data-identifier="composer-link-toolbar"],
 .fk-d-menu[data-identifier="composer-image-toolbar"],
 .fk-d-menu[data-identifier="composer-image-alt-text"],
+.fk-d-menu[data-identifier="composer-preview-toolbar"],
 .fk-d-menu[data-identifier="composer-onebox-toolbar"] {
   user-select: none;
   z-index: z("composer", "dropdown");

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -340,9 +340,7 @@
     }
   }
 
-  // A block showing a rendered result in place of its source. Both faces share
-  // one cell, so the block keeps its footprint when they are swapped and the
-  // document below it does not move.
+  // both faces share one grid cell, so swapping them does not move the document
   .composer-preview-node {
     position: relative;
     display: grid;
@@ -361,18 +359,17 @@
     }
 
     // hidden, but still holding its space
-    &:not(.--source) .composer-preview-node__source,
-    &.--source .composer-preview-node__preview {
+    &:not(.--source) &__source,
+    &.--source &__preview {
       visibility: hidden;
     }
 
-    .composer-preview-node__source pre {
+    &__source pre {
       margin: 0;
       height: 100%;
       overflow: auto;
 
-      // the code element paints the source's backdrop, so it has to fill the row
-      // the taller face sized — overriding the cap code blocks carry elsewhere
+      // the code element paints the backdrop, so it must fill the taller face's row
       code {
         box-sizing: border-box;
         min-height: 100%;
@@ -380,12 +377,11 @@
       }
     }
 
-    .composer-preview-node__preview {
+    &__preview {
       user-select: none;
       cursor: pointer;
 
-      // renderers mark the raw source hidden once they have replaced it; the
-      // editor's own display rules would otherwise override that
+      // the editor's display rules would otherwise override a renderer's [hidden]
       [hidden] {
         display: none;
       }

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -358,9 +358,10 @@
       outline-offset: 2px;
     }
 
-    // hidden, but still holding its space
-    &:not(.--source) &__source,
-    &.--source &__preview {
+    // hidden, but still holding its space. `&` is a complex selector here, so
+    // the hidden face is named in full rather than suffixed onto a second `&`
+    &:not(.--source) .composer-preview-node__source,
+    &.--source .composer-preview-node__preview {
       visibility: hidden;
     }
 

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -359,7 +359,7 @@
       outline-offset: 2px;
     }
 
-    // hidden, but still holding its space: swapping faces must not resize
+    // hidden, but still holding its space
     &:not(.--source) .composer-preview-node__source,
     &.--source .composer-preview-node__preview {
       visibility: hidden;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3727,6 +3727,10 @@ en:
         remove_preview: "Remove preview"
         link_copied: "Link copied!"
 
+      preview_node:
+        show_source: "Show source"
+        show_preview: "Show preview"
+
       unsupported_token: "The rich text editor doesn’t support all features used in this post; switching you to the Markdown editor."
 
     notifications:

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -1,13 +1,14 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn } from "@ember/helper";
 import { action } from "@ember/object";
-import DButton from "discourse/ui-kit/d-button";
-import { i18n } from "discourse-i18n";
+import {
+  registerPreviewNodeView,
+  TOOLBAR_IDENTIFIER,
+} from "discourse/lib/composer/preview-block";
 
 /**
  * Node view for block nodes wrapping the source of something that can be
- * rendered, showing the rendered result with a control to show the source.
+ * rendered, showing the rendered result in its place.
  *
  * The node holds its source in a single `preview_source` child, so editing it
  * is ordinary code editing — highlighting, undo and redo all come from the
@@ -16,67 +17,71 @@ import { i18n } from "discourse-i18n";
  * so editing around it cannot merge neighboring text into the source.
  *
  * ```js
- * nodeSpec: { my_node: { content: "preview_source", atom: true, isolating: true, ... } },
+ * nodeSpec: {
+ *   my_node: {
+ *     content: "preview_source",
+ *     atom: true,
+ *     isolating: true,
+ *     previewControls: [{ id, icon, title, className, action }],
+ *     ...
+ *   },
+ * },
  * nodeViews: {
  *   my_node: {
  *     component: PreviewNodeView,
  *     hasContent: true,
- *     options: {
- *       preview: MyPreviewComponent,
- *       controls: [{ icon, label, action }],
- *     },
+ *     options: { preview: MyPreviewComponent },
  *   },
  * }
  * ```
  *
  * The preview component is rendered with `@source` and `@node`. Controls a
- * feature contributes join the one the editor provides, and are called with
- * `{ node, view, getPos, context }`.
+ * feature declares join the source toggle in the toolbar shown for the block,
+ * and are called with `{ node, view, getPos, context }`.
  */
 export default class PreviewNodeView extends Component {
   @tracked showingSource;
 
-  // the source as it was last rendered: while it is being edited the preview
-  // keeps showing this, so it neither re-renders on every keystroke nor
-  // rebuilds itself for a half-typed source
-  @tracked renderedSource;
+  // The node the preview last rendered. Everything the feature reads comes from
+  // this rather than from the live node, so the preview holds still while the
+  // source is being edited, and swapping faces over an untouched source does
+  // not make the feature lay the same thing out again.
+  @tracked renderedNode;
 
   constructor() {
     super(...arguments);
 
-    this.renderedSource = this.args.node.textContent;
+    this.renderedNode = this.args.node;
     // nothing to preview yet when an empty node was just inserted
-    this.showingSource = !this.renderedSource;
+    this.showingSource = !this.source;
 
     this.args.dom.classList.add("composer-preview-node");
     this.args.contentDOM?.classList.add("composer-preview-node__source");
     this.#syncMode();
+
+    registerPreviewNodeView(this.args.dom, this);
     this.args.onSetup?.(this);
+  }
+
+  // the editor's own position closure: it maps through later transactions and
+  // reports undefined once the block is gone
+  getPos() {
+    return this.args.getPos();
   }
 
   get source() {
     return this.args.node.textContent;
   }
 
-  get previewSource() {
-    return this.showingSource ? this.renderedSource : this.source;
-  }
-
-  get toggleLabel() {
-    return this.showingSource
-      ? i18n("composer.preview_node.show_preview")
-      : i18n("composer.preview_node.show_source");
+  get renderedSource() {
+    return this.renderedNode.textContent;
   }
 
   @action
   toggleSource() {
-    if (!this.showingSource) {
-      // freeze what the preview shows for as long as the source is being edited
-      this.renderedSource = this.source;
-    }
-
     this.showingSource = !this.showingSource;
     this.#syncMode();
+    this.#syncRendered();
 
     const pos = this.args.getPos();
     if (pos === undefined) {
@@ -97,14 +102,10 @@ export default class PreviewNodeView extends Component {
     view.focus();
   }
 
-  @action
-  runControl(control) {
-    control.action({
-      node: this.args.node,
-      view: this.args.view,
-      getPos: this.args.getPos,
-      context: this.args.pluginParams.getContext(),
-    });
+  // the source can still change under a shown preview, through undo or a
+  // transaction the editor applies on its own
+  update() {
+    this.#syncRendered();
   }
 
   selectNode() {
@@ -115,17 +116,23 @@ export default class PreviewNodeView extends Component {
     this.args.dom.classList.remove("ProseMirror-selectednode");
   }
 
-  // the controls are the node view's own, so the editor should not treat
-  // clicking them as clicking into the document
+  // the toolbar is portaled into this node view, so the editor should not treat
+  // clicking it as clicking into the document
   stopEvent(event) {
     return (
       event.target instanceof Node &&
-      !!event.target.closest?.(".composer-preview-node__controls")
+      !!event.target.closest?.(`[data-identifier="${TOOLBAR_IDENTIFIER}"]`)
     );
   }
 
   #syncMode() {
     this.args.dom.classList.toggle("--source", this.showingSource);
+  }
+
+  #syncRendered() {
+    if (!this.showingSource && this.renderedNode !== this.args.node) {
+      this.renderedNode = this.args.node;
+    }
   }
 
   <template>
@@ -134,23 +141,8 @@ export default class PreviewNodeView extends Component {
       contenteditable="false"
       aria-hidden={{if this.showingSource "true" "false"}}
     >{{#let @options.preview as |Preview|}}<Preview
-          @source={{this.previewSource}}
-          @node={{@node}}
-        />{{/let}}</div><div
-      class="composer-preview-node__controls"
-      contenteditable="false"
-      role="group"
-    >{{#each @options.controls as |control|}}<DButton
-          @icon={{control.icon}}
-          @translatedTitle={{control.label}}
-          @action={{fn this.runControl control}}
-          class="btn-flat composer-preview-node__control"
-        />{{/each}}<DButton
-        @icon={{if this.showingSource "eye" "code"}}
-        @translatedTitle={{this.toggleLabel}}
-        @action={{this.toggleSource}}
-        aria-pressed={{if this.showingSource "true" "false"}}
-        class="btn-flat composer-preview-node__control composer-preview-node__toggle"
-      /></div>{{~! strip whitespace ~}}
+          @source={{this.renderedSource}}
+          @node={{this.renderedNode}}
+        />{{/let}}</div>{{~! strip whitespace ~}}
   </template>
 }

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -58,9 +58,6 @@ export default class PreviewNodeView extends Component {
     return this.args.node.textContent;
   }
 
-  // the preview follows the source, except while it is being edited: there it
-  // holds still, so it neither re-renders on every keystroke nor rebuilds
-  // itself for a half-typed source
   get previewSource() {
     return this.showingSource ? this.renderedSource : this.source;
   }

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -58,6 +58,13 @@ export default class PreviewNodeView extends Component {
     return this.args.node.textContent;
   }
 
+  // the preview follows the source, except while it is being edited: there it
+  // holds still, so it neither re-renders on every keystroke nor rebuilds
+  // itself for a half-typed source
+  get previewSource() {
+    return this.showingSource ? this.renderedSource : this.source;
+  }
+
   get toggleLabel() {
     return this.showingSource
       ? i18n("composer.preview_node.show_preview")
@@ -66,12 +73,12 @@ export default class PreviewNodeView extends Component {
 
   @action
   toggleSource() {
-    this.showingSource = !this.showingSource;
-
     if (!this.showingSource) {
+      // freeze what the preview shows for as long as the source is being edited
       this.renderedSource = this.source;
     }
 
+    this.showingSource = !this.showingSource;
     this.#syncMode();
 
     const pos = this.args.getPos();
@@ -111,15 +118,6 @@ export default class PreviewNodeView extends Component {
     this.args.dom.classList.remove("ProseMirror-selectednode");
   }
 
-  // reaching the source with the caret has to reveal it, or the caret lands
-  // somewhere out of sight
-  setSelection() {
-    if (!this.showingSource) {
-      this.showingSource = true;
-      this.#syncMode();
-    }
-  }
-
   // the controls are the node view's own, so the editor should not treat
   // clicking them as clicking into the document
   stopEvent(event) {
@@ -139,7 +137,7 @@ export default class PreviewNodeView extends Component {
       contenteditable="false"
       aria-hidden={{if this.showingSource "true" "false"}}
     >{{#let @options.preview as |Preview|}}<Preview
-          @source={{this.renderedSource}}
+          @source={{this.previewSource}}
           @node={{@node}}
         />{{/let}}</div><div
       class="composer-preview-node__controls"

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -1,0 +1,125 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import icon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+/**
+ * Node view for block nodes wrapping the source of something that can be
+ * rendered, showing the rendered result with an instant toggle to the source.
+ *
+ * The node holds its source in a single `code_block` child, so editing it is
+ * ordinary code editing — syntax highlighting, undo and redo all come from the
+ * editor itself. The wrapper must be `isolating` so that editing around it
+ * cannot merge neighboring text into the source.
+ *
+ * ```js
+ * nodeSpec: { my_node: { content: "code_block", isolating: true, ... } },
+ * nodeViews: {
+ *   my_node: {
+ *     component: PreviewNodeView,
+ *     hasContent: true,
+ *     options: { preview: MyPreviewComponent },
+ *   },
+ * }
+ * ```
+ *
+ * The preview component is rendered with `@source` (the source text) and
+ * `@node`.
+ */
+export default class PreviewNodeView extends Component {
+  // nothing to preview yet when an empty node was just inserted
+  @tracked showingSource = !this.args.node.textContent;
+
+  constructor() {
+    super(...arguments);
+    this.args.dom.classList.add("composer-preview-node");
+    this.args.contentDOM?.classList.add("composer-preview-node__source");
+    this.#syncMode();
+    this.args.onSetup?.(this);
+  }
+
+  get source() {
+    return this.args.node.textContent;
+  }
+
+  get toggleLabel() {
+    return this.showingSource
+      ? i18n("composer.preview_node.show_preview")
+      : i18n("composer.preview_node.show_source");
+  }
+
+  @action
+  toggleSource(event) {
+    event.preventDefault();
+
+    this.showingSource = !this.showingSource;
+    this.#syncMode();
+
+    const pos = this.args.getPos();
+    if (pos === undefined) {
+      return;
+    }
+
+    const { view } = this.args;
+    const { NodeSelection, TextSelection } = this.args.pluginParams.pmState;
+    const tr = view.state.tr;
+
+    // the source is hidden while previewing, so the selection cannot stay in it
+    tr.setSelection(
+      this.showingSource
+        ? TextSelection.create(tr.doc, pos + 2 + this.source.length)
+        : NodeSelection.create(tr.doc, pos)
+    );
+
+    view.dispatch(tr);
+    view.focus();
+  }
+
+  selectNode() {
+    this.args.dom.classList.add("ProseMirror-selectednode");
+  }
+
+  deselectNode() {
+    this.args.dom.classList.remove("ProseMirror-selectednode");
+  }
+
+  // reaching the source with the caret — by arrowing into the node, or clicking
+  // where it would be — has to reveal it, or the caret lands out of sight
+  setSelection() {
+    if (!this.showingSource) {
+      this.showingSource = true;
+      this.#syncMode();
+    }
+  }
+
+  // the preview is not editable, and the source is a node of its own
+  stopEvent() {
+    return false;
+  }
+
+  #syncMode() {
+    this.args.dom.classList.toggle("--source", this.showingSource);
+  }
+
+  <template>
+    {{~! strip whitespace ~}}<button
+      type="button"
+      class="composer-preview-node__toggle btn-flat"
+      title={{this.toggleLabel}}
+      aria-label={{this.toggleLabel}}
+      aria-pressed={{if this.showingSource "true" "false"}}
+      contenteditable="false"
+      {{on "click" this.toggleSource}}
+    >{{icon (if this.showingSource "eye" "code")}}</button>{{#unless
+      this.showingSource
+    }}<div class="composer-preview-node__preview" contenteditable="false">{{#let
+          @options.preview
+          as |Preview|
+        }}<Preview
+            @source={{this.source}}
+            @node={{@node}}
+          />{{/let}}</div>{{/unless}}{{~! strip whitespace ~}}
+  </template>
+}

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -145,12 +145,12 @@ export default class PreviewNodeView extends Component {
       role="group"
     >{{#each @options.controls as |control|}}<DButton
           @icon={{control.icon}}
-          @title={{control.label}}
+          @translatedTitle={{control.label}}
           @action={{fn this.runControl control}}
           class="btn-flat composer-preview-node__control"
         />{{/each}}<DButton
         @icon={{if this.showingSource "eye" "code"}}
-        @title={{this.toggleLabel}}
+        @translatedTitle={{this.toggleLabel}}
         @action={{this.toggleSource}}
         aria-pressed={{if this.showingSource "true" "false"}}
         class="btn-flat composer-preview-node__control composer-preview-node__toggle"

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -1,72 +1,55 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import {
-  registerPreviewNodeView,
-  TOOLBAR_IDENTIFIER,
-} from "discourse/lib/composer/preview-block";
+
+/** Identifier of the menu the toolbar for a preview block is shown in. */
+export const TOOLBAR_IDENTIFIER = "composer-preview-toolbar";
+
+const nodeViews = new WeakMap();
+
+/** @returns {PreviewNodeView|undefined} the view rendering the block at `dom` */
+export function previewNodeViewFor(dom) {
+  return nodeViews.get(dom);
+}
 
 /**
- * Node view for block nodes wrapping the source of something that can be
- * rendered, showing the rendered result in its place.
+ * Renders a block's `preview_source` child in place of the source itself.
  *
- * The node holds its source in a single `preview_source` child, so editing it
- * is ordinary code editing — highlighting, undo and redo all come from the
- * editor itself. The wrapper must be an `atom`, so the editor moves over it as
- * a unit rather than stepping into source it is not showing, and `isolating`,
- * so editing around it cannot merge neighboring text into the source.
+ * The wrapper must be `atom` and `isolating`, or the editor will step into
+ * source it is not showing and merge neighboring text into it.
  *
  * ```js
  * nodeSpec: {
- *   my_node: {
- *     content: "preview_source",
- *     atom: true,
- *     isolating: true,
- *     previewControls: [{ id, icon, title, className, action }],
- *     ...
- *   },
+ *   my_node: { content: "preview_source", atom: true, isolating: true, previewControls: [...] },
  * },
  * nodeViews: {
- *   my_node: {
- *     component: PreviewNodeView,
- *     hasContent: true,
- *     options: { preview: MyPreviewComponent },
- *   },
+ *   my_node: { component: PreviewNodeView, hasContent: true, options: { preview: MyPreview } },
  * }
  * ```
  *
- * The preview component is rendered with `@source` and `@node`. Controls a
- * feature declares join the source toggle in the toolbar shown for the block,
- * and are called with `{ node, view, getPos, context }`.
+ * The preview gets `@source` and `@node`; controls get `{ node, view, context }`.
+ *
+ * @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension}
  */
 export default class PreviewNodeView extends Component {
   @tracked showingSource;
 
-  // The node the preview last rendered. Everything the feature reads comes from
-  // this rather than from the live node, so the preview holds still while the
-  // source is being edited, and swapping faces over an untouched source does
-  // not make the feature lay the same thing out again.
+  // the node the preview last rendered, so it holds still while the source is
+  // edited and is not laid out again over a source that has not changed
   @tracked renderedNode;
 
   constructor() {
     super(...arguments);
 
     this.renderedNode = this.args.node;
-    // nothing to preview yet when an empty node was just inserted
     this.showingSource = !this.source;
 
     this.args.dom.classList.add("composer-preview-node");
     this.args.contentDOM?.classList.add("composer-preview-node__source");
     this.#syncMode();
 
-    registerPreviewNodeView(this.args.dom, this);
+    nodeViews.set(this.args.dom, this);
     this.args.onSetup?.(this);
-  }
-
-  // the editor's own position closure: it maps through later transactions and
-  // reports undefined once the block is gone
-  getPos() {
-    return this.args.getPos();
   }
 
   get source() {
@@ -94,7 +77,8 @@ export default class PreviewNodeView extends Component {
 
     tr.setSelection(
       this.showingSource
-        ? TextSelection.create(tr.doc, pos + 2 + this.source.length)
+        ? // just inside the source, past the wrapper and the source's own start
+          TextSelection.create(tr.doc, pos + 2 + this.source.length)
         : NodeSelection.create(tr.doc, pos)
     );
 
@@ -102,8 +86,6 @@ export default class PreviewNodeView extends Component {
     view.focus();
   }
 
-  // the source can still change under a shown preview, through undo or a
-  // transaction the editor applies on its own
   update() {
     this.#syncRendered();
   }
@@ -116,8 +98,7 @@ export default class PreviewNodeView extends Component {
     this.args.dom.classList.remove("ProseMirror-selectednode");
   }
 
-  // the toolbar is portaled into this node view, so the editor should not treat
-  // clicking it as clicking into the document
+  // the toolbar is portaled into this node view, so its clicks are not document clicks
   stopEvent(event) {
     return (
       event.target instanceof Node &&

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -1,39 +1,53 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { on } from "@ember/modifier";
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
-import icon from "discourse/ui-kit/helpers/d-icon";
+import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
 /**
  * Node view for block nodes wrapping the source of something that can be
- * rendered, showing the rendered result with an instant toggle to the source.
+ * rendered, showing the rendered result with a control to show the source.
  *
- * The node holds its source in a single `code_block` child, so editing it is
- * ordinary code editing — syntax highlighting, undo and redo all come from the
- * editor itself. The wrapper must be `isolating` so that editing around it
- * cannot merge neighboring text into the source.
+ * The node holds its source in a single `preview_source` child, so editing it
+ * is ordinary code editing — highlighting, undo and redo all come from the
+ * editor itself. The wrapper must be an `atom`, so the editor moves over it as
+ * a unit rather than stepping into source it is not showing, and `isolating`,
+ * so editing around it cannot merge neighboring text into the source.
  *
  * ```js
- * nodeSpec: { my_node: { content: "code_block", isolating: true, ... } },
+ * nodeSpec: { my_node: { content: "preview_source", atom: true, isolating: true, ... } },
  * nodeViews: {
  *   my_node: {
  *     component: PreviewNodeView,
  *     hasContent: true,
- *     options: { preview: MyPreviewComponent },
+ *     options: {
+ *       preview: MyPreviewComponent,
+ *       controls: [{ icon, label, action }],
+ *     },
  *   },
  * }
  * ```
  *
- * The preview component is rendered with `@source` (the source text) and
- * `@node`.
+ * The preview component is rendered with `@source` and `@node`. Controls a
+ * feature contributes join the one the editor provides, and are called with
+ * `{ node, view, getPos, context }`.
  */
 export default class PreviewNodeView extends Component {
-  // nothing to preview yet when an empty node was just inserted
-  @tracked showingSource = !this.args.node.textContent;
+  @tracked showingSource;
+
+  // the source as it was last rendered: while it is being edited the preview
+  // keeps showing this, so it neither re-renders on every keystroke nor
+  // rebuilds itself for a half-typed source
+  @tracked renderedSource;
 
   constructor() {
     super(...arguments);
+
+    this.renderedSource = this.args.node.textContent;
+    // nothing to preview yet when an empty node was just inserted
+    this.showingSource = !this.renderedSource;
+
     this.args.dom.classList.add("composer-preview-node");
     this.args.contentDOM?.classList.add("composer-preview-node__source");
     this.#syncMode();
@@ -51,10 +65,13 @@ export default class PreviewNodeView extends Component {
   }
 
   @action
-  toggleSource(event) {
-    event.preventDefault();
-
+  toggleSource() {
     this.showingSource = !this.showingSource;
+
+    if (!this.showingSource) {
+      this.renderedSource = this.source;
+    }
+
     this.#syncMode();
 
     const pos = this.args.getPos();
@@ -66,7 +83,6 @@ export default class PreviewNodeView extends Component {
     const { NodeSelection, TextSelection } = this.args.pluginParams.pmState;
     const tr = view.state.tr;
 
-    // the source is hidden while previewing, so the selection cannot stay in it
     tr.setSelection(
       this.showingSource
         ? TextSelection.create(tr.doc, pos + 2 + this.source.length)
@@ -77,6 +93,16 @@ export default class PreviewNodeView extends Component {
     view.focus();
   }
 
+  @action
+  runControl(control) {
+    control.action({
+      node: this.args.node,
+      view: this.args.view,
+      getPos: this.args.getPos,
+      context: this.args.pluginParams.getContext(),
+    });
+  }
+
   selectNode() {
     this.args.dom.classList.add("ProseMirror-selectednode");
   }
@@ -85,8 +111,8 @@ export default class PreviewNodeView extends Component {
     this.args.dom.classList.remove("ProseMirror-selectednode");
   }
 
-  // reaching the source with the caret — by arrowing into the node, or clicking
-  // where it would be — has to reveal it, or the caret lands out of sight
+  // reaching the source with the caret has to reveal it, or the caret lands
+  // somewhere out of sight
   setSelection() {
     if (!this.showingSource) {
       this.showingSource = true;
@@ -94,9 +120,13 @@ export default class PreviewNodeView extends Component {
     }
   }
 
-  // the preview is not editable, and the source is a node of its own
-  stopEvent() {
-    return false;
+  // the controls are the node view's own, so the editor should not treat
+  // clicking them as clicking into the document
+  stopEvent(event) {
+    return (
+      event.target instanceof Node &&
+      !!event.target.closest?.(".composer-preview-node__controls")
+    );
   }
 
   #syncMode() {
@@ -104,22 +134,28 @@ export default class PreviewNodeView extends Component {
   }
 
   <template>
-    {{~! strip whitespace ~}}<button
-      type="button"
-      class="composer-preview-node__toggle btn-flat"
-      title={{this.toggleLabel}}
-      aria-label={{this.toggleLabel}}
-      aria-pressed={{if this.showingSource "true" "false"}}
+    {{~! strip whitespace ~}}<div
+      class="composer-preview-node__preview"
       contenteditable="false"
-      {{on "click" this.toggleSource}}
-    >{{icon (if this.showingSource "eye" "code")}}</button>{{#unless
-      this.showingSource
-    }}<div class="composer-preview-node__preview" contenteditable="false">{{#let
-          @options.preview
-          as |Preview|
-        }}<Preview
-            @source={{this.source}}
-            @node={{@node}}
-          />{{/let}}</div>{{/unless}}{{~! strip whitespace ~}}
+      aria-hidden={{if this.showingSource "true" "false"}}
+    >{{#let @options.preview as |Preview|}}<Preview
+          @source={{this.renderedSource}}
+          @node={{@node}}
+        />{{/let}}</div><div
+      class="composer-preview-node__controls"
+      contenteditable="false"
+      role="group"
+    >{{#each @options.controls as |control|}}<DButton
+          @icon={{control.icon}}
+          @title={{control.label}}
+          @action={{fn this.runControl control}}
+          class="btn-flat composer-preview-node__control"
+        />{{/each}}<DButton
+        @icon={{if this.showingSource "eye" "code"}}
+        @title={{this.toggleLabel}}
+        @action={{this.toggleSource}}
+        aria-pressed={{if this.showingSource "true" "false"}}
+        class="btn-flat composer-preview-node__control composer-preview-node__toggle"
+      /></div>{{~! strip whitespace ~}}
   </template>
 }

--- a/frontend/discourse/app/components/composer/toolbar-buttons.gjs
+++ b/frontend/discourse/app/components/composer/toolbar-buttons.gjs
@@ -11,8 +11,7 @@ export default class ComposerToolbarButtons extends Component {
     return button === this.firstButton ? 0 : button.tabindex;
   }
 
-  // the tab stop has to be a button that is actually rendered: a toolbar whose
-  // leading button is hidden by its condition would otherwise have none
+  // the tab stop must be a rendered button: the leading one may be hidden by its condition
   get firstButton() {
     const { isFirst = true } = this.args;
 
@@ -24,10 +23,7 @@ export default class ComposerToolbarButtons extends Component {
 
     return this.args.data.groups
       .flatMap((group) => group.buttons ?? [])
-      .find(
-        (button) =>
-          this.isActionable(button) && (button.condition?.(context) ?? true)
-      );
+      .find((button) => this.isActionable(button) && button.condition(context));
   }
 
   isActionable(button) {

--- a/frontend/discourse/app/components/composer/toolbar-buttons.gjs
+++ b/frontend/discourse/app/components/composer/toolbar-buttons.gjs
@@ -11,14 +11,23 @@ export default class ComposerToolbarButtons extends Component {
     return button === this.firstButton ? 0 : button.tabindex;
   }
 
+  // the tab stop has to be a button that is actually rendered: a toolbar whose
+  // leading button is hidden by its condition would otherwise have none
   get firstButton() {
     const { isFirst = true } = this.args;
-    return (
-      isFirst &&
-      this.args.data.groups
-        .find((group) => group.buttons?.length > 0)
-        ?.buttons.filter(this.isActionable)[0]
-    );
+
+    if (!isFirst) {
+      return false;
+    }
+
+    const { context } = this.args.data;
+
+    return this.args.data.groups
+      .flatMap((group) => group.buttons ?? [])
+      .find(
+        (button) =>
+          this.isActionable(button) && (button.condition?.(context) ?? true)
+      );
   }
 
   isActionable(button) {

--- a/frontend/discourse/app/lib/composer/preview-block.js
+++ b/frontend/discourse/app/lib/composer/preview-block.js
@@ -49,3 +49,27 @@ export function selectPreviewSource(tr, TextSelection, from) {
     ? tr
     : tr.setSelection(TextSelection.create(tr.doc, pos)).scrollIntoView();
 }
+
+/** Identifier of the menu the preview block's toolbar is shown in. */
+export const TOOLBAR_IDENTIFIER = "composer-preview-toolbar";
+
+const nodeViews = new WeakMap();
+
+/**
+ * Registers the node view rendering a preview block, so the toolbar plugin can
+ * reach the controls and the source toggle of the block a selection is in.
+ *
+ * @param {HTMLElement} dom the node view's outer element
+ * @param {object} nodeView
+ */
+export function registerPreviewNodeView(dom, nodeView) {
+  nodeViews.set(dom, nodeView);
+}
+
+/**
+ * @param {HTMLElement} dom the node view's outer element
+ * @returns {object|undefined} the node view registered for it
+ */
+export function previewNodeViewFor(dom) {
+  return nodeViews.get(dom);
+}

--- a/frontend/discourse/app/lib/composer/preview-block.js
+++ b/frontend/discourse/app/lib/composer/preview-block.js
@@ -1,0 +1,51 @@
+/**
+ * Builds the source of a preview block, trimmed of the padding cooked markup
+ * puts around it while keeping the line breaks within it.
+ *
+ * @param {import("prosemirror-model").Schema} schema
+ * @param {string} source
+ * @param {string} [params] language the source is highlighted as
+ * @returns {import("prosemirror-model").Node} a `preview_source` node
+ */
+export function previewSourceNode(schema, source, params = "") {
+  const trimmed = source.trim();
+
+  return schema.nodes.preview_source.create(
+    { params },
+    trimmed ? schema.text(trimmed) : null
+  );
+}
+
+/**
+ * Puts the caret in the source of a preview block that a transaction just
+ * inserted, so typing carries on inside the block rather than in the text it
+ * interrupted.
+ *
+ * Fitting the block into the document may move it past the position it was
+ * written to, so the source is found by looking forward from there — the block
+ * was inserted at `from`, so the first `preview_source` at or after it is the
+ * one that was just created.
+ *
+ * @param {import("prosemirror-state").Transaction} tr transaction that inserted the block
+ * @param {typeof import("prosemirror-state").TextSelection} TextSelection from `pmState`
+ * @param {number} from position the block was written to
+ * @returns {import("prosemirror-state").Transaction} the same transaction
+ */
+export function selectPreviewSource(tr, TextSelection, from) {
+  let pos;
+
+  tr.doc.nodesBetween(from, tr.doc.content.size, (node, nodePos) => {
+    if (pos !== undefined) {
+      return false;
+    }
+
+    if (node.type.name === "preview_source") {
+      pos = nodePos + 1;
+      return false;
+    }
+  });
+
+  return pos === undefined
+    ? tr
+    : tr.setSelection(TextSelection.create(tr.doc, pos)).scrollIntoView();
+}

--- a/frontend/discourse/app/lib/composer/preview-block.js
+++ b/frontend/discourse/app/lib/composer/preview-block.js
@@ -1,6 +1,6 @@
 /**
  * Builds the source of a preview block, trimmed of the padding cooked markup
- * puts around it while keeping the line breaks within it.
+ * puts around it.
  *
  * @param {import("prosemirror-model").Schema} schema
  * @param {string} source
@@ -17,17 +17,13 @@ export function previewSourceNode(schema, source, params = "") {
 }
 
 /**
- * Puts the caret in the source of a preview block that a transaction just
- * inserted, so typing carries on inside the block rather than in the text it
- * interrupted.
+ * Puts the caret in the source of a preview block a transaction just inserted.
  *
- * Fitting the block into the document may move it past the position it was
- * written to, so the source is found by looking forward from there — the block
- * was inserted at `from`, so the first `preview_source` at or after it is the
- * one that was just created.
+ * Fitting the block in can move it past `from`, so the first `preview_source`
+ * at or after it is the one that was just created.
  *
- * @param {import("prosemirror-state").Transaction} tr transaction that inserted the block
- * @param {typeof import("prosemirror-state").TextSelection} TextSelection from `pmState`
+ * @param {import("prosemirror-state").Transaction} tr
+ * @param {typeof import("prosemirror-state").TextSelection} TextSelection
  * @param {number} from position the block was written to
  * @returns {import("prosemirror-state").Transaction} the same transaction
  */
@@ -48,28 +44,4 @@ export function selectPreviewSource(tr, TextSelection, from) {
   return pos === undefined
     ? tr
     : tr.setSelection(TextSelection.create(tr.doc, pos)).scrollIntoView();
-}
-
-/** Identifier of the menu the preview block's toolbar is shown in. */
-export const TOOLBAR_IDENTIFIER = "composer-preview-toolbar";
-
-const nodeViews = new WeakMap();
-
-/**
- * Registers the node view rendering a preview block, so the toolbar plugin can
- * reach the controls and the source toggle of the block a selection is in.
- *
- * @param {HTMLElement} dom the node view's outer element
- * @param {object} nodeView
- */
-export function registerPreviewNodeView(dom, nodeView) {
-  nodeViews.set(dom, nodeView);
-}
-
-/**
- * @param {HTMLElement} dom the node view's outer element
- * @returns {object|undefined} the node view registered for it
- */
-export function previewNodeViewFor(dom) {
-  return nodeViews.get(dom);
 }

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -199,7 +199,7 @@ export interface GlimmerNodeViewDescriptor {
   name?: string;
   /** Whether the node view exposes editable child content. */
   hasContent?: boolean;
-  /** Passed to the component as `@options`, letting reusable node views be configured per node. */
+  /** Passed to the component as `@options`. */
   options?: Record<string, unknown>;
   /** Determines whether the node view should be rendered. */
   shouldRender?: (params: {

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -199,6 +199,8 @@ export interface GlimmerNodeViewDescriptor {
   name?: string;
   /** Whether the node view exposes editable child content. */
   hasContent?: boolean;
+  /** Passed to the component as `@options`, letting reusable node views be configured per node. */
+  options?: Record<string, unknown>;
   /** Determines whether the node view should be rendered. */
   shouldRender?: (params: {
     /** Node represented by the view. */

--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
@@ -113,7 +113,9 @@ type NodeViewComponent = ComponentLike<{
     view: EditorView;
     getPos: () => number | undefined;
     dom: HTMLElement;
+    contentDOM?: HTMLElement;
     pluginParams: PluginParams;
+    options: Record<string, unknown>;
     onSetup: (instance: unknown) => void;
   };
 }>;
@@ -477,7 +479,9 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
           @view={{nodeView.view}}
           @getPos={{nodeView.getPos}}
           @dom={{nodeView.dom}}
+          @contentDOM={{nodeView.contentDOM}}
           @pluginParams={{nodeView.pluginParams}}
+          @options={{nodeView.options}}
           @onSetup={{nodeView.setComponentInstance}}
         />
       {{~/in-element~}}

--- a/frontend/discourse/app/static/prosemirror/core/plugin.js
+++ b/frontend/discourse/app/static/prosemirror/core/plugin.js
@@ -17,7 +17,7 @@ import GlimmerNodeView from "../lib/glimmer-node-view";
   - `name: "customName"` - CSS class suffix (defaults to the key)
   - `hasContent: true` - for nodes with editable content inside
   - `shouldRender: ({ node, view, getPos, pluginParams }) => boolean` - for conditional rendering
-  - `options: {}` - passed to the component as `@options`, for reusable node views
+  - `options: {}` - passed to the component as `@options`
 */
 export function extractNodeViews(extensions, pluginParams) {
   /** @type {Record<string, import('prosemirror-view').NodeViewConstructor>} */

--- a/frontend/discourse/app/static/prosemirror/core/plugin.js
+++ b/frontend/discourse/app/static/prosemirror/core/plugin.js
@@ -17,6 +17,7 @@ import GlimmerNodeView from "../lib/glimmer-node-view";
   - `name: "customName"` - CSS class suffix (defaults to the key)
   - `hasContent: true` - for nodes with editable content inside
   - `shouldRender: ({ node, view, getPos, pluginParams }) => boolean` - for conditional rendering
+  - `options: {}` - passed to the component as `@options`, for reusable node views
 */
 export function extractNodeViews(extensions, pluginParams) {
   /** @type {Record<string, import('prosemirror-view').NodeViewConstructor>} */
@@ -42,6 +43,7 @@ export function extractNodeViews(extensions, pluginParams) {
               component: nodeView.component,
               name: nodeView.name || name,
               hasContent: nodeView.hasContent,
+              options: nodeView.options,
             });
           };
           continue;

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -193,7 +193,7 @@ const extension = {
   async plugins({ getContext }) {
     return highlightPlugin(
       (hljs = await ensureHighlightJs(getContext().session.highlightJsPath)),
-      ["code_block", "html_block"],
+      ["code_block", "html_block", "preview_source"],
 
       // NOTE: If the language has not been set with the code block, we default to plain
       // text rather than autodetecting. This is to work around an infinite loop issue

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
@@ -1,0 +1,35 @@
+/**
+ * The source of a block that is shown rendered, held by a node view that
+ * previews it (see `discourse/components/composer/preview-node-view`).
+ *
+ * It behaves like a code block without being one: the language belongs to the
+ * feature rather than the author, so there is no language picker, and it never
+ * serializes on its own — the feature wrapping it writes its own markup.
+ *
+ * @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension}
+ */
+const extension = {
+  nodeSpec: {
+    preview_source: {
+      attrs: { params: { default: "" } },
+      content: "text*",
+      code: true,
+      defining: true,
+      marks: "",
+      parseDOM: [
+        { tag: "pre.preview-source", preserveWhitespace: "full" },
+        // a plain code block pasted into a preview block is its source
+        { tag: "pre", preserveWhitespace: "full" },
+      ],
+      toDOM: () => ["pre", { class: "preview-source" }, ["code", 0]],
+    },
+  },
+
+  serializeNode: {
+    preview_source: (state, node) => {
+      state.text(node.textContent, false);
+    },
+  },
+};
+
+export default extension;

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
@@ -16,11 +16,7 @@ const extension = {
       code: true,
       defining: true,
       marks: "",
-      parseDOM: [
-        { tag: "pre.preview-source", preserveWhitespace: "full" },
-        // a plain code block pasted into a preview block is its source
-        { tag: "pre", preserveWhitespace: "full" },
-      ],
+      parseDOM: [{ tag: "pre.preview-source", preserveWhitespace: "full" }],
       toDOM: () => ["pre", { class: "preview-source" }, ["code", 0]],
     },
   },

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
@@ -15,6 +15,9 @@ const extension = {
       content: "text*",
       code: true,
       defining: true,
+      // the block around it is the unit to select, so a click that would select
+      // the source resolves to its parent instead
+      selectable: false,
       marks: "",
       parseDOM: [{ tag: "pre.preview-source", preserveWhitespace: "full" }],
       toDOM: () => ["pre", { class: "preview-source" }, ["code", 0]],

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-source.js
@@ -1,10 +1,7 @@
 /**
- * The source of a block that is shown rendered, held by a node view that
- * previews it (see `discourse/components/composer/preview-node-view`).
- *
- * It behaves like a code block without being one: the language belongs to the
- * feature rather than the author, so there is no language picker, and it never
- * serializes on its own — the feature wrapping it writes its own markup.
+ * The source of a block shown rendered by `composer/preview-node-view`.
+ * Highlighted like a code block, but the language belongs to the feature
+ * rather than the author, so there is no language picker.
  *
  * @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension}
  */
@@ -15,8 +12,7 @@ const extension = {
       content: "text*",
       code: true,
       defining: true,
-      // the block around it is the unit to select, so a click that would select
-      // the source resolves to its parent instead
+      // clicks resolve to the block around it, which is the unit to select
       selectable: false,
       marks: "",
       parseDOM: [{ tag: "pre.preview-source", preserveWhitespace: "full" }],

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -1,21 +1,18 @@
-import { trackedObject } from "@ember/reactive/collections";
 import { NodeSelection } from "prosemirror-state";
-import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
 import {
   previewNodeViewFor,
   TOOLBAR_IDENTIFIER,
-} from "discourse/lib/composer/preview-block";
+} from "discourse/components/composer/preview-node-view";
+import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
 import { ToolbarBase } from "discourse/lib/composer/toolbar";
 import { rovingButtonBar } from "discourse/lib/roving-button-bar";
 
 const MENU_PADDING = 8;
 
 /**
- * Finds the preview block a selection acts on: either one selected as a node,
- * or the one whose source the caret is in, so the toolbar stays up while the
- * source is being edited.
+ * Finds the preview block a selection acts on: one selected as a node, or the
+ * one whose source the caret is in.
  *
- * @param {import("prosemirror-state").EditorState} state
  * @returns {{ node: import("prosemirror-model").Node, pos: number }|null}
  */
 export function activePreviewBlock({ selection, schema }) {
@@ -82,7 +79,7 @@ class PreviewToolbarPluginView {
   #replacedToolbar;
   #toolbars = new Map();
   #toolbar;
-  #state;
+  #pos;
 
   #view;
   #getContext;
@@ -120,17 +117,12 @@ class PreviewToolbarPluginView {
   }
 
   #updateState({ node, pos }) {
-    if (!this.#state) {
-      this.#state = trackedObject({ pos });
-    } else {
-      this.#state.pos = pos;
-    }
-
+    this.#pos = pos;
     this.#toolbar = this.#toolbarFor(node.type);
   }
 
-  // one toolbar per node type: the buttons a feature contributes are fixed, and
-  // everything they act on is resolved from the selection when they run
+  // one toolbar per node type: its buttons are fixed and resolve their target
+  // from the selection when they run
   #toolbarFor(type) {
     let toolbar = this.#toolbars.get(type.name);
 
@@ -150,24 +142,21 @@ class PreviewToolbarPluginView {
   }
 
   #nodeView() {
-    const dom = this.#view.nodeDOM(this.#state.pos);
+    const dom = this.#view.nodeDOM(this.#pos);
 
     return dom instanceof HTMLElement ? previewNodeViewFor(dom) : undefined;
   }
 
   #runControl(control) {
-    const nodeView = this.#nodeView();
-    const getPos = () => nodeView?.getPos();
-    const pos = getPos();
+    const active = activePreviewBlock(this.#view.state);
 
-    if (pos === undefined) {
+    if (!active) {
       return;
     }
 
     control.action({
-      node: this.#view.state.doc.nodeAt(pos),
+      node: active.node,
       view: this.#view,
-      getPos,
       context: this.#getContext(),
     });
   }
@@ -193,14 +182,13 @@ class PreviewToolbarPluginView {
   }
 
   async #showFloatingToolbar() {
-    const trigger = this.#view.nodeDOM(this.#state.pos);
+    const trigger = this.#view.nodeDOM(this.#pos);
 
     if (!(trigger instanceof HTMLElement)) {
       return;
     }
 
-    // claimed before the await below: two updates in one microtask would
-    // otherwise each create an instance, and the first would be orphaned
+    // claimed before the await: two updates in one microtask would orphan an instance
     if (this.#menuTrigger === trigger) {
       return;
     }
@@ -261,8 +249,7 @@ class PreviewToolbarPluginView {
 }
 
 /**
- * Toolbar for the block a `preview_source` belongs to, shown while it is
- * selected or its source is being edited.
+ * Toolbar for the block a `preview_source` belongs to.
  *
  * @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension}
  */
@@ -289,8 +276,7 @@ const extension = {
             return false;
           }
 
-          // through this editor's own toolbar, so a second editor on the page
-          // cannot take the focus
+          // this editor's own toolbar, so a second editor cannot take the focus
           if (!pluginView?.focusToolbar()) {
             return false;
           }

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -1,0 +1,312 @@
+import { trackedObject } from "@ember/reactive/collections";
+import { NodeSelection } from "prosemirror-state";
+import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
+import {
+  previewNodeViewFor,
+  TOOLBAR_IDENTIFIER,
+} from "discourse/lib/composer/preview-block";
+import { ToolbarBase } from "discourse/lib/composer/toolbar";
+import { rovingButtonBar } from "discourse/lib/roving-button-bar";
+
+const MENU_PADDING = 8;
+
+/**
+ * Finds the preview block a selection acts on: either one selected as a node,
+ * or the one whose source the caret is in, so the toolbar stays up while the
+ * source is being edited.
+ *
+ * @param {import("prosemirror-state").EditorState} state
+ * @returns {{ node: import("prosemirror-model").Node, pos: number }|null}
+ */
+export function activePreviewBlock({ selection, schema }) {
+  const previewSource = schema.nodes.preview_source;
+
+  if (!previewSource) {
+    return null;
+  }
+
+  if (
+    selection instanceof NodeSelection &&
+    selection.node.firstChild?.type === previewSource
+  ) {
+    return { node: selection.node, pos: selection.from };
+  }
+
+  const { $head } = selection;
+
+  for (let depth = $head.depth; depth > 0; depth--) {
+    const node = $head.node(depth);
+
+    if (node.firstChild?.type === previewSource) {
+      return { node, pos: $head.before(depth) };
+    }
+  }
+
+  return null;
+}
+
+class PreviewToolbar extends ToolbarBase {
+  constructor(opts = {}) {
+    super(opts);
+
+    opts.controls.forEach((control) => {
+      this.addButton({
+        ...control,
+        action: () => opts.runControl(control),
+      });
+    });
+
+    this.addButton({
+      id: "preview-show-source",
+      icon: "code",
+      title: "composer.preview_node.show_source",
+      className: "composer-preview-toolbar__show-source",
+      condition: () => !opts.isShowingSource(),
+      action: opts.toggleSource,
+    });
+
+    this.addButton({
+      id: "preview-show-preview",
+      icon: "eye",
+      title: "composer.preview_node.show_preview",
+      className: "composer-preview-toolbar__show-preview",
+      condition: () => opts.isShowingSource(),
+      action: opts.toggleSource,
+    });
+  }
+}
+
+class PreviewToolbarPluginView {
+  #menuInstance;
+  #menuTrigger;
+  #replacedToolbar;
+  #toolbars = new Map();
+  #toolbar;
+  #state;
+
+  #view;
+  #getContext;
+
+  constructor({ getContext }) {
+    this.#getContext = getContext;
+  }
+
+  update(view) {
+    this.#view = view;
+
+    const active = activePreviewBlock(view.state);
+
+    if (!active) {
+      // Don't tear down while a toolbar button is focused.
+      if (!this.#menuInstance?.content?.contains(document.activeElement)) {
+        this.#resetToolbar();
+      }
+      return;
+    }
+
+    this.#updateState(active);
+    this.#displayToolbar();
+  }
+
+  #resetToolbar() {
+    this.#menuInstance?.destroy();
+    this.#menuInstance = null;
+    this.#menuTrigger = null;
+
+    if (this.#replacedToolbar) {
+      this.#getContext().replaceToolbar(null, this.#replacedToolbar);
+      this.#replacedToolbar = null;
+    }
+  }
+
+  #updateState({ node, pos }) {
+    if (!this.#state) {
+      this.#state = trackedObject({ pos });
+    } else {
+      this.#state.pos = pos;
+    }
+
+    this.#toolbar = this.#toolbarFor(node.type);
+  }
+
+  // one toolbar per node type: the buttons a feature contributes are fixed, and
+  // everything they act on is resolved from the selection when they run
+  #toolbarFor(type) {
+    let toolbar = this.#toolbars.get(type.name);
+
+    if (!toolbar) {
+      toolbar = new PreviewToolbar({
+        controls: type.spec.previewControls ?? [],
+        runControl: (control) => this.#runControl(control),
+        toggleSource: () => this.#nodeView()?.toggleSource(),
+        isShowingSource: () => !!this.#nodeView()?.showingSource,
+      });
+
+      toolbar.rovingButtonBar = this.#rovingButtonBar.bind(this);
+      this.#toolbars.set(type.name, toolbar);
+    }
+
+    return toolbar;
+  }
+
+  #nodeView() {
+    const dom = this.#view.nodeDOM(this.#state.pos);
+
+    return dom instanceof HTMLElement ? previewNodeViewFor(dom) : undefined;
+  }
+
+  #runControl(control) {
+    const nodeView = this.#nodeView();
+    const getPos = () => nodeView?.getPos();
+    const pos = getPos();
+
+    if (pos === undefined) {
+      return;
+    }
+
+    control.action({
+      node: this.#view.state.doc.nodeAt(pos),
+      view: this.#view,
+      getPos,
+      context: this.#getContext(),
+    });
+  }
+
+  #rovingButtonBar(event) {
+    if (event.key === "Tab") {
+      event.preventDefault();
+      this.#view.focus();
+      return false;
+    }
+    return rovingButtonBar(event);
+  }
+
+  #displayToolbar() {
+    if (this.#getContext().capabilities.viewport.sm) {
+      this.#showFloatingToolbar();
+    } else if (this.#replacedToolbar !== this.#toolbar) {
+      // replacing again on every transaction would re-render the whole bar for
+      // each keystroke typed into the source
+      this.#getContext().replaceToolbar(this.#toolbar);
+      this.#replacedToolbar = this.#toolbar;
+    }
+  }
+
+  async #showFloatingToolbar() {
+    const trigger = this.#view.nodeDOM(this.#state.pos);
+
+    if (!(trigger instanceof HTMLElement)) {
+      return;
+    }
+
+    // claimed before the await below: two updates in one microtask would
+    // otherwise each create an instance, and the first would be orphaned
+    if (this.#menuTrigger === trigger) {
+      return;
+    }
+
+    this.#menuInstance?.destroy();
+    this.#menuTrigger = trigger;
+
+    this.#menuInstance = await this.#getContext().menu.newInstance(trigger, {
+      identifier: TOOLBAR_IDENTIFIER,
+      component: ToolbarButtons,
+      placement: "top-end",
+      fallbackPlacements: ["top-end"],
+      padding: MENU_PADDING,
+      data: this.#toolbar,
+      portalOutletElement: trigger,
+      closeOnClickOutside: false,
+      closeOnEscape: false,
+      closeOnScroll: false,
+      trapTab: false,
+      offset({ rects }) {
+        return {
+          mainAxis: -MENU_PADDING - rects.floating.height,
+          crossAxis: -MENU_PADDING,
+        };
+      },
+      limitShift: {
+        offset: ({ rects }) => ({
+          crossAxis: Math.min(
+            rects.floating.height + 2 * MENU_PADDING,
+            rects.reference.height - MENU_PADDING
+          ),
+        }),
+      },
+    });
+
+    await this.#menuInstance.show();
+  }
+
+  focusToolbar() {
+    const focusable = this.#menuInstance?.content?.querySelector(
+      'button, a, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (!focusable) {
+      return false;
+    }
+
+    focusable.focus();
+
+    return true;
+  }
+
+  destroy() {
+    this.#resetToolbar();
+    this.#toolbars.clear();
+    this.#toolbar = null;
+  }
+}
+
+/**
+ * Toolbar for the block a `preview_source` belongs to, shown while it is
+ * selected or its source is being edited.
+ *
+ * @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension}
+ */
+const extension = {
+  plugins: ({ pmState: { Plugin }, getContext }) => {
+    let pluginView;
+
+    return new Plugin({
+      props: {
+        handleKeyDown(view, event) {
+          if (event.key !== "Tab" || event.shiftKey) {
+            return false;
+          }
+
+          const { selection, schema } = view.state;
+          const previewSource = schema.nodes.preview_source;
+
+          // only from the selected block: inside the source, Tab is typing
+          if (
+            !previewSource ||
+            !(selection instanceof NodeSelection) ||
+            selection.node.firstChild?.type !== previewSource
+          ) {
+            return false;
+          }
+
+          // through this editor's own toolbar, so a second editor on the page
+          // cannot take the focus
+          if (!pluginView?.focusToolbar()) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          return true;
+        },
+      },
+
+      view() {
+        pluginView = new PreviewToolbarPluginView({ getContext });
+        return pluginView;
+      },
+    });
+  },
+};
+
+export default extension;

--- a/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
+++ b/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
@@ -23,6 +23,7 @@ import oneboxToolbar from "./onebox-toolbar";
 import orderedList from "./ordered-list";
 import overrideDragGhost from "./override-drag-ghost";
 import previewSource from "./preview-source";
+import previewToolbar from "./preview-toolbar";
 import quote from "./quote";
 import strikethrough from "./strikethrough";
 import table from "./table";
@@ -67,6 +68,7 @@ const defaultExtensions: RichEditorExtension[] = [
   grid,
   uploadPlaceholder,
   previewSource,
+  previewToolbar,
 ];
 
 defaultExtensions.forEach(registerRichEditorExtension);

--- a/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
+++ b/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
@@ -22,6 +22,7 @@ import onebox from "./onebox";
 import oneboxToolbar from "./onebox-toolbar";
 import orderedList from "./ordered-list";
 import overrideDragGhost from "./override-drag-ghost";
+import previewSource from "./preview-source";
 import quote from "./quote";
 import strikethrough from "./strikethrough";
 import table from "./table";
@@ -65,6 +66,7 @@ const defaultExtensions: RichEditorExtension[] = [
   hardBreak,
   grid,
   uploadPlaceholder,
+  previewSource,
 ];
 
 defaultExtensions.forEach(registerRichEditorExtension);

--- a/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
+++ b/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
@@ -62,6 +62,12 @@ export default class GlimmerNodeView {
   }
 
   update(node) {
+    // the editor offers this view for reuse before creating a new one; a node
+    // of another type needs its own view, and its own component
+    if (node.type !== this.node.type) {
+      return false;
+    }
+
     // the editor calls this for every transaction, but only hands over a new
     // node object when this node changed; assigning regardless would re-render
     // the component on every keystroke anywhere in the document

--- a/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
+++ b/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
@@ -62,9 +62,8 @@ export default class GlimmerNodeView {
   }
 
   update(node) {
-    // the editor calls this for every transaction, but only hands over a new
-    // node object when this node changed; assigning regardless would re-render
-    // the component on every keystroke anywhere in the document
+    // assigning an unchanged node would re-render the component on every
+    // keystroke anywhere in the document
     if (node !== this.node) {
       this.node = node;
       this.#componentInstance?.update?.(node);

--- a/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
+++ b/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
@@ -62,17 +62,12 @@ export default class GlimmerNodeView {
   }
 
   update(node) {
-    // the editor offers this view for reuse before creating a new one; a node
-    // of another type needs its own view, and its own component
-    if (node.type !== this.node.type) {
-      return false;
-    }
-
     // the editor calls this for every transaction, but only hands over a new
     // node object when this node changed; assigning regardless would re-render
     // the component on every keystroke anywhere in the document
     if (node !== this.node) {
       this.node = node;
+      this.#componentInstance?.update?.(node);
     }
 
     return true;

--- a/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
+++ b/frontend/discourse/app/static/prosemirror/lib/glimmer-node-view.js
@@ -10,6 +10,7 @@ import { next } from "@ember/runloop";
  * @property {import("discourse/lib/composer/rich-editor-extensions").PluginParams} pluginParams
  * @property {any} component
  * @property {string} name
+ * @property {Record<string, unknown>} [options]
  */
 export default class GlimmerNodeView {
   @tracked node;
@@ -28,12 +29,14 @@ export default class GlimmerNodeView {
     component,
     name,
     hasContent = false,
+    options,
   }) {
     this.node = node;
     this.view = view;
     this.getPos = getPos;
     this.pluginParams = pluginParams ?? { getContext };
     this.component = component;
+    this.options = options;
 
     this.pluginParams.getContext().addGlimmerNodeView(this);
 
@@ -59,7 +62,12 @@ export default class GlimmerNodeView {
   }
 
   update(node) {
-    this.node = node;
+    // the editor calls this for every transaction, but only hands over a new
+    // node object when this node changed; assigning regardless would re-render
+    // the component on every keystroke anywhere in the document
+    if (node !== this.node) {
+      this.node = node;
+    }
 
     return true;
   }

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
@@ -1,9 +1,9 @@
-import Component from "@glimmer/component";
 import { settled } from "@ember/test-helpers";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import { module, test } from "qunit";
-import PreviewNodeView from "discourse/components/composer/preview-node-view";
-import { previewNodeViewFor } from "discourse/lib/composer/preview-block";
+import PreviewNodeView, {
+  previewNodeViewFor,
+} from "discourse/components/composer/preview-node-view";
 import {
   registerRichEditorExtension,
   resetRichEditorExtensions,
@@ -12,18 +12,9 @@ import { activePreviewBlock } from "discourse/static/prosemirror/extensions/prev
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
 
-let renders;
-
-class PreviewStub extends Component {
-  get shown() {
-    renders++;
-    return this.args.source;
-  }
-
-  <template>
-    <span class="preview-stub">{{this.shown}}</span>
-  </template>
-}
+const PreviewStub = <template>
+  <span class="preview-stub">{{@source}}</span>
+</template>;
 
 const extension = {
   nodeSpec: {
@@ -33,7 +24,6 @@ const extension = {
       atom: true,
       defining: true,
       isolating: true,
-      selectable: true,
       parseDOM: [{ tag: "div.test-preview", preserveWhitespace: "full" }],
       toDOM: () => ["div", { class: "test-preview" }, 0],
     },
@@ -57,8 +47,7 @@ const extension = {
   },
 };
 
-// the extension has no markdown rule, so blocks are inserted into the document
-// directly rather than parsed out of the editor's initial value
+// no markdown rule here, so blocks are inserted directly
 async function insertBlock(view, source) {
   const { schema } = view.state;
   const block = schema.nodes.test_preview.createAndFill(
@@ -73,8 +62,7 @@ async function insertBlock(view, source) {
   await settled();
 }
 
-// the toolbar is a float-kit menu, which does not mount in a rendering test —
-// it is covered by a system spec, and this drives the seam its button acts on
+// float-kit does not mount in a rendering test; drive the seam the button acts on
 async function toggleSource(view) {
   previewNodeViewFor(view.nodeDOM(0)).toggleSource();
   await settled();
@@ -86,7 +74,6 @@ module(
     setupRenderingTest(hooks);
 
     hooks.beforeEach(async function () {
-      renders = 0;
       await resetRichEditorExtensions();
       registerRichEditorExtension(extension);
     });
@@ -117,7 +104,6 @@ module(
         "preview_source",
         "the caret is inside the source"
       );
-      assert.true(selection.empty, "nothing is selected");
       assert.strictEqual(
         selection.$head.parentOffset,
         3,
@@ -136,6 +122,11 @@ module(
         editorClass.view.state.selection.node?.type.name,
         "test_preview",
         "the block is selected, so its toolbar stays up"
+      );
+      assert.strictEqual(
+        editorClass.value.trim(),
+        "[test]\nabc\n[/test]",
+        "and the markdown is untouched"
       );
     });
 
@@ -199,35 +190,6 @@ module(
         activePreviewBlock(view.state),
         null,
         "and nothing once the caret leaves"
-      );
-    });
-
-    test("serializes the same source after the faces are swapped", async function (assert) {
-      const [editorClass] = await setupRichEditor(assert, "");
-      await insertBlock(editorClass.view, "the source");
-
-      await toggleSource(editorClass.view);
-      await toggleSource(editorClass.view);
-
-      assert.strictEqual(
-        editorClass.value.trim(),
-        "[test]\nthe source\n[/test]",
-        "swapping faces leaves the markdown untouched"
-      );
-    });
-
-    test("does not render the preview again over an untouched source", async function (assert) {
-      const [editorClass] = await setupRichEditor(assert, "");
-      await insertBlock(editorClass.view, "the source");
-
-      const before = renders;
-      await toggleSource(editorClass.view);
-      await toggleSource(editorClass.view);
-
-      assert.strictEqual(
-        renders,
-        before,
-        "swapping faces leaves the feature's render alone"
       );
     });
 

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
@@ -1,18 +1,29 @@
-import { click, settled } from "@ember/test-helpers";
+import Component from "@glimmer/component";
+import { settled } from "@ember/test-helpers";
+import { NodeSelection, TextSelection } from "prosemirror-state";
 import { module, test } from "qunit";
 import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import { previewNodeViewFor } from "discourse/lib/composer/preview-block";
 import {
   registerRichEditorExtension,
   resetRichEditorExtensions,
 } from "discourse/lib/composer/rich-editor-extensions";
+import { activePreviewBlock } from "discourse/static/prosemirror/extensions/preview-toolbar";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
 
-let ranControl;
+let renders;
 
-const PreviewStub = <template>
-  <span class="preview-stub">{{@source}}</span>
-</template>;
+class PreviewStub extends Component {
+  get shown() {
+    renders++;
+    return this.args.source;
+  }
+
+  <template>
+    <span class="preview-stub">{{this.shown}}</span>
+  </template>
+}
 
 const extension = {
   nodeSpec: {
@@ -32,16 +43,7 @@ const extension = {
     test_preview: {
       component: PreviewNodeView,
       hasContent: true,
-      options: {
-        preview: PreviewStub,
-        controls: [
-          {
-            icon: "gear",
-            label: "Do the thing",
-            action: () => (ranControl = true),
-          },
-        ],
-      },
+      options: { preview: PreviewStub },
     },
   },
 
@@ -66,9 +68,15 @@ async function insertBlock(view, source) {
       : null
   );
 
-  view.dispatch(
-    view.state.tr.replaceWith(0, view.state.doc.content.size, block)
-  );
+  const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, block);
+  view.dispatch(tr.setSelection(NodeSelection.create(tr.doc, 0)));
+  await settled();
+}
+
+// the toolbar is a float-kit menu, which does not mount in a rendering test —
+// it is covered by a system spec, and this drives the seam its button acts on
+async function toggleSource(view) {
+  previewNodeViewFor(view.nodeDOM(0)).toggleSource();
   await settled();
 }
 
@@ -78,7 +86,7 @@ module(
     setupRenderingTest(hooks);
 
     hooks.beforeEach(async function () {
-      ranControl = false;
+      renders = 0;
       await resetRichEditorExtensions();
       registerRichEditorExtension(extension);
     });
@@ -90,10 +98,10 @@ module(
       assert.dom(".composer-preview-node").doesNotHaveClass("--source");
       assert.dom(".preview-stub").hasText("the source");
 
-      await click(".composer-preview-node__toggle");
+      await toggleSource(editorClass.view);
       assert.dom(".composer-preview-node").hasClass("--source");
 
-      await click(".composer-preview-node__toggle");
+      await toggleSource(editorClass.view);
       assert.dom(".composer-preview-node").doesNotHaveClass("--source");
     });
 
@@ -101,7 +109,7 @@ module(
       const [editorClass] = await setupRichEditor(assert, "");
       await insertBlock(editorClass.view, "abc");
 
-      await click(".composer-preview-node__toggle");
+      await toggleSource(editorClass.view);
 
       const { selection } = editorClass.view.state;
       assert.strictEqual(
@@ -117,6 +125,20 @@ module(
       );
     });
 
+    test("selects the block again when the source is hidden", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "abc");
+
+      await toggleSource(editorClass.view);
+      await toggleSource(editorClass.view);
+
+      assert.strictEqual(
+        editorClass.view.state.selection.node?.type.name,
+        "test_preview",
+        "the block is selected, so its toolbar stays up"
+      );
+    });
+
     test("starts on the source when there is nothing to preview yet", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, "");
       await insertBlock(editorClass.view, "");
@@ -128,7 +150,7 @@ module(
       const [editorClass] = await setupRichEditor(assert, "");
       await insertBlock(editorClass.view, "before");
 
-      await click(".composer-preview-node__toggle");
+      await toggleSource(editorClass.view);
 
       const { view } = editorClass;
       view.dispatch(view.state.tr.insertText("-after", 2, 8));
@@ -138,23 +160,86 @@ module(
         .dom(".preview-stub")
         .hasText("before", "the preview keeps the source it last rendered");
 
-      await click(".composer-preview-node__toggle");
+      await toggleSource(view);
       assert
         .dom(".preview-stub")
         .hasText("-after", "and catches up once the source is hidden again");
     });
 
-    test("renders a contributed control and runs it", async function (assert) {
+    test("finds the block a selection acts on, so the toolbar follows it", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "the source");
+      const { view } = editorClass;
+
+      assert.strictEqual(
+        activePreviewBlock(view.state)?.node.type.name,
+        "test_preview",
+        "the selected block"
+      );
+
+      await toggleSource(view);
+      const inSource = activePreviewBlock(view.state);
+      assert.strictEqual(
+        inSource?.node.type.name,
+        "test_preview",
+        "the block whose source the caret is in, not the source itself"
+      );
+      assert.strictEqual(
+        view.state.doc.nodeAt(inSource.pos)?.type.name,
+        "test_preview",
+        "at the block's own position"
+      );
+
+      view.dispatch(
+        view.state.tr.setSelection(TextSelection.atEnd(view.state.doc))
+      );
+      await settled();
+
+      assert.strictEqual(
+        activePreviewBlock(view.state),
+        null,
+        "and nothing once the caret leaves"
+      );
+    });
+
+    test("serializes the same source after the faces are swapped", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, "");
       await insertBlock(editorClass.view, "the source");
 
-      assert.dom(".composer-preview-node__control").exists({ count: 2 });
-      assert
-        .dom(".composer-preview-node__controls .btn:first-child")
-        .hasAttribute("title", "Do the thing");
+      await toggleSource(editorClass.view);
+      await toggleSource(editorClass.view);
 
-      await click(".composer-preview-node__controls .btn:first-child");
-      assert.true(ranControl, "the control's action ran");
+      assert.strictEqual(
+        editorClass.value.trim(),
+        "[test]\nthe source\n[/test]",
+        "swapping faces leaves the markdown untouched"
+      );
+    });
+
+    test("does not render the preview again over an untouched source", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "the source");
+
+      const before = renders;
+      await toggleSource(editorClass.view);
+      await toggleSource(editorClass.view);
+
+      assert.strictEqual(
+        renders,
+        before,
+        "swapping faces leaves the feature's render alone"
+      );
+    });
+
+    test("renders again when the source changes under a shown preview", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "before");
+
+      const { view } = editorClass;
+      view.dispatch(view.state.tr.insertText("-after", 2, 8));
+      await settled();
+
+      assert.dom(".preview-stub").hasText("-after", "the preview catches up");
     });
   }
 );

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
@@ -1,0 +1,160 @@
+import { click, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
+
+let ranControl;
+
+const PreviewStub = <template>
+  <span class="preview-stub">{{@source}}</span>
+</template>;
+
+const extension = {
+  nodeSpec: {
+    test_preview: {
+      group: "block",
+      content: "preview_source",
+      atom: true,
+      defining: true,
+      isolating: true,
+      selectable: true,
+      parseDOM: [{ tag: "div.test-preview", preserveWhitespace: "full" }],
+      toDOM: () => ["div", { class: "test-preview" }, 0],
+    },
+  },
+
+  nodeViews: {
+    test_preview: {
+      component: PreviewNodeView,
+      hasContent: true,
+      options: {
+        preview: PreviewStub,
+        controls: [
+          {
+            icon: "gear",
+            label: "Do the thing",
+            action: () => (ranControl = true),
+          },
+        ],
+      },
+    },
+  },
+
+  serializeNode: {
+    test_preview(state, node) {
+      state.write("[test]\n");
+      state.text(node.textContent, false);
+      state.write("\n[/test]");
+      state.closeBlock(node);
+    },
+  },
+};
+
+// the extension has no markdown rule, so blocks are inserted into the document
+// directly rather than parsed out of the editor's initial value
+async function insertBlock(view, source) {
+  const { schema } = view.state;
+  const block = schema.nodes.test_preview.createAndFill(
+    null,
+    source
+      ? schema.nodes.preview_source.create(null, schema.text(source))
+      : null
+  );
+
+  view.dispatch(
+    view.state.tr.replaceWith(0, view.state.doc.content.size, block)
+  );
+  await settled();
+}
+
+module(
+  "Integration | Component | prosemirror-editor - preview node view",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function () {
+      ranControl = false;
+      await resetRichEditorExtensions();
+      registerRichEditorExtension(extension);
+    });
+
+    test("shows the rendered source, and swaps faces on toggle", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "the source");
+
+      assert.dom(".composer-preview-node").doesNotHaveClass("--source");
+      assert.dom(".preview-stub").hasText("the source");
+
+      await click(".composer-preview-node__toggle");
+      assert.dom(".composer-preview-node").hasClass("--source");
+
+      await click(".composer-preview-node__toggle");
+      assert.dom(".composer-preview-node").doesNotHaveClass("--source");
+    });
+
+    test("puts the caret in the source when it is shown", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "abc");
+
+      await click(".composer-preview-node__toggle");
+
+      const { selection } = editorClass.view.state;
+      assert.strictEqual(
+        selection.$head.parent.type.name,
+        "preview_source",
+        "the caret is inside the source"
+      );
+      assert.true(selection.empty, "nothing is selected");
+      assert.strictEqual(
+        selection.$head.parentOffset,
+        3,
+        "the caret is at the end of the source"
+      );
+    });
+
+    test("starts on the source when there is nothing to preview yet", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "");
+
+      assert.dom(".composer-preview-node").hasClass("--source");
+    });
+
+    test("holds the preview still while the source is edited", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "before");
+
+      await click(".composer-preview-node__toggle");
+
+      const { view } = editorClass;
+      view.dispatch(view.state.tr.insertText("-after", 2, 8));
+      await settled();
+
+      assert
+        .dom(".preview-stub")
+        .hasText("before", "the preview keeps the source it last rendered");
+
+      await click(".composer-preview-node__toggle");
+      assert
+        .dom(".preview-stub")
+        .hasText("-after", "and catches up once the source is hidden again");
+    });
+
+    test("renders a contributed control and runs it", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "the source");
+
+      assert.dom(".composer-preview-node__control").exists({ count: 2 });
+      assert
+        .dom(".composer-preview-node__controls .btn:first-child")
+        .hasAttribute("title", "Do the thing");
+
+      await click(".composer-preview-node__controls .btn:first-child");
+      assert.true(ranControl, "the control's action ran");
+    });
+  }
+);

--- a/plugins/discourse-graphviz/assets/javascripts/discourse-markdown/discourse-graphviz.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse-markdown/discourse-graphviz.js
@@ -40,12 +40,10 @@ export function setup(helper) {
       },
     });
 
-    // a single token keeps the graph source out of the token stream as text, so
-    // the rich editor can hold it as an attribute of one leaf node
     md.renderer.rules.graphviz = (tokens, idx) => {
       const token = tokens[idx];
       const source = md.utils.escapeHtml(token.content);
-      const engine = md.utils.escapeHtml(token.attrGet("data-engine"));
+      const engine = token.attrGet("data-engine");
 
       return `<div class="graphviz is-loading" data-engine="${engine}">\n${source}\n</div>\n`;
     };

--- a/plugins/discourse-graphviz/assets/javascripts/discourse-markdown/discourse-graphviz.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse-markdown/discourse-graphviz.js
@@ -1,34 +1,53 @@
+const ENGINES = ["dot", "neato", "circo", "fdp", "osage", "twopi"];
+
 export function setup(helper) {
   if (!helper.markdownIt) {
     return;
   }
 
-  helper.allowList(["div.graphviz", "div.graphviz.is-loading"]);
+  helper.allowList([
+    "div.graphviz",
+    "div[class=graphviz is-loading]",
+    "div[data-engine]",
+  ]);
 
   helper.registerOptions((opts, siteSettings) => {
     opts.features.graphviz = siteSettings.discourse_graphviz_enabled;
   });
 
   helper.registerPlugin((md) => {
-    if (md.options.discourse.features.graphviz) {
-      md.block.bbcode.ruler.push("graphviz", {
-        tag: "graphviz",
-
-        replace(state, tagInfo, content) {
-          const engines = ["dot", "neato", "circo", "fdp", "osage", "twopi"];
-          const token = state.push("html_raw", "", 0);
-
-          const escaped = state.md.utils.escapeHtml(content);
-          const inputEngine = state.md.utils.escapeHtml(tagInfo.attrs.engine);
-          const engine = engines.includes(inputEngine)
-            ? `data-engine='${inputEngine}'`
-            : "data-engine='dot'";
-
-          token.content = `<div class="graphviz is-loading" ${engine}>\n${escaped}\n</div>\n`;
-
-          return true;
-        },
-      });
+    if (!md.options.discourse.features.graphviz) {
+      return;
     }
+
+    md.block.bbcode.ruler.push("graphviz", {
+      tag: "graphviz",
+
+      replace(state, tagInfo, content) {
+        const token = state.push("graphviz", "div", 0);
+        token.block = true;
+        token.content = content;
+        token.attrs = [
+          [
+            "data-engine",
+            ENGINES.includes(tagInfo.attrs.engine)
+              ? tagInfo.attrs.engine
+              : "dot",
+          ],
+        ];
+
+        return true;
+      },
+    });
+
+    // a single token keeps the graph source out of the token stream as text, so
+    // the rich editor can hold it as an attribute of one leaf node
+    md.renderer.rules.graphviz = (tokens, idx) => {
+      const token = tokens[idx];
+      const source = md.utils.escapeHtml(token.content);
+      const engine = md.utils.escapeHtml(token.attrGet("data-engine"));
+
+      return `<div class="graphviz is-loading" data-engine="${engine}">\n${source}\n</div>\n`;
+    };
   });
 }

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/api-initializers/discourse-graphviz.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/api-initializers/discourse-graphviz.js
@@ -1,5 +1,6 @@
 import { apiInitializer } from "discourse/lib/api";
 import GraphvizInline from "../components/graphviz-inline";
+import richEditorExtension from "../lib/rich-editor-extension";
 
 function applyGraphviz(element, helper) {
   const src = element.textContent.trim();
@@ -17,6 +18,8 @@ function applyGraphviz(element, helper) {
 }
 
 export default apiInitializer((api) => {
+  api.registerRichEditorExtension(richEditorExtension);
+
   api.decorateCookedElement((element, helper) => {
     element
       .querySelectorAll("div.graphviz")

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/components/graphviz-preview.gjs
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/components/graphviz-preview.gjs
@@ -1,0 +1,5 @@
+import GraphvizDiagram from "./graphviz-diagram";
+
+export default <template>
+  <GraphvizDiagram @src={{@source}} @engine={{@node.attrs.engine}} />
+</template>

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -7,6 +7,12 @@ import GraphvizPreview from "../components/graphviz-preview";
 // exclude it simply get an unhighlighted code block
 const LANGUAGE = "dot";
 
+// kept in step with the engines the markdown rule accepts, so a diagram parsed
+// from pasted HTML cannot serialize an engine the bbcode tag would not survive
+const ENGINES = ["dot", "neato", "circo", "fdp", "osage", "twopi"];
+
+const toEngine = (engine) => (ENGINES.includes(engine) ? engine : "dot");
+
 /** @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension} */
 const extension = {
   nodeSpec: {
@@ -25,7 +31,7 @@ const extension = {
       parseDOM: [
         {
           tag: "div.graphviz",
-          getAttrs: (dom) => ({ engine: dom.dataset.engine || "dot" }),
+          getAttrs: (dom) => ({ engine: toEngine(dom.dataset.engine) }),
         },
       ],
       toDOM: (node) => [
@@ -45,7 +51,9 @@ const extension = {
         controls: [
           {
             icon: "discourse-expand",
-            label: i18n("graphviz.fullscreen"),
+            get label() {
+              return i18n("graphviz.fullscreen");
+            },
             action: ({ node, context }) =>
               context.modal.show(GraphvizFullscreen, {
                 model: { src: node.textContent, engine: node.attrs.engine },
@@ -59,7 +67,7 @@ const extension = {
   parse: {
     graphviz: (state, token) => {
       state.openNode(state.schema.nodes.graphviz, {
-        engine: token.attrGet("data-engine") || "dot",
+        engine: toEngine(token.attrGet("data-engine")),
       });
       state.openNode(state.schema.nodes.preview_source, { params: LANGUAGE });
       state.addText(token.content.trim());

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -1,4 +1,6 @@
 import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import { i18n } from "discourse-i18n";
+import GraphvizFullscreen from "../components/graphviz-fullscreen";
 import GraphvizPreview from "../components/graphviz-preview";
 
 // highlight.js calls the DOT language "dot"; sites whose highlighted_languages
@@ -38,7 +40,19 @@ const extension = {
     graphviz: {
       component: PreviewNodeView,
       hasContent: true,
-      options: { preview: GraphvizPreview },
+      options: {
+        preview: GraphvizPreview,
+        controls: [
+          {
+            icon: "discourse-expand",
+            label: i18n("graphviz.fullscreen"),
+            action: ({ node, context }) =>
+              context.modal.show(GraphvizFullscreen, {
+                model: { src: node.textContent, engine: node.attrs.engine },
+              }),
+          },
+        ],
+      },
     },
   },
 

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -1,4 +1,8 @@
 import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import {
+  previewSourceNode,
+  selectPreviewSource,
+} from "discourse/lib/composer/preview-block";
 import { i18n } from "discourse-i18n";
 import GraphvizFullscreen from "../components/graphviz-fullscreen";
 import GraphvizPreview from "../components/graphviz-preview";
@@ -32,6 +36,13 @@ const extension = {
         {
           tag: "div.graphviz",
           getAttrs: (dom) => ({ engine: toEngine(dom.dataset.engine) }),
+          // a cooked diagram holds its source as plain text, which the parser
+          // would otherwise collapse, running the statements together
+          getContent: (dom, schema) =>
+            schema.nodes.graphviz.create(
+              null,
+              previewSourceNode(schema, dom.textContent, LANGUAGE)
+            ).content,
         },
       ],
       toDOM: (node) => [
@@ -78,16 +89,21 @@ const extension = {
     },
   },
 
-  inputRules: ({ schema }) => ({
+  inputRules: ({ schema, pmState: { TextSelection } }) => ({
     match: /\[graphviz(?: engine=(\w+))?]$/,
     handler: (state, match, start, end) => {
-      const graphviz = schema.nodes.graphviz.createAndFill(
-        { engine: match[1] || "dot" },
-        schema.nodes.preview_source.create({ params: LANGUAGE })
+      const graphviz = schema.nodes.graphviz.create(
+        { engine: toEngine(match[1]) },
+        previewSourceNode(schema, "", LANGUAGE)
       );
       const isAtStart = state.doc.resolve(start).parentOffset === 0;
+      const from = isAtStart ? start - 1 : start;
 
-      return state.tr.replaceWith(isAtStart ? start - 1 : start, end, graphviz);
+      return selectPreviewSource(
+        state.tr.replaceWith(from, end, graphviz),
+        TextSelection,
+        from
+      );
     },
   }),
 

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -3,7 +3,6 @@ import {
   previewSourceNode,
   selectPreviewSource,
 } from "discourse/lib/composer/preview-block";
-import { i18n } from "discourse-i18n";
 import GraphvizFullscreen from "../components/graphviz-fullscreen";
 import GraphvizPreview from "../components/graphviz-preview";
 
@@ -23,12 +22,12 @@ const extension = {
     graphviz: {
       attrs: { engine: { default: "dot" } },
       group: "block",
-      // isolating keeps the text around it from merging into the source
       content: "preview_source",
       // the node view owns the source, so the editor moves over the block as a
       // unit rather than stepping into text it is not showing
       atom: true,
       defining: true,
+      // keeps the text around it from merging into the source
       isolating: true,
       selectable: true,
       createGapCursor: true,
@@ -50,6 +49,18 @@ const extension = {
         { class: "graphviz", "data-engine": node.attrs.engine },
         0,
       ],
+      previewControls: [
+        {
+          id: "graphviz-fullscreen",
+          icon: "discourse-expand",
+          title: "graphviz.fullscreen",
+          className: "composer-preview-toolbar__graphviz-fullscreen",
+          action: ({ node, context }) =>
+            context.modal.show(GraphvizFullscreen, {
+              model: { src: node.textContent, engine: node.attrs.engine },
+            }),
+        },
+      ],
     },
   },
 
@@ -57,21 +68,7 @@ const extension = {
     graphviz: {
       component: PreviewNodeView,
       hasContent: true,
-      options: {
-        preview: GraphvizPreview,
-        controls: [
-          {
-            icon: "discourse-expand",
-            get label() {
-              return i18n("graphviz.fullscreen");
-            },
-            action: ({ node, context }) =>
-              context.modal.show(GraphvizFullscreen, {
-                model: { src: node.textContent, engine: node.attrs.engine },
-              }),
-          },
-        ],
-      },
+      options: { preview: GraphvizPreview },
     },
   },
 

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -6,12 +6,9 @@ import {
 import GraphvizFullscreen from "../components/graphviz-fullscreen";
 import GraphvizPreview from "../components/graphviz-preview";
 
-// highlight.js calls the DOT language "dot"; sites whose highlighted_languages
-// exclude it simply get an unhighlighted code block
 const LANGUAGE = "dot";
 
-// kept in step with the engines the markdown rule accepts, so a diagram parsed
-// from pasted HTML cannot serialize an engine the bbcode tag would not survive
+// kept in step with the engines the markdown rule accepts
 const ENGINES = ["dot", "neato", "circo", "fdp", "osage", "twopi"];
 
 const toEngine = (engine) => (ENGINES.includes(engine) ? engine : "dot");
@@ -23,20 +20,15 @@ const extension = {
       attrs: { engine: { default: "dot" } },
       group: "block",
       content: "preview_source",
-      // the node view owns the source, so the editor moves over the block as a
-      // unit rather than stepping into text it is not showing
       atom: true,
       defining: true,
-      // keeps the text around it from merging into the source
       isolating: true,
-      selectable: true,
       createGapCursor: true,
       parseDOM: [
         {
           tag: "div.graphviz",
           getAttrs: (dom) => ({ engine: toEngine(dom.dataset.engine) }),
-          // a cooked diagram holds its source as plain text, which the parser
-          // would otherwise collapse, running the statements together
+          // cooked source is plain text the parser would otherwise collapse
           getContent: (dom, schema) =>
             schema.nodes.graphviz.create(
               null,
@@ -75,7 +67,7 @@ const extension = {
   parse: {
     graphviz: (state, token) => {
       state.openNode(state.schema.nodes.graphviz, {
-        engine: toEngine(token.attrGet("data-engine")),
+        engine: token.attrGet("data-engine"),
       });
       state.openNode(state.schema.nodes.preview_source, { params: LANGUAGE });
       state.addText(token.content.trim());

--- a/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/plugins/discourse-graphviz/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -1,0 +1,84 @@
+import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import GraphvizPreview from "../components/graphviz-preview";
+
+// highlight.js calls the DOT language "dot"; sites whose highlighted_languages
+// exclude it simply get an unhighlighted code block
+const LANGUAGE = "dot";
+
+/** @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension} */
+const extension = {
+  nodeSpec: {
+    graphviz: {
+      attrs: { engine: { default: "dot" } },
+      group: "block",
+      // isolating keeps the text around it from merging into the source
+      content: "preview_source",
+      // the node view owns the source, so the editor moves over the block as a
+      // unit rather than stepping into text it is not showing
+      atom: true,
+      defining: true,
+      isolating: true,
+      selectable: true,
+      createGapCursor: true,
+      parseDOM: [
+        {
+          tag: "div.graphviz",
+          getAttrs: (dom) => ({ engine: dom.dataset.engine || "dot" }),
+        },
+      ],
+      toDOM: (node) => [
+        "div",
+        { class: "graphviz", "data-engine": node.attrs.engine },
+        0,
+      ],
+    },
+  },
+
+  nodeViews: {
+    graphviz: {
+      component: PreviewNodeView,
+      hasContent: true,
+      options: { preview: GraphvizPreview },
+    },
+  },
+
+  parse: {
+    graphviz: (state, token) => {
+      state.openNode(state.schema.nodes.graphviz, {
+        engine: token.attrGet("data-engine") || "dot",
+      });
+      state.openNode(state.schema.nodes.preview_source, { params: LANGUAGE });
+      state.addText(token.content.trim());
+      state.closeNode();
+      state.closeNode();
+
+      return true;
+    },
+  },
+
+  inputRules: ({ schema }) => ({
+    match: /\[graphviz(?: engine=(\w+))?]$/,
+    handler: (state, match, start, end) => {
+      const graphviz = schema.nodes.graphviz.createAndFill(
+        { engine: match[1] || "dot" },
+        schema.nodes.preview_source.create({ params: LANGUAGE })
+      );
+      const isAtStart = state.doc.resolve(start).parentOffset === 0;
+
+      return state.tr.replaceWith(isAtStart ? start - 1 : start, end, graphviz);
+    },
+  }),
+
+  serializeNode: {
+    graphviz(state, node) {
+      const { engine } = node.attrs;
+
+      state.write(`[graphviz${engine === "dot" ? "" : ` engine=${engine}`}]\n`);
+      state.text(node.textContent, false);
+      state.write("\n[/graphviz]");
+      state.closeBlock(node);
+    },
+  },
+};
+
+export default extension;

--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -1,7 +1,8 @@
 // Reserve the diagram box up-front (placeholder and rendered wrapper alike) so
 // the layout does not shift when the client renders the graph.
 div.graphviz.is-loading,
-.graphviz-wrapper {
+.graphviz-wrapper,
+.composer-graphviz-node .composer-preview-node__preview {
   margin: 1em 0;
   aspect-ratio: 16 / 9;
   background-color: var(--primary-50);

--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -1,8 +1,7 @@
 // Reserve the diagram box up-front (placeholder and rendered wrapper alike) so
 // the layout does not shift when the client renders the graph.
 div.graphviz.is-loading,
-.graphviz-wrapper,
-.composer-graphviz-node .composer-preview-node__preview {
+.graphviz-wrapper {
   margin: 1em 0;
   aspect-ratio: 16 / 9;
   background-color: var(--primary-50);
@@ -10,6 +9,12 @@ div.graphviz.is-loading,
   &:first-child {
     margin-top: 0;
   }
+}
+
+// In the editor the block already has a frame, and both of its faces share one
+// cell, so the box needs no reserving — only a floor for a source not yet typed.
+.composer-graphviz-node .composer-preview-node__preview {
+  min-height: 3em;
 }
 
 // Hide the raw DOT source until the client replaces the placeholder.

--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -11,8 +11,7 @@ div.graphviz.is-loading,
   }
 }
 
-// In the editor the block already has a frame, so the box needs no reserving —
-// only a floor for a source not yet typed.
+// floor for a diagram not yet typed; the block supplies the frame
 .composer-graphviz-node .composer-preview-node__preview {
   min-height: 3em;
 }

--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -11,8 +11,8 @@ div.graphviz.is-loading,
   }
 }
 
-// In the editor the block already has a frame, and both of its faces share one
-// cell, so the box needs no reserving — only a floor for a source not yet typed.
+// In the editor the block already has a frame, so the box needs no reserving —
+// only a floor for a source not yet typed.
 .composer-graphviz-node .composer-preview-node__preview {
   min-height: 3em;
 }

--- a/plugins/discourse-graphviz/config/locales/client.en.yml
+++ b/plugins/discourse-graphviz/config/locales/client.en.yml
@@ -2,5 +2,6 @@ en:
   js:
     graphviz:
       composer_title: "Insert Graphviz graph"
+      fullscreen: "Expand diagram"
     composer:
       graphviz_sample: "digraph G {\n  a -> b;\n  b -> c;\n  a -> c;\n}"

--- a/plugins/discourse-graphviz/spec/system/edit_graphviz_in_rich_editor_spec.rb
+++ b/plugins/discourse-graphviz/spec/system/edit_graphviz_in_rich_editor_spec.rb
@@ -17,58 +17,33 @@ describe "Edit graphviz in the rich editor" do
   it "lets the user swap a diagram between its source and the drawing" do
     compose_diagram
 
-    expect(rich).to have_css(".composer-preview-node")
+    expect(toolbar).to have_toolbar
 
     toolbar.click_show_preview
 
     expect(rich).to have_css(".composer-preview-node .graphviz-diagram svg")
     expect(rich).to have_no_css(".composer-preview-node.--source")
 
-    toolbar.click_show_source
-
-    expect(rich).to have_css(".composer-preview-node.--source")
-  end
-
-  it "keeps the source intact when the diagram is swapped back and forth" do
-    compose_diagram
-
-    toolbar.click_show_preview
-    toolbar.click_show_source
-
-    composer.toggle_rich_editor
-
-    expect(composer.composer_input.value).to eq("[graphviz]\ndigraph G { a -> b; }\n[/graphviz]")
-  end
-
-  it "shows the toolbar only on the diagram the user is working on" do
-    compose_diagram
-
-    expect(toolbar).to have_toolbar
-
-    toolbar.click_show_preview
     composer.type_content(:down)
 
     expect(toolbar).to have_no_toolbar
 
     rich.find(".composer-preview-node .graphviz-diagram").click
+    toolbar.click_show_source
 
-    expect(toolbar).to have_toolbar
+    expect(rich).to have_css(".composer-preview-node.--source")
   end
 
-  it "opens the diagram full screen from the toolbar" do
-    compose_diagram
-
-    toolbar.click_control(fullscreen_control)
-
-    expect(page).to have_css(".d-modal.graphviz-fullscreen .graphviz-diagram svg")
-  end
-
-  it "lets the user reach the toolbar from the selected diagram with the keyboard" do
+  it "lets the user open the diagram full screen from the keyboard" do
     compose_diagram
 
     toolbar.click_show_preview
     composer.type_content(:tab)
 
     expect(toolbar).to have_focused_control(fullscreen_control)
+
+    page.send_keys(:enter)
+
+    expect(page).to have_css(".d-modal.graphviz-fullscreen .graphviz-diagram svg")
   end
 end

--- a/plugins/discourse-graphviz/spec/system/edit_graphviz_in_rich_editor_spec.rb
+++ b/plugins/discourse-graphviz/spec/system/edit_graphviz_in_rich_editor_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+describe "Edit graphviz in the rich editor" do
+  include_context "with prosemirror editor"
+
+  let(:toolbar) { PageObjects::Components::ComposerPreviewToolbar.new }
+  let(:fullscreen_control) { "composer-preview-toolbar__graphviz-fullscreen" }
+
+  before { SiteSetting.discourse_graphviz_enabled = true }
+
+  def compose_diagram
+    open_composer
+    composer.type_content("[graphviz]")
+    composer.type_content("digraph G { a -> b; }")
+  end
+
+  it "lets the user swap a diagram between its source and the drawing" do
+    compose_diagram
+
+    expect(rich).to have_css(".composer-preview-node")
+
+    toolbar.click_show_preview
+
+    expect(rich).to have_css(".composer-preview-node .graphviz-diagram svg")
+    expect(rich).to have_no_css(".composer-preview-node.--source")
+
+    toolbar.click_show_source
+
+    expect(rich).to have_css(".composer-preview-node.--source")
+  end
+
+  it "keeps the source intact when the diagram is swapped back and forth" do
+    compose_diagram
+
+    toolbar.click_show_preview
+    toolbar.click_show_source
+
+    composer.toggle_rich_editor
+
+    expect(composer.composer_input.value).to eq("[graphviz]\ndigraph G { a -> b; }\n[/graphviz]")
+  end
+
+  it "shows the toolbar only on the diagram the user is working on" do
+    compose_diagram
+
+    expect(toolbar).to have_toolbar
+
+    toolbar.click_show_preview
+    composer.type_content(:down)
+
+    expect(toolbar).to have_no_toolbar
+
+    rich.find(".composer-preview-node .graphviz-diagram").click
+
+    expect(toolbar).to have_toolbar
+  end
+
+  it "opens the diagram full screen from the toolbar" do
+    compose_diagram
+
+    toolbar.click_control(fullscreen_control)
+
+    expect(page).to have_css(".d-modal.graphviz-fullscreen .graphviz-diagram svg")
+  end
+
+  it "lets the user reach the toolbar from the selected diagram with the keyboard" do
+    compose_diagram
+
+    toolbar.click_show_preview
+    composer.type_content(:tab)
+
+    expect(toolbar).to have_focused_control(fullscreen_control)
+  end
+end

--- a/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
@@ -69,5 +69,36 @@ module(
         `the graph source is untouched, got: ${editorClass.value}`
       );
     });
+
+    test("keeps the line breaks of a pasted diagram", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      const { view } = editorClass;
+
+      view.pasteHTML(
+        '<div class="graphviz is-loading" data-engine="neato">\ndigraph G {\n  a -&gt; b;\n  b -&gt; c;\n}\n</div>'
+      );
+
+      assert.strictEqual(
+        editorClass.value.trim(),
+        "[graphviz engine=neato]\ndigraph G {\n  a -> b;\n  b -> c;\n}\n[/graphviz]",
+        "the source survives the round trip through cooked HTML"
+      );
+    });
+
+    test("puts the caret in the source of a diagram it just inserted", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "before");
+      const { view } = editorClass;
+
+      view.dispatch(view.state.tr.insertText("[graphviz"));
+      const pos = view.state.selection.from;
+      view.someProp("handleTextInput", (f) => f(view, pos, pos, "]"));
+
+      const { selection } = view.state;
+      assert.strictEqual(
+        selection.$head.parent.type.name,
+        "preview_source",
+        "typing carries on inside the new diagram"
+      );
+    });
   }
 );

--- a/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
@@ -17,57 +17,20 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
       this.siteSettings.discourse_graphviz_enabled = true;
 
-      resetRichEditorExtensions().then(() => {
-        registerRichEditorExtension(richEditorExtension);
+      await resetRichEditorExtensions();
+      registerRichEditorExtension(richEditorExtension);
+    });
+
+    [
+      ["no engine", GRAPH],
+      ["an engine", GRAPH.replace("[graphviz]", "[graphviz engine=neato]")],
+    ].forEach(([name, markdown]) => {
+      test(`round-trips a graph with ${name}`, async function (assert) {
+        await testMarkdown(assert, markdown, () => {}, markdown);
       });
-    });
-
-    test("round-trips a graph", async function (assert) {
-      await testMarkdown(
-        assert,
-        GRAPH,
-        (a) => a.dom(".composer-preview-node").exists(),
-        GRAPH
-      );
-    });
-
-    test("round-trips a graph with an engine", async function (assert) {
-      const graph = GRAPH.replace("[graphviz]", "[graphviz engine=neato]");
-
-      await testMarkdown(
-        assert,
-        graph,
-        (a) => a.dom(".composer-preview-node").exists(),
-        graph
-      );
-    });
-
-    test("keeps the source when the text around it is edited", async function (assert) {
-      const [editorClass] = await setupRichEditor(
-        assert,
-        `before\n\n${GRAPH}\n\nafter`
-      );
-      const { view } = editorClass;
-
-      let graphPos;
-      view.state.doc.descendants((node, pos) => {
-        if (node.type.name === "graphviz") {
-          graphPos = pos;
-        }
-      });
-
-      // delete across the graph's closing boundary, as backspacing at the start
-      // of the paragraph that follows it would
-      const boundary = graphPos + view.state.doc.nodeAt(graphPos).nodeSize;
-      view.dispatch(view.state.tr.delete(boundary, boundary + 1));
-
-      assert.true(
-        editorClass.value.includes(GRAPH),
-        `the graph source is untouched, got: ${editorClass.value}`
-      );
     });
 
     test("keeps the line breaks of a pasted diagram", async function (assert) {

--- a/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
@@ -1,0 +1,73 @@
+import { module, test } from "qunit";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  setupRichEditor,
+  testMarkdown,
+} from "discourse/tests/helpers/rich-editor-helper";
+import richEditorExtension from "discourse/plugins/discourse-graphviz/discourse/lib/rich-editor-extension";
+
+const GRAPH = "[graphviz]\ndigraph G {\n  a -> b;\n}\n[/graphviz]";
+
+module(
+  "Integration | Component | prosemirror-editor - graphviz extension",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.siteSettings.discourse_graphviz_enabled = true;
+
+      resetRichEditorExtensions().then(() => {
+        registerRichEditorExtension(richEditorExtension);
+      });
+    });
+
+    test("round-trips a graph", async function (assert) {
+      await testMarkdown(
+        assert,
+        GRAPH,
+        (a) => a.dom(".composer-preview-node").exists(),
+        GRAPH
+      );
+    });
+
+    test("round-trips a graph with an engine", async function (assert) {
+      const graph = GRAPH.replace("[graphviz]", "[graphviz engine=neato]");
+
+      await testMarkdown(
+        assert,
+        graph,
+        (a) => a.dom(".composer-preview-node").exists(),
+        graph
+      );
+    });
+
+    test("keeps the source when the text around it is edited", async function (assert) {
+      const [editorClass] = await setupRichEditor(
+        assert,
+        `before\n\n${GRAPH}\n\nafter`
+      );
+      const { view } = editorClass;
+
+      let graphPos;
+      view.state.doc.descendants((node, pos) => {
+        if (node.type.name === "graphviz") {
+          graphPos = pos;
+        }
+      });
+
+      // delete across the graph's closing boundary, as backspacing at the start
+      // of the paragraph that follows it would
+      const boundary = graphPos + view.state.doc.nodeAt(graphPos).nodeSize;
+      view.dispatch(view.state.tr.delete(boundary, boundary + 1));
+
+      assert.true(
+        editorClass.value.includes(GRAPH),
+        `the graph source is untouched, got: ${editorClass.value}`
+      );
+    });
+  }
+);

--- a/spec/system/page_objects/components/composer_preview_toolbar.rb
+++ b/spec/system/page_objects/components/composer_preview_toolbar.rb
@@ -23,7 +23,6 @@ module PageObjects
         self
       end
 
-      # a control the feature owning the block contributes, by its class
       def click_control(class_name)
         page.find("#{TOOLBAR_SELECTOR} button.#{class_name}").click
         self

--- a/spec/system/page_objects/components/composer_preview_toolbar.rb
+++ b/spec/system/page_objects/components/composer_preview_toolbar.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class ComposerPreviewToolbar < PageObjects::Components::Base
+      TOOLBAR_SELECTOR = "[data-identifier='composer-preview-toolbar']"
+
+      def has_toolbar?
+        page.has_css?(TOOLBAR_SELECTOR)
+      end
+
+      def has_no_toolbar?
+        page.has_no_css?(TOOLBAR_SELECTOR)
+      end
+
+      def click_show_source
+        page.find("#{TOOLBAR_SELECTOR} button.composer-preview-toolbar__show-source").click
+        self
+      end
+
+      def click_show_preview
+        page.find("#{TOOLBAR_SELECTOR} button.composer-preview-toolbar__show-preview").click
+        self
+      end
+
+      # a control the feature owning the block contributes, by its class
+      def click_control(class_name)
+        page.find("#{TOOLBAR_SELECTOR} button.#{class_name}").click
+        self
+      end
+
+      def has_focused_control?(class_name)
+        page.has_css?("#{TOOLBAR_SELECTOR} button.#{class_name}:focus")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Features that render something from a block of source, like diagrams and charts, had no way to appear in the rich editor: their markdown produced raw HTML, which the editor could not parse, so opening the post fell back to the Markdown editor.

This adds a preview block primitive and builds graphviz on it. A `preview_source` node holds the source as code, and a `PreviewNodeView` renders the feature's own component in its place, with a node toolbar — the one images and oneboxes use — to swap back to the source and to carry controls the feature contributes. The graphviz markdown rule now emits a structured token instead of raw HTML, which means its output passes through the sanitizer for the first time (`html_raw` bypasses it, so the plugin's allowList entries had never been exercised).

A companion PR in discourse-chart builds charts on the same primitive.
