### PR TITLE
FIX: Restore push subscriptions the platform silently drops

### DIFF
--- a/app/controllers/push_notification_controller.rb
+++ b/app/controllers/push_notification_controller.rb
@@ -3,16 +3,20 @@
 class PushNotificationController < ApplicationController
   layout false
   before_action :ensure_logged_in
+  before_action :ensure_current_push_user
   skip_before_action :preload_json
 
   def subscribe
-    PushNotificationPusher.subscribe(
-      current_user,
-      push_params,
-      params[:send_confirmation],
-      user_auth_token_id: request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY]&.id,
-    )
-    render json: success_json
+    if PushNotificationPusher.subscribe(
+         current_user,
+         push_params,
+         params[:send_confirmation],
+         user_auth_token_id: request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY]&.id,
+       )
+      render json: success_json
+    else
+      head :conflict
+    end
   end
 
   def unsubscribe
@@ -21,6 +25,12 @@ class PushNotificationController < ApplicationController
   end
 
   private
+
+  def ensure_current_push_user
+    return if params[:user_id].blank? || params[:user_id].to_s == current_user.id.to_s
+
+    head :conflict
+  end
 
   def push_params
     params.require(:subscription).permit(:endpoint, keys: %i[p256dh auth])

--- a/app/controllers/push_notification_controller.rb
+++ b/app/controllers/push_notification_controller.rb
@@ -6,7 +6,12 @@ class PushNotificationController < ApplicationController
   skip_before_action :preload_json
 
   def subscribe
-    PushNotificationPusher.subscribe(current_user, push_params, params[:send_confirmation])
+    PushNotificationPusher.subscribe(
+      current_user,
+      push_params,
+      params[:send_confirmation],
+      user_auth_token_id: request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY]&.id,
+    )
     render json: success_json
   end
 

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -74,6 +74,10 @@ class PushNotificationPusher
 
   def self.subscribe(user, push_params, send_confirmation)
     data = push_params.to_json
+    # An origin has one live subscription, so registering it transfers delivery
+    # away from any account that is no longer active in that browser.
+    PushSubscription.where(data: data).where.not(user: user).delete_all
+
     subscriptions = PushSubscription.where(user: user, data: data)
     subscriptions_count = subscriptions.count
 

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -72,22 +72,35 @@ class PushNotificationPusher
     user.push_subscriptions.clear
   end
 
-  def self.subscribe(user, push_params, send_confirmation)
+  def self.subscribe(user, push_params, send_confirmation, user_auth_token_id: nil)
     data = push_params.to_json
-    # An origin has one live subscription, so registering it transfers delivery
-    # away from any account that is no longer active in that browser.
-    PushSubscription.where(data: data).where.not(user: user).delete_all
+    new_subscription = nil
 
-    subscriptions = PushSubscription.where(user: user, data: data)
-    subscriptions_count = subscriptions.count
+    # A browser endpoint belongs to one active account. Serialize transfers so
+    # concurrent registrations cannot deliver both accounts to one browser.
+    DistributedMutex.synchronize(subscription_mutex_key(data)) do
+      next if user_auth_token_id && !user_auth_token_valid?(user_auth_token_id, user)
 
-    new_subscription =
-      if subscriptions_count == 1
-        subscriptions.first
-      else
-        subscriptions.destroy_all
-        PushSubscription.create!(user: user, data: data)
+      PushSubscription.where(data: data).where.not(user: user).delete_all
+
+      subscriptions = PushSubscription.where(user: user, data: data)
+      subscriptions_count = subscriptions.count
+
+      new_subscription =
+        if subscriptions_count == 1
+          subscriptions.first
+        else
+          subscriptions.destroy_all
+          PushSubscription.create!(user: user, data: data)
+        end
+
+      if user_auth_token_id && !user_auth_token_valid?(user_auth_token_id, user)
+        new_subscription.destroy!
+        new_subscription = nil
       end
+    end
+
+    return if !new_subscription
 
     if send_confirmation == "true"
       message = {
@@ -104,8 +117,24 @@ class PushNotificationPusher
   end
 
   def self.unsubscribe(user, subscription)
-    PushSubscription.where(user: user, data: subscription.to_json).delete_all
+    data = subscription.to_json
+    DistributedMutex.synchronize(subscription_mutex_key(data)) do
+      PushSubscription.where(user: user, data: data).delete_all
+    end
   end
+
+  def self.subscription_mutex_key(data)
+    "push_subscription_#{Digest::SHA1.hexdigest(data)}"
+  end
+  private_class_method :subscription_mutex_key
+
+  def self.user_auth_token_valid?(user_auth_token_id, user)
+    UserAuthToken
+      .where(id: user_auth_token_id)
+      .where("user_id = :user_id OR impersonated_user_id = :user_id", user_id: user.id)
+      .exists?
+  end
+  private_class_method :user_auth_token_valid?
 
   def self.get_badge
     if (url = SiteSetting.site_push_notifications_icon_url).present?

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -100,7 +100,7 @@ class PushNotificationPusher
       end
     end
 
-    return if !new_subscription
+    return false if !new_subscription
 
     if send_confirmation == "true"
       message = {
@@ -113,7 +113,10 @@ class PushNotificationPusher
       }
 
       send_notification(user, new_subscription, message)
+      return false if new_subscription.destroyed?
     end
+
+    true
   end
 
   def self.unsubscribe(user, subscription)

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -78,10 +78,10 @@ class PushNotificationPusher
     subscriptions_count = subscriptions.count
 
     new_subscription =
-      if subscriptions_count > 1
+      if subscriptions_count == 1
+        subscriptions.first
+      else
         subscriptions.destroy_all
-        PushSubscription.create!(user: user, data: data)
-      elsif subscriptions_count == 0
         PushSubscription.create!(user: user, data: data)
       end
 

--- a/frontend/discourse/app/components/notification-consent-banner.gjs
+++ b/frontend/discourse/app/components/notification-consent-banner.gjs
@@ -1,34 +1,14 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { keyValueStore as pushNotificationKeyValueStore } from "discourse/lib/push-notifications";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
-
-const userDismissedPromptKey = "dismissed-prompt";
 
 export default class NotificationConsentBanner extends Component {
   @service capabilities;
   @service currentUser;
   @service desktopNotifications;
   @service siteSettings;
-
-  @tracked bannerDismissed;
-
-  constructor() {
-    super(...arguments);
-    this.bannerDismissed = pushNotificationKeyValueStore.getItem(
-      userDismissedPromptKey
-    );
-  }
-
-  setBannerDismissed(value) {
-    pushNotificationKeyValueStore.setItem(userDismissedPromptKey, value);
-    this.bannerDismissed = pushNotificationKeyValueStore.getItem(
-      userDismissedPromptKey
-    );
-  }
 
   get showNotificationPromptBanner() {
     return (
@@ -37,21 +17,21 @@ export default class NotificationConsentBanner extends Component {
       this.currentUser &&
       this.capabilities.isPwa &&
       Notification.permission !== "denied" &&
-      Notification.permission !== "granted" &&
       !this.desktopNotifications.isEnabled &&
-      !this.bannerDismissed
+      !this.desktopNotifications.consentPromptDismissed &&
+      (Notification.permission !== "granted" ||
+        this.desktopNotifications.canRestorePushWithoutPrompt)
     );
   }
 
   @action
   turnon() {
     this.desktopNotifications.enable();
-    this.setBannerDismissed(true);
   }
 
   @action
   dismiss() {
-    this.setBannerDismissed(false);
+    this.desktopNotifications.dismissConsentPrompt();
   }
 
   <template>

--- a/frontend/discourse/app/components/notification-consent-banner.gjs
+++ b/frontend/discourse/app/components/notification-consent-banner.gjs
@@ -11,16 +11,17 @@ export default class NotificationConsentBanner extends Component {
   @service siteSettings;
 
   get showNotificationPromptBanner() {
+    const pushNeedsAttention = this.desktopNotifications.pushNeedsAttention;
+
     return (
       this.siteSettings.push_notifications_prompt &&
       !this.desktopNotifications.isNotSupported &&
       this.currentUser &&
       this.capabilities.isPwa &&
       Notification.permission !== "denied" &&
-      !this.desktopNotifications.isEnabled &&
       !this.desktopNotifications.consentPromptDismissed &&
-      (Notification.permission !== "granted" ||
-        this.desktopNotifications.canRestorePushWithoutPrompt)
+      (!this.desktopNotifications.isEnabled || pushNeedsAttention) &&
+      (Notification.permission !== "granted" || pushNeedsAttention)
     );
   }
 

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -10,11 +10,7 @@ import {
 } from "discourse/lib/desktop-notifications";
 import EmbedMode from "discourse/lib/embed-mode";
 import { isTesting } from "discourse/lib/environment";
-import {
-  isPushNotificationsEnabled,
-  register as registerPushNotifications,
-  unsubscribe as unsubscribePushNotifications,
-} from "discourse/lib/push-notifications";
+import { listenForPushNotificationMessages } from "discourse/lib/push-notifications";
 import { currentThemeId } from "discourse/lib/theme-selector";
 import Notification from "discourse/models/notification";
 
@@ -22,6 +18,7 @@ class SubscribeUserNotificationsInit {
   @service appEvents;
   @service capabilities;
   @service currentUser;
+  @service desktopNotifications;
   @service messageBus;
   @service pmTopicTrackingState;
   @service router;
@@ -79,16 +76,22 @@ class SubscribeUserNotificationsInit {
 
       initDesktopNotifications(this.messageBus);
 
-      if (isPushNotificationsEnabled(this.currentUser)) {
-        disableDesktopNotifications();
-        registerPushNotifications(
-          this.currentUser,
-          this.router,
-          this.appEvents
-        );
-      } else {
-        unsubscribePushNotifications(this.currentUser);
-      }
+      listenForPushNotificationMessages(this.router, this.appEvents);
+
+      // MessageBus alerts stay on until push is confirmed: disabling them up
+      // front left the device with neither transport whenever the subscription
+      // turned out to be gone
+      this.desktopNotifications
+        .reconcilePushSubscription()
+        .then((result) => {
+          if (result === "subscribed") {
+            disableDesktopNotifications();
+          }
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error(e);
+        });
     }
   }
 

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -6,7 +6,7 @@ import {
   alertChannel,
   init as initDesktopNotifications,
   onNotification as onDesktopNotification,
-  unsubscribe as unsubscribeDesktopNotifications,
+  setPushTransport,
 } from "discourse/lib/desktop-notifications";
 import EmbedMode from "discourse/lib/embed-mode";
 import { isTesting } from "discourse/lib/environment";
@@ -119,27 +119,31 @@ export class SubscribeUserNotificationsInit {
   reconcileTransports() {
     this.pushReconciliation ??= this.desktopNotifications
       .reconcilePushSubscription()
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        return null;
+      })
       .then((result) => {
-        if (result === "subscribed") {
-          // Push suppression is session-local so a later failed recovery still
-          // has a MessageBus fallback.
-          unsubscribeDesktopNotifications(this.messageBus, this.currentUser);
+        // The alert channel stays subscribed either way; only this session
+        // flag decides whether its handlers show anything.
+        if (result === "subscribed" || result === "unconfirmed") {
+          // "unconfirmed" still delivers: the device kept the subscription the
+          // server already knows, only the redundant resync went unanswered.
+          setPushTransport("delivering");
         } else if (
           this.desktopNotifications.pushIntent === "subscribed" &&
           this.desktopNotifications.isGrantedPermission &&
           !this.capabilities.isMobileDevice
         ) {
-          // Clear persistent suppression written by older builds when the
-          // browser transport is needed as a fallback.
-          this.desktopNotifications.setIsEnabledBrowser(true);
+          // Session-only: push may be broken, so in-tab alerts stand in
+          // without rewriting the stored browser-notification preference.
+          setPushTransport("fallback");
+        } else {
+          setPushTransport(null);
         }
 
         return result;
-      })
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.error(e);
-        return null;
       })
       .finally(() => (this.pushReconciliation = null));
 

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -143,7 +143,7 @@ export class SubscribeUserNotificationsInit {
       })
       .then((result) => {
         let transport = null;
-        if (result === "subscribed") {
+        if (result === "subscribed" || result === "unconfirmed") {
           transport = "delivering";
         } else if (
           this.desktopNotifications.pushIntent !== "off" &&

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -4,6 +4,7 @@ import { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
 import {
   alertChannel,
+  currentPushTransportEpoch,
   init as initDesktopNotifications,
   onNotification as onDesktopNotification,
   setPushTransport,
@@ -13,6 +14,8 @@ import { isTesting } from "discourse/lib/environment";
 import { listenForPushNotificationMessages } from "discourse/lib/push-notifications";
 import { currentThemeId } from "discourse/lib/theme-selector";
 import Notification from "discourse/models/notification";
+
+const PUSH_RECONCILE_COOLDOWN_MS = 60_000;
 
 export class SubscribeUserNotificationsInit {
   @service appEvents;
@@ -121,12 +124,15 @@ export class SubscribeUserNotificationsInit {
       return this.pushReconciliation;
     }
 
+    this._lastPushReconciliationAt = Date.now();
+
     // Until reconciliation reports back, the stored intent is the only evidence
     // there is. Assuming push delivers keeps a notification arriving during the
     // round trip from being shown twice.
     if (this.desktopNotifications.pushIntent === "subscribed") {
       setPushTransport("delivering");
     }
+    const transportEpoch = currentPushTransportEpoch();
 
     this.pushReconciliation = this.desktopNotifications
       .reconcilePushSubscription()
@@ -136,19 +142,19 @@ export class SubscribeUserNotificationsInit {
         return null;
       })
       .then((result) => {
-        if (result === "subscribed" || result === "unconfirmed") {
-          // "unconfirmed" still delivers: the device kept the subscription the
-          // server already knows, only the redundant resync went unanswered.
-          setPushTransport("delivering");
+        let transport = null;
+        if (result === "subscribed") {
+          transport = "delivering";
         } else if (
-          this.desktopNotifications.pushIntent === "subscribed" &&
+          this.desktopNotifications.pushIntent !== "off" &&
           this.desktopNotifications.isGrantedPermission &&
+          this.desktopNotifications.isPushNotificationsPreferred &&
           !this.capabilities.isMobileDevice
         ) {
-          setPushTransport("fallback");
-        } else {
-          setPushTransport(null);
+          transport = "fallback";
         }
+
+        setPushTransport(transport, { ifEpoch: transportEpoch });
 
         return result;
       })
@@ -314,15 +320,20 @@ export class SubscribeUserNotificationsInit {
 
   @bind
   onAlert(data) {
+    // Avoid retrying every alert when a subscription cannot be repaired.
+    if (
+      this.desktopNotifications.pushIntent !== "off" &&
+      this.desktopNotifications.isGrantedPermission &&
+      this.desktopNotifications.isPushNotificationsPreferred &&
+      this.desktopNotifications.pushSubscriptionConfirmed !== true &&
+      Date.now() - (this._lastPushReconciliationAt ?? 0) >
+        PUSH_RECONCILE_COOLDOWN_MS
+    ) {
+      this.reconcileTransports();
+    }
+
+    // MessageBus cannot display a mobile notification
     if (this.capabilities.isMobileDevice) {
-      if (
-        this.desktopNotifications.pushIntent === "subscribed" &&
-        this.desktopNotifications.pushSubscriptionConfirmed !== true
-      ) {
-        // MessageBus cannot display mobile notifications, but an alert proves
-        // connectivity is back, so repair push for subsequent notifications.
-        this.reconcileTransports();
-      }
       return;
     }
 

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -125,8 +125,6 @@ export class SubscribeUserNotificationsInit {
         return null;
       })
       .then((result) => {
-        // The alert channel stays subscribed either way; only this session
-        // flag decides whether its handlers show anything.
         if (result === "subscribed" || result === "unconfirmed") {
           // "unconfirmed" still delivers: the device kept the subscription the
           // server already knows, only the redundant resync went unanswered.
@@ -136,8 +134,6 @@ export class SubscribeUserNotificationsInit {
           this.desktopNotifications.isGrantedPermission &&
           !this.capabilities.isMobileDevice
         ) {
-          // Session-only: push may be broken, so in-tab alerts stand in
-          // without rewriting the stored browser-notification preference.
           setPushTransport("fallback");
         } else {
           setPushTransport(null);

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -117,7 +117,18 @@ export class SubscribeUserNotificationsInit {
   }
 
   reconcileTransports() {
-    this.pushReconciliation ??= this.desktopNotifications
+    if (this.pushReconciliation) {
+      return this.pushReconciliation;
+    }
+
+    // Until reconciliation reports back, the stored intent is the only evidence
+    // there is. Assuming push delivers keeps a notification arriving during the
+    // round trip from being shown twice.
+    if (this.desktopNotifications.pushIntent === "subscribed") {
+      setPushTransport("delivering");
+    }
+
+    this.pushReconciliation = this.desktopNotifications
       .reconcilePushSubscription()
       .catch((e) => {
         // eslint-disable-next-line no-console

--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -4,9 +4,9 @@ import { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
 import {
   alertChannel,
-  disable as disableDesktopNotifications,
   init as initDesktopNotifications,
   onNotification as onDesktopNotification,
+  unsubscribe as unsubscribeDesktopNotifications,
 } from "discourse/lib/desktop-notifications";
 import EmbedMode from "discourse/lib/embed-mode";
 import { isTesting } from "discourse/lib/environment";
@@ -14,7 +14,7 @@ import { listenForPushNotificationMessages } from "discourse/lib/push-notificati
 import { currentThemeId } from "discourse/lib/theme-selector";
 import Notification from "discourse/models/notification";
 
-class SubscribeUserNotificationsInit {
+export class SubscribeUserNotificationsInit {
   @service appEvents;
   @service capabilities;
   @service currentUser;
@@ -78,20 +78,7 @@ class SubscribeUserNotificationsInit {
 
       listenForPushNotificationMessages(this.router, this.appEvents);
 
-      // MessageBus alerts stay on until push is confirmed: disabling them up
-      // front left the device with neither transport whenever the subscription
-      // turned out to be gone
-      this.desktopNotifications
-        .reconcilePushSubscription()
-        .then((result) => {
-          if (result === "subscribed") {
-            disableDesktopNotifications();
-          }
-        })
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error(e);
-        });
+      this.reconcileTransports();
     }
   }
 
@@ -127,6 +114,36 @@ class SubscribeUserNotificationsInit {
     this.messageBus.unsubscribe("/client_settings", this.onClientSettings);
 
     this.messageBus.unsubscribe(alertChannel(this.currentUser), this.onAlert);
+  }
+
+  reconcileTransports() {
+    this.pushReconciliation ??= this.desktopNotifications
+      .reconcilePushSubscription()
+      .then((result) => {
+        if (result === "subscribed") {
+          // Push suppression is session-local so a later failed recovery still
+          // has a MessageBus fallback.
+          unsubscribeDesktopNotifications(this.messageBus, this.currentUser);
+        } else if (
+          this.desktopNotifications.pushIntent === "subscribed" &&
+          this.desktopNotifications.isGrantedPermission &&
+          !this.capabilities.isMobileDevice
+        ) {
+          // Clear persistent suppression written by older builds when the
+          // browser transport is needed as a fallback.
+          this.desktopNotifications.setIsEnabledBrowser(true);
+        }
+
+        return result;
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        return null;
+      })
+      .finally(() => (this.pushReconciliation = null));
+
+    return this.pushReconciliation;
   }
 
   @bind
@@ -286,14 +303,24 @@ class SubscribeUserNotificationsInit {
 
   @bind
   onAlert(data) {
-    if (!this.capabilities.isMobileDevice) {
-      return onDesktopNotification(
-        data,
-        this.siteSettings,
-        this.currentUser,
-        this.appEvents
-      );
+    if (this.capabilities.isMobileDevice) {
+      if (
+        this.desktopNotifications.pushIntent === "subscribed" &&
+        this.desktopNotifications.pushSubscriptionConfirmed !== true
+      ) {
+        // MessageBus cannot display mobile notifications, but an alert proves
+        // connectivity is back, so repair push for subsequent notifications.
+        this.reconcileTransports();
+      }
+      return;
     }
+
+    return onDesktopNotification(
+      data,
+      this.siteSettings,
+      this.currentUser,
+      this.appEvents
+    );
   }
 }
 

--- a/frontend/discourse/app/lib/desktop-notifications.js
+++ b/frontend/discourse/app/lib/desktop-notifications.js
@@ -13,6 +13,7 @@ let liveEnabled = false;
 // nor overwrite a real preference. "fallback" may bypass a stored opt-out:
 // older builds force-wrote it on every boot while push was on.
 let pushTransport = null;
+let pushTransportEpoch = 0;
 let havePermission = null;
 let mbClientId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
@@ -31,7 +32,7 @@ export function clearDesktopNotificationHandlers() {
 // Called from an initializer
 function init(messageBus) {
   liveEnabled = false;
-  pushTransport = null;
+  setPushTransport(null);
   mbClientId = messageBus.clientId;
 
   if (!User.current()) {
@@ -241,8 +242,18 @@ function disable() {
   keyValueStore.setItem("notifications-disabled", "disabled");
 }
 
-function setPushTransport(value) {
+function setPushTransport(value, { ifEpoch } = {}) {
+  if (ifEpoch !== undefined && ifEpoch !== pushTransportEpoch) {
+    return false;
+  }
+
   pushTransport = value;
+  pushTransportEpoch++;
+  return true;
+}
+
+function currentPushTransportEpoch() {
+  return pushTransportEpoch;
 }
 
 function getPushTransport() {
@@ -258,6 +269,7 @@ export {
   confirmNotification,
   disable,
   setPushTransport,
+  currentPushTransportEpoch,
   getPushTransport,
   canUserReceiveNotifications,
 };

--- a/frontend/discourse/app/lib/desktop-notifications.js
+++ b/frontend/discourse/app/lib/desktop-notifications.js
@@ -9,12 +9,9 @@ import { i18n } from "discourse-i18n";
 
 let primaryTab = false;
 let liveEnabled = false;
-// Session-local verdict from push reconciliation. "delivering" suppresses
-// in-tab alerts that would double what push already shows; "fallback" lets
-// them through past a stored opt-out, which older builds force-wrote on every
-// boot while push was on, so for push users it carries no user signal. Kept
-// out of localStorage so one bad boot can neither outlive the session nor
-// overwrite a real preference.
+// Kept out of localStorage so one bad boot can neither outlive the session
+// nor overwrite a real preference. "fallback" may bypass a stored opt-out:
+// older builds force-wrote it on every boot while push was on.
 let pushTransport = null;
 let havePermission = null;
 let mbClientId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
@@ -244,8 +241,6 @@ function disable() {
   keyValueStore.setItem("notifications-disabled", "disabled");
 }
 
-// Gates every in-tab handler, core and plugin alike, since they all reach
-// notifications through `canUserReceiveNotifications`.
 function setPushTransport(value) {
   pushTransport = value;
 }

--- a/frontend/discourse/app/lib/desktop-notifications.js
+++ b/frontend/discourse/app/lib/desktop-notifications.js
@@ -9,6 +9,13 @@ import { i18n } from "discourse-i18n";
 
 let primaryTab = false;
 let liveEnabled = false;
+// Session-local verdict from push reconciliation. "delivering" suppresses
+// in-tab alerts that would double what push already shows; "fallback" lets
+// them through past a stored opt-out, which older builds force-wrote on every
+// boot while push was on, so for push users it carries no user signal. Kept
+// out of localStorage so one bad boot can neither outlive the session nor
+// overwrite a real preference.
+let pushTransport = null;
 let havePermission = null;
 let mbClientId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
@@ -27,6 +34,7 @@ export function clearDesktopNotificationHandlers() {
 // Called from an initializer
 function init(messageBus) {
   liveEnabled = false;
+  pushTransport = null;
   mbClientId = messageBus.clientId;
 
   if (!User.current()) {
@@ -135,7 +143,14 @@ function canUserReceiveNotifications(user) {
     return false;
   }
 
-  if (keyValueStore.getItem("notifications-disabled") === "disabled") {
+  if (pushTransport === "delivering") {
+    return false;
+  }
+
+  if (
+    pushTransport !== "fallback" &&
+    keyValueStore.getItem("notifications-disabled") === "disabled"
+  ) {
     return false;
   }
 
@@ -229,6 +244,16 @@ function disable() {
   keyValueStore.setItem("notifications-disabled", "disabled");
 }
 
+// Gates every in-tab handler, core and plugin alike, since they all reach
+// notifications through `canUserReceiveNotifications`.
+function setPushTransport(value) {
+  pushTransport = value;
+}
+
+function getPushTransport() {
+  return pushTransport;
+}
+
 export {
   context,
   init,
@@ -237,5 +262,7 @@ export {
   alertChannel,
   confirmNotification,
   disable,
+  setPushTransport,
+  getPushTransport,
   canUserReceiveNotifications,
 };

--- a/frontend/discourse/app/lib/logout.js
+++ b/frontend/discourse/app/lib/logout.js
@@ -2,8 +2,11 @@ import { isEmpty } from "@ember/utils";
 import { isTesting } from "discourse/lib/environment";
 import getURL from "discourse/lib/get-url";
 import { helperContext } from "discourse/lib/helpers";
+import { clearPushSubscriptionConfirmationForOrigin } from "discourse/lib/push-notifications";
 
 export default function logout({ redirect } = {}) {
+  clearPushSubscriptionConfirmationForOrigin();
+
   if (isTesting()) {
     return;
   }

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -3,9 +3,13 @@ import { helperContext } from "discourse/lib/helpers";
 import KeyValueStore from "discourse/lib/key-value-store";
 
 export const keyValueStore = new KeyValueStore("discourse_push_notifications_");
+export const pushNotificationPreferenceStore = new KeyValueStore(
+  "push_notification_preferences_"
+);
 
 // a worker that failed to install never activates, so `ready` would hang
 const SERVICE_WORKER_READY_TIMEOUT_MS = 5000;
+const ADOPTION_IN_PROGRESS = "adopting";
 
 export function userSubscriptionKey(user) {
   return `subscribed-${user.get("id")}`;
@@ -14,7 +18,12 @@ export function userSubscriptionKey(user) {
 // The user's last expressed choice on this device; the platform's actual
 // subscription can be purged behind our back (common on iOS home screen apps).
 export function getSubscriptionIntent(user) {
-  const value = keyValueStore.getItem(userSubscriptionKey(user));
+  const key = userSubscriptionKey(user);
+  if (pushNotificationPreferenceStore.getItem(key) === "off") {
+    return "off";
+  }
+
+  const value = keyValueStore.getItem(key);
 
   if (value === "subscribed") {
     return "subscribed";
@@ -22,6 +31,8 @@ export function getSubscriptionIntent(user) {
 
   // older builds stored the boolean `false` (stringified) on explicit disable
   if (value === "off" || value === "false") {
+    pushNotificationPreferenceStore.setItem(key, "off");
+    keyValueStore.remove(key);
     return "off";
   }
 
@@ -31,32 +42,17 @@ export function getSubscriptionIntent(user) {
 }
 
 export function setSubscriptionIntent(user, intent) {
-  if (intent) {
-    keyValueStore.setItem(userSubscriptionKey(user), intent);
+  const key = userSubscriptionKey(user);
+
+  if (intent === "off") {
+    pushNotificationPreferenceStore.setItem(key, "off");
+    keyValueStore.remove(key);
+  } else if (intent === "subscribed") {
+    pushNotificationPreferenceStore.remove(key);
+    keyValueStore.setItem(key, intent);
   } else {
-    keyValueStore.remove(userSubscriptionKey(user));
+    keyValueStore.remove(key);
   }
-}
-
-// "unconfirmed" is only safe for an endpoint the server acknowledged in an
-// earlier session. A brand-new one it never answered for must keep the in-tab
-// fallback alive, or a device whose row was never created goes silent.
-function confirmedEndpointKey(user) {
-  return `confirmed-endpoint-${user.get("id")}`;
-}
-
-function markEndpointConfirmed(user, subscription) {
-  keyValueStore.setItem(
-    confirmedEndpointKey(user),
-    subscription.toJSON().endpoint
-  );
-}
-
-function isEndpointConfirmed(user, subscription) {
-  return (
-    keyValueStore.getItem(confirmedEndpointKey(user)) ===
-    subscription.toJSON().endpoint
-  );
 }
 
 function sendSubscriptionToServer(subscription, sendConfirmation) {
@@ -151,24 +147,28 @@ async function discardPlatformSubscription(subscription) {
   }
 }
 
-// The POST recreates the server row, so a disable that landed while it was in
-// flight has to be replayed against it: `unsubscribe()` has already invalidated
-// the platform subscription, leaving no other handle on that row.
-async function confirmResync(user, subscription) {
-  if (getSubscriptionIntent(user) === "off") {
+// The POST recreates the server row, so an opt-out or logout that landed while
+// it was in flight has to be replayed against it.
+async function confirmResync(user, subscription, previousIntent) {
+  const currentIntent = getSubscriptionIntent(user);
+  const storedIntent = keyValueStore.getItem(userSubscriptionKey(user));
+  if (
+    currentIntent === "off" ||
+    (previousIntent === "subscribed" && currentIntent === null) ||
+    (previousIntent === null &&
+      currentIntent === null &&
+      storedIntent !== ADOPTION_IN_PROGRESS)
+  ) {
     await retireServerSubscription(subscription);
     return null;
   }
 
-  markEndpointConfirmed(user, subscription);
+  setSubscriptionIntent(user, "subscribed");
   return "subscribed";
 }
 
-// Returns "subscribed" when the server knows about a working subscription,
-// "unconfirmed" when the device still has the one it was told about earlier but
-// the resync could not reach the server, "lost" when the user has to opt in
-// again, and null when there was nothing to conclude — a transient failure, so
-// the intent is kept and the next boot retries.
+// Returns the verified state, "lost" when permission vanished, or null when no
+// conclusion was possible.
 export async function reconcileSubscription(
   user,
   { resubscribe = false, applicationServerKey } = {}
@@ -195,21 +195,19 @@ export async function reconcileSubscription(
   // pending, and the branches below destroy subscriptions.
   const intent = getSubscriptionIntent(user);
 
-  if (intent === null) {
-    if (subscription) {
-      // An origin has only one subscription. With no current-user intent its
-      // ownership cannot be verified, so retaining it could expose another
-      // account's notifications after an abnormal session replacement.
-      await discardPlatformSubscription(subscription);
-    }
-    return null;
-  }
-
   if (intent === "off") {
     // Only drop the platform subscription once the server row is gone: it is
     // the sole way back to that row if the request failed.
     if (subscription && (await retireServerSubscription(subscription))) {
-      await discardPlatformSubscription(subscription);
+      const currentIntent = getSubscriptionIntent(user);
+      if (currentIntent === "off") {
+        await discardPlatformSubscription(subscription);
+      } else if (
+        currentIntent === "subscribed" &&
+        (await resyncSubscriptionWithServer(subscription))
+      ) {
+        return await confirmResync(user, subscription, currentIntent);
+      }
     }
     return null;
   }
@@ -218,23 +216,42 @@ export async function reconcileSubscription(
   // revoked grant counts as a loss whether or not the subscription object
   // itself survived.
   if (Notification.permission !== "granted") {
-    setSubscriptionIntent(user, null);
-    return "lost";
+    if (intent === "subscribed") {
+      setSubscriptionIntent(user, null);
+      return "lost";
+    }
+    return null;
   }
 
   if (subscription) {
-    if (await resyncSubscriptionWithServer(subscription)) {
-      return await confirmResync(user, subscription);
+    if (intent === null) {
+      if (!resubscribe) {
+        return null;
+      }
+      keyValueStore.setItem(userSubscriptionKey(user), ADOPTION_IN_PROGRESS);
     }
 
-    // A failed request is not proof the row is missing, so an endpoint the
-    // server acknowledged before still counts as delivering.
-    return isEndpointConfirmed(user, subscription) ? "unconfirmed" : null;
+    if (await resyncSubscriptionWithServer(subscription)) {
+      return await confirmResync(user, subscription, intent);
+    }
+
+    if (
+      keyValueStore.getItem(userSubscriptionKey(user)) === ADOPTION_IN_PROGRESS
+    ) {
+      setSubscriptionIntent(user, null);
+    }
+
+    return null;
   }
 
-  // the grant survived the platform purge, so the restore needs no prompt
-  if (!resubscribe) {
+  // The origin-level grant is the opt-in. Restore for every account except
+  // those which explicitly opted out.
+  if (!resubscribe || !applicationServerKey) {
     return null;
+  }
+
+  if (intent === null) {
+    keyValueStore.setItem(userSubscriptionKey(user), ADOPTION_IN_PROGRESS);
   }
 
   try {
@@ -246,16 +263,26 @@ export async function reconcileSubscription(
     // a failed restore is not an opt-out: keep the intent and retry next boot
     // eslint-disable-next-line no-console
     console.error(e);
+    if (
+      keyValueStore.getItem(userSubscriptionKey(user)) === ADOPTION_IN_PROGRESS
+    ) {
+      keyValueStore.remove(userSubscriptionKey(user));
+    }
     return null;
   }
 
   if (await resyncSubscriptionWithServer(subscription)) {
-    return await confirmResync(user, subscription);
+    return await confirmResync(user, subscription, intent);
   }
 
   // Left in place: only one subscription exists per origin, so discarding it can
   // destroy one another tab just confirmed. It stays unacknowledged, so the next
   // boot keeps the fallback and resyncs this same endpoint.
+  if (
+    keyValueStore.getItem(userSubscriptionKey(user)) === ADOPTION_IN_PROGRESS
+  ) {
+    keyValueStore.remove(userSubscriptionKey(user));
+  }
   return null;
 }
 

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -4,12 +4,45 @@ import KeyValueStore from "discourse/lib/key-value-store";
 
 export const keyValueStore = new KeyValueStore("discourse_push_notifications_");
 
+// a worker that failed to install never activates, so `ready` would hang; this
+// bounds both the boot resync and the button press behind `enable()`
+const SERVICE_WORKER_READY_TIMEOUT_MS = 5000;
+
 export function userSubscriptionKey(user) {
   return `subscribed-${user.get("id")}`;
 }
 
+// The stored intent is the user's last expressed choice on this device; the
+// actual subscription lives in the platform's PushManager and can be purged
+// behind our back (common on iOS home screen apps).
+// "subscribed" = wants push, "off" = explicitly disabled, null = unknown.
+export function getSubscriptionIntent(user) {
+  const value = keyValueStore.getItem(userSubscriptionKey(user));
+
+  if (value === "subscribed") {
+    return "subscribed";
+  }
+
+  // older builds stored the boolean `false` (stringified) on explicit disable
+  if (value === "off" || value === "false") {
+    return "off";
+  }
+
+  // older builds also stamped "" for every user without a subscription, so an
+  // empty value carries no signal
+  return null;
+}
+
+export function setSubscriptionIntent(user, intent) {
+  if (intent) {
+    keyValueStore.setItem(userSubscriptionKey(user), intent);
+  } else {
+    keyValueStore.remove(userSubscriptionKey(user));
+  }
+}
+
 function sendSubscriptionToServer(subscription, sendConfirmation) {
-  ajax("/push_notifications/subscribe", {
+  return ajax("/push_notifications/subscribe", {
     type: "POST",
     data: {
       subscription: subscription.toJSON(),
@@ -18,58 +51,55 @@ function sendSubscriptionToServer(subscription, sendConfirmation) {
   });
 }
 
-export function isPushNotificationsSupported() {
-  let caps = helperContext().capabilities;
-  if (
-    !(
-      "serviceWorker" in navigator &&
-      typeof ServiceWorkerRegistration !== "undefined" &&
-      typeof Notification !== "undefined" &&
-      "showNotification" in ServiceWorkerRegistration.prototype &&
-      "PushManager" in window &&
-      !caps.isAppWebview &&
-      navigator.serviceWorker.controller &&
-      navigator.serviceWorker.controller.state === "activated"
-    )
-  ) {
+// Reports whether the server now knows about this subscription. Retried on the
+// next boot, so a failure is logged rather than raised.
+async function resyncSubscriptionWithServer(subscription) {
+  try {
+    await sendSubscriptionToServer(subscription, false);
+    return true;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
     return false;
   }
-
-  return true;
 }
 
-export function isPushNotificationsEnabled(user) {
+// `navigator.serviceWorker.ready` never rejects, so guard against
+// environments where no service worker ever registers
+function serviceWorkerRegistration() {
+  return new Promise((resolve) => {
+    const timer = setTimeout(
+      () => resolve(null),
+      SERVICE_WORKER_READY_TIMEOUT_MS
+    );
+
+    navigator.serviceWorker.ready.then((registration) => {
+      clearTimeout(timer);
+      resolve(registration);
+    });
+  });
+}
+
+export function isPushNotificationsSupported() {
+  const caps = helperContext().capabilities;
+
+  // deliberately no check that a service worker controls the page: right
+  // after a (re-)install nothing does, and that is exactly when a purged
+  // subscription needs to be restored
   return (
-    user &&
-    !user.isInDoNotDisturb() &&
-    isPushNotificationsSupported() &&
-    keyValueStore.getItem(userSubscriptionKey(user))
+    "serviceWorker" in navigator &&
+    typeof ServiceWorkerRegistration !== "undefined" &&
+    typeof Notification !== "undefined" &&
+    "showNotification" in ServiceWorkerRegistration.prototype &&
+    "PushManager" in window &&
+    !caps.isAppWebview
   );
 }
 
-export function register(user, router, appEvents) {
+export function listenForPushNotificationMessages(router, appEvents) {
   if (!isPushNotificationsSupported()) {
     return;
   }
-  if (Notification.permission === "denied" || !user) {
-    return;
-  }
-
-  navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
-    serviceWorkerRegistration.pushManager
-      .getSubscription()
-      .then((subscription) => {
-        if (subscription) {
-          sendSubscriptionToServer(subscription, false);
-          // Resync localStorage
-          keyValueStore.setItem(userSubscriptionKey(user), "subscribed");
-        }
-      })
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.error(e);
-      });
-  });
 
   navigator.serviceWorker.addEventListener("message", (event) => {
     if ("url" in event.data) {
@@ -79,22 +109,125 @@ export function register(user, router, appEvents) {
   });
 }
 
+// Tells the server to forget this device's subscription. Scoped to the current
+// user server-side, so it can never drop a row belonging to another account
+// sharing the browser.
+function retireServerSubscription(subscription) {
+  return ajax("/push_notifications/unsubscribe", {
+    type: "POST",
+    data: { subscription: subscription.toJSON() },
+  }).catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  });
+}
+
+// Reconciles the device's actual push subscription with the user's stored
+// intent.
+//
+// Returns "subscribed" when a subscription exists (or was restored), "lost"
+// when the user has to opt in again, and null when there was nothing to
+// conclude — a transient failure, so the intent is kept and the next boot
+// retries.
+export async function reconcileSubscription(
+  user,
+  { resubscribe = false, applicationServerKey } = {}
+) {
+  if (!user || !isPushNotificationsSupported()) {
+    return null;
+  }
+
+  const intent = getSubscriptionIntent(user);
+  if (intent === null) {
+    return null;
+  }
+
+  const registration = await serviceWorkerRegistration();
+  if (!registration) {
+    return null;
+  }
+
+  let subscription;
+  try {
+    subscription = await registration.pushManager.getSubscription();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    return null;
+  }
+
+  if (intent === "off") {
+    // The browser subscription is deliberately left alone: only one exists per
+    // origin, so on a shared browser it may now belong to whoever subscribed
+    // most recently. Retiring our own server row is what actually stops
+    // delivery, and it retries here because the teardown at the time may have
+    // failed offline.
+    if (subscription) {
+      await retireServerSubscription(subscription);
+    }
+    return null;
+  }
+
+  // A subscription the browser refuses to display is not a working one, so a
+  // revoked grant counts as a loss whether or not the subscription object
+  // itself survived.
+  if (Notification.permission !== "granted") {
+    setSubscriptionIntent(user, null);
+    return "lost";
+  }
+
+  if (subscription) {
+    return (await resyncSubscriptionWithServer(subscription))
+      ? "subscribed"
+      : null;
+  }
+
+  // The platform dropped the subscription but the grant survived, so it can be
+  // restored with no prompt and no UI — the common case on iOS home screen
+  // apps.
+
+  if (!resubscribe) {
+    return null;
+  }
+
+  try {
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: new Uint8Array(applicationServerKey.split("|")),
+    });
+  } catch (e) {
+    // a failed restore is not an opt-out: keep the intent and retry next boot
+    // eslint-disable-next-line no-console
+    console.error(e);
+    return null;
+  }
+
+  return (await resyncSubscriptionWithServer(subscription))
+    ? "subscribed"
+    : null;
+}
+
 export function subscribe(callback, applicationServerKey) {
   if (!isPushNotificationsSupported()) {
     return;
   }
 
-  return navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
-    return serviceWorkerRegistration.pushManager
+  return serviceWorkerRegistration().then((registration) => {
+    if (!registration) {
+      return false;
+    }
+
+    return registration.pushManager
       .subscribe({
         userVisibleOnly: true,
         applicationServerKey: new Uint8Array(applicationServerKey.split("|")),
       })
       .then((subscription) => {
-        sendSubscriptionToServer(subscription, true);
-        if (callback) {
-          callback();
-        }
+        sendSubscriptionToServer(subscription, true).catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error(e);
+        });
+        callback?.();
         return true;
       })
       .catch((e) => {
@@ -129,9 +262,10 @@ export function unsubscribe(user, callback) {
     return;
   }
 
-  keyValueStore.setItem(userSubscriptionKey(user), "");
-  return navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
-    serviceWorkerRegistration.pushManager
+  setSubscriptionIntent(user, "off");
+
+  return serviceWorkerRegistration().then((registration) => {
+    registration?.pushManager
       .getSubscription()
       .then((subscription) => {
         if (subscription) {
@@ -150,9 +284,7 @@ export function unsubscribe(user, callback) {
         console.error(e);
       });
 
-    if (callback) {
-      callback();
-    }
+    callback?.();
     return true;
   });
 }

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -4,18 +4,15 @@ import KeyValueStore from "discourse/lib/key-value-store";
 
 export const keyValueStore = new KeyValueStore("discourse_push_notifications_");
 
-// a worker that failed to install never activates, so `ready` would hang; this
-// bounds both the boot resync and the button press behind `enable()`
+// a worker that failed to install never activates, so `ready` would hang
 const SERVICE_WORKER_READY_TIMEOUT_MS = 5000;
 
 export function userSubscriptionKey(user) {
   return `subscribed-${user.get("id")}`;
 }
 
-// The stored intent is the user's last expressed choice on this device; the
-// actual subscription lives in the platform's PushManager and can be purged
-// behind our back (common on iOS home screen apps).
-// "subscribed" = wants push, "off" = explicitly disabled, null = unknown.
+// The user's last expressed choice on this device; the platform's actual
+// subscription can be purged behind our back (common on iOS home screen apps).
 export function getSubscriptionIntent(user) {
   const value = keyValueStore.getItem(userSubscriptionKey(user));
 
@@ -72,8 +69,7 @@ function sendSubscriptionToServer(subscription, sendConfirmation) {
   });
 }
 
-// Reports whether the server now knows about this subscription. Retried on the
-// next boot, so a failure is logged rather than raised.
+// retried on the next boot, so a failure is logged rather than raised
 async function resyncSubscriptionWithServer(subscription) {
   try {
     await sendSubscriptionToServer(subscription, false);
@@ -130,9 +126,8 @@ export function listenForPushNotificationMessages(router, appEvents) {
   });
 }
 
-// Tells the server to forget this device's subscription. Scoped to the current
-// user server-side, so it can never drop a row belonging to another account
-// sharing the browser.
+// Scoped to the current user server-side, so it can never drop a row
+// belonging to another account sharing the browser.
 async function retireServerSubscription(subscription) {
   try {
     await ajax("/push_notifications/unsubscribe", {
@@ -156,9 +151,6 @@ async function discardPlatformSubscription(subscription) {
   }
 }
 
-// Reconciles the device's actual push subscription with the user's stored
-// intent.
-//
 // Returns "subscribed" when the server knows about a working subscription,
 // "unconfirmed" when the device still has the one it was told about earlier but
 // the resync could not reach the server, "lost" when the user has to opt in
@@ -228,10 +220,7 @@ export async function reconcileSubscription(
     return isEndpointConfirmed(user, subscription) ? "unconfirmed" : null;
   }
 
-  // The platform dropped the subscription but the grant survived, so it can be
-  // restored with no prompt and no UI — the common case on iOS home screen
-  // apps.
-
+  // the grant survived the platform purge, so the restore needs no prompt
   if (!resubscribe) {
     return null;
   }

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -41,6 +41,27 @@ export function setSubscriptionIntent(user, intent) {
   }
 }
 
+// "unconfirmed" is only safe for an endpoint the server acknowledged in an
+// earlier session. A brand-new one it never answered for must keep the in-tab
+// fallback alive, or a device whose row was never created goes silent.
+function confirmedEndpointKey(user) {
+  return `confirmed-endpoint-${user.get("id")}`;
+}
+
+function markEndpointConfirmed(user, subscription) {
+  keyValueStore.setItem(
+    confirmedEndpointKey(user),
+    subscription.toJSON().endpoint
+  );
+}
+
+function isEndpointConfirmed(user, subscription) {
+  return (
+    keyValueStore.getItem(confirmedEndpointKey(user)) ===
+    subscription.toJSON().endpoint
+  );
+}
+
 function sendSubscriptionToServer(subscription, sendConfirmation) {
   return ajax("/push_notifications/subscribe", {
     type: "POST",
@@ -112,14 +133,18 @@ export function listenForPushNotificationMessages(router, appEvents) {
 // Tells the server to forget this device's subscription. Scoped to the current
 // user server-side, so it can never drop a row belonging to another account
 // sharing the browser.
-function retireServerSubscription(subscription) {
-  return ajax("/push_notifications/unsubscribe", {
-    type: "POST",
-    data: { subscription: subscription.toJSON() },
-  }).catch((e) => {
+async function retireServerSubscription(subscription) {
+  try {
+    await ajax("/push_notifications/unsubscribe", {
+      type: "POST",
+      data: { subscription: subscription.toJSON() },
+    });
+    return true;
+  } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);
-  });
+    return false;
+  }
 }
 
 async function discardPlatformSubscription(subscription) {
@@ -147,7 +172,6 @@ export async function reconcileSubscription(
     return null;
   }
 
-  const intent = getSubscriptionIntent(user);
   const registration = await serviceWorkerRegistration();
   if (!registration) {
     return null;
@@ -162,6 +186,10 @@ export async function reconcileSubscription(
     return null;
   }
 
+  // Re-read: `enable()` can record an intent while the awaits above are still
+  // pending, and the branches below destroy subscriptions.
+  const intent = getSubscriptionIntent(user);
+
   if (intent === null) {
     if (subscription) {
       // An origin has only one subscription. With no current-user intent its
@@ -173,8 +201,9 @@ export async function reconcileSubscription(
   }
 
   if (intent === "off") {
-    if (subscription) {
-      await retireServerSubscription(subscription);
+    // Only drop the platform subscription once the server row is gone: it is
+    // the sole way back to that row if the request failed.
+    if (subscription && (await retireServerSubscription(subscription))) {
       await discardPlatformSubscription(subscription);
     }
     return null;
@@ -189,11 +218,14 @@ export async function reconcileSubscription(
   }
 
   if (subscription) {
-    // The server was told about this endpoint when it was created, so a failed
-    // resync leaves it working; only a restored one is new to the server.
-    return (await resyncSubscriptionWithServer(subscription))
-      ? "subscribed"
-      : "unconfirmed";
+    if (await resyncSubscriptionWithServer(subscription)) {
+      markEndpointConfirmed(user, subscription);
+      return "subscribed";
+    }
+
+    // A failed request is not proof the row is missing, so an endpoint the
+    // server acknowledged before still counts as delivering.
+    return isEndpointConfirmed(user, subscription) ? "unconfirmed" : null;
   }
 
   // The platform dropped the subscription but the grant survived, so it can be
@@ -217,12 +249,13 @@ export async function reconcileSubscription(
   }
 
   if (await resyncSubscriptionWithServer(subscription)) {
+    markEndpointConfirmed(user, subscription);
     return "subscribed";
   }
 
-  // Do not let an endpoint that was never confirmed become indistinguishable
-  // from one that previously worked when the next boot finds it.
-  await discardPlatformSubscription(subscription);
+  // Left in place: only one subscription exists per origin, so discarding it can
+  // destroy one another tab just confirmed. It stays unacknowledged, so the next
+  // boot keeps the fallback and resyncs this same endpoint.
   return null;
 }
 
@@ -289,10 +322,12 @@ export async function unsubscribe(user, callback) {
     const subscription = await registration?.pushManager.getSubscription();
 
     if (subscription) {
-      // `unsubscribe()` resolves false when the platform already dropped the
-      // subscription, so the server row has to be retired either way
-      await retireServerSubscription(subscription);
-      await subscription.unsubscribe();
+      // The row is retired first and unconditionally: `unsubscribe()` resolves
+      // false for an already-dropped subscription, and the endpoint is the only
+      // handle on that row, so it is kept until the row is actually gone.
+      if (await retireServerSubscription(subscription)) {
+        await subscription.unsubscribe();
+      }
     }
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -6,10 +6,16 @@ export const keyValueStore = new KeyValueStore("discourse_push_notifications_");
 export const pushNotificationPreferenceStore = new KeyValueStore(
   "push_notification_preferences_"
 );
+export const pushNotificationConfirmationStore = new KeyValueStore(
+  "push_notification_confirmation_"
+);
 
 // a worker that failed to install never activates, so `ready` would hang
 const SERVICE_WORKER_READY_TIMEOUT_MS = 5000;
 const ADOPTION_IN_PROGRESS = "adopting";
+const CONFIRMED_SUBSCRIPTION_KEY = "active";
+const SUBSCRIPTION_OPERATION_KEY = "operation";
+let nextSubscriptionOperationId = 0;
 
 export function userSubscriptionKey(user) {
   return `subscribed-${user.get("id")}`;
@@ -55,10 +61,70 @@ export function setSubscriptionIntent(user, intent) {
   }
 }
 
-function sendSubscriptionToServer(subscription, sendConfirmation) {
+function beginSubscriptionOperation(action) {
+  const operation = `${action}-${Date.now()}-${++nextSubscriptionOperationId}`;
+  keyValueStore.setItem(SUBSCRIPTION_OPERATION_KEY, operation);
+  return operation;
+}
+
+function isCurrentSubscriptionOperation(operation) {
+  return currentSubscriptionOperation() === operation;
+}
+
+function currentSubscriptionOperation() {
+  return keyValueStore.getItem(SUBSCRIPTION_OPERATION_KEY);
+}
+
+function currentSubscriptionOperationAction() {
+  return currentSubscriptionOperation()?.split("-", 1)[0];
+}
+
+function markEndpointConfirmed(user, subscription) {
+  pushNotificationConfirmationStore.setObject({
+    key: CONFIRMED_SUBSCRIPTION_KEY,
+    value: {
+      userId: user.get("id"),
+      endpoint: subscription.toJSON().endpoint,
+    },
+  });
+}
+
+function isEndpointConfirmed(user, subscription) {
+  const confirmation = pushNotificationConfirmationStore.getObject(
+    CONFIRMED_SUBSCRIPTION_KEY
+  );
+
+  return (
+    confirmation?.userId === user.get("id") &&
+    confirmation.endpoint === subscription.toJSON().endpoint
+  );
+}
+
+export function clearPushSubscriptionConfirmation(user, subscription) {
+  const confirmation = pushNotificationConfirmationStore.getObject(
+    CONFIRMED_SUBSCRIPTION_KEY
+  );
+  const endpoint = subscription?.toJSON
+    ? subscription.toJSON().endpoint
+    : subscription?.endpoint;
+
+  if (
+    confirmation?.userId === user.get("id") &&
+    (!endpoint || confirmation.endpoint === endpoint)
+  ) {
+    pushNotificationConfirmationStore.remove(CONFIRMED_SUBSCRIPTION_KEY);
+  }
+}
+
+export function clearPushSubscriptionConfirmationForOrigin() {
+  pushNotificationConfirmationStore.remove(CONFIRMED_SUBSCRIPTION_KEY);
+}
+
+function sendSubscriptionToServer(user, subscription, sendConfirmation) {
   return ajax("/push_notifications/subscribe", {
     type: "POST",
     data: {
+      user_id: user.get("id"),
       subscription: subscription.toJSON(),
       send_confirmation: sendConfirmation,
     },
@@ -66,9 +132,9 @@ function sendSubscriptionToServer(subscription, sendConfirmation) {
 }
 
 // retried on the next boot, so a failure is logged rather than raised
-async function resyncSubscriptionWithServer(subscription) {
+async function resyncSubscriptionWithServer(user, subscription) {
   try {
-    await sendSubscriptionToServer(subscription, false);
+    await sendSubscriptionToServer(user, subscription, false);
     return true;
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -124,11 +190,11 @@ export function listenForPushNotificationMessages(router, appEvents) {
 
 // Scoped to the current user server-side, so it can never drop a row
 // belonging to another account sharing the browser.
-async function retireServerSubscription(subscription) {
+async function retireServerSubscription(user, subscription) {
   try {
     await ajax("/push_notifications/unsubscribe", {
       type: "POST",
-      data: { subscription: subscription.toJSON() },
+      data: { user_id: user.get("id"), subscription: subscription.toJSON() },
     });
     return true;
   } catch (e) {
@@ -149,7 +215,12 @@ async function discardPlatformSubscription(subscription) {
 
 // The POST recreates the server row, so an opt-out or logout that landed while
 // it was in flight has to be replayed against it.
-async function confirmResync(user, subscription, previousIntent) {
+async function confirmResync(
+  user,
+  subscription,
+  previousIntent,
+  reconciliationOperation
+) {
   const currentIntent = getSubscriptionIntent(user);
   const storedIntent = keyValueStore.getItem(userSubscriptionKey(user));
   if (
@@ -159,22 +230,44 @@ async function confirmResync(user, subscription, previousIntent) {
       currentIntent === null &&
       storedIntent !== ADOPTION_IN_PROGRESS)
   ) {
-    await retireServerSubscription(subscription);
+    if (
+      reconciliationOperation &&
+      !isCurrentSubscriptionOperation(reconciliationOperation) &&
+      currentSubscriptionOperationAction() === "enable"
+    ) {
+      return null;
+    }
+
+    if (await retireServerSubscription(user, subscription)) {
+      clearPushSubscriptionConfirmation(user, subscription);
+    }
     return null;
   }
 
   setSubscriptionIntent(user, "subscribed");
+  markEndpointConfirmed(user, subscription);
   return "subscribed";
 }
 
-// Returns the verified state, "lost" when permission vanished, or null when no
-// conclusion was possible.
+// Returns the verified state, "unconfirmed" for an endpoint acknowledged on an
+// earlier boot, "lost" when permission vanished, or null when no conclusion was
+// possible.
 export async function reconcileSubscription(
   user,
   { resubscribe = false, applicationServerKey } = {}
 ) {
   if (!user || !isPushNotificationsSupported()) {
     return null;
+  }
+
+  const initialIntent = getSubscriptionIntent(user);
+  let reconciliationOperation;
+  if (
+    resubscribe &&
+    initialIntent !== "off" &&
+    Notification.permission === "granted"
+  ) {
+    reconciliationOperation = beginSubscriptionOperation("enable");
   }
 
   const registration = await serviceWorkerRegistration();
@@ -196,17 +289,36 @@ export async function reconcileSubscription(
   const intent = getSubscriptionIntent(user);
 
   if (intent === "off") {
+    const operation = currentSubscriptionOperation();
+
+    if (currentSubscriptionOperationAction() === "enable") {
+      return null;
+    }
+
     // Only drop the platform subscription once the server row is gone: it is
     // the sole way back to that row if the request failed.
-    if (subscription && (await retireServerSubscription(subscription))) {
+    if (subscription && (await retireServerSubscription(user, subscription))) {
+      clearPushSubscriptionConfirmation(user, subscription);
+      if (
+        currentSubscriptionOperation() !== operation ||
+        currentSubscriptionOperationAction() === "enable"
+      ) {
+        return null;
+      }
+
       const currentIntent = getSubscriptionIntent(user);
       if (currentIntent === "off") {
         await discardPlatformSubscription(subscription);
       } else if (
         currentIntent === "subscribed" &&
-        (await resyncSubscriptionWithServer(subscription))
+        (await resyncSubscriptionWithServer(user, subscription))
       ) {
-        return await confirmResync(user, subscription, currentIntent);
+        return await confirmResync(
+          user,
+          subscription,
+          currentIntent,
+          reconciliationOperation
+        );
       }
     }
     return null;
@@ -231,8 +343,13 @@ export async function reconcileSubscription(
       keyValueStore.setItem(userSubscriptionKey(user), ADOPTION_IN_PROGRESS);
     }
 
-    if (await resyncSubscriptionWithServer(subscription)) {
-      return await confirmResync(user, subscription, intent);
+    if (await resyncSubscriptionWithServer(user, subscription)) {
+      return await confirmResync(
+        user,
+        subscription,
+        intent,
+        reconciliationOperation
+      );
     }
 
     if (
@@ -241,7 +358,7 @@ export async function reconcileSubscription(
       setSubscriptionIntent(user, null);
     }
 
-    return null;
+    return isEndpointConfirmed(user, subscription) ? "unconfirmed" : null;
   }
 
   // The origin-level grant is the opt-in. Restore for every account except
@@ -271,8 +388,13 @@ export async function reconcileSubscription(
     return null;
   }
 
-  if (await resyncSubscriptionWithServer(subscription)) {
-    return await confirmResync(user, subscription, intent);
+  if (await resyncSubscriptionWithServer(user, subscription)) {
+    return await confirmResync(
+      user,
+      subscription,
+      intent,
+      reconciliationOperation
+    );
   }
 
   // Left in place: only one subscription exists per origin, so discarding it can
@@ -286,10 +408,13 @@ export async function reconcileSubscription(
   return null;
 }
 
-export function subscribe(callback, applicationServerKey) {
+export function subscribe(user, callback, applicationServerKey) {
   if (!isPushNotificationsSupported()) {
     return;
   }
+
+  const operation = beginSubscriptionOperation("enable");
+  clearPushSubscriptionConfirmationForOrigin();
 
   return serviceWorkerRegistration().then((registration) => {
     if (!registration) {
@@ -304,7 +429,19 @@ export function subscribe(callback, applicationServerKey) {
       .then(async (subscription) => {
         // a subscription the server never recorded receives nothing, so it
         // must not be reported as enabled
-        await sendSubscriptionToServer(subscription, true);
+        await sendSubscriptionToServer(user, subscription, true);
+
+        if (!isCurrentSubscriptionOperation(operation)) {
+          if (currentSubscriptionOperationAction() === "disable") {
+            if (await retireServerSubscription(user, subscription)) {
+              clearPushSubscriptionConfirmation(user, subscription);
+            }
+            await discardPlatformSubscription(subscription);
+          }
+          return false;
+        }
+
+        markEndpointConfirmed(user, subscription);
         callback?.();
         return true;
       })
@@ -336,29 +473,46 @@ export async function getCurrentPushSubscription() {
 }
 
 export async function unsubscribe(user, callback) {
+  const operation = beginSubscriptionOperation("disable");
   setSubscriptionIntent(user, "off");
 
   if (!isPushNotificationsSupported()) {
-    callback?.();
-    return true;
+    if (isCurrentSubscriptionOperation(operation)) {
+      callback?.();
+      return true;
+    }
+    return false;
   }
 
   const registration = await serviceWorkerRegistration();
+  if (!registration) {
+    return false;
+  }
 
   try {
-    const subscription = await registration?.pushManager.getSubscription();
+    const subscription = await registration.pushManager.getSubscription();
 
     if (subscription) {
       // The row is retired first and unconditionally: `unsubscribe()` resolves
       // false for an already-dropped subscription, and the endpoint is the only
       // handle on that row, so it is kept until the row is actually gone.
-      if (await retireServerSubscription(subscription)) {
-        await subscription.unsubscribe();
+      if (!(await retireServerSubscription(user, subscription))) {
+        return false;
       }
+      if (!isCurrentSubscriptionOperation(operation)) {
+        return false;
+      }
+      clearPushSubscriptionConfirmation(user, subscription);
+      await subscription.unsubscribe();
     }
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);
+    return false;
+  }
+
+  if (!isCurrentSubscriptionOperation(operation)) {
+    return false;
   }
 
   callback?.();

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -122,13 +122,23 @@ function retireServerSubscription(subscription) {
   });
 }
 
+async function discardPlatformSubscription(subscription) {
+  try {
+    await subscription.unsubscribe();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+}
+
 // Reconciles the device's actual push subscription with the user's stored
 // intent.
 //
-// Returns "subscribed" when a subscription exists (or was restored), "lost"
-// when the user has to opt in again, and null when there was nothing to
-// conclude — a transient failure, so the intent is kept and the next boot
-// retries.
+// Returns "subscribed" when the server knows about a working subscription,
+// "unconfirmed" when the device still has the one it was told about earlier but
+// the resync could not reach the server, "lost" when the user has to opt in
+// again, and null when there was nothing to conclude — a transient failure, so
+// the intent is kept and the next boot retries.
 export async function reconcileSubscription(
   user,
   { resubscribe = false, applicationServerKey } = {}
@@ -138,10 +148,6 @@ export async function reconcileSubscription(
   }
 
   const intent = getSubscriptionIntent(user);
-  if (intent === null) {
-    return null;
-  }
-
   const registration = await serviceWorkerRegistration();
   if (!registration) {
     return null;
@@ -156,14 +162,20 @@ export async function reconcileSubscription(
     return null;
   }
 
+  if (intent === null) {
+    if (subscription) {
+      // An origin has only one subscription. With no current-user intent its
+      // ownership cannot be verified, so retaining it could expose another
+      // account's notifications after an abnormal session replacement.
+      await discardPlatformSubscription(subscription);
+    }
+    return null;
+  }
+
   if (intent === "off") {
-    // The browser subscription is deliberately left alone: only one exists per
-    // origin, so on a shared browser it may now belong to whoever subscribed
-    // most recently. Retiring our own server row is what actually stops
-    // delivery, and it retries here because the teardown at the time may have
-    // failed offline.
     if (subscription) {
       await retireServerSubscription(subscription);
+      await discardPlatformSubscription(subscription);
     }
     return null;
   }
@@ -177,9 +189,11 @@ export async function reconcileSubscription(
   }
 
   if (subscription) {
+    // The server was told about this endpoint when it was created, so a failed
+    // resync leaves it working; only a restored one is new to the server.
     return (await resyncSubscriptionWithServer(subscription))
       ? "subscribed"
-      : null;
+      : "unconfirmed";
   }
 
   // The platform dropped the subscription but the grant survived, so it can be
@@ -202,9 +216,14 @@ export async function reconcileSubscription(
     return null;
   }
 
-  return (await resyncSubscriptionWithServer(subscription))
-    ? "subscribed"
-    : null;
+  if (await resyncSubscriptionWithServer(subscription)) {
+    return "subscribed";
+  }
+
+  // Do not let an endpoint that was never confirmed become indistinguishable
+  // from one that previously worked when the next boot finds it.
+  await discardPlatformSubscription(subscription);
+  return null;
 }
 
 export function subscribe(callback, applicationServerKey) {
@@ -222,11 +241,10 @@ export function subscribe(callback, applicationServerKey) {
         userVisibleOnly: true,
         applicationServerKey: new Uint8Array(applicationServerKey.split("|")),
       })
-      .then((subscription) => {
-        sendSubscriptionToServer(subscription, true).catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error(e);
-        });
+      .then(async (subscription) => {
+        // a subscription the server never recorded receives nothing, so it
+        // must not be reported as enabled
+        await sendSubscriptionToServer(subscription, true);
         callback?.();
         return true;
       })
@@ -257,34 +275,30 @@ export async function getCurrentPushSubscription() {
   }
 }
 
-export function unsubscribe(user, callback) {
-  if (!isPushNotificationsSupported()) {
-    return;
-  }
-
+export async function unsubscribe(user, callback) {
   setSubscriptionIntent(user, "off");
 
-  return serviceWorkerRegistration().then((registration) => {
-    registration?.pushManager
-      .getSubscription()
-      .then((subscription) => {
-        if (subscription) {
-          subscription.unsubscribe().then((successful) => {
-            if (successful) {
-              ajax("/push_notifications/unsubscribe", {
-                type: "POST",
-                data: { subscription: subscription.toJSON() },
-              });
-            }
-          });
-        }
-      })
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.error(e);
-      });
-
+  if (!isPushNotificationsSupported()) {
     callback?.();
     return true;
-  });
+  }
+
+  const registration = await serviceWorkerRegistration();
+
+  try {
+    const subscription = await registration?.pushManager.getSubscription();
+
+    if (subscription) {
+      // `unsubscribe()` resolves false when the platform already dropped the
+      // subscription, so the server row has to be retired either way
+      await retireServerSubscription(subscription);
+      await subscription.unsubscribe();
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+
+  callback?.();
+  return true;
 }

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -151,6 +151,19 @@ async function discardPlatformSubscription(subscription) {
   }
 }
 
+// The POST recreates the server row, so a disable that landed while it was in
+// flight has to be replayed against it: `unsubscribe()` has already invalidated
+// the platform subscription, leaving no other handle on that row.
+async function confirmResync(user, subscription) {
+  if (getSubscriptionIntent(user) === "off") {
+    await retireServerSubscription(subscription);
+    return null;
+  }
+
+  markEndpointConfirmed(user, subscription);
+  return "subscribed";
+}
+
 // Returns "subscribed" when the server knows about a working subscription,
 // "unconfirmed" when the device still has the one it was told about earlier but
 // the resync could not reach the server, "lost" when the user has to opt in
@@ -211,8 +224,7 @@ export async function reconcileSubscription(
 
   if (subscription) {
     if (await resyncSubscriptionWithServer(subscription)) {
-      markEndpointConfirmed(user, subscription);
-      return "subscribed";
+      return await confirmResync(user, subscription);
     }
 
     // A failed request is not proof the row is missing, so an endpoint the
@@ -238,8 +250,7 @@ export async function reconcileSubscription(
   }
 
   if (await resyncSubscriptionWithServer(subscription)) {
-    markEndpointConfirmed(user, subscription);
-    return "subscribed";
+    return await confirmResync(user, subscription);
   }
 
   // Left in place: only one subscription exists per origin, so discarding it can

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -22,8 +22,26 @@ const keyValueStore = new KeyValueStore(context);
 const DISABLED = "disabled";
 const ENABLED = "enabled";
 
+// the dismissal used to be recorded once for the whole browser
+const LEGACY_CONSENT_PROMPT_DISMISSED_KEY = "dismissed-prompt";
+
 function consentPromptDismissedKey(user) {
   return `dismissed-prompt-${user.get("id")}`;
+}
+
+function readConsentPromptDismissed(user) {
+  const userKey = consentPromptDismissedKey(user);
+  const userDismissed = pushNotificationKeyValueStore.getItem(userKey);
+  const legacyDismissed = pushNotificationKeyValueStore.getItem(
+    LEGACY_CONSENT_PROMPT_DISMISSED_KEY
+  );
+
+  if (legacyDismissed) {
+    pushNotificationKeyValueStore.setItem(userKey, "dismissed");
+    pushNotificationKeyValueStore.remove(LEGACY_CONSENT_PROMPT_DISMISSED_KEY);
+  }
+
+  return Boolean(userDismissed || legacyDismissed);
 }
 
 @disableImplicitInjections
@@ -43,11 +61,7 @@ export default class DesktopNotificationsService extends Service {
     super(...arguments);
 
     this.consentPromptDismissed = this.currentUser
-      ? Boolean(
-          pushNotificationKeyValueStore.getItem(
-            consentPromptDismissedKey(this.currentUser)
-          )
-        )
+      ? readConsentPromptDismissed(this.currentUser)
       : false;
 
     this.isEnabledBrowser = this.isGrantedPermission
@@ -170,7 +184,11 @@ export default class DesktopNotificationsService extends Service {
       applicationServerKey: this.siteSettings.vapid_public_key_bytes,
     });
 
-    this.pushSubscriptionConfirmed = result === "subscribed";
+    // "unconfirmed" leaves the question open, so the stored intent stays the
+    // best evidence and the UI does not flip on a single failed request
+    if (result !== "unconfirmed") {
+      this.pushSubscriptionConfirmed = result === "subscribed";
+    }
 
     if (result === "lost") {
       this.pushIntent = null;

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -209,9 +209,15 @@ export default class DesktopNotificationsService extends Service {
       this.setIsEnabledBrowser(false);
     }
     if (this.pushIntent === "subscribed") {
-      await unsubscribePushNotification(this.currentUser, () => {
-        this.setIsEnabledPush(false);
-      });
+      const disabled = await unsubscribePushNotification(
+        this.currentUser,
+        () => {
+          this.setIsEnabledPush(false);
+        }
+      );
+      if (!disabled) {
+        return false;
+      }
     }
     setPushTransport(null);
 
@@ -248,9 +254,13 @@ export default class DesktopNotificationsService extends Service {
     }
 
     if (this.isPushNotificationsPreferred) {
-      const subscribed = await subscribePushNotification(() => {
-        this.setIsEnabledPush(true);
-      }, this.siteSettings.vapid_public_key_bytes);
+      const subscribed = await subscribePushNotification(
+        this.currentUser,
+        () => {
+          this.setIsEnabledPush(true);
+        },
+        this.siteSettings.vapid_public_key_bytes
+      );
 
       if (subscribed) {
         setPushTransport("delivering");

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -184,10 +184,13 @@ export default class DesktopNotificationsService extends Service {
       applicationServerKey: this.siteSettings.vapid_public_key_bytes,
     });
 
-    // "unconfirmed" leaves the question open, so the stored intent stays the
-    // best evidence and the UI does not flip on a single failed request
-    if (result !== "unconfirmed") {
-      this.pushSubscriptionConfirmed = result === "subscribed";
+    // Only conclusive results move the toggle: "unconfirmed" and null leave
+    // the stored intent as the best evidence, so one failed boot cannot flip
+    // the UI off while push may still deliver.
+    if (result === "subscribed") {
+      this.pushSubscriptionConfirmed = true;
+    } else if (result === "lost") {
+      this.pushSubscriptionConfirmed = false;
     }
 
     if (result === "lost") {

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -4,6 +4,7 @@ import Service, { service } from "@ember/service";
 import {
   confirmNotification,
   context,
+  setPushTransport,
 } from "discourse/lib/desktop-notifications";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import KeyValueStore from "discourse/lib/key-value-store";
@@ -125,14 +126,12 @@ export default class DesktopNotificationsService extends Service {
     );
   }
 
-  // The permission grant outlived the stored intent (e.g. iOS wiped local
-  // storage): one explicit click restores push without a permission prompt.
-  get canRestorePushWithoutPrompt() {
+  get pushNeedsAttention() {
     return (
-      !!this.currentUser &&
-      this.pushIntent === null &&
+      this.pushIntent !== "off" &&
       this.isGrantedPermission &&
-      this.isPushNotificationsPreferred
+      this.isPushNotificationsPreferred &&
+      this.pushSubscriptionConfirmed === false
     );
   }
 
@@ -151,6 +150,9 @@ export default class DesktopNotificationsService extends Service {
     setSubscriptionIntent(this.currentUser, intent);
     this.pushIntent = intent;
     this.pushSubscriptionConfirmed = value;
+    if (value) {
+      this.rearmConsentPrompt();
+    }
   }
 
   dismissConsentPrompt() {
@@ -176,26 +178,26 @@ export default class DesktopNotificationsService extends Service {
     this.consentPromptDismissed = false;
   }
 
-  // Called at boot: restores a platform-purged subscription when possible,
-  // and re-arms the consent prompt when it isn't.
+  // Reconciles stored intent with platform/server state for transport and UI.
   async reconcilePushSubscription() {
     const result = await reconcileSubscription(this.currentUser, {
       resubscribe: this.isPushNotificationsPreferred,
       applicationServerKey: this.siteSettings.vapid_public_key_bytes,
     });
 
-    // Only conclusive results move the toggle: "unconfirmed" and null leave
-    // the stored intent as the best evidence, so one failed boot cannot flip
-    // the UI off while push may still deliver.
     if (result === "subscribed") {
+      this.pushIntent = "subscribed";
       this.pushSubscriptionConfirmed = true;
     } else if (result === "lost") {
-      this.pushSubscriptionConfirmed = false;
-    }
-
-    if (result === "lost") {
       this.pushIntent = null;
+      this.pushSubscriptionConfirmed = false;
       this.rearmConsentPrompt();
+    } else if (
+      this.pushIntent !== "off" &&
+      this.isGrantedPermission &&
+      this.isPushNotificationsPreferred
+    ) {
+      this.pushSubscriptionConfirmed = false;
     }
 
     return result;
@@ -211,6 +213,7 @@ export default class DesktopNotificationsService extends Service {
         this.setIsEnabledPush(false);
       });
     }
+    setPushTransport(null);
 
     return true;
   }
@@ -249,7 +252,10 @@ export default class DesktopNotificationsService extends Service {
         this.setIsEnabledPush(true);
       }, this.siteSettings.vapid_public_key_bytes);
 
-      if (!subscribed) {
+      if (subscribed) {
+        setPushTransport("delivering");
+      } else {
+        this.pushSubscriptionConfirmed = false;
         this.toasts.error({
           duration: "short",
           data: {

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -8,18 +8,23 @@ import {
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import KeyValueStore from "discourse/lib/key-value-store";
 import {
+  getSubscriptionIntent,
   isPushNotificationsSupported,
   keyValueStore as pushNotificationKeyValueStore,
+  reconcileSubscription,
+  setSubscriptionIntent,
   subscribe as subscribePushNotification,
   unsubscribe as unsubscribePushNotification,
-  userSubscriptionKey as pushNotificationUserSubscriptionKey,
 } from "discourse/lib/push-notifications";
 import { i18n } from "discourse-i18n";
 
 const keyValueStore = new KeyValueStore(context);
 const DISABLED = "disabled";
 const ENABLED = "enabled";
-const SUBSCRIBED = "subscribed";
+
+function consentPromptDismissedKey(user) {
+  return `dismissed-prompt-${user.get("id")}`;
+}
 
 @disableImplicitInjections
 export default class DesktopNotificationsService extends Service {
@@ -29,19 +34,28 @@ export default class DesktopNotificationsService extends Service {
   @service toasts;
 
   @tracked isEnabledBrowser = false;
-  @tracked isEnabledPush = false;
+  @tracked pushIntent = null;
+  // null until boot reconciliation reports back, so the UI does not flicker
+  @tracked pushSubscriptionConfirmed = null;
+  @tracked consentPromptDismissed = false;
 
   constructor() {
     super(...arguments);
 
+    this.consentPromptDismissed = this.currentUser
+      ? Boolean(
+          pushNotificationKeyValueStore.getItem(
+            consentPromptDismissedKey(this.currentUser)
+          )
+        )
+      : false;
+
     this.isEnabledBrowser = this.isGrantedPermission
       ? keyValueStore.getItem("notifications-disabled") === ENABLED
       : false;
-    this.isEnabledPush = this.currentUser
-      ? pushNotificationKeyValueStore.getItem(
-          pushNotificationUserSubscriptionKey(this.currentUser)
-        ) === SUBSCRIBED
-      : false;
+    this.pushIntent = this.currentUser
+      ? getSubscriptionIntent(this.currentUser)
+      : null;
   }
 
   get isNotSupported() {
@@ -68,6 +82,13 @@ export default class DesktopNotificationsService extends Service {
     return this.notificationsPermission === "granted";
   }
 
+  get isEnabledPush() {
+    return (
+      this.pushIntent === "subscribed" &&
+      this.pushSubscriptionConfirmed !== false
+    );
+  }
+
   get isEnabled() {
     return this.isEnabledPush || this.isEnabledBrowser;
   }
@@ -90,6 +111,17 @@ export default class DesktopNotificationsService extends Service {
     );
   }
 
+  // The permission grant outlived the stored intent (e.g. iOS wiped local
+  // storage): one explicit click restores push without a permission prompt.
+  get canRestorePushWithoutPrompt() {
+    return (
+      !!this.currentUser &&
+      this.pushIntent === null &&
+      this.isGrantedPermission &&
+      this.isPushNotificationsPreferred
+    );
+  }
+
   setIsEnabledBrowser(value) {
     const status = value ? ENABLED : DISABLED;
     keyValueStore.setItem("notifications-disabled", status);
@@ -97,19 +129,55 @@ export default class DesktopNotificationsService extends Service {
   }
 
   setIsEnabledPush(value) {
-    const user = this.currentUser;
-    const status = value ? SUBSCRIBED : value;
-
-    if (!user) {
+    if (!this.currentUser) {
       return false;
     }
 
-    pushNotificationKeyValueStore.setItem(
-      pushNotificationUserSubscriptionKey(user),
-      status
-    );
+    const intent = value ? "subscribed" : "off";
+    setSubscriptionIntent(this.currentUser, intent);
+    this.pushIntent = intent;
+    this.pushSubscriptionConfirmed = value;
+  }
 
-    this.isEnabledPush = value;
+  dismissConsentPrompt() {
+    if (!this.currentUser) {
+      return;
+    }
+
+    pushNotificationKeyValueStore.setItem(
+      consentPromptDismissedKey(this.currentUser),
+      "dismissed"
+    );
+    this.consentPromptDismissed = true;
+  }
+
+  rearmConsentPrompt() {
+    if (!this.currentUser) {
+      return;
+    }
+
+    pushNotificationKeyValueStore.remove(
+      consentPromptDismissedKey(this.currentUser)
+    );
+    this.consentPromptDismissed = false;
+  }
+
+  // Called at boot: restores a platform-purged subscription when possible,
+  // and re-arms the consent prompt when it isn't.
+  async reconcilePushSubscription() {
+    const result = await reconcileSubscription(this.currentUser, {
+      resubscribe: this.isPushNotificationsPreferred,
+      applicationServerKey: this.siteSettings.vapid_public_key_bytes,
+    });
+
+    this.pushSubscriptionConfirmed = result === "subscribed";
+
+    if (result === "lost") {
+      this.pushIntent = null;
+      this.rearmConsentPrompt();
+    }
+
+    return result;
   }
 
   @action
@@ -117,7 +185,7 @@ export default class DesktopNotificationsService extends Service {
     if (this.isEnabledBrowser) {
       this.setIsEnabledBrowser(false);
     }
-    if (this.isEnabledPush) {
+    if (this.pushIntent === "subscribed") {
       await unsubscribePushNotification(this.currentUser, () => {
         this.setIsEnabledPush(false);
       });
@@ -126,8 +194,35 @@ export default class DesktopNotificationsService extends Service {
     return true;
   }
 
+  // `Notification.requestPermission` needs the click's user activation, which
+  // expires while awaiting the service worker, so permission is always asked
+  // for first. Both the promise and the legacy callback form are handled, and a
+  // rejection (no activation, insecure context) must not hang the caller.
+  async requestPermission() {
+    if (this.isGrantedPermission || this.isDeniedPermission) {
+      return this.notificationsPermission;
+    }
+
+    try {
+      return await new Promise((resolve, reject) => {
+        const result = Notification.requestPermission(resolve);
+        if (result?.then) {
+          result.then(resolve, reject);
+        }
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      return "default";
+    }
+  }
+
   @action
   async enable() {
+    if ((await this.requestPermission()) !== "granted") {
+      return false;
+    }
+
     if (this.isPushNotificationsPreferred) {
       const subscribed = await subscribePushNotification(() => {
         this.setIsEnabledPush(true);
@@ -143,16 +238,10 @@ export default class DesktopNotificationsService extends Service {
       }
 
       return subscribed;
-    } else {
-      await Notification.requestPermission((permission) => {
-        confirmNotification(this.siteSettings);
-        if (permission === "granted") {
-          this.setIsEnabledBrowser(true);
-          return true;
-        } else {
-          return false;
-        }
-      });
     }
+
+    confirmNotification(this.siteSettings);
+    this.setIsEnabledBrowser(true);
+    return true;
   }
 }

--- a/frontend/discourse/tests/integration/components/notification-consent-banner-test.gjs
+++ b/frontend/discourse/tests/integration/components/notification-consent-banner-test.gjs
@@ -1,0 +1,121 @@
+import { tracked } from "@glimmer/tracking";
+import Service from "@ember/service";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import NotificationConsentBanner from "discourse/components/notification-consent-banner";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+class StubDesktopNotifications extends Service {
+  @tracked isNotSupported = false;
+  @tracked isEnabled = false;
+  @tracked consentPromptDismissed = false;
+  @tracked canRestorePushWithoutPrompt = false;
+  @tracked enableCalls = 0;
+  @tracked dismissCalls = 0;
+
+  enable() {
+    this.enableCalls++;
+  }
+
+  dismissConsentPrompt() {
+    this.dismissCalls++;
+    this.consentPromptDismissed = true;
+  }
+}
+
+module("Integration | Component | NotificationConsentBanner", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register(
+      "service:desktop-notifications",
+      StubDesktopNotifications
+    );
+    sinon.stub(this.owner.lookup("service:capabilities"), "isPwa").value(true);
+    this.desktopNotifications = this.owner.lookup(
+      "service:desktop-notifications"
+    );
+    this.siteSettings.push_notifications_prompt = true;
+  });
+
+  function stubPermission(value) {
+    sinon.stub(Notification, "permission").get(() => value);
+  }
+
+  test("prompts for consent when permission has not been decided", async function (assert) {
+    stubPermission("default");
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").exists();
+  });
+
+  test("prompts when a lost subscription can be restored without a permission prompt", async function (assert) {
+    stubPermission("granted");
+    this.desktopNotifications.canRestorePushWithoutPrompt = true;
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").exists("the banner offers to re-enable");
+  });
+
+  test("stays hidden while permission is granted and nothing was lost", async function (assert) {
+    stubPermission("granted");
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").doesNotExist();
+  });
+
+  test("stays hidden once permission has been denied", async function (assert) {
+    stubPermission("denied");
+    this.desktopNotifications.canRestorePushWithoutPrompt = true;
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").doesNotExist();
+  });
+
+  test("stays hidden once the prompt has been dismissed", async function (assert) {
+    stubPermission("default");
+    this.desktopNotifications.consentPromptDismissed = true;
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").doesNotExist();
+  });
+
+  test("stays hidden while notifications are already enabled", async function (assert) {
+    stubPermission("default");
+    this.desktopNotifications.isEnabled = true;
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").doesNotExist();
+  });
+
+  test("dismissing hides the banner and records the dismissal", async function (assert) {
+    stubPermission("default");
+
+    await render(<template><NotificationConsentBanner /></template>);
+    await click(".consent_banner .btn-transparent.close");
+
+    assert.dom(".consent_banner").doesNotExist();
+    assert.true(this.desktopNotifications.consentPromptDismissed);
+  });
+
+  test("enabling notifications delegates to the service without recording a dismissal", async function (assert) {
+    stubPermission("default");
+
+    await render(<template><NotificationConsentBanner /></template>);
+    await click(".consent_banner .btn-link");
+
+    assert.strictEqual(this.desktopNotifications.enableCalls, 1);
+    assert.strictEqual(
+      this.desktopNotifications.dismissCalls,
+      0,
+      "turning notifications on must not latch the prompt off, so a failed enable can re-show it"
+    );
+  });
+});

--- a/frontend/discourse/tests/integration/components/notification-consent-banner-test.gjs
+++ b/frontend/discourse/tests/integration/components/notification-consent-banner-test.gjs
@@ -9,8 +9,8 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 class StubDesktopNotifications extends Service {
   @tracked isNotSupported = false;
   @tracked isEnabled = false;
+  @tracked pushNeedsAttention = false;
   @tracked consentPromptDismissed = false;
-  @tracked canRestorePushWithoutPrompt = false;
   @tracked enableCalls = 0;
   @tracked dismissCalls = 0;
 
@@ -51,16 +51,7 @@ module("Integration | Component | NotificationConsentBanner", function (hooks) {
     assert.dom(".consent_banner").exists();
   });
 
-  test("prompts when a lost subscription can be restored without a permission prompt", async function (assert) {
-    stubPermission("granted");
-    this.desktopNotifications.canRestorePushWithoutPrompt = true;
-
-    await render(<template><NotificationConsentBanner /></template>);
-
-    assert.dom(".consent_banner").exists("the banner offers to re-enable");
-  });
-
-  test("stays hidden while permission is granted and nothing was lost", async function (assert) {
+  test("stays hidden while permission is granted", async function (assert) {
     stubPermission("granted");
 
     await render(<template><NotificationConsentBanner /></template>);
@@ -68,9 +59,17 @@ module("Integration | Component | NotificationConsentBanner", function (hooks) {
     assert.dom(".consent_banner").doesNotExist();
   });
 
+  test("prompts when granted push needs attention", async function (assert) {
+    stubPermission("granted");
+    this.desktopNotifications.pushNeedsAttention = true;
+
+    await render(<template><NotificationConsentBanner /></template>);
+
+    assert.dom(".consent_banner").exists("the banner offers to repair push");
+  });
+
   test("stays hidden once permission has been denied", async function (assert) {
     stubPermission("denied");
-    this.desktopNotifications.canRestorePushWithoutPrompt = true;
 
     await render(<template><NotificationConsentBanner /></template>);
 

--- a/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
+++ b/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
@@ -23,6 +23,7 @@ module(
     function build(result, { pushIntent = "subscribed" } = {}) {
       const desktopNotifications = {
         isGrantedPermission: true,
+        isPushNotificationsPreferred: true,
         pushIntent,
         reconcilePushSubscription: sinon.stub().resolves(result),
         setIsEnabledBrowser: sinon.spy(),
@@ -30,9 +31,13 @@ module(
 
       return {
         capabilities: { isMobileDevice: false },
-        currentUser,
+        currentUser: { ...currentUser, isInDoNotDisturb: () => false },
+        siteSettings: {},
+        appEvents: { trigger: sinon.spy() },
         desktopNotifications,
         messageBus: { unsubscribe: sinon.spy() },
+        reconcileTransports:
+          SubscribeUserNotificationsInit.prototype.reconcileTransports,
       };
     }
 
@@ -59,26 +64,6 @@ module(
       );
     });
 
-    test("treats an unconfirmed subscription as delivering", async function (assert) {
-      const instance = build("unconfirmed");
-
-      await reconcile(instance);
-
-      assert.strictEqual(
-        getPushTransport(),
-        "delivering",
-        "the device still has the subscription the server knows, so an in-tab fallback would double every notification"
-      );
-      assert.false(
-        instance.desktopNotifications.setIsEnabledBrowser.called,
-        "and nothing persistent is written over the user's own choice"
-      );
-      assert.strictEqual(
-        keyValueStore.getItem("notifications-disabled"),
-        undefined
-      );
-    });
-
     test("falls back to in-tab notifications for the session when push is not delivering", async function (assert) {
       const instance = build(null);
 
@@ -96,6 +81,45 @@ module(
       assert.strictEqual(
         keyValueStore.getItem("notifications-disabled"),
         undefined
+      );
+    });
+
+    test("a desktop alert retries push after reconciliation fails", async function (assert) {
+      const clock = sinon.useFakeTimers();
+      const instance = build(null);
+      const { reconcilePushSubscription } = instance.desktopNotifications;
+      reconcilePushSubscription.onSecondCall().resolves("subscribed");
+      const onAlert = Object.getOwnPropertyDescriptor(
+        SubscribeUserNotificationsInit.prototype,
+        "onAlert"
+      ).get.call(instance);
+
+      try {
+        await reconcile(instance);
+        setPushTransport("delivering");
+        onAlert({});
+        assert.strictEqual(
+          reconcilePushSubscription.callCount,
+          1,
+          "an alert during the cooldown does not retry"
+        );
+
+        clock.tick(60_001);
+        onAlert({});
+        await instance.pushReconciliation;
+      } finally {
+        clock.restore();
+      }
+
+      assert.strictEqual(
+        reconcilePushSubscription.callCount,
+        2,
+        "a transient failure is retried without waiting for a reload"
+      );
+      assert.strictEqual(
+        getPushTransport(),
+        "delivering",
+        "successful retry suppresses the in-tab fallback"
       );
     });
 
@@ -119,9 +143,47 @@ module(
       assert.strictEqual(getPushTransport(), "delivering");
     });
 
-    test("leaves the stored preference in charge when push was never wanted", async function (assert) {
-      setPushTransport("delivering");
+    test("a completed enable overrides an older reconciliation verdict", async function (assert) {
+      let finishReconciliation;
       const instance = build(null, { pushIntent: null });
+      instance.desktopNotifications.reconcilePushSubscription = () =>
+        new Promise((resolve) => (finishReconciliation = resolve));
+
+      const pending = reconcile(instance);
+      instance.desktopNotifications.pushIntent = "subscribed";
+      setPushTransport("delivering");
+      finishReconciliation(null);
+      await pending;
+
+      assert.strictEqual(
+        getPushTransport(),
+        "delivering",
+        "the stale fallback cannot overrule the explicit enable"
+      );
+    });
+
+    test("a completed disable overrides an older reconciliation verdict", async function (assert) {
+      let finishReconciliation;
+      const instance = build(null);
+      instance.desktopNotifications.reconcilePushSubscription = () =>
+        new Promise((resolve) => (finishReconciliation = resolve));
+
+      const pending = reconcile(instance);
+      instance.desktopNotifications.pushIntent = "off";
+      setPushTransport(null);
+      finishReconciliation("subscribed");
+      await pending;
+
+      assert.strictEqual(
+        getPushTransport(),
+        null,
+        "the stale delivery verdict cannot overrule the explicit opt-out"
+      );
+    });
+
+    test("leaves an explicit opt-out in charge", async function (assert) {
+      setPushTransport("delivering");
+      const instance = build(null, { pushIntent: "off" });
 
       await reconcile(instance);
 

--- a/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
+++ b/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
@@ -1,7 +1,11 @@
 import { module, test } from "qunit";
 import sinon from "sinon";
 import { SubscribeUserNotificationsInit } from "discourse/instance-initializers/subscribe-user-notifications";
-import { context } from "discourse/lib/desktop-notifications";
+import {
+  context,
+  getPushTransport,
+  setPushTransport,
+} from "discourse/lib/desktop-notifications";
 import KeyValueStore from "discourse/lib/key-value-store";
 
 module(
@@ -12,53 +16,97 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove("notifications-disabled");
+      // module-level state: leaving it set would silence other suites
+      setPushTransport(null);
     });
 
-    test("uses session-local push suppression and restores the browser fallback on a later failure", async function (assert) {
-      const messageBus = { unsubscribe: sinon.spy() };
+    function build(result, { pushIntent = "subscribed" } = {}) {
       const desktopNotifications = {
         isGrantedPermission: true,
-        pushIntent: "subscribed",
-        reconcilePushSubscription: sinon.stub().resolves("subscribed"),
-        setIsEnabledBrowser(value) {
-          keyValueStore.setItem(
-            "notifications-disabled",
-            value ? "enabled" : "disabled"
-          );
-        },
+        pushIntent,
+        reconcilePushSubscription: sinon.stub().resolves(result),
+        setIsEnabledBrowser: sinon.spy(),
       };
-      const instance = {
+
+      return {
         capabilities: { isMobileDevice: false },
         currentUser,
         desktopNotifications,
-        messageBus,
+        messageBus: { unsubscribe: sinon.spy() },
       };
+    }
 
-      keyValueStore.setItem("notifications-disabled", "disabled");
-      await SubscribeUserNotificationsInit.prototype.reconcileTransports.call(
+    function reconcile(instance) {
+      return SubscribeUserNotificationsInit.prototype.reconcileTransports.call(
         instance
       );
+    }
 
-      assert.true(
-        messageBus.unsubscribe.calledWith("/notification-alert/42"),
-        "successful push only removes the MessageBus alert for this session"
+    test("suppresses in-tab notifications for the session once push delivers", async function (assert) {
+      const instance = build("subscribed");
+
+      await reconcile(instance);
+
+      assert.strictEqual(getPushTransport(), "delivering");
+      assert.false(
+        instance.messageBus.unsubscribe.called,
+        "the alert channel stays subscribed, so clearing the session flag is all it takes to get the fallback back"
       );
       assert.strictEqual(
         keyValueStore.getItem("notifications-disabled"),
-        "disabled",
-        "it does not persist transport suppression"
+        undefined,
+        "and suppression is not persisted, so the next boot decides afresh"
       );
+    });
 
-      desktopNotifications.reconcilePushSubscription.resolves(null);
-      await SubscribeUserNotificationsInit.prototype.reconcileTransports.call(
-        instance
-      );
+    test("treats an unconfirmed subscription as delivering", async function (assert) {
+      const instance = build("unconfirmed");
+
+      await reconcile(instance);
 
       assert.strictEqual(
-        keyValueStore.getItem("notifications-disabled"),
-        "enabled",
-        "a later failed recovery clears suppression left by older builds"
+        getPushTransport(),
+        "delivering",
+        "the device still has the subscription the server knows, so an in-tab fallback would double every notification"
       );
+      assert.false(
+        instance.desktopNotifications.setIsEnabledBrowser.called,
+        "and nothing persistent is written over the user's own choice"
+      );
+      assert.strictEqual(
+        keyValueStore.getItem("notifications-disabled"),
+        undefined
+      );
+    });
+
+    test("falls back to in-tab notifications for the session when push is not delivering", async function (assert) {
+      const instance = build(null);
+
+      await reconcile(instance);
+
+      assert.strictEqual(
+        getPushTransport(),
+        "fallback",
+        "in-tab alerts stand in past the suppression older builds persisted"
+      );
+      assert.false(
+        instance.desktopNotifications.setIsEnabledBrowser.called,
+        "without permanently overwriting the stored browser-notification preference"
+      );
+      assert.strictEqual(
+        keyValueStore.getItem("notifications-disabled"),
+        undefined
+      );
+    });
+
+    test("leaves the stored preference in charge when push was never wanted", async function (assert) {
+      setPushTransport("delivering");
+      const instance = build(null, { pushIntent: null });
+
+      await reconcile(instance);
+
+      assert.strictEqual(getPushTransport(), null);
+      assert.false(instance.desktopNotifications.setIsEnabledBrowser.called);
     });
   }
 );

--- a/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
+++ b/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
@@ -1,0 +1,64 @@
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { SubscribeUserNotificationsInit } from "discourse/instance-initializers/subscribe-user-notifications";
+import { context } from "discourse/lib/desktop-notifications";
+import KeyValueStore from "discourse/lib/key-value-store";
+
+module(
+  "Unit | Instance Initializer | subscribe-user-notifications",
+  function (hooks) {
+    const keyValueStore = new KeyValueStore(context);
+    const currentUser = { get: (key) => (key === "id" ? 42 : undefined) };
+
+    hooks.afterEach(function () {
+      keyValueStore.remove("notifications-disabled");
+    });
+
+    test("uses session-local push suppression and restores the browser fallback on a later failure", async function (assert) {
+      const messageBus = { unsubscribe: sinon.spy() };
+      const desktopNotifications = {
+        isGrantedPermission: true,
+        pushIntent: "subscribed",
+        reconcilePushSubscription: sinon.stub().resolves("subscribed"),
+        setIsEnabledBrowser(value) {
+          keyValueStore.setItem(
+            "notifications-disabled",
+            value ? "enabled" : "disabled"
+          );
+        },
+      };
+      const instance = {
+        capabilities: { isMobileDevice: false },
+        currentUser,
+        desktopNotifications,
+        messageBus,
+      };
+
+      keyValueStore.setItem("notifications-disabled", "disabled");
+      await SubscribeUserNotificationsInit.prototype.reconcileTransports.call(
+        instance
+      );
+
+      assert.true(
+        messageBus.unsubscribe.calledWith("/notification-alert/42"),
+        "successful push only removes the MessageBus alert for this session"
+      );
+      assert.strictEqual(
+        keyValueStore.getItem("notifications-disabled"),
+        "disabled",
+        "it does not persist transport suppression"
+      );
+
+      desktopNotifications.reconcilePushSubscription.resolves(null);
+      await SubscribeUserNotificationsInit.prototype.reconcileTransports.call(
+        instance
+      );
+
+      assert.strictEqual(
+        keyValueStore.getItem("notifications-disabled"),
+        "enabled",
+        "a later failed recovery clears suppression left by older builds"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
+++ b/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
@@ -99,6 +99,26 @@ module(
       );
     });
 
+    test("assumes push delivers while reconciliation is still in flight", async function (assert) {
+      let finishReconciliation;
+      const instance = build(null);
+      instance.desktopNotifications.reconcilePushSubscription = () =>
+        new Promise((resolve) => (finishReconciliation = resolve));
+
+      const pending = reconcile(instance);
+
+      assert.strictEqual(
+        getPushTransport(),
+        "delivering",
+        "a notification arriving during the boot round trip would be shown twice"
+      );
+
+      finishReconciliation("subscribed");
+      await pending;
+
+      assert.strictEqual(getPushTransport(), "delivering");
+    });
+
     test("leaves the stored preference in charge when push was never wanted", async function (assert) {
       setPushTransport("delivering");
       const instance = build(null, { pushIntent: null });

--- a/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
+++ b/frontend/discourse/tests/unit/instance-initializers/subscribe-user-notifications-test.js
@@ -84,6 +84,18 @@ module(
       );
     });
 
+    test("avoids duplicate fallback for a previously confirmed endpoint", async function (assert) {
+      const instance = build("unconfirmed");
+
+      await reconcile(instance);
+
+      assert.strictEqual(
+        getPushTransport(),
+        "delivering",
+        "a transient resync failure does not duplicate a known working endpoint"
+      );
+    });
+
     test("a desktop alert retries push after reconciliation fails", async function (assert) {
       const clock = sinon.useFakeTimers();
       const instance = build(null);

--- a/frontend/discourse/tests/unit/lib/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/desktop-notifications-test.js
@@ -1,0 +1,51 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import {
+  canUserReceiveNotifications,
+  context,
+  init,
+  setPushTransport,
+} from "discourse/lib/desktop-notifications";
+import KeyValueStore from "discourse/lib/key-value-store";
+import { logIn } from "discourse/tests/helpers/qunit-helpers";
+
+module("Unit | Lib | desktop-notifications", function (hooks) {
+  setupTest(hooks);
+
+  const keyValueStore = new KeyValueStore(context);
+  const user = { isInDoNotDisturb: () => false };
+
+  hooks.beforeEach(function () {
+    logIn(this.owner);
+    sinon.stub(Notification, "permission").get(() => "granted");
+    init({ clientId: "test-client" });
+    // the test tab may be hidden; a focus event always marks it primary
+    window.dispatchEvent(new Event("focus"));
+  });
+
+  hooks.afterEach(function () {
+    keyValueStore.remove("notifications-disabled");
+    setPushTransport(null);
+  });
+
+  test("suppresses in-tab alerts while push is delivering", function (assert) {
+    assert.true(canUserReceiveNotifications(user));
+
+    setPushTransport("delivering");
+
+    assert.false(canUserReceiveNotifications(user));
+  });
+
+  test("the stored opt-out only rules while push is not standing in", function (assert) {
+    keyValueStore.setItem("notifications-disabled", "disabled");
+
+    assert.false(canUserReceiveNotifications(user));
+
+    // older builds force-wrote the opt-out on every boot while push was on,
+    // so it cannot silence the fallback for a broken push subscription
+    setPushTransport("fallback");
+
+    assert.true(canUserReceiveNotifications(user));
+  });
+});

--- a/frontend/discourse/tests/unit/lib/logout-test.js
+++ b/frontend/discourse/tests/unit/lib/logout-test.js
@@ -1,0 +1,23 @@
+import { module, test } from "qunit";
+import logout from "discourse/lib/logout";
+import { pushNotificationConfirmationStore } from "discourse/lib/push-notifications";
+
+module("Unit | Lib | logout", function (hooks) {
+  hooks.afterEach(function () {
+    pushNotificationConfirmationStore.remove("active");
+  });
+
+  test("clears the active push endpoint confirmation", function (assert) {
+    pushNotificationConfirmationStore.setObject({
+      key: "active",
+      value: { userId: 42, endpoint: "current" },
+    });
+
+    logout();
+
+    assert.strictEqual(
+      pushNotificationConfirmationStore.getObject("active"),
+      undefined
+    );
+  });
+});

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -114,6 +114,7 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove(userSubscriptionKey(user));
+      keyValueStore.remove(`confirmed-endpoint-${user.get("id")}`);
     });
 
     test("restores a subscription the platform dropped while permission is granted", async function (assert) {
@@ -275,16 +276,42 @@ module(
       );
       assert.strictEqual(
         pushManager.platformUnsubscribeCalls,
-        1,
-        "the unconfirmed endpoint is discarded so the next boot restores it again"
+        0,
+        "only one subscription exists per origin, so a restore this tab could not confirm must not destroy one another tab just did"
       );
-      assert.strictEqual(pushManager.subscription, null);
+    });
+
+    test("does not claim an endpoint the server never acknowledged is delivering", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "never-synced" }),
+      };
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        null,
+        "the row may never have been created, so the in-tab fallback has to stay alive rather than be silenced"
+      );
+      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
     });
 
     test("keeps an existing subscription when only the resync failed", async function (assert) {
       setSubscriptionIntent(user, "subscribed");
       sinon.stub(Notification, "permission").get(() => "granted");
       pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+
+      // a first boot in which the server acknowledged this endpoint
+      await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
       pretender.post("/push_notifications/subscribe", () => response(500, {}));
 
       const result = await reconcileSubscription(user, {
@@ -352,6 +379,37 @@ module(
       const result = await reconcileSubscription(user, { resubscribe: true });
 
       assert.strictEqual(result, null);
+      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
+    });
+
+    test("re-reads the intent recorded while it was awaiting the platform", async function (assert) {
+      let platformUnsubscribeCalls = 0;
+      const subscription = {
+        toJSON: () => ({ endpoint: "just-enabled" }),
+        unsubscribe: () => {
+          platformUnsubscribeCalls++;
+          return Promise.resolve(true);
+        },
+      };
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.getSubscription = () => {
+        // the consent banner's `enable()` completes while reconcile is parked
+        // on this await, so the intent it read on entry is already stale
+        setSubscriptionIntent(user, "subscribed");
+        return Promise.resolve(subscription);
+      };
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        platformUnsubscribeCalls,
+        0,
+        "a subscription the user just created must not be destroyed by a stale intent read"
+      );
+      assert.strictEqual(result, "subscribed");
       assert.strictEqual(getSubscriptionIntent(user), "subscribed");
     });
 
@@ -437,6 +495,7 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove(userSubscriptionKey(user));
+      keyValueStore.remove(`confirmed-endpoint-${user.get("id")}`);
     });
 
     test("retires the server subscription even when the platform already dropped it", async function (assert) {

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -1,12 +1,15 @@
-import { settled } from "@ember/test-helpers";
+import { settled, waitUntil } from "@ember/test-helpers";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import { helperContext } from "discourse/lib/helpers";
 import {
   getSubscriptionIntent,
   keyValueStore,
   reconcileSubscription,
   setSubscriptionIntent,
+  subscribe,
+  unsubscribe,
   userSubscriptionKey,
 } from "discourse/lib/push-notifications";
 import pretender, {
@@ -92,7 +95,14 @@ module(
         },
         subscribe() {
           this.subscribeCalls++;
-          this.subscription = { toJSON: () => ({ endpoint: "restored" }) };
+          this.subscription = {
+            toJSON: () => ({ endpoint: "restored" }),
+            unsubscribe: () => {
+              this.platformUnsubscribeCalls++;
+              this.subscription = null;
+              return Promise.resolve(true);
+            },
+          };
           return Promise.resolve(this.subscription);
         },
       };
@@ -169,7 +179,13 @@ module(
     });
 
     test("never adopts an existing subscription when the intent is unknown", async function (assert) {
-      pushManager.subscription = { toJSON: () => ({ endpoint: "other-user" }) };
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "other-user" }),
+        unsubscribe: () => {
+          pushManager.platformUnsubscribeCalls++;
+          return Promise.resolve(true);
+        },
+      };
       sinon.stub(Notification, "permission").get(() => "granted");
 
       const result = await reconcileSubscription(user, {
@@ -185,6 +201,11 @@ module(
       );
       await settled();
       assert.deepEqual(subscribeRequests, [], "nothing is sent to the server");
+      assert.strictEqual(
+        pushManager.platformUnsubscribeCalls,
+        1,
+        "an unverifiably owned subscription cannot leak the previous account's notifications"
+      );
     });
 
     test("does not resubscribe when push is not the preferred transport", async function (assert) {
@@ -252,6 +273,31 @@ module(
         "subscribed",
         "the intent survives for the next boot to retry"
       );
+      assert.strictEqual(
+        pushManager.platformUnsubscribeCalls,
+        1,
+        "the unconfirmed endpoint is discarded so the next boot restores it again"
+      );
+      assert.strictEqual(pushManager.subscription, null);
+    });
+
+    test("keeps an existing subscription when only the resync failed", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        "unconfirmed",
+        "the server was told about this endpoint when it was created, so a failed resync does not stop delivery"
+      );
+      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
     });
 
     test("treats a revoked permission grant as a loss even when the subscription survived", async function (assert) {
@@ -313,6 +359,10 @@ module(
       setSubscriptionIntent(user, "off");
       pushManager.subscription = {
         toJSON: () => ({ endpoint: "left-behind" }),
+        unsubscribe: () => {
+          pushManager.platformUnsubscribeCalls++;
+          return Promise.resolve(true);
+        },
       };
 
       const result = await reconcileSubscription(user, { resubscribe: true });
@@ -330,9 +380,133 @@ module(
       );
       assert.strictEqual(
         pushManager.platformUnsubscribeCalls,
-        0,
-        "the platform subscription is left alone, it may belong to another account"
+        1,
+        "the endpoint is invalidated so it cannot retain another account's delivery"
       );
+    });
+  }
+);
+
+module(
+  "Unit | Lib | push-notifications | subscribe and unsubscribe",
+  function (hooks) {
+    setupTest(hooks);
+
+    const user = { get: (key) => (key === "id" ? 42 : undefined) };
+    const applicationServerKey = "1|2|3";
+
+    let pushManager;
+    let subscribeRequests;
+    let unsubscribeRequests;
+    let platformUnsubscribeCalls;
+
+    hooks.beforeEach(function () {
+      subscribeRequests = [];
+      unsubscribeRequests = [];
+      platformUnsubscribeCalls = 0;
+
+      pretender.post("/push_notifications/subscribe", (request) => {
+        subscribeRequests.push(parsePostData(request.requestBody));
+        return response({ success: "OK" });
+      });
+      pretender.post("/push_notifications/unsubscribe", (request) => {
+        unsubscribeRequests.push(parsePostData(request.requestBody));
+        return response({ success: "OK" });
+      });
+
+      const subscription = {
+        toJSON: () => ({ endpoint: "current" }),
+        // the platform reports false once it has dropped the subscription
+        // itself, which is exactly when the server row is still there
+        unsubscribe: () => {
+          platformUnsubscribeCalls++;
+          return Promise.resolve(false);
+        },
+      };
+
+      pushManager = {
+        subscription,
+        getSubscription: () => Promise.resolve(pushManager.subscription),
+        subscribe: () => Promise.resolve(subscription),
+      };
+
+      sinon
+        .stub(navigator.serviceWorker, "ready")
+        .get(() => Promise.resolve({ pushManager }));
+    });
+
+    hooks.afterEach(function () {
+      keyValueStore.remove(userSubscriptionKey(user));
+    });
+
+    test("retires the server subscription even when the platform already dropped it", async function (assert) {
+      await unsubscribe(user, () => {});
+
+      assert.deepEqual(
+        unsubscribeRequests,
+        [{ subscription: { endpoint: "current" } }],
+        "delivery only stops once the server row is gone, so it is never conditional on the platform teardown"
+      );
+      assert.strictEqual(platformUnsubscribeCalls, 1);
+      assert.strictEqual(getSubscriptionIntent(user), "off");
+    });
+
+    test("records the opt-out when push is no longer supported", async function (assert) {
+      sinon.stub(helperContext().capabilities, "isAppWebview").value(true);
+
+      assert.true(await unsubscribe(user, () => assert.step("disabled")));
+
+      assert.strictEqual(getSubscriptionIntent(user), "off");
+      assert.verifySteps(["disabled"]);
+    });
+
+    test("does not finish disabling until platform teardown settles", async function (assert) {
+      let finishPlatformUnsubscribe;
+      pushManager.subscription.unsubscribe = () => {
+        platformUnsubscribeCalls++;
+        return new Promise((resolve) => {
+          finishPlatformUnsubscribe = resolve;
+        });
+      };
+
+      const disabling = unsubscribe(user, () => assert.step("disabled"));
+
+      await waitUntil(() => platformUnsubscribeCalls === 1);
+      assert.verifySteps(
+        [],
+        "the callback does not report disabled while platform teardown is pending"
+      );
+
+      finishPlatformUnsubscribe(true);
+      assert.true(await disabling);
+      assert.verifySteps(["disabled"]);
+    });
+
+    test("reports success once the server has the subscription", async function (assert) {
+      const subscribed = await subscribe(() => {}, applicationServerKey);
+
+      assert.true(subscribed);
+      assert.deepEqual(subscribeRequests, [
+        {
+          subscription: { endpoint: "current" },
+          send_confirmation: "true",
+        },
+      ]);
+    });
+
+    test("does not report success when the server never recorded the subscription", async function (assert) {
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      const subscribed = await subscribe(
+        () => assert.step("enabled"),
+        applicationServerKey
+      );
+
+      assert.false(
+        subscribed,
+        "a subscription the server does not know about receives nothing"
+      );
+      assert.verifySteps([], "the intent is never recorded as subscribed");
     });
   }
 );

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -3,9 +3,11 @@ import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import { helperContext } from "discourse/lib/helpers";
+import KeyValueStore from "discourse/lib/key-value-store";
 import {
   getSubscriptionIntent,
   keyValueStore,
+  pushNotificationPreferenceStore,
   reconcileSubscription,
   setSubscriptionIntent,
   subscribe,
@@ -24,6 +26,7 @@ module("Unit | Lib | push-notifications", function (hooks) {
 
   hooks.afterEach(function () {
     keyValueStore.remove(userSubscriptionKey(user));
+    pushNotificationPreferenceStore.remove(userSubscriptionKey(user));
   });
 
   test("getSubscriptionIntent returns the stored intent", function (assert) {
@@ -40,6 +43,19 @@ module("Unit | Lib | push-notifications", function (hooks) {
 
   test("getSubscriptionIntent maps the legacy explicit-disable value to off", function (assert) {
     keyValueStore.setItem(userSubscriptionKey(user), "false");
+    assert.strictEqual(getSubscriptionIntent(user), "off");
+    assert.strictEqual(
+      pushNotificationPreferenceStore.getItem(userSubscriptionKey(user)),
+      "off",
+      "the old opt-out is migrated to storage which survives logout"
+    );
+  });
+
+  test("an explicit opt-out survives logout storage cleanup", function (assert) {
+    setSubscriptionIntent(user, "off");
+
+    new KeyValueStore("discourse_").abandonLocal();
+
     assert.strictEqual(getSubscriptionIntent(user), "off");
   });
 
@@ -114,7 +130,7 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove(userSubscriptionKey(user));
-      keyValueStore.remove(`confirmed-endpoint-${user.get("id")}`);
+      pushNotificationPreferenceStore.remove(userSubscriptionKey(user));
     });
 
     test("restores a subscription the platform dropped while permission is granted", async function (assert) {
@@ -179,9 +195,9 @@ module(
       assert.strictEqual(getSubscriptionIntent(user), "off");
     });
 
-    test("never adopts an existing subscription when the intent is unknown", async function (assert) {
+    test("adopts an existing subscription when the intent is unknown", async function (assert) {
       pushManager.subscription = {
-        toJSON: () => ({ endpoint: "other-user" }),
+        toJSON: () => ({ endpoint: "existing" }),
         unsubscribe: () => {
           pushManager.platformUnsubscribeCalls++;
           return Promise.resolve(true);
@@ -194,19 +210,48 @@ module(
         applicationServerKey,
       });
 
-      assert.strictEqual(result, null);
+      assert.strictEqual(result, "subscribed");
       assert.strictEqual(
         getSubscriptionIntent(user),
-        null,
-        "a live subscription may belong to another user of the same browser"
+        "subscribed",
+        "the origin-level permission applies unless this user opted out"
       );
       await settled();
-      assert.deepEqual(subscribeRequests, [], "nothing is sent to the server");
+      assert.deepEqual(
+        subscribeRequests,
+        [
+          {
+            subscription: { endpoint: "existing" },
+            send_confirmation: "false",
+          },
+        ],
+        "the POST transfers the endpoint to the current account"
+      );
       assert.strictEqual(
         pushManager.platformUnsubscribeCalls,
-        1,
-        "an unverifiably owned subscription cannot leak the previous account's notifications"
+        0,
+        "adoption preserves the working platform subscription"
       );
+    });
+
+    test("creates a subscription by default when permission is already granted", async function (assert) {
+      sinon.stub(Notification, "permission").get(() => "granted");
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, "subscribed");
+      assert.strictEqual(
+        pushManager.subscribeCalls,
+        1,
+        "the origin-level notification grant opts the account into push"
+      );
+      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
+      assert.deepEqual(subscribeRequests, [
+        { subscription: { endpoint: "restored" }, send_confirmation: "false" },
+      ]);
     });
 
     test("does not resubscribe when push is not the preferred transport", async function (assert) {
@@ -281,12 +326,10 @@ module(
       );
     });
 
-    test("does not claim an endpoint the server never acknowledged is delivering", async function (assert) {
+    test("does not suppress fallback when an existing subscription cannot be confirmed", async function (assert) {
       setSubscriptionIntent(user, "subscribed");
       sinon.stub(Notification, "permission").get(() => "granted");
-      pushManager.subscription = {
-        toJSON: () => ({ endpoint: "never-synced" }),
-      };
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
       pretender.post("/push_notifications/subscribe", () => response(500, {}));
 
       const result = await reconcileSubscription(user, {
@@ -297,34 +340,13 @@ module(
       assert.strictEqual(
         result,
         null,
-        "the row may never have been created, so the in-tab fallback has to stay alive rather than be silenced"
+        "only a successful server response proves push can deliver"
       );
-      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
-    });
-
-    test("keeps an existing subscription when only the resync failed", async function (assert) {
-      setSubscriptionIntent(user, "subscribed");
-      sinon.stub(Notification, "permission").get(() => "granted");
-      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
-
-      // a first boot in which the server acknowledged this endpoint
-      await reconcileSubscription(user, {
-        resubscribe: true,
-        applicationServerKey,
-      });
-      pretender.post("/push_notifications/subscribe", () => response(500, {}));
-
-      const result = await reconcileSubscription(user, {
-        resubscribe: true,
-        applicationServerKey,
-      });
-
       assert.strictEqual(
-        result,
-        "unconfirmed",
-        "the server was told about this endpoint when it was created, so a failed resync does not stop delivery"
+        getSubscriptionIntent(user),
+        "subscribed",
+        "the preference survives so reconciliation can retry"
       );
-      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
     });
 
     test("treats a revoked permission grant as a loss even when the subscription survived", async function (assert) {
@@ -440,6 +462,61 @@ module(
       );
     });
 
+    test("retires a row a stale resync recreated after logout", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+      pretender.post("/push_notifications/subscribe", (request) => {
+        subscribeRequests.push(parsePostData(request.requestBody));
+        setSubscriptionIntent(user, null);
+        return response({ success: "OK" });
+      });
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        null,
+        "the logged-out account is not restored"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        null,
+        "the stale request does not recreate local state"
+      );
+      assert.deepEqual(
+        unsubscribeRequests,
+        [{ subscription: { endpoint: "existing" } }],
+        "the stale account's recreated row is retired"
+      );
+    });
+
+    test("retires an adoption that completes after logout", async function (assert) {
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+      pretender.post("/push_notifications/subscribe", (request) => {
+        subscribeRequests.push(parsePostData(request.requestBody));
+        setSubscriptionIntent(user, null);
+        return response({ success: "OK" });
+      });
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null, "the logged-out account is not adopted");
+      assert.strictEqual(getSubscriptionIntent(user), null);
+      assert.deepEqual(
+        unsubscribeRequests,
+        [{ subscription: { endpoint: "existing" } }],
+        "the stale account's row is retired"
+      );
+    });
+
     test("retries retiring the server subscription when the user turned push off", async function (assert) {
       setSubscriptionIntent(user, "off");
       pushManager.subscription = {
@@ -467,6 +544,44 @@ module(
         pushManager.platformUnsubscribeCalls,
         1,
         "the endpoint is invalidated so it cannot retain another account's delivery"
+      );
+    });
+
+    test("replays an enable that lands during opt-out cleanup", async function (assert) {
+      setSubscriptionIntent(user, "off");
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "re-enabled" }),
+        unsubscribe: () => {
+          pushManager.platformUnsubscribeCalls++;
+          return Promise.resolve(true);
+        },
+      };
+      pretender.post("/push_notifications/unsubscribe", (request) => {
+        unsubscribeRequests.push(parsePostData(request.requestBody));
+        setSubscriptionIntent(user, "subscribed");
+        return response({ success: "OK" });
+      });
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, "subscribed");
+      assert.strictEqual(
+        pushManager.platformUnsubscribeCalls,
+        0,
+        "the explicit enable keeps the platform subscription"
+      );
+      assert.deepEqual(
+        subscribeRequests,
+        [
+          {
+            subscription: { endpoint: "re-enabled" },
+            send_confirmation: "false",
+          },
+        ],
+        "the row is recreated after the stale teardown"
       );
     });
   }
@@ -522,7 +637,7 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove(userSubscriptionKey(user));
-      keyValueStore.remove(`confirmed-endpoint-${user.get("id")}`);
+      pushNotificationPreferenceStore.remove(userSubscriptionKey(user));
     });
 
     test("retires the server subscription even when the platform already dropped it", async function (assert) {

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -1,0 +1,338 @@
+import { settled } from "@ember/test-helpers";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import {
+  getSubscriptionIntent,
+  keyValueStore,
+  reconcileSubscription,
+  setSubscriptionIntent,
+  userSubscriptionKey,
+} from "discourse/lib/push-notifications";
+import pretender, {
+  parsePostData,
+  response,
+} from "discourse/tests/helpers/create-pretender";
+
+module("Unit | Lib | push-notifications", function (hooks) {
+  setupTest(hooks);
+
+  const user = { get: (key) => (key === "id" ? 42 : undefined) };
+
+  hooks.afterEach(function () {
+    keyValueStore.remove(userSubscriptionKey(user));
+  });
+
+  test("getSubscriptionIntent returns the stored intent", function (assert) {
+    setSubscriptionIntent(user, "subscribed");
+    assert.strictEqual(getSubscriptionIntent(user), "subscribed");
+
+    setSubscriptionIntent(user, "off");
+    assert.strictEqual(getSubscriptionIntent(user), "off");
+  });
+
+  test("getSubscriptionIntent returns null when nothing is stored", function (assert) {
+    assert.strictEqual(getSubscriptionIntent(user), null);
+  });
+
+  test("getSubscriptionIntent maps the legacy explicit-disable value to off", function (assert) {
+    keyValueStore.setItem(userSubscriptionKey(user), "false");
+    assert.strictEqual(getSubscriptionIntent(user), "off");
+  });
+
+  test("getSubscriptionIntent treats the legacy empty value as unknown", function (assert) {
+    keyValueStore.setItem(userSubscriptionKey(user), "");
+    assert.strictEqual(
+      getSubscriptionIntent(user),
+      null,
+      "older builds stamped an empty value for every unsubscribed user, so it carries no signal"
+    );
+  });
+
+  test("setSubscriptionIntent with null clears the stored value", function (assert) {
+    setSubscriptionIntent(user, "subscribed");
+    setSubscriptionIntent(user, null);
+    assert.strictEqual(
+      keyValueStore.getItem(userSubscriptionKey(user)),
+      undefined
+    );
+  });
+});
+
+module(
+  "Unit | Lib | push-notifications | reconcileSubscription",
+  function (hooks) {
+    setupTest(hooks);
+
+    const user = { get: (key) => (key === "id" ? 42 : undefined) };
+    const applicationServerKey = "1|2|3";
+
+    let pushManager;
+    let subscribeRequests;
+    let unsubscribeRequests;
+
+    hooks.beforeEach(function () {
+      subscribeRequests = [];
+      unsubscribeRequests = [];
+      pretender.post("/push_notifications/subscribe", (request) => {
+        subscribeRequests.push(parsePostData(request.requestBody));
+        return response({ success: "OK" });
+      });
+      pretender.post("/push_notifications/unsubscribe", (request) => {
+        unsubscribeRequests.push(parsePostData(request.requestBody));
+        return response({ success: "OK" });
+      });
+
+      pushManager = {
+        subscription: null,
+        subscribeCalls: 0,
+        platformUnsubscribeCalls: 0,
+        getSubscription() {
+          return Promise.resolve(this.subscription);
+        },
+        subscribe() {
+          this.subscribeCalls++;
+          this.subscription = { toJSON: () => ({ endpoint: "restored" }) };
+          return Promise.resolve(this.subscription);
+        },
+      };
+
+      sinon
+        .stub(navigator.serviceWorker, "ready")
+        .get(() => Promise.resolve({ pushManager }));
+    });
+
+    hooks.afterEach(function () {
+      keyValueStore.remove(userSubscriptionKey(user));
+    });
+
+    test("restores a subscription the platform dropped while permission is granted", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, "subscribed");
+      assert.strictEqual(pushManager.subscribeCalls, 1, "it resubscribes");
+      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
+
+      await settled();
+      assert.deepEqual(
+        subscribeRequests,
+        [
+          {
+            subscription: { endpoint: "restored" },
+            send_confirmation: "false",
+          },
+        ],
+        "the restored subscription is sent to the server without a confirmation push"
+      );
+    });
+
+    test("reports the subscription lost when permission is no longer granted", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "default");
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, "lost");
+      assert.strictEqual(
+        pushManager.subscribeCalls,
+        0,
+        "it cannot resubscribe"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        null,
+        "the stale intent is cleared so the consent prompt can return"
+      );
+    });
+
+    test("leaves an explicit opt-out alone", async function (assert) {
+      setSubscriptionIntent(user, "off");
+      sinon.stub(Notification, "permission").get(() => "granted");
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null);
+      assert.strictEqual(pushManager.subscribeCalls, 0);
+      assert.strictEqual(getSubscriptionIntent(user), "off");
+    });
+
+    test("never adopts an existing subscription when the intent is unknown", async function (assert) {
+      pushManager.subscription = { toJSON: () => ({ endpoint: "other-user" }) };
+      sinon.stub(Notification, "permission").get(() => "granted");
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null);
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        null,
+        "a live subscription may belong to another user of the same browser"
+      );
+      await settled();
+      assert.deepEqual(subscribeRequests, [], "nothing is sent to the server");
+    });
+
+    test("does not resubscribe when push is not the preferred transport", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: false,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        null,
+        "no restore is attempted, so none is claimed either way"
+      );
+      assert.strictEqual(pushManager.subscribeCalls, 0);
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        "subscribed",
+        "the intent survives"
+      );
+    });
+
+    test("resyncs the server when the device already has a subscription", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, "subscribed");
+      assert.strictEqual(
+        pushManager.subscribeCalls,
+        0,
+        "an existing subscription is not replaced"
+      );
+
+      await settled();
+      assert.deepEqual(subscribeRequests, [
+        { subscription: { endpoint: "existing" }, send_confirmation: "false" },
+      ]);
+    });
+
+    test("does not claim success when the server never received the subscription", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        null,
+        "a subscription the server does not know about cannot receive pushes, so the caller must not silence the fallback"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        "subscribed",
+        "the intent survives for the next boot to retry"
+      );
+    });
+
+    test("treats a revoked permission grant as a loss even when the subscription survived", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "default");
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "undisplayable" }),
+      };
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        "lost",
+        "a subscription the browser will not display is not a working one"
+      );
+      assert.strictEqual(getSubscriptionIntent(user), null);
+
+      await settled();
+      assert.deepEqual(
+        subscribeRequests,
+        [],
+        "nothing is resynced as subscribed"
+      );
+    });
+
+    test("keeps the intent when a restore fails for a transient reason", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscribe = () => Promise.reject(new Error("offline"));
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null, "nothing is concluded");
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        "subscribed",
+        "a network failure is not turned into an opt-out"
+      );
+    });
+
+    test("keeps the intent when the key needed to resubscribe is missing", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+
+      const result = await reconcileSubscription(user, { resubscribe: true });
+
+      assert.strictEqual(result, null);
+      assert.strictEqual(getSubscriptionIntent(user), "subscribed");
+    });
+
+    test("retries retiring the server subscription when the user turned push off", async function (assert) {
+      setSubscriptionIntent(user, "off");
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "left-behind" }),
+      };
+
+      const result = await reconcileSubscription(user, { resubscribe: true });
+
+      assert.strictEqual(result, null);
+      assert.deepEqual(
+        unsubscribeRequests,
+        [{ subscription: { endpoint: "left-behind" } }],
+        "a teardown that failed earlier is retried so delivery actually stops"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        "off",
+        "the opt-out is preserved"
+      );
+      assert.strictEqual(
+        pushManager.platformUnsubscribeCalls,
+        0,
+        "the platform subscription is left alone, it may belong to another account"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -413,6 +413,33 @@ module(
       assert.strictEqual(getSubscriptionIntent(user), "subscribed");
     });
 
+    test("retires a row the resync recreated after the user opted out", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+      pretender.post("/push_notifications/subscribe", (request) => {
+        subscribeRequests.push(parsePostData(request.requestBody));
+        // the user hits disable while the resync POST is in flight
+        setSubscriptionIntent(user, "off");
+        return response({ success: "OK" });
+      });
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null, "the opt-out stands");
+      assert.strictEqual(getSubscriptionIntent(user), "off");
+
+      await settled();
+      assert.deepEqual(
+        unsubscribeRequests,
+        [{ subscription: { endpoint: "existing" } }],
+        "the recreated row is retired; the platform subscription is already gone, so nothing else can reach it"
+      );
+    });
+
     test("retries retiring the server subscription when the user turned push off", async function (assert) {
       setSubscriptionIntent(user, "off");
       pushManager.subscription = {

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -7,6 +7,7 @@ import KeyValueStore from "discourse/lib/key-value-store";
 import {
   getSubscriptionIntent,
   keyValueStore,
+  pushNotificationConfirmationStore,
   pushNotificationPreferenceStore,
   reconcileSubscription,
   setSubscriptionIntent,
@@ -26,6 +27,8 @@ module("Unit | Lib | push-notifications", function (hooks) {
 
   hooks.afterEach(function () {
     keyValueStore.remove(userSubscriptionKey(user));
+    keyValueStore.remove("operation");
+    pushNotificationConfirmationStore.remove("active");
     pushNotificationPreferenceStore.remove(userSubscriptionKey(user));
   });
 
@@ -130,6 +133,8 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove(userSubscriptionKey(user));
+      keyValueStore.remove("operation");
+      pushNotificationConfirmationStore.remove("active");
       pushNotificationPreferenceStore.remove(userSubscriptionKey(user));
     });
 
@@ -151,6 +156,7 @@ module(
         subscribeRequests,
         [
           {
+            user_id: "42",
             subscription: { endpoint: "restored" },
             send_confirmation: "false",
           },
@@ -221,6 +227,7 @@ module(
         subscribeRequests,
         [
           {
+            user_id: "42",
             subscription: { endpoint: "existing" },
             send_confirmation: "false",
           },
@@ -250,7 +257,11 @@ module(
       );
       assert.strictEqual(getSubscriptionIntent(user), "subscribed");
       assert.deepEqual(subscribeRequests, [
-        { subscription: { endpoint: "restored" }, send_confirmation: "false" },
+        {
+          user_id: "42",
+          subscription: { endpoint: "restored" },
+          send_confirmation: "false",
+        },
       ]);
     });
 
@@ -295,7 +306,11 @@ module(
 
       await settled();
       assert.deepEqual(subscribeRequests, [
-        { subscription: { endpoint: "existing" }, send_confirmation: "false" },
+        {
+          user_id: "42",
+          subscription: { endpoint: "existing" },
+          send_confirmation: "false",
+        },
       ]);
     });
 
@@ -347,6 +362,56 @@ module(
         "subscribed",
         "the preference survives so reconciliation can retry"
       );
+    });
+
+    test("keeps using a server-confirmed endpoint during a later transient resync failure", async function (assert) {
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+
+      await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        "unconfirmed",
+        "a prior acknowledgement makes duplicate fallback less safe than retaining push"
+      );
+    });
+
+    test("does not trust another account's confirmed endpoint", async function (assert) {
+      const otherUser = { get: (key) => (key === "id" ? 43 : undefined) };
+      setSubscriptionIntent(user, "subscribed");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = { toJSON: () => ({ endpoint: "existing" }) };
+
+      await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      const result = await reconcileSubscription(otherUser, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(
+        result,
+        null,
+        "the new account keeps its fallback until its own transfer is acknowledged"
+      );
+      keyValueStore.remove(userSubscriptionKey(otherUser));
+      keyValueStore.remove("operation");
+      pushNotificationPreferenceStore.remove(userSubscriptionKey(otherUser));
     });
 
     test("treats a revoked permission grant as a loss even when the subscription survived", async function (assert) {
@@ -457,7 +522,7 @@ module(
       await settled();
       assert.deepEqual(
         unsubscribeRequests,
-        [{ subscription: { endpoint: "existing" } }],
+        [{ user_id: "42", subscription: { endpoint: "existing" } }],
         "the recreated row is retired; the platform subscription is already gone, so nothing else can reach it"
       );
     });
@@ -489,7 +554,7 @@ module(
       );
       assert.deepEqual(
         unsubscribeRequests,
-        [{ subscription: { endpoint: "existing" } }],
+        [{ user_id: "42", subscription: { endpoint: "existing" } }],
         "the stale account's recreated row is retired"
       );
     });
@@ -512,7 +577,7 @@ module(
       assert.strictEqual(getSubscriptionIntent(user), null);
       assert.deepEqual(
         unsubscribeRequests,
-        [{ subscription: { endpoint: "existing" } }],
+        [{ user_id: "42", subscription: { endpoint: "existing" } }],
         "the stale account's row is retired"
       );
     });
@@ -532,7 +597,7 @@ module(
       assert.strictEqual(result, null);
       assert.deepEqual(
         unsubscribeRequests,
-        [{ subscription: { endpoint: "left-behind" } }],
+        [{ user_id: "42", subscription: { endpoint: "left-behind" } }],
         "a teardown that failed earlier is retried so delivery actually stops"
       );
       assert.strictEqual(
@@ -577,12 +642,94 @@ module(
         subscribeRequests,
         [
           {
+            user_id: "42",
             subscription: { endpoint: "re-enabled" },
             send_confirmation: "false",
           },
         ],
         "the row is recreated after the stale teardown"
       );
+    });
+
+    test("does not let opt-out cleanup invalidate another account's later enable", async function (assert) {
+      const otherUser = { get: (key) => (key === "id" ? 43 : undefined) };
+      let enabling;
+      setSubscriptionIntent(user, "off");
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "transferred" }),
+        unsubscribe: () => {
+          pushManager.platformUnsubscribeCalls++;
+          return Promise.resolve(true);
+        },
+      };
+      pushManager.subscribe = () => Promise.resolve(pushManager.subscription);
+      pretender.post("/push_notifications/unsubscribe", (request) => {
+        unsubscribeRequests.push(parsePostData(request.requestBody));
+        enabling = subscribe(
+          otherUser,
+          () => setSubscriptionIntent(otherUser, "subscribed"),
+          applicationServerKey
+        );
+        return response({ success: "OK" });
+      });
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null);
+      assert.true(await enabling, "the later explicit enable succeeds");
+      assert.strictEqual(
+        pushManager.platformUnsubscribeCalls,
+        0,
+        "the stale cleanup leaves the transferred endpoint valid"
+      );
+      assert.strictEqual(getSubscriptionIntent(user), "off");
+      assert.strictEqual(getSubscriptionIntent(otherUser), "subscribed");
+
+      keyValueStore.remove(userSubscriptionKey(otherUser));
+      pushNotificationPreferenceStore.remove(userSubscriptionKey(otherUser));
+    });
+
+    test("does not let opt-out cleanup invalidate another account's automatic adoption", async function (assert) {
+      const otherUser = { get: (key) => (key === "id" ? 43 : undefined) };
+      let adoption;
+      setSubscriptionIntent(user, "off");
+      sinon.stub(Notification, "permission").get(() => "granted");
+      pushManager.subscription = {
+        toJSON: () => ({ endpoint: "adopted" }),
+        unsubscribe: () => {
+          pushManager.platformUnsubscribeCalls++;
+          return Promise.resolve(true);
+        },
+      };
+      pretender.post("/push_notifications/unsubscribe", (request) => {
+        unsubscribeRequests.push(parsePostData(request.requestBody));
+        adoption = reconcileSubscription(otherUser, {
+          resubscribe: true,
+          applicationServerKey,
+        });
+        return response({ success: "OK" });
+      });
+
+      const result = await reconcileSubscription(user, {
+        resubscribe: true,
+        applicationServerKey,
+      });
+
+      assert.strictEqual(result, null);
+      assert.strictEqual(await adoption, "subscribed");
+      assert.strictEqual(
+        pushManager.platformUnsubscribeCalls,
+        0,
+        "the stale cleanup leaves the automatically adopted endpoint valid"
+      );
+      assert.strictEqual(getSubscriptionIntent(user), "off");
+      assert.strictEqual(getSubscriptionIntent(otherUser), "subscribed");
+
+      keyValueStore.remove(userSubscriptionKey(otherUser));
+      pushNotificationPreferenceStore.remove(userSubscriptionKey(otherUser));
     });
   }
 );
@@ -637,6 +784,8 @@ module(
 
     hooks.afterEach(function () {
       keyValueStore.remove(userSubscriptionKey(user));
+      keyValueStore.remove("operation");
+      pushNotificationConfirmationStore.remove("active");
       pushNotificationPreferenceStore.remove(userSubscriptionKey(user));
     });
 
@@ -645,7 +794,7 @@ module(
 
       assert.deepEqual(
         unsubscribeRequests,
-        [{ subscription: { endpoint: "current" } }],
+        [{ user_id: "42", subscription: { endpoint: "current" } }],
         "delivery only stops once the server row is gone, so it is never conditional on the platform teardown"
       );
       assert.strictEqual(platformUnsubscribeCalls, 1);
@@ -683,12 +832,88 @@ module(
       assert.verifySteps(["disabled"]);
     });
 
+    test("does not report disabled while the server row still exists", async function (assert) {
+      pretender.post("/push_notifications/unsubscribe", () =>
+        response(500, {})
+      );
+
+      const disabled = await unsubscribe(user, () => assert.step("disabled"));
+
+      assert.false(disabled, "the caller can surface or retry the failure");
+      assert.strictEqual(
+        platformUnsubscribeCalls,
+        0,
+        "the endpoint remains available for a later server cleanup attempt"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        "off",
+        "the explicit preference is retained for boot reconciliation"
+      );
+      assert.verifySteps([], "the success callback is not invoked");
+    });
+
+    test("does not report disabled when the platform subscription cannot be read", async function (assert) {
+      sinon.stub(console, "error");
+      pushManager.getSubscription = () =>
+        Promise.reject(new Error("subscription lookup failed"));
+
+      const disabled = await unsubscribe(user, () => assert.step("disabled"));
+
+      assert.false(disabled);
+      assert.deepEqual(unsubscribeRequests, []);
+      assert.verifySteps([], "the success callback is not invoked");
+    });
+
+    test("a later enable prevents an in-flight disable from invalidating its endpoint", async function (assert) {
+      const otherUser = { get: (key) => (key === "id" ? 43 : undefined) };
+      let enabling;
+      setSubscriptionIntent(user, "subscribed");
+      pretender.post("/push_notifications/unsubscribe", (request) => {
+        unsubscribeRequests.push(parsePostData(request.requestBody));
+        enabling = subscribe(
+          otherUser,
+          () => {
+            setSubscriptionIntent(otherUser, "subscribed");
+            assert.step("enabled");
+          },
+          applicationServerKey
+        );
+        return response({ success: "OK" });
+      });
+
+      const disabled = await unsubscribe(user, () => assert.step("disabled"));
+      const enabled = await enabling;
+
+      assert.false(disabled, "the superseded disable does not report success");
+      assert.true(enabled, "the later enable owns the final state");
+      assert.strictEqual(
+        platformUnsubscribeCalls,
+        0,
+        "the stale disable leaves the newly registered endpoint valid"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(otherUser),
+        "subscribed",
+        "the other account owns the origin-level endpoint"
+      );
+      assert.strictEqual(
+        getSubscriptionIntent(user),
+        "off",
+        "the original account keeps its per-account opt-out"
+      );
+      assert.verifySteps(["enabled"]);
+      keyValueStore.remove(userSubscriptionKey(otherUser));
+      pushNotificationPreferenceStore.remove(userSubscriptionKey(otherUser));
+    });
+
     test("reports success once the server has the subscription", async function (assert) {
-      const subscribed = await subscribe(() => {}, applicationServerKey);
+      const subscribed = await subscribe(user, () => {}, applicationServerKey);
 
       assert.true(subscribed);
       assert.deepEqual(subscribeRequests, [
         {
+          user_id: "42",
           subscription: { endpoint: "current" },
           send_confirmation: "true",
         },
@@ -699,6 +924,7 @@ module(
       pretender.post("/push_notifications/subscribe", () => response(500, {}));
 
       const subscribed = await subscribe(
+        user,
         () => assert.step("enabled"),
         applicationServerKey
       );
@@ -708,6 +934,22 @@ module(
         "a subscription the server does not know about receives nothing"
       );
       assert.verifySteps([], "the intent is never recorded as subscribed");
+    });
+
+    test("an explicit enable invalidates another account's endpoint confirmation", async function (assert) {
+      const otherUser = { get: (key) => (key === "id" ? 43 : undefined) };
+      pushNotificationConfirmationStore.setObject({
+        key: "active",
+        value: { userId: 42, endpoint: "current" },
+      });
+      pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+      assert.false(await subscribe(otherUser, null, applicationServerKey));
+      assert.strictEqual(
+        pushNotificationConfirmationStore.getObject("active"),
+        undefined,
+        "a transfer attempt makes the old ownership assertion unsafe"
+      );
     });
   }
 );

--- a/frontend/discourse/tests/unit/routes/application-test.js
+++ b/frontend/discourse/tests/unit/routes/application-test.js
@@ -1,0 +1,45 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { pushNotificationConfirmationStore } from "discourse/lib/push-notifications";
+
+module("Unit | Route | application", function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    pushNotificationConfirmationStore.remove("active");
+  });
+
+  test("logout clears the server confirmation for the current account", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const currentUser = store.createRecord("user", {
+      id: 42,
+      username: "current-user",
+    });
+    sinon.stub(currentUser, "destroySession").resolves({ redirect_url: "/" });
+    this.owner.unregister("service:current-user");
+    this.owner.register("service:current-user", currentUser, {
+      instantiate: false,
+    });
+    sinon.stub(navigator.serviceWorker, "getRegistration").resolves({
+      pushManager: {
+        getSubscription: () =>
+          Promise.resolve({
+            toJSON: () => ({ endpoint: "current" }),
+          }),
+      },
+    });
+    pushNotificationConfirmationStore.setObject({
+      key: "active",
+      value: { userId: 42, endpoint: "current" },
+    });
+
+    await this.owner.lookup("route:application").logout();
+
+    assert.strictEqual(
+      pushNotificationConfirmationStore.getObject("active"),
+      undefined,
+      "a later login cannot trust a row the logout request retired"
+    );
+  });
+});

--- a/frontend/discourse/tests/unit/services/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/services/desktop-notifications-test.js
@@ -15,8 +15,13 @@ module("Unit | Service | desktop-notifications", function (hooks) {
     ).enable_desktop_push_notifications = true;
   });
 
-  hooks.afterEach(function () {
+  hooks.afterEach(async function () {
     this.service.rearmConsentPrompt();
+
+    const { keyValueStore } = await import("discourse/lib/push-notifications");
+    keyValueStore.remove(
+      `confirmed-endpoint-${this.owner.lookup("service:current-user").id}`
+    );
   });
 
   function unusablePushManager() {
@@ -79,12 +84,16 @@ module("Unit | Service | desktop-notifications", function (hooks) {
       "the service stops reporting push as enabled"
     );
     assert.false(
+      this.service.pushSubscriptionConfirmed,
+      "a loss is conclusive, unlike a transient failure"
+    );
+    assert.false(
       this.service.consentPromptDismissed,
       "the consent prompt is re-armed so the user can opt back in"
     );
   });
 
-  test("stops reporting push as enabled when a restore could not be confirmed", async function (assert) {
+  test("keeps reporting push as enabled when reconciliation concluded nothing", async function (assert) {
     const { setSubscriptionIntent } =
       await import("discourse/lib/push-notifications");
     setSubscriptionIntent(
@@ -92,11 +101,6 @@ module("Unit | Service | desktop-notifications", function (hooks) {
       "subscribed"
     );
     this.service.pushIntent = "subscribed";
-
-    assert.true(
-      this.service.isEnabledPush,
-      "before reconciling, intent stands"
-    );
 
     sinon.stub(Notification, "permission").get(() => "granted");
     sinon
@@ -111,11 +115,11 @@ module("Unit | Service | desktop-notifications", function (hooks) {
       "subscribed",
       "the intent is kept so the next boot retries"
     );
-    assert.false(
+    assert.true(
       this.service.isEnabledPush,
-      "but the UI must not claim push is working"
+      "the stored intent stays the best evidence, so one failed boot must not flip the toggle off"
     );
-    assert.false(this.service.isSubscribed);
+    assert.true(this.service.isSubscribed);
   });
 
   test("keeps push enabled when only the boot resync failed", async function (assert) {
@@ -136,6 +140,12 @@ module("Unit | Service | desktop-notifications", function (hooks) {
         },
       })
     );
+    // a first boot in which the server acknowledged this endpoint
+    pretender.post("/push_notifications/subscribe", () =>
+      response({ success: "OK" })
+    );
+    await this.service.reconcilePushSubscription();
+
     pretender.post("/push_notifications/subscribe", () => response(500, {}));
 
     const result = await this.service.reconcilePushSubscription();

--- a/frontend/discourse/tests/unit/services/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/services/desktop-notifications-test.js
@@ -7,6 +7,7 @@ import {
 } from "discourse/lib/desktop-notifications";
 import {
   keyValueStore as pushNotificationKeyValueStore,
+  pushNotificationConfirmationStore,
   pushNotificationPreferenceStore,
   userSubscriptionKey,
 } from "discourse/lib/push-notifications";
@@ -25,13 +26,12 @@ module("Unit | Service | desktop-notifications", function (hooks) {
   });
 
   hooks.afterEach(function () {
+    const currentUser = this.owner.lookup("service:current-user");
     this.service.rearmConsentPrompt();
-    pushNotificationKeyValueStore.remove(
-      userSubscriptionKey(this.owner.lookup("service:current-user"))
-    );
-    pushNotificationPreferenceStore.remove(
-      userSubscriptionKey(this.owner.lookup("service:current-user"))
-    );
+    pushNotificationKeyValueStore.remove(userSubscriptionKey(currentUser));
+    pushNotificationKeyValueStore.remove("operation");
+    pushNotificationConfirmationStore.remove("active");
+    pushNotificationPreferenceStore.remove(userSubscriptionKey(currentUser));
     setPushTransport(null);
   });
 
@@ -161,7 +161,7 @@ module("Unit | Service | desktop-notifications", function (hooks) {
 
     const result = await this.service.reconcilePushSubscription();
 
-    assert.strictEqual(result, null);
+    assert.strictEqual(result, "unconfirmed");
     assert.strictEqual(
       this.service.pushIntent,
       "subscribed",

--- a/frontend/discourse/tests/unit/services/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/services/desktop-notifications-test.js
@@ -140,7 +140,6 @@ module("Unit | Service | desktop-notifications", function (hooks) {
         },
       })
     );
-    // a first boot in which the server acknowledged this endpoint
     pretender.post("/push_notifications/subscribe", () =>
       response({ success: "OK" })
     );

--- a/frontend/discourse/tests/unit/services/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/services/desktop-notifications-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
 
 module("Unit | Service | desktop-notifications", function (hooks) {
@@ -115,6 +116,73 @@ module("Unit | Service | desktop-notifications", function (hooks) {
       "but the UI must not claim push is working"
     );
     assert.false(this.service.isSubscribed);
+  });
+
+  test("keeps push enabled when only the boot resync failed", async function (assert) {
+    const { setSubscriptionIntent } =
+      await import("discourse/lib/push-notifications");
+    setSubscriptionIntent(
+      this.owner.lookup("service:current-user"),
+      "subscribed"
+    );
+    this.service.pushIntent = "subscribed";
+
+    sinon.stub(Notification, "permission").get(() => "granted");
+    sinon.stub(navigator.serviceWorker, "ready").get(() =>
+      Promise.resolve({
+        pushManager: {
+          getSubscription: () =>
+            Promise.resolve({ toJSON: () => ({ endpoint: "existing" }) }),
+        },
+      })
+    );
+    pretender.post("/push_notifications/subscribe", () => response(500, {}));
+
+    const result = await this.service.reconcilePushSubscription();
+
+    assert.strictEqual(result, "unconfirmed");
+    assert.true(
+      this.service.isEnabledPush,
+      "one unreachable request must not report a working subscription as off"
+    );
+    assert.true(this.service.isSubscribed);
+  });
+
+  test("migrates a legacy consent prompt dismissal to the current user", async function (assert) {
+    const { keyValueStore } = await import("discourse/lib/push-notifications");
+    const currentUser = this.owner.lookup("service:current-user");
+    // older builds stored the stringified boolean under one key per browser
+    keyValueStore.setItem("dismissed-prompt", "false");
+
+    const serviceFactory = this.owner.factoryFor(
+      "service:desktop-notifications"
+    );
+    const service = serviceFactory.create();
+
+    assert.true(
+      service.consentPromptDismissed,
+      "a prompt the user already refused does not come back on upgrade"
+    );
+    assert.strictEqual(
+      keyValueStore.getItem("dismissed-prompt"),
+      undefined,
+      "the browser-wide key is consumed so it cannot affect another account"
+    );
+    assert.strictEqual(
+      keyValueStore.getItem(`dismissed-prompt-${currentUser.id}`),
+      "dismissed",
+      "the dismissal is retained for the account that inherited it"
+    );
+
+    const originalUserId = currentUser.id;
+    currentUser.set("id", originalUserId + 1);
+    const otherUserService = serviceFactory.create();
+    currentUser.set("id", originalUserId);
+
+    assert.false(
+      otherUserService.consentPromptDismissed,
+      "the legacy dismissal does not suppress the prompt for another account"
+    );
   });
 
   test("push can still be switched off after an unconfirmed restore", async function (assert) {

--- a/frontend/discourse/tests/unit/services/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/services/desktop-notifications-test.js
@@ -1,6 +1,15 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import {
+  getPushTransport,
+  setPushTransport,
+} from "discourse/lib/desktop-notifications";
+import {
+  keyValueStore as pushNotificationKeyValueStore,
+  pushNotificationPreferenceStore,
+  userSubscriptionKey,
+} from "discourse/lib/push-notifications";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
 
@@ -15,13 +24,15 @@ module("Unit | Service | desktop-notifications", function (hooks) {
     ).enable_desktop_push_notifications = true;
   });
 
-  hooks.afterEach(async function () {
+  hooks.afterEach(function () {
     this.service.rearmConsentPrompt();
-
-    const { keyValueStore } = await import("discourse/lib/push-notifications");
-    keyValueStore.remove(
-      `confirmed-endpoint-${this.owner.lookup("service:current-user").id}`
+    pushNotificationKeyValueStore.remove(
+      userSubscriptionKey(this.owner.lookup("service:current-user"))
     );
+    pushNotificationPreferenceStore.remove(
+      userSubscriptionKey(this.owner.lookup("service:current-user"))
+    );
+    setPushTransport(null);
   });
 
   function unusablePushManager() {
@@ -93,7 +104,7 @@ module("Unit | Service | desktop-notifications", function (hooks) {
     );
   });
 
-  test("keeps reporting push as enabled when reconciliation concluded nothing", async function (assert) {
+  test("surfaces attention when reconciliation concludes nothing", async function (assert) {
     const { setSubscriptionIntent } =
       await import("discourse/lib/push-notifications");
     setSubscriptionIntent(
@@ -115,14 +126,15 @@ module("Unit | Service | desktop-notifications", function (hooks) {
       "subscribed",
       "the intent is kept so the next boot retries"
     );
-    assert.true(
+    assert.false(
       this.service.isEnabledPush,
-      "the stored intent stays the best evidence, so one failed boot must not flip the toggle off"
+      "an unverified restore is not reported as working"
     );
-    assert.true(this.service.isSubscribed);
+    assert.false(this.service.isSubscribed);
+    assert.true(this.service.pushNeedsAttention, "the banner can offer repair");
   });
 
-  test("keeps push enabled when only the boot resync failed", async function (assert) {
+  test("keeps the preference when the boot resync fails", async function (assert) {
     const { setSubscriptionIntent } =
       await import("discourse/lib/push-notifications");
     setSubscriptionIntent(
@@ -149,12 +161,21 @@ module("Unit | Service | desktop-notifications", function (hooks) {
 
     const result = await this.service.reconcilePushSubscription();
 
-    assert.strictEqual(result, "unconfirmed");
-    assert.true(
-      this.service.isEnabledPush,
-      "one unreachable request must not report a working subscription as off"
+    assert.strictEqual(result, null);
+    assert.strictEqual(
+      this.service.pushIntent,
+      "subscribed",
+      "the preference survives for the retry"
     );
-    assert.true(this.service.isSubscribed);
+    assert.false(
+      this.service.isEnabledPush,
+      "push is not reported as verified"
+    );
+    assert.true(this.service.pushNeedsAttention, "the banner can offer repair");
+    assert.false(
+      this.service.isSubscribed,
+      "the toggle surfaces the unverified state"
+    );
   });
 
   test("migrates a legacy consent prompt dismissal to the current user", async function (assert) {
@@ -194,13 +215,14 @@ module("Unit | Service | desktop-notifications", function (hooks) {
     );
   });
 
-  test("push can still be switched off after an unconfirmed restore", async function (assert) {
+  test("push can still be switched off after a failed restore", async function (assert) {
     const { getSubscriptionIntent, setSubscriptionIntent } =
       await import("discourse/lib/push-notifications");
     const user = this.owner.lookup("service:current-user");
     setSubscriptionIntent(user, "subscribed");
     this.service.pushIntent = "subscribed";
     this.service.pushSubscriptionConfirmed = false;
+    setPushTransport("delivering");
 
     sinon
       .stub(navigator.serviceWorker, "ready")
@@ -211,9 +233,65 @@ module("Unit | Service | desktop-notifications", function (hooks) {
     assert.strictEqual(
       getSubscriptionIntent(user),
       "off",
-      "turning it off follows the stored intent, not the unconfirmed state"
+      "turning it off follows the stored intent after a transient failure"
     );
     assert.false(this.service.isEnabledPush);
+    assert.strictEqual(
+      getPushTransport(),
+      null,
+      "the explicit opt-out immediately owns transport arbitration"
+    );
+  });
+
+  test("adoption updates the service state", async function (assert) {
+    const subscription = {
+      toJSON: () => ({ endpoint: "adopted" }),
+    };
+    sinon.stub(Notification, "permission").get(() => "granted");
+    sinon.stub(navigator.serviceWorker, "ready").get(() =>
+      Promise.resolve({
+        pushManager: {
+          getSubscription: () => Promise.resolve(subscription),
+        },
+      })
+    );
+    pretender.post("/push_notifications/subscribe", () =>
+      response({ success: "OK" })
+    );
+
+    const result = await this.service.reconcilePushSubscription();
+
+    assert.strictEqual(result, "subscribed");
+    assert.strictEqual(
+      this.service.pushIntent,
+      "subscribed",
+      "the tracked state follows the adopted stored intent"
+    );
+    assert.true(this.service.isEnabledPush, "the toggle reports push enabled");
+  });
+
+  test("a successful enable marks push as delivering", async function (assert) {
+    const subscription = {
+      toJSON: () => ({ endpoint: "enabled" }),
+    };
+    sinon.stub(Notification, "permission").get(() => "granted");
+    sinon.stub(navigator.serviceWorker, "ready").get(() =>
+      Promise.resolve({
+        pushManager: {
+          subscribe: () => Promise.resolve(subscription),
+        },
+      })
+    );
+    pretender.post("/push_notifications/subscribe", () =>
+      response({ success: "OK" })
+    );
+
+    assert.true(await this.service.enable(), "push is enabled");
+    assert.strictEqual(
+      getPushTransport(),
+      "delivering",
+      "in-tab alerts are suppressed without waiting for a reload"
+    );
   });
 
   test("the consent prompt dismissal is recorded against the current user", async function (assert) {
@@ -280,6 +358,10 @@ module("Unit | Service | desktop-notifications", function (hooks) {
     assert.false(
       this.service.isSubscribed,
       "isSubscribed agrees with the reported failure"
+    );
+    assert.true(
+      this.service.pushNeedsAttention,
+      "the repair banner remains visible after the failed enable"
     );
   });
 });

--- a/frontend/discourse/tests/unit/services/desktop-notifications-test.js
+++ b/frontend/discourse/tests/unit/services/desktop-notifications-test.js
@@ -1,0 +1,208 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { logIn } from "discourse/tests/helpers/qunit-helpers";
+
+module("Unit | Service | desktop-notifications", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    logIn(this.owner);
+    this.service = this.owner.lookup("service:desktop-notifications");
+    this.owner.lookup(
+      "service:site-settings"
+    ).enable_desktop_push_notifications = true;
+  });
+
+  hooks.afterEach(function () {
+    this.service.rearmConsentPrompt();
+  });
+
+  function unusablePushManager() {
+    return {
+      getSubscription: () => Promise.resolve(null),
+      subscribe: () => Promise.reject(new Error("no push service")),
+    };
+  }
+
+  function stubUnusablePushService() {
+    sinon
+      .stub(navigator.serviceWorker, "ready")
+      .get(() => Promise.resolve({ pushManager: unusablePushManager() }));
+  }
+
+  test("asks for permission before touching the service worker", async function (assert) {
+    // the request has to happen inside the click's user activation; awaiting the
+    // service worker first expires it and the prompt is refused
+    sinon.stub(Notification, "permission").get(() => "default");
+    let readyAwaited = false;
+    sinon.stub(navigator.serviceWorker, "ready").get(() => {
+      readyAwaited = true;
+      return Promise.resolve({ pushManager: unusablePushManager() });
+    });
+    const requested = sinon
+      .stub(Notification, "requestPermission")
+      .callsFake((callback) => Promise.resolve(callback?.("denied")));
+
+    const enabled = await this.service.enable();
+
+    assert.false(enabled);
+    assert.true(requested.called, "permission is requested");
+    assert.false(
+      readyAwaited,
+      "it gives up before awaiting the service worker, so the gesture is never spent"
+    );
+  });
+
+  test("clears the intent and re-arms the consent prompt when the subscription is lost", async function (assert) {
+    const { setSubscriptionIntent } =
+      await import("discourse/lib/push-notifications");
+    setSubscriptionIntent(
+      this.owner.lookup("service:current-user"),
+      "subscribed"
+    );
+    this.service.pushIntent = "subscribed";
+    this.service.dismissConsentPrompt();
+
+    sinon.stub(Notification, "permission").get(() => "default");
+    sinon
+      .stub(navigator.serviceWorker, "ready")
+      .get(() => Promise.resolve({ pushManager: unusablePushManager() }));
+
+    const result = await this.service.reconcilePushSubscription();
+
+    assert.strictEqual(result, "lost");
+    assert.strictEqual(
+      this.service.pushIntent,
+      null,
+      "the service stops reporting push as enabled"
+    );
+    assert.false(
+      this.service.consentPromptDismissed,
+      "the consent prompt is re-armed so the user can opt back in"
+    );
+  });
+
+  test("stops reporting push as enabled when a restore could not be confirmed", async function (assert) {
+    const { setSubscriptionIntent } =
+      await import("discourse/lib/push-notifications");
+    setSubscriptionIntent(
+      this.owner.lookup("service:current-user"),
+      "subscribed"
+    );
+    this.service.pushIntent = "subscribed";
+
+    assert.true(
+      this.service.isEnabledPush,
+      "before reconciling, intent stands"
+    );
+
+    sinon.stub(Notification, "permission").get(() => "granted");
+    sinon
+      .stub(navigator.serviceWorker, "ready")
+      .get(() => Promise.resolve({ pushManager: unusablePushManager() }));
+
+    const result = await this.service.reconcilePushSubscription();
+
+    assert.strictEqual(result, null, "the failure is transient");
+    assert.strictEqual(
+      this.service.pushIntent,
+      "subscribed",
+      "the intent is kept so the next boot retries"
+    );
+    assert.false(
+      this.service.isEnabledPush,
+      "but the UI must not claim push is working"
+    );
+    assert.false(this.service.isSubscribed);
+  });
+
+  test("push can still be switched off after an unconfirmed restore", async function (assert) {
+    const { getSubscriptionIntent, setSubscriptionIntent } =
+      await import("discourse/lib/push-notifications");
+    const user = this.owner.lookup("service:current-user");
+    setSubscriptionIntent(user, "subscribed");
+    this.service.pushIntent = "subscribed";
+    this.service.pushSubscriptionConfirmed = false;
+
+    sinon
+      .stub(navigator.serviceWorker, "ready")
+      .get(() => Promise.resolve({ pushManager: unusablePushManager() }));
+
+    await this.service.disable();
+
+    assert.strictEqual(
+      getSubscriptionIntent(user),
+      "off",
+      "turning it off follows the stored intent, not the unconfirmed state"
+    );
+    assert.false(this.service.isEnabledPush);
+  });
+
+  test("the consent prompt dismissal is recorded against the current user", async function (assert) {
+    const { keyValueStore } = await import("discourse/lib/push-notifications");
+    const userId = this.owner.lookup("service:current-user").id;
+
+    this.service.dismissConsentPrompt();
+
+    assert.true(this.service.consentPromptDismissed);
+    assert.strictEqual(
+      keyValueStore.getItem(`dismissed-prompt-${userId}`),
+      "dismissed",
+      "the dismissal is stored under this user's key, not a shared one"
+    );
+
+    this.service.rearmConsentPrompt();
+
+    assert.false(this.service.consentPromptDismissed);
+    assert.strictEqual(
+      keyValueStore.getItem(`dismissed-prompt-${userId}`),
+      undefined
+    );
+  });
+
+  test("does not enable anything when permission is refused", async function (assert) {
+    sinon.stub(Notification, "permission").get(() => "default");
+    sinon
+      .stub(Notification, "requestPermission")
+      .callsFake((callback) => Promise.resolve(callback?.("denied")));
+
+    const enabled = await this.service.enable();
+
+    assert.false(enabled);
+    assert.false(this.service.isEnabledBrowser);
+    assert.false(this.service.isEnabledPush);
+  });
+
+  test("a rejected permission request resolves instead of hanging", async function (assert) {
+    // the request is only made when permission is still undecided
+    sinon.stub(Notification, "permission").get(() => "default");
+    sinon
+      .stub(Notification, "requestPermission")
+      .callsFake(() => Promise.reject(new Error("NotAllowedError")));
+
+    const enabled = await this.service.enable();
+
+    assert.false(enabled, "enable() settles rather than blocking the caller");
+  });
+
+  test("reports failure without silently switching transport when push cannot subscribe", async function (assert) {
+    stubUnusablePushService();
+    sinon.stub(Notification, "permission").get(() => "granted");
+
+    assert.true(this.service.isPushNotificationsPreferred);
+
+    const enabled = await this.service.enable();
+
+    assert.false(enabled, "the failure is reported to the caller");
+    assert.false(
+      this.service.isEnabledBrowser,
+      "it does not quietly enable a transport the UI is not describing"
+    );
+    assert.false(this.service.isEnabledPush);
+    assert.false(
+      this.service.isSubscribed,
+      "isSubscribed agrees with the reported failure"
+    );
+  });
+});

--- a/spec/requests/push_notification_controller_spec.rb
+++ b/spec/requests/push_notification_controller_spec.rb
@@ -43,6 +43,48 @@ RSpec.describe PushNotificationController do
       expect(user.push_subscriptions.count).to eq(1)
     end
 
+    it "rejects a subscription request started by another account" do
+      post "/push_notifications/subscribe.json",
+           params: {
+             user_id: Fabricate(:user).id,
+             subscription: {
+               endpoint: "stale-account-endpoint",
+               keys: {
+                 p256dh: "256dh",
+                 auth: "auth",
+               },
+             },
+             send_confirmation: false,
+           }
+
+      expect(response.status).to eq(409)
+      expect(user.push_subscriptions).to be_empty
+    end
+
+    it "returns a conflict when the session expires during registration" do
+      invalidate_session = ->(subscription) do
+        user.user_auth_tokens.destroy_all if subscription.user_id == user.id
+      end
+      PushSubscription.set_callback(:create, :after, invalidate_session)
+
+      post "/push_notifications/subscribe.json",
+           params: {
+             subscription: {
+               endpoint: "stale-endpoint",
+               keys: {
+                 p256dh: "256dh",
+                 auth: "auth",
+               },
+             },
+             send_confirmation: false,
+           }
+
+      expect(response.status).to eq(409)
+      expect(user.push_subscriptions).to be_empty
+    ensure
+      PushSubscription.skip_callback(:create, :after, invalidate_session) if invalidate_session
+    end
+
     it "should fix duplicate subscriptions" do
       subscription = { endpoint: "endpoint", keys: { p256dh: "256dh", auth: "auth" } }
       PushSubscription.create user: user, data: subscription.to_json
@@ -89,6 +131,20 @@ RSpec.describe PushNotificationController do
 
       expect(response.status).to eq(200)
       expect(user.push_subscriptions).to eq([])
+    end
+
+    it "rejects an unsubscribe request started by another account" do
+      sub = { endpoint: "endpoint", keys: { p256dh: "256dh", auth: "auth" } }
+      PushSubscription.create!(user: user, data: sub.to_json)
+
+      post "/push_notifications/unsubscribe.json",
+           params: {
+             user_id: Fabricate(:user).id,
+             subscription: sub,
+           }
+
+      expect(response.status).to eq(409)
+      expect(user.push_subscriptions.count).to eq(1)
     end
 
     it "should unsubscribe without subscription" do

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -317,5 +317,25 @@ RSpec.describe PushNotificationPusher do
         )
       end
     end
+
+    describe ".subscribe" do
+      it "sends the confirmation notification when the subscription already exists" do
+        params =
+          ActionController::Parameters.new(
+            endpoint: "endpoint",
+            keys: {
+              p256dh: "p256dh",
+              auth: "auth",
+            },
+          ).permit(:endpoint, keys: %i[p256dh auth])
+
+        WebPush.expects(:payload_send).once
+
+        PushNotificationPusher.subscribe(user, params, "false")
+        PushNotificationPusher.subscribe(user, params, "true")
+
+        expect(user.push_subscriptions.count).to eq(1)
+      end
+    end
   end
 end

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -353,6 +353,64 @@ RSpec.describe PushNotificationPusher do
 
         expect(PushSubscription.where(data: params.to_json).pluck(:user_id)).to eq([user.id])
       end
+
+      it "rejects a registration whose login session ended before it acquired the endpoint lock" do
+        params =
+          ActionController::Parameters.new(
+            endpoint: "stale-endpoint",
+            keys: {
+              p256dh: "p256dh",
+              auth: "auth",
+            },
+          ).permit(:endpoint, keys: %i[p256dh auth])
+        auth_token = UserAuthToken.generate!(user_id: user.id)
+        auth_token_id = auth_token.id
+
+        auth_token.destroy!
+        PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token_id)
+
+        expect(PushSubscription.where(user: user, data: params.to_json)).to be_empty
+      end
+
+      it "removes a registration when its login session ends during the write" do
+        params =
+          ActionController::Parameters.new(
+            endpoint: "racing-endpoint",
+            keys: {
+              p256dh: "p256dh",
+              auth: "auth",
+            },
+          ).permit(:endpoint, keys: %i[p256dh auth])
+        auth_token = UserAuthToken.generate!(user_id: user.id)
+        invalidate_token = ->(subscription) do
+          auth_token.destroy! if subscription.user_id == user.id
+        end
+        PushSubscription.set_callback(:create, :after, invalidate_token)
+
+        PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token.id)
+
+        expect(PushSubscription.where(user: user, data: params.to_json)).to be_empty
+      ensure
+        PushSubscription.skip_callback(:create, :after, invalidate_token) if invalidate_token
+      end
+
+      it "accepts the active token when registering for its impersonated user" do
+        admin = Fabricate(:admin)
+        auth_token = UserAuthToken.generate!(user_id: admin.id)
+        auth_token.update!(impersonated_user_id: user.id)
+        params =
+          ActionController::Parameters.new(
+            endpoint: "impersonated-endpoint",
+            keys: {
+              p256dh: "p256dh",
+              auth: "auth",
+            },
+          ).permit(:endpoint, keys: %i[p256dh auth])
+
+        PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token.id)
+
+        expect(PushSubscription.where(user: user, data: params.to_json)).to exist
+      end
     end
   end
 end

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -337,6 +337,22 @@ RSpec.describe PushNotificationPusher do
         expect(user.push_subscriptions.count).to eq(1)
       end
 
+      it "rejects a subscription destroyed by the confirmation notification" do
+        params =
+          ActionController::Parameters.new(
+            endpoint: "expired-endpoint",
+            keys: {
+              p256dh: "",
+              auth: "auth",
+            },
+          ).permit(:endpoint, keys: %i[p256dh auth])
+
+        result = PushNotificationPusher.subscribe(user, params, "true")
+
+        expect(result).to eq(false)
+        expect(user.push_subscriptions).to be_empty
+      end
+
       it "transfers an existing browser subscription to the current user" do
         previous_user = Fabricate(:user)
         params =
@@ -367,8 +383,10 @@ RSpec.describe PushNotificationPusher do
         auth_token_id = auth_token.id
 
         auth_token.destroy!
-        PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token_id)
+        result =
+          PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token_id)
 
+        expect(result).to eq(false)
         expect(PushSubscription.where(user: user, data: params.to_json)).to be_empty
       end
 
@@ -387,8 +405,10 @@ RSpec.describe PushNotificationPusher do
         end
         PushSubscription.set_callback(:create, :after, invalidate_token)
 
-        PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token.id)
+        result =
+          PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token.id)
 
+        expect(result).to eq(false)
         expect(PushSubscription.where(user: user, data: params.to_json)).to be_empty
       ensure
         PushSubscription.skip_callback(:create, :after, invalidate_token) if invalidate_token
@@ -407,8 +427,10 @@ RSpec.describe PushNotificationPusher do
             },
           ).permit(:endpoint, keys: %i[p256dh auth])
 
-        PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token.id)
+        result =
+          PushNotificationPusher.subscribe(user, params, "false", user_auth_token_id: auth_token.id)
 
+        expect(result).to eq(true)
         expect(PushSubscription.where(user: user, data: params.to_json)).to exist
       end
     end

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -336,6 +336,23 @@ RSpec.describe PushNotificationPusher do
 
         expect(user.push_subscriptions.count).to eq(1)
       end
+
+      it "transfers an existing browser subscription to the current user" do
+        previous_user = Fabricate(:user)
+        params =
+          ActionController::Parameters.new(
+            endpoint: "shared-endpoint",
+            keys: {
+              p256dh: "p256dh",
+              auth: "auth",
+            },
+          ).permit(:endpoint, keys: %i[p256dh auth])
+
+        PushNotificationPusher.subscribe(previous_user, params, "false")
+        PushNotificationPusher.subscribe(user, params, "false")
+
+        expect(PushSubscription.where(data: params.to_json).pluck(:user_id)).to eq([user.id])
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, browsers could silently lose push subscriptions while retaining permission, and account switches or overlapping reconciliation and toggle requests could leave stale server ownership, suppress fallback delivery, or duplicate notifications.

This change treats the origin-level notification grant as the default opt-in unless an account explicitly opts out, reconciles platform and server state with account-bound lifecycle operations, preserves only previously proven delivery across transient failures, and invalidates that proof on logout.