### PR TITLE
DEV: Let `dPointerDrag` preserve presses on descendants

### DIFF
--- a/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
+++ b/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
@@ -431,10 +431,17 @@ It transfers nothing and has no targets.
 | `bodyClass`       | `string`                           | Class applied to `document.body` while dragging. |
 | `cancelCommits`   | `boolean`                          | Whether a cancel commits the last value.         |
 | `stopPropagation` | `boolean`                          | Whether to stop the pointer events propagating.  |
+| `preservePress`   | `boolean`                          | Keep descendants interactive through a press.    |
 | `touchAction`     | `TouchActionToken`                 | The `touch-action` to apply for the gesture.     |
 
 Always handle `onDragCancel`. A gesture interrupted by the browser otherwise
 leaves whatever `onDragStart` opened still open.
+
+A handle is the usual consumer, and the defaults suit it: the press is cancelled
+so it moves no focus, and this element takes the capture. A surface large enough
+to wrap the content the user is reaching for wants `preservePress`, which keeps
+the press, leaves the capture on the pressed node until the gesture moves, and
+refuses native drag-and-drop.
 
 # DResizeSeparator
 

--- a/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
+++ b/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
@@ -444,6 +444,14 @@ the press, leaves the capture on the pressed node until the gesture moves, and
 refuses native drag-and-drop. On either path, the click that would trail a
 completed drag is swallowed — a tap clicks, a drag never does.
 
+`touchAction` names the pans the browser may still perform, and it is arbitrated
+only as far as the nearest scroll container: a value on an ancestor never reaches
+inside one, and a pan that starts inside one is claimed by the browser —
+cancelling the gesture — even when there is nothing to scroll that way. A surface
+wrapping a scroller therefore declares the split on the scroller itself, and can
+hold an axis the scroller would otherwise take only while it has nothing to
+scroll.
+
 # DResizeSeparator
 
 The default for resizing between two regions. `dResizeEdge` underneath keeps the

--- a/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
+++ b/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
@@ -434,6 +434,12 @@ It transfers nothing and has no targets.
 | `preservePress`   | `boolean`                          | Keep descendants interactive through a press.    |
 | `touchAction`     | `TouchActionToken`                 | The `touch-action` to apply for the gesture.     |
 
+Every callback's `info` carries `origin`, `current`, `delta`, `velocity` in
+pixels per millisecond, and `moved`. Velocity is measured over the interval
+since the previous report and the release is itself a report, so a gesture parked
+before release reads as still: a consumer deciding a flick needs no expiry of its
+own.
+
 Always handle `onDragCancel`. A gesture interrupted by the browser otherwise
 leaves whatever `onDragStart` opened still open.
 

--- a/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
+++ b/docs/developer-guides/docs/03-code-internals/29-drag-and-gesture-primitives.md
@@ -441,7 +441,8 @@ A handle is the usual consumer, and the defaults suit it: the press is cancelled
 so it moves no focus, and this element takes the capture. A surface large enough
 to wrap the content the user is reaching for wants `preservePress`, which keeps
 the press, leaves the capture on the pressed node until the gesture moves, and
-refuses native drag-and-drop.
+refuses native drag-and-drop. On either path, the click that would trail a
+completed drag is swallowed — a tap clicks, a drag never does.
 
 # DResizeSeparator
 

--- a/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
@@ -20,6 +20,14 @@ export type TouchActionToken =
  */
 const DEFAULT_TOUCH_ACTION: TouchActionToken = "none";
 
+/**
+ * How much recent pointer history velocity is measured over. A release trails
+ * the last movement by a frame or two, so measuring only the final interval
+ * would report every gesture as still; measuring a window keeps a flick's speed
+ * while a pointer held still for longer than this decays to nothing.
+ */
+const VELOCITY_WINDOW_MS = 100;
+
 /** A point in client coordinates. */
 type Point = Readonly<{ x: number; y: number }>;
 
@@ -38,6 +46,14 @@ export interface DPointerDragInfo {
 
   /** How far the pointer has travelled since the press. */
   readonly delta: Point;
+
+  /**
+   * Pixels per millisecond, signed per axis, measured over the pointer's recent
+   * history rather than the last interval alone: a flick still reads fast when
+   * the release trails it by a frame, and a pointer held still reads as still,
+   * so a consumer deciding a flick needs no expiry of its own.
+   */
+  readonly velocity: Point;
 
   /**
    * Whether `onDrag` has fired at least once for THIS gesture. It separates a
@@ -261,15 +277,42 @@ export function registerPointerDrag(
   let bodyClassLease: ElementClassLease | null = null;
   let capturedNode: Element = element;
   let pressPreserved = false;
+  let samples: { x: number; y: number; time: number }[] = [];
+  let velocity: Point = { x: 0, y: 0 };
   let watchingDocumentLoss = false;
   // Set by the cleanup below. A consumer can destroy its own registration from
   // inside `onDragStart`, and the rest of that dispatch still runs.
   let tornDown = false;
 
+  // Sampled from the events themselves, never from building a report: a report is
+  // only built for a callback the consumer actually registered.
+  const sample = (event: PointerEvent) => {
+    samples.push({
+      x: event.clientX,
+      y: event.clientY,
+      time: event.timeStamp,
+    });
+
+    const cutoff = event.timeStamp - VELOCITY_WINDOW_MS;
+    samples = samples.filter(({ time }) => time >= cutoff);
+
+    const oldest = samples[0];
+    const newest = samples[samples.length - 1];
+    const elapsed = newest.time - oldest.time;
+    velocity =
+      elapsed > 0
+        ? {
+            x: (newest.x - oldest.x) / elapsed,
+            y: (newest.y - oldest.y) / elapsed,
+          }
+        : { x: 0, y: 0 };
+  };
+
   const dragInfo = (event: PointerEvent): DPointerDragInfo => ({
     origin: { x: originX, y: originY },
     current: { x: event.clientX, y: event.clientY },
     delta: { x: event.clientX - originX, y: event.clientY - originY },
+    velocity,
     moved,
   });
 
@@ -284,6 +327,8 @@ export function registerPointerDrag(
     engaged = false;
     moved = false;
     pressPreserved = false;
+    samples = [];
+    velocity = { x: 0, y: 0 };
     appliedClass = null;
     bodyClassLease = null;
 
@@ -363,6 +408,7 @@ export function registerPointerDrag(
    * @param event - The event ending the gesture.
    */
   const cancelGesture = (args: DPointerDragArgs, event: PointerEvent) => {
+    sample(event);
     const info = dragInfo(event);
     try {
       if (args.cancelCommits) {
@@ -448,6 +494,7 @@ export function registerPointerDrag(
     originX = event.clientX;
     originY = event.clientY;
     moved = false;
+    sample(event);
 
     let vetoed;
     try {
@@ -525,6 +572,7 @@ export function registerPointerDrag(
       return;
     }
     const args = getArgsRef();
+    sample(event);
     if (!engaged) {
       const threshold = args.threshold ?? 0;
       if (
@@ -567,6 +615,7 @@ export function registerPointerDrag(
     if (pointerId === null || event.pointerId !== pointerId) {
       return;
     }
+    sample(event);
     if (moved) {
       suppressDragClick(event.pointerId);
     }

--- a/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
@@ -542,19 +542,22 @@ export function registerPointerDrag(
     args.onDrag?.(event, dragInfo(event));
   };
 
-  // Cancelling the press does not suppress the click; capture only retargets
-  // it at this element. At the target node listeners run in registration
-  // order whatever their phase, so the swallow has to sit above it.
-  const swallowClick = (event: MouseEvent) => {
-    if (event.target instanceof Node && element.contains(event.target)) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  };
+  // a drag still ends in a click; only a listener above the target beats its own
+  const suppressDragClick = (draggedPointerId: number) => {
+    const swallowClick = (event: MouseEvent) => {
+      const isThisPointersClick =
+        event instanceof PointerEvent &&
+        event.pointerId === draggedPointerId &&
+        event.target instanceof Node &&
+        element.contains(event.target);
 
-  const suppressDragClick = () => {
+      if (isThisPointersClick) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+
     window.addEventListener("click", swallowClick, true);
-    // the click, if any, arrives in the same task as the release
     setTimeout(() => {
       window.removeEventListener("click", swallowClick, true);
     }, 0);
@@ -565,7 +568,7 @@ export function registerPointerDrag(
       return;
     }
     if (moved) {
-      suppressDragClick();
+      suppressDragClick(event.pointerId);
     }
     // Commit before releasing capture, so the caller sees a consistent gesture
     // state while it reads the final value. Finalised in a `finally` so a

--- a/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
@@ -125,6 +125,18 @@ interface DPointerDragSignature {
       stopPropagation?: boolean;
 
       /**
+       * Whether a press on a descendant keeps behaving like a press on that
+       * descendant. Defaults to `false`, which suits a handle: the press is
+       * cancelled, moves no focus, and this element takes the pointer capture.
+       *
+       * When set — for a surface wrapping interactive content — descendants keep
+       * focus, selection, `mousedown`, and a tap's `click`; a drag's `click` is
+       * still suppressed, and native drag-and-drop is refused while the gesture
+       * is live.
+       */
+      preservePress?: boolean;
+
+      /**
        * Whether a gesture that ends without the pointer being released on this
        * element — `pointercancel`, or the capture being taken away — commits via
        * `onDragEnd` instead of discarding via `onDragCancel`. Defaults to
@@ -177,7 +189,7 @@ export type DPointerDragArgs = DPointerDragSignature["Args"]["Named"];
  */
 const pointerOwners = new Map<
   number,
-  { element: HTMLElement; supersede: (event: PointerEvent) => void }
+  { captureTarget: Element; supersede: (event: PointerEvent) => void }
 >();
 
 /**
@@ -251,6 +263,8 @@ export function registerPointerDrag(
   // rather than re-read when it is time to remove it.
   let appliedClass: string | null = null;
   let bodyClassLease: ElementClassLease | null = null;
+  let capturedNode: Element = element;
+  let watchingDocumentLoss = false;
   // Set by the cleanup below. A consumer can destroy its own registration from
   // inside `onDragStart`, and the rest of that dispatch still runs.
   let tornDown = false;
@@ -278,14 +292,21 @@ export function registerPointerDrag(
     if (finishedPointer !== null) {
       // Only while the claim is still ours: a later claimant owns the entry from
       // the moment it supersedes us, and must not have it deleted underneath it.
-      if (pointerOwners.get(finishedPointer)?.supersede === onSuperseded) {
+      const owner = pointerOwners.get(finishedPointer);
+      const stillOurs = !owner || owner.supersede === onSuperseded;
+
+      if (owner && stillOurs) {
         pointerOwners.delete(finishedPointer);
       }
-      try {
-        element.releasePointerCapture(finishedPointer);
-      } catch {
-        // Already released if the element was removed mid-gesture.
+      if (stillOurs) {
+        try {
+          capturedNode.releasePointerCapture(finishedPointer);
+        } catch {
+          // Already released if the element was removed mid-gesture.
+        }
       }
+      capturedNode = element;
+      unwatchDocumentLoss();
     }
     if (classToRemove) {
       // Unguarded: `appliedClass` is only ever set to a token `classList.add`
@@ -293,6 +314,46 @@ export function registerPointerDrag(
       element.classList.remove(classToRemove);
     }
     finishedBodyClassLease?.release();
+  };
+
+  const watchDocumentLoss = () => {
+    if (!watchingDocumentLoss) {
+      document.addEventListener(
+        "lostpointercapture",
+        onLostPointerCapture,
+        true
+      );
+      watchingDocumentLoss = true;
+    }
+  };
+
+  const unwatchDocumentLoss = () => {
+    if (watchingDocumentLoss) {
+      document.removeEventListener(
+        "lostpointercapture",
+        onLostPointerCapture,
+        true
+      );
+      watchingDocumentLoss = false;
+    }
+  };
+
+  const transferCaptureToSurface = (event: PointerEvent) => {
+    if (capturedNode === element) {
+      return;
+    }
+    try {
+      element.setPointerCapture(event.pointerId);
+    } catch {
+      return;
+    }
+    capturedNode = element;
+    unwatchDocumentLoss();
+
+    const owner = pointerOwners.get(event.pointerId);
+    if (owner?.supersede === onSuperseded) {
+      owner.captureTarget = element;
+    }
   };
 
   /**
@@ -336,20 +397,26 @@ export function registerPointerDrag(
     if (event.button !== 0 || pointerId !== null) {
       return;
     }
+    const args = getArgsRef();
+    const initialCaptureTarget =
+      args.preservePress && event.target instanceof Element
+        ? event.target
+        : element;
+
     // Capture first, before telling anyone a gesture started. Capture is what
     // routes the rest of the gesture back to this element, so without it a
     // pointer leaving the element would never deliver its release and the
     // in-flight guard would then reject every later press. Abort rather than
     // begin a gesture that cannot finish.
     try {
-      element.setPointerCapture(event.pointerId);
+      initialCaptureTarget.setPointerCapture(event.pointerId);
     } catch {
       return;
     }
 
     const releaseCapture = () => {
       try {
-        element.releasePointerCapture(event.pointerId);
+        initialCaptureTarget.releasePointerCapture(event.pointerId);
       } catch {
         // Already gone if the element was detached in between.
       }
@@ -369,14 +436,13 @@ export function registerPointerDrag(
         return;
       }
       try {
-        prior.element.setPointerCapture(event.pointerId);
+        prior.captureTarget.setPointerCapture(event.pointerId);
       } catch {
         // The prior claimant's element is gone; nothing to hand back.
         releaseCapture();
       }
     };
 
-    const args = getArgsRef();
     // Before the dispatch below, which reports them.
     originX = event.clientX;
     originY = event.clientY;
@@ -400,6 +466,10 @@ export function registerPointerDrag(
     }
 
     pointerId = event.pointerId;
+    capturedNode = initialCaptureTarget;
+    if (initialCaptureTarget !== element) {
+      watchDocumentLoss();
+    }
     engaged = !(args.threshold > 0);
 
     // A press bubbles, so an ancestor registration starts its own gesture from
@@ -410,7 +480,10 @@ export function registerPointerDrag(
     // back through `hasPointerCapture`, which cannot tell a lost claim apart from
     // a pointer that was never real.
     const superseded = pointerOwners.get(event.pointerId);
-    pointerOwners.set(event.pointerId, { element, supersede: onSuperseded });
+    pointerOwners.set(event.pointerId, {
+      captureTarget: initialCaptureTarget,
+      supersede: onSuperseded,
+    });
 
     if (args.draggingClass) {
       try {
@@ -433,7 +506,9 @@ export function registerPointerDrag(
 
     // Only an accepted press is suppressed. A secondary button, a press during
     // an active gesture, or a vetoed one must reach whatever else was listening.
-    event.preventDefault();
+    if (!args.preservePress) {
+      event.preventDefault();
+    }
     if (args.stopPropagation) {
       event.stopPropagation();
     }
@@ -456,6 +531,9 @@ export function registerPointerDrag(
         return;
       }
       engaged = true;
+    }
+    if (!moved) {
+      transferCaptureToSurface(event);
     }
     // Latched before the dispatch, so this report already counts as movement.
     moved = true;
@@ -484,8 +562,23 @@ export function registerPointerDrag(
     cancelGesture(getArgsRef(), event);
   };
 
+  /**
+   * Refuses native drag-and-drop while a gesture is live, which the cancelled
+   * press would otherwise have done.
+   */
+  const onNativeDragStart = (event: DragEvent) => {
+    if (pointerId !== null) {
+      event.preventDefault();
+    }
+  };
+
   const onLostPointerCapture = (event: PointerEvent) => {
     if (pointerId === null || event.pointerId !== pointerId) {
+      return;
+    }
+    const activeCaptureWasLost =
+      event.target === capturedNode || event.target === document;
+    if (!activeCaptureWasLost) {
       return;
     }
     // Once capture is gone, a pointer no longer over this element delivers its
@@ -502,6 +595,7 @@ export function registerPointerDrag(
   // changes orientation between gestures is not stuck with the first value.
   syncTouchAction(element, getArgsRef().touchAction);
 
+  element.addEventListener("dragstart", onNativeDragStart);
   element.addEventListener("pointerdown", onPointerDown);
   element.addEventListener("pointermove", onPointerMove);
   element.addEventListener("pointerup", onPointerUp);
@@ -511,6 +605,8 @@ export function registerPointerDrag(
   return () => {
     tornDown = true;
     finish();
+    unwatchDocumentLoss();
+    element.removeEventListener("dragstart", onNativeDragStart);
     element.removeEventListener("pointerdown", onPointerDown);
     element.removeEventListener("pointermove", onPointerMove);
     element.removeEventListener("pointerup", onPointerUp);

--- a/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
@@ -126,10 +126,9 @@ interface DPointerDragSignature {
 
       /**
        * Whether a press on a descendant keeps behaving like a press on that
-       * descendant: it keeps focus, selection, `mousedown`, and a tap's `click`,
-       * while a drag's `click` and native drag-and-drop are still suppressed.
+       * descendant: it keeps focus, selection, `mousedown`, and a tap's `click`.
        * Defaults to `false`, which suits a handle; presses on the element itself
-       * always take the handle path.
+       * always take the handle path, and a drag never produces a click either way.
        */
       preservePress?: boolean;
 
@@ -543,9 +542,30 @@ export function registerPointerDrag(
     args.onDrag?.(event, dragInfo(event));
   };
 
+  // Cancelling the press does not suppress the click; capture only retargets
+  // it at this element. At the target node listeners run in registration
+  // order whatever their phase, so the swallow has to sit above it.
+  const swallowClick = (event: MouseEvent) => {
+    if (event.target instanceof Node && element.contains(event.target)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  const suppressDragClick = () => {
+    window.addEventListener("click", swallowClick, true);
+    // the click, if any, arrives in the same task as the release
+    setTimeout(() => {
+      window.removeEventListener("click", swallowClick, true);
+    }, 0);
+  };
+
   const onPointerUp = (event: PointerEvent) => {
     if (pointerId === null || event.pointerId !== pointerId) {
       return;
+    }
+    if (moved) {
+      suppressDragClick();
     }
     // Commit before releasing capture, so the caller sees a consistent gesture
     // state while it reads the final value. Finalised in a `finally` so a
@@ -565,10 +585,6 @@ export function registerPointerDrag(
     cancelGesture(getArgsRef(), event);
   };
 
-  /**
-   * Refuses native drag-and-drop while a gesture is live, which the cancelled
-   * press would otherwise have done.
-   */
   const onNativeDragStart = (event: DragEvent) => {
     if (pointerId !== null && pressPreserved) {
       event.preventDefault();
@@ -598,7 +614,7 @@ export function registerPointerDrag(
   // changes orientation between gestures is not stuck with the first value.
   syncTouchAction(element, getArgsRef().touchAction);
 
-  element.addEventListener("dragstart", onNativeDragStart);
+  element.addEventListener("dragstart", onNativeDragStart, true);
   element.addEventListener("pointerdown", onPointerDown);
   element.addEventListener("pointermove", onPointerMove);
   element.addEventListener("pointerup", onPointerUp);
@@ -609,7 +625,7 @@ export function registerPointerDrag(
     tornDown = true;
     finish();
     unwatchDocumentLoss();
-    element.removeEventListener("dragstart", onNativeDragStart);
+    element.removeEventListener("dragstart", onNativeDragStart, true);
     element.removeEventListener("pointerdown", onPointerDown);
     element.removeEventListener("pointermove", onPointerMove);
     element.removeEventListener("pointerup", onPointerUp);

--- a/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
@@ -126,13 +126,10 @@ interface DPointerDragSignature {
 
       /**
        * Whether a press on a descendant keeps behaving like a press on that
-       * descendant. Defaults to `false`, which suits a handle: the press is
-       * cancelled, moves no focus, and this element takes the pointer capture.
-       *
-       * When set — for a surface wrapping interactive content — descendants keep
-       * focus, selection, `mousedown`, and a tap's `click`; a drag's `click` is
-       * still suppressed, and native drag-and-drop is refused while the gesture
-       * is live.
+       * descendant: it keeps focus, selection, `mousedown`, and a tap's `click`,
+       * while a drag's `click` and native drag-and-drop are still suppressed.
+       * Defaults to `false`, which suits a handle; presses on the element itself
+       * always take the handle path.
        */
       preservePress?: boolean;
 
@@ -264,6 +261,7 @@ export function registerPointerDrag(
   let appliedClass: string | null = null;
   let bodyClassLease: ElementClassLease | null = null;
   let capturedNode: Element = element;
+  let pressPreserved = false;
   let watchingDocumentLoss = false;
   // Set by the cleanup below. A consumer can destroy its own registration from
   // inside `onDragStart`, and the rest of that dispatch still runs.
@@ -286,6 +284,7 @@ export function registerPointerDrag(
     pointerId = null;
     engaged = false;
     moved = false;
+    pressPreserved = false;
     appliedClass = null;
     bodyClassLease = null;
 
@@ -398,10 +397,13 @@ export function registerPointerDrag(
       return;
     }
     const args = getArgsRef();
-    const initialCaptureTarget =
-      args.preservePress && event.target instanceof Element
+    const pressedDescendant =
+      args.preservePress &&
+      event.target instanceof Element &&
+      event.target !== element
         ? event.target
-        : element;
+        : null;
+    const initialCaptureTarget = pressedDescendant ?? element;
 
     // Capture first, before telling anyone a gesture started. Capture is what
     // routes the rest of the gesture back to this element, so without it a
@@ -506,9 +508,10 @@ export function registerPointerDrag(
 
     // Only an accepted press is suppressed. A secondary button, a press during
     // an active gesture, or a vetoed one must reach whatever else was listening.
-    if (!args.preservePress) {
+    if (!pressedDescendant) {
       event.preventDefault();
     }
+    pressPreserved = Boolean(pressedDescendant);
     if (args.stopPropagation) {
       event.stopPropagation();
     }
@@ -567,7 +570,7 @@ export function registerPointerDrag(
    * press would otherwise have done.
    */
   const onNativeDragStart = (event: DragEvent) => {
-    if (pointerId !== null) {
+    if (pointerId !== null && pressPreserved) {
       event.preventDefault();
     }
   };

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -426,6 +426,297 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
         "a secondary-button press and a vetoed one both reach document-level listeners"
       );
     });
+
+    test("preservePress leaves an accepted press uncancelled and functional", async function (assert) {
+      const seen = [];
+      const recordPhase = (phase) => () => seen.push(phase);
+
+      await render(
+        <template>
+          <div
+            class="dpd-target"
+            {{dPointerDrag
+              onDragStart=(recordPhase "start")
+              onDrag=(recordPhase "drag")
+              onDragEnd=(recordPhase "end")
+              preservePress=true
+            }}
+          ></div>
+        </template>
+      );
+      stubPointerCapture(".dpd-target");
+
+      await triggerEvent(".dpd-target", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 10,
+      });
+      await triggerEvent(".dpd-target", "pointermove", {
+        pointerId: 1,
+        clientX: 40,
+        clientY: 10,
+      });
+      await triggerEvent(".dpd-target", "pointerup", {
+        pointerId: 1,
+        clientX: 40,
+        clientY: 10,
+      });
+
+      assert.deepEqual(
+        prevented,
+        [false],
+        "a surface holding its own interactive content keeps the compatibility mousedown"
+      );
+      assert.deepEqual(
+        seen,
+        ["start", "drag", "end"],
+        "and the uncancelled press still drives the whole gesture"
+      );
+    });
+  });
+
+  module("preservePress", function () {
+    test("the element takes the capture by default", async function (assert) {
+      await render(
+        <template>
+          <div class="dpd-surface" {{dPointerDrag}}>
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      const { ownerOf } = stubSharedPointerCapture([
+        ".dpd-surface",
+        ".dpd-child",
+      ]);
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+      });
+
+      assert.dom(ownerOf(1)).hasClass("dpd-surface");
+    });
+
+    test("preserves a pressed descendant until dragging begins", async function (assert) {
+      const seen = [];
+      const onDrag = () => seen.push("drag");
+
+      await render(
+        <template>
+          <div
+            class="dpd-surface"
+            {{dPointerDrag onDrag=onDrag preservePress=true}}
+          >
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      const { ownerOf } = stubSharedPointerCapture([
+        ".dpd-surface",
+        ".dpd-child",
+      ]);
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+      });
+
+      assert
+        .dom(ownerOf(1))
+        .hasClass(
+          "dpd-child",
+          "so mouseup, and the click computed from it, stay on the control that was pressed"
+        );
+
+      await triggerEvent(".dpd-child", "pointermove", {
+        pointerId: 1,
+        clientX: 30,
+      });
+
+      assert.true(
+        seen.length > 0,
+        "and the gesture still reports, because a retargeted event bubbles to the element holding the listeners"
+      );
+    });
+
+    test("the capture comes back once the gesture moves", async function (assert) {
+      await render(
+        <template>
+          <div class="dpd-surface" {{dPointerDrag preservePress=true}}>
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      const { ownerOf } = stubSharedPointerCapture([
+        ".dpd-surface",
+        ".dpd-child",
+      ]);
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+      });
+      await triggerEvent(".dpd-child", "pointermove", {
+        pointerId: 1,
+        clientX: 40,
+      });
+
+      assert
+        .dom(ownerOf(1))
+        .hasClass(
+          "dpd-surface",
+          "a drag hands the capture back to the element"
+        );
+    });
+
+    test("handing the capture back does not end the gesture", async function (assert) {
+      const seen = [];
+      const onDrag = () => seen.push("drag");
+      const onDragCancel = () => seen.push("cancel");
+
+      await render(
+        <template>
+          <div
+            class="dpd-surface"
+            {{dPointerDrag
+              onDrag=onDrag
+              onDragCancel=onDragCancel
+              preservePress=true
+            }}
+          >
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+      });
+      await triggerEvent(".dpd-child", "pointermove", {
+        pointerId: 1,
+        clientX: 40,
+      });
+      await triggerEvent(".dpd-child", "lostpointercapture", { pointerId: 1 });
+      await triggerEvent(".dpd-child", "pointermove", {
+        pointerId: 1,
+        clientX: 80,
+      });
+
+      assert.deepEqual(
+        seen,
+        ["drag", "drag"],
+        "the gesture still holds the pointer, so the handover is not an ending"
+      );
+    });
+
+    test("a captured descendant's loss reaches the gesture from the document", async function (assert) {
+      const seen = [];
+      const onDragStart = () => seen.push("start");
+      const onDragCancel = () => seen.push("cancel");
+
+      await render(
+        <template>
+          <div
+            class="dpd-surface"
+            {{dPointerDrag
+              onDragStart=onDragStart
+              onDragCancel=onDragCancel
+              preservePress=true
+            }}
+          >
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+      });
+      const lost = new PointerEvent("lostpointercapture", { pointerId: 1 });
+      document.dispatchEvent(lost);
+      await settled();
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 2,
+      });
+
+      assert.deepEqual(
+        seen,
+        ["start", "cancel", "start"],
+        "the gesture ends, rather than latching and rejecting every later press"
+      );
+    });
+
+    test("a superseded registration leaves the winner's capture alone", async function (assert) {
+      await render(
+        <template>
+          <div class="dpd-surface" {{dPointerDrag preservePress=true}}>
+            <button type="button" class="dpd-child" {{dPointerDrag}}></button>
+          </div>
+        </template>
+      );
+      const { ownerOf } = stubSharedPointerCapture([
+        ".dpd-surface",
+        ".dpd-child",
+      ]);
+
+      await triggerEvent(".dpd-child", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+      });
+
+      assert
+        .dom(ownerOf(1))
+        .hasClass(
+          "dpd-child",
+          "the claim that won still holds it, rather than being released by the one it displaced"
+        );
+    });
+
+    test("a live gesture refuses native drag-and-drop", async function (assert) {
+      await render(
+        <template>
+          <div class="dpd-surface" {{dPointerDrag preservePress=true}}>
+            <a href="#test" class="dpd-link">link</a>
+          </div>
+        </template>
+      );
+      stubPointerCapture(".dpd-surface");
+
+      const beforePress = new DragEvent("dragstart", {
+        bubbles: true,
+        cancelable: true,
+      });
+      find(".dpd-link").dispatchEvent(beforePress);
+
+      await triggerEvent(".dpd-surface", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+      });
+      const duringGesture = new DragEvent("dragstart", {
+        bubbles: true,
+        cancelable: true,
+      });
+      find(".dpd-link").dispatchEvent(duringGesture);
+
+      assert.false(
+        beforePress.defaultPrevented,
+        "a drag with no gesture in flight is left alone"
+      );
+      assert.true(
+        duringGesture.defaultPrevented,
+        "a drag begun during the gesture is refused, so the pointer is not cancelled under it"
+      );
+    });
   });
 
   module("configurable pointer lifecycle", function () {
@@ -907,15 +1198,9 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
         "teardown still removes the pointer-drag attribute"
       );
       assert.deepEqual(
-        events.removed,
-        [
-          "pointerdown",
-          "pointermove",
-          "pointerup",
-          "pointercancel",
-          "lostpointercapture",
-        ],
-        "teardown still removes every pointer listener"
+        [...events.removed].sort(),
+        [...events.added].sort(),
+        "teardown still removes every listener it added"
       );
     });
 

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -477,6 +477,53 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       );
     });
 
+    test("a drag swallows the click that follows it; a tap's click passes", async function (assert) {
+      const clicks = [];
+
+      await render(
+        <template>
+          <div class="dpd-surface" {{dPointerDrag preservePress=true}}>
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
+      find(".dpd-surface").addEventListener("click", () =>
+        clicks.push("click")
+      );
+      const child = find(".dpd-child");
+
+      const dispatch = (type, options = {}) =>
+        child.dispatchEvent(
+          new PointerEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+            pointerId: 1,
+            ...options,
+          })
+        );
+      const clickChild = () =>
+        child.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      // the click follows the release within one task; settling in between
+      // would flush the swallow away, as the browser's next task does
+      dispatch("pointerdown", { clientX: 0 });
+      dispatch("pointermove", { clientX: 40 });
+      dispatch("pointerup", { clientX: 40 });
+      clickChild();
+      await settled();
+
+      assert.deepEqual(clicks, [], "the drag's click never lands");
+
+      dispatch("pointerdown", { clientX: 0 });
+      dispatch("pointerup", { clientX: 0 });
+      clickChild();
+      await settled();
+
+      assert.deepEqual(clicks, ["click"], "a tap's click still does");
+    });
+
     test("a press on the element itself takes the handle path despite preservePress", async function (assert) {
       await render(
         <template>

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -427,37 +427,39 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       );
     });
 
-    test("preservePress leaves an accepted press uncancelled and functional", async function (assert) {
+    test("preservePress leaves a descendant press uncancelled and functional", async function (assert) {
       const seen = [];
       const recordPhase = (phase) => () => seen.push(phase);
 
       await render(
         <template>
           <div
-            class="dpd-target"
+            class="dpd-surface"
             {{dPointerDrag
               onDragStart=(recordPhase "start")
               onDrag=(recordPhase "drag")
               onDragEnd=(recordPhase "end")
               preservePress=true
             }}
-          ></div>
+          >
+            <button type="button" class="dpd-child"></button>
+          </div>
         </template>
       );
-      stubPointerCapture(".dpd-target");
+      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
 
-      await triggerEvent(".dpd-target", "pointerdown", {
+      await triggerEvent(".dpd-child", "pointerdown", {
         button: 0,
         pointerId: 1,
         clientX: 10,
         clientY: 10,
       });
-      await triggerEvent(".dpd-target", "pointermove", {
+      await triggerEvent(".dpd-child", "pointermove", {
         pointerId: 1,
         clientX: 40,
         clientY: 10,
       });
-      await triggerEvent(".dpd-target", "pointerup", {
+      await triggerEvent(".dpd-child", "pointerup", {
         pointerId: 1,
         clientX: 40,
         clientY: 10,
@@ -466,12 +468,34 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       assert.deepEqual(
         prevented,
         [false],
-        "a surface holding its own interactive content keeps the compatibility mousedown"
+        "the descendant keeps the compatibility mousedown its content needs"
       );
       assert.deepEqual(
         seen,
         ["start", "drag", "end"],
         "and the uncancelled press still drives the whole gesture"
+      );
+    });
+
+    test("a press on the element itself takes the handle path despite preservePress", async function (assert) {
+      await render(
+        <template>
+          <div class="dpd-surface" {{dPointerDrag preservePress=true}}>
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
+
+      await triggerEvent(".dpd-surface", "pointerdown", {
+        button: 0,
+        pointerId: 1,
+      });
+
+      assert.deepEqual(
+        prevented,
+        [true],
+        "there is no descendant to preserve, so a drag here cannot end in a click on the surface"
       );
     });
   });
@@ -495,7 +519,9 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
         pointerId: 1,
       });
 
-      assert.dom(ownerOf(1)).hasClass("dpd-surface");
+      assert
+        .dom(ownerOf(1))
+        .hasClass("dpd-surface", "without preservePress the element captures");
     });
 
     test("preserves a pressed descendant until dragging begins", async function (assert) {
@@ -541,38 +567,7 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       );
     });
 
-    test("the capture comes back once the gesture moves", async function (assert) {
-      await render(
-        <template>
-          <div class="dpd-surface" {{dPointerDrag preservePress=true}}>
-            <button type="button" class="dpd-child"></button>
-          </div>
-        </template>
-      );
-      const { ownerOf } = stubSharedPointerCapture([
-        ".dpd-surface",
-        ".dpd-child",
-      ]);
-
-      await triggerEvent(".dpd-child", "pointerdown", {
-        button: 0,
-        pointerId: 1,
-        clientX: 0,
-      });
-      await triggerEvent(".dpd-child", "pointermove", {
-        pointerId: 1,
-        clientX: 40,
-      });
-
-      assert
-        .dom(ownerOf(1))
-        .hasClass(
-          "dpd-surface",
-          "a drag hands the capture back to the element"
-        );
-    });
-
-    test("handing the capture back does not end the gesture", async function (assert) {
+    test("the capture comes back once the gesture moves, without ending it", async function (assert) {
       const seen = [];
       const onDrag = () => seen.push("drag");
       const onDragCancel = () => seen.push("cancel");
@@ -591,17 +586,34 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
           </div>
         </template>
       );
-      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
+      const { ownerOf } = stubSharedPointerCapture([
+        ".dpd-surface",
+        ".dpd-child",
+      ]);
 
       await triggerEvent(".dpd-child", "pointerdown", {
         button: 0,
         pointerId: 1,
         clientX: 0,
       });
+
+      assert
+        .dom(ownerOf(1))
+        .hasClass("dpd-child", "a tap's click stays on the pressed control");
+
       await triggerEvent(".dpd-child", "pointermove", {
         pointerId: 1,
         clientX: 40,
       });
+
+      assert
+        .dom(ownerOf(1))
+        .hasClass(
+          "dpd-surface",
+          "a drag hands the capture back to the element"
+        );
+
+      // the node that gave the capture up reports a loss, and it bubbles here
       await triggerEvent(".dpd-child", "lostpointercapture", { pointerId: 1 });
       await triggerEvent(".dpd-child", "pointermove", {
         pointerId: 1,
@@ -611,7 +623,7 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       assert.deepEqual(
         seen,
         ["drag", "drag"],
-        "the gesture still holds the pointer, so the handover is not an ending"
+        "the handover is not an ending: the gesture keeps reporting"
       );
     });
 
@@ -690,7 +702,7 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
           </div>
         </template>
       );
-      stubPointerCapture(".dpd-surface");
+      stubSharedPointerCapture([".dpd-surface", ".dpd-link"]);
 
       const beforePress = new DragEvent("dragstart", {
         bubbles: true,
@@ -698,7 +710,7 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       });
       find(".dpd-link").dispatchEvent(beforePress);
 
-      await triggerEvent(".dpd-surface", "pointerdown", {
+      await triggerEvent(".dpd-link", "pointerdown", {
         button: 0,
         pointerId: 1,
       });

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -499,12 +499,12 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
             bubbles: true,
             cancelable: true,
             button: 0,
-            pointerId: 1,
+            pointerId: 7,
             ...options,
           })
         );
-      const clickChild = () =>
-        child.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      // a real trailing click carries the pointer that drew the gesture
+      const clickChild = () => dispatch("click");
 
       // the click follows the release within one task; settling in between
       // would flush the swallow away, as the browser's next task does
@@ -522,6 +522,50 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       await settled();
 
       assert.deepEqual(clicks, ["click"], "a tap's click still does");
+    });
+
+    test("a click raised by the drag's own end handler still lands", async function (assert) {
+      const clicks = [];
+      const onDragEnd = () => find(".dpd-child").click();
+
+      await render(
+        <template>
+          <div
+            class="dpd-surface"
+            {{dPointerDrag preservePress=true onDragEnd=onDragEnd}}
+          >
+            <button type="button" class="dpd-child"></button>
+          </div>
+        </template>
+      );
+      stubSharedPointerCapture([".dpd-surface", ".dpd-child"]);
+      find(".dpd-surface").addEventListener("click", () =>
+        clicks.push("click")
+      );
+      const child = find(".dpd-child");
+
+      const dispatch = (type, options = {}) =>
+        child.dispatchEvent(
+          new PointerEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+            pointerId: 7,
+            ...options,
+          })
+        );
+
+      dispatch("pointerdown", { clientX: 0 });
+      dispatch("pointermove", { clientX: 40 });
+      dispatch("pointerup", { clientX: 40 });
+      await settled();
+
+      // the swallow is armed, but a programmatic click carries no pointer to match
+      assert.deepEqual(
+        clicks,
+        ["click"],
+        "the handler's own click is not the drag's"
+      );
     });
 
     test("a press on the element itself takes the handle path despite preservePress", async function (assert) {

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -101,6 +101,47 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
     );
   });
 
+  test("reports velocity over the last interval, and a parked release as still", async function (assert) {
+    const seen = [];
+    const record = (event, info) =>
+      seen.push(Math.round(info.velocity.y * 100) / 100);
+
+    await render(
+      <template>
+        <div
+          class="dpd-target"
+          {{dPointerDrag onDrag=record onDragEnd=record}}
+        ></div>
+      </template>
+    );
+
+    stubPointerCapture(".dpd-target");
+    const target = find(".dpd-target");
+    // synthetic events share a timestamp, which would read as an infinite flick
+    const dispatch = (type, { y, time }) => {
+      const event = new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        pointerId: 1,
+        clientY: y,
+      });
+      Object.defineProperty(event, "timeStamp", { value: time });
+      target.dispatchEvent(event);
+    };
+
+    dispatch("pointerdown", { y: 0, time: 1000 });
+    dispatch("pointermove", { y: 40, time: 1010 });
+    dispatch("pointerup", { y: 40, time: 1260 });
+    await settled();
+
+    assert.deepEqual(
+      seen,
+      [4, 0],
+      "a 40px flick over 10ms reads 4px/ms, and parking 250ms before release reads still"
+    );
+  });
+
   test("a release that never moved says so, so a click is not a drag", async function (assert) {
     const ends = [];
     const onDragEnd = (event, info) => ends.push(info.moved);

--- a/frontend/discourse/type-tests/ui-kit/d-pointer-drag-errors-test.gts
+++ b/frontend/discourse/type-tests/ui-kit/d-pointer-drag-errors-test.gts
@@ -15,6 +15,9 @@ const Test = <template>
   {{! @glint-expect-error - stopPropagation is a flag, not a string }}
   <span {{dPointerDrag stopPropagation="true"}}></span>
 
+  {{! @glint-expect-error - preservePress is a flag, not a string }}
+  <span {{dPointerDrag preservePress="true"}}></span>
+
   {{! @glint-expect-error - onDrag receives the event; it cannot take extra arguments }}
   <span {{dPointerDrag onDrag=onGesture extra=1}}></span>
 

--- a/frontend/discourse/type-tests/ui-kit/d-pointer-drag-test.gts
+++ b/frontend/discourse/type-tests/ui-kit/d-pointer-drag-test.gts
@@ -21,6 +21,7 @@ const Test = <template>
       bodyClass="d-resizing-ew"
       threshold=4
       stopPropagation=true
+      preservePress=true
       cancelCommits=true
       touchAction="pan-y"
     }}


### PR DESCRIPTION
Previously, `dPointerDrag` cancelled every accepted press, so a drag surface wrapping interactive content lost focus on tap, text selection, and every descendant's `click` (pointer capture retargets `mouseup`, and with it the click the browser computes from it). Consumers deciding a flick also had to track velocity themselves.

This change adds `preservePress`, which keeps the press whole and leaves the capture on the pressed node until the gesture moves, so a tap clicks and a drag does not; the click trailing a completed drag is swallowed on every path, matched to the pointer that drew it so a consumer's own programmatic click still lands. Every report now also carries `info.velocity`, measured across the pointer's recent history, so a flick reads fast even though the release trails it and a pointer held still reads as still.

Stacked under #42812 and #42858, its first two consumers, which both drop their own velocity tracking onto it.
