### PR TITLE
DEV: Move modal swipe dismissal to the pointer-drag gesture

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -160,11 +160,14 @@ html:not(.keyboard-visible).mobile-device {
   &__body {
     overflow-y: auto;
 
-    // pan arbitration stops at the nearest scroll container, so the swipe
-    // gesture's touch-action on the modal container does not reach in here
+    // pan arbitration stops here, so this is where the axes are split
     touch-action: pan-y pinch-zoom;
     padding: 1rem 1.5rem;
     box-sizing: border-box;
+
+    &.--no-scroll {
+      touch-action: pan-x pinch-zoom;
+    }
 
     &.empty {
       display: none;

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -165,7 +165,7 @@ html:not(.keyboard-visible).mobile-device {
     padding: 1rem 1.5rem;
     box-sizing: border-box;
 
-    &.--no-scroll {
+    &.is-not-scrollable {
       touch-action: pan-x pinch-zoom;
     }
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -159,6 +159,10 @@ html:not(.keyboard-visible).mobile-device {
 
   &__body {
     overflow-y: auto;
+
+    // pan arbitration stops at the nearest scroll container, so the swipe
+    // gesture's touch-action on the modal container does not reach in here
+    touch-action: pan-y pinch-zoom;
     padding: 1rem 1.5rem;
     box-sizing: border-box;
 

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -216,26 +216,35 @@ export default class DModal extends Component<DModalSignature> {
     // the browser claims a vertical pan started here even with nothing to
     // scroll, so the swipe only gets the axis back while that is true
     const watched = new WeakSet<Element>();
-    const overflowObserver = new ResizeObserver((_entries, observer) => {
+    const syncPannableAxis = () => {
       el.classList.toggle(
         BODY_NO_SCROLL_CLASS,
         el.scrollHeight <= el.clientHeight
       );
 
-      // content can outgrow a body whose own box has stopped changing; the
-      // guard keeps re-observation from re-reporting on its own
+      // the body's own box can stop changing while a child still grows
       for (const child of el.children) {
         if (!watched.has(child)) {
           watched.add(child);
-          observer.observe(child);
+          overflowObserver.observe(child);
         }
       }
-    });
+    };
+    const overflowObserver = new ResizeObserver(syncPannableAxis);
+    // content can also arrive, or grow in place, resizing nothing that is watched
+    const contentObserver = new MutationObserver(syncPannableAxis);
     overflowObserver.observe(el);
+    contentObserver.observe(el, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    syncPannableAxis();
 
     return () => {
       unlock(el, undefined);
       overflowObserver.disconnect();
+      contentObserver.disconnect();
 
       if (this.capabilities.isIOS) {
         this.appEvents.off(

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -74,6 +74,7 @@ const ENTER_HANDLING_CONTROLS = [
 const UNAVAILABLE_PRIMARY = '[disabled], :disabled, [aria-disabled="true"]';
 
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
+const SWIPE_VELOCITY_EXPIRY_MS = 100;
 const SWIPE_CLOSE_DISTANCE_RATIO = 0.25;
 const SWIPE_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
 
@@ -225,7 +226,12 @@ export default class DModal extends Component<DModalSignature> {
   });
   #modalContainer: HTMLElement;
   #lockedScrollY?: number;
-  #drag: { lastY: number; lastTime: number; velocityY: number } | null = null;
+  #drag: {
+    pointerId: number;
+    lastY: number;
+    lastTime: number;
+    velocityY: number;
+  } | null = null;
   @tracked _wrapperElement?: HTMLElement;
 
   get autofocus() {
@@ -299,11 +305,11 @@ export default class DModal extends Component<DModalSignature> {
 
   @action
   handleDragStart(event: PointerEvent) {
-    // pointer events unify mouse and touch, so the mobile gate is explicit
-    if (!this.mobileDismissable || this.animating) {
+    if (!this.mobileDismissable || this.animating || this.#drag) {
       return false;
     }
     this.#drag = {
+      pointerId: event.pointerId,
       lastY: event.clientY,
       lastTime: event.timeStamp,
       velocityY: 0,
@@ -313,7 +319,7 @@ export default class DModal extends Component<DModalSignature> {
   @action
   async handleDrag(event: PointerEvent, info: DPointerDragInfo) {
     const drag = this.#drag;
-    if (!drag || this.animating) {
+    if (!drag || drag.pointerId !== event.pointerId || this.animating) {
       return;
     }
 
@@ -333,19 +339,23 @@ export default class DModal extends Component<DModalSignature> {
   @action
   async handleDragEnd(event: PointerEvent, info: DPointerDragInfo) {
     const drag = this.#drag;
+    if (!drag || drag.pointerId !== event.pointerId) {
+      return;
+    }
     this.#drag = null;
 
-    if (!drag || !info.moved || this.animating) {
+    if (!info.moved || this.animating) {
       return;
     }
 
     const closeDistance =
       this.#modalContainer.clientHeight * SWIPE_CLOSE_DISTANCE_RATIO;
+    const idleMs = event.timeStamp - drag.lastTime;
+    const velocityY = idleMs > SWIPE_VELOCITY_EXPIRY_MS ? 0 : drag.velocityY;
 
     if (
       info.delta.y <= 0 ||
-      (drag.velocityY < SWIPE_VELOCITY_THRESHOLD &&
-        info.delta.y < closeDistance)
+      (velocityY < SWIPE_VELOCITY_THRESHOLD && info.delta.y < closeDistance)
     ) {
       return await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
     }
@@ -354,27 +364,14 @@ export default class DModal extends Component<DModalSignature> {
   }
 
   @action
-  async handleBackdropDragEnd(event: PointerEvent, info: DPointerDragInfo) {
-    if (!this.#drag) {
-      return;
-    }
-
-    // the gesture claims the press, so a motionless release is the backdrop tap
-    if (!info.moved) {
-      this.#drag = null;
-      return this.closeModal(CLOSE_INITIATED_BY_CLICK_OUTSIDE);
-    }
-
-    await this.handleDragEnd(event, info);
-  }
-
-  @action
   async handleDragCancel(event: PointerEvent, info: DPointerDragInfo) {
     const drag = this.#drag;
+    if (!drag || drag.pointerId !== event.pointerId) {
+      return;
+    }
     this.#drag = null;
 
-    // the browser claimed the touch; a displaced modal settles back
-    if (drag && info.moved && !this.animating) {
+    if (info.moved && !this.animating) {
       await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
     }
   }
@@ -726,7 +723,7 @@ export default class DModal extends Component<DModalSignature> {
           {{dPointerDrag
             onDragStart=this.handleDragStart
             onDrag=this.handleDrag
-            onDragEnd=this.handleBackdropDragEnd
+            onDragEnd=this.handleDragEnd
             onDragCancel=this.handleDragCancel
             threshold=5
             touchAction="pan-x"

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -300,7 +300,6 @@ export default class DModal extends Component<DModalSignature> {
   @action
   handleDragStart(event: PointerEvent) {
     // pointer events unify mouse and touch, so the mobile gate is explicit
-    // where touch-only events used to imply it
     if (!this.mobileDismissable || this.animating) {
       return false;
     }
@@ -374,8 +373,7 @@ export default class DModal extends Component<DModalSignature> {
     const drag = this.#drag;
     this.#drag = null;
 
-    // the browser claimed the touch, usually for the modal body's own scroll;
-    // a displaced modal settles back rather than staying where it was left
+    // the browser claimed the touch; a displaced modal settles back
     if (drag && info.moved && !this.animating) {
       await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
     }

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -75,7 +75,6 @@ const UNAVAILABLE_PRIMARY = '[disabled], :disabled, [aria-disabled="true"]';
 
 const BODY_NOT_SCROLLABLE_CLASS = "is-not-scrollable";
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
-const SWIPE_VELOCITY_EXPIRY_MS = 100;
 const SWIPE_CLOSE_DISTANCE_RATIO = 0.25;
 const SWIPE_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
 
@@ -257,12 +256,7 @@ export default class DModal extends Component<DModalSignature> {
   });
   #modalContainer: HTMLElement;
   #lockedScrollY?: number;
-  #drag: {
-    pointerId: number;
-    lastY: number;
-    lastTime: number;
-    velocityY: number;
-  } | null = null;
+  #dragPointerId: number | null = null;
   @tracked _wrapperElement?: HTMLElement;
 
   get autofocus() {
@@ -336,28 +330,21 @@ export default class DModal extends Component<DModalSignature> {
 
   @action
   handleDragStart(event: PointerEvent) {
-    if (!this.mobileDismissable || this.animating || this.#drag) {
+    if (
+      !this.mobileDismissable ||
+      this.animating ||
+      this.#dragPointerId !== null
+    ) {
       return false;
     }
-    this.#drag = {
-      pointerId: event.pointerId,
-      lastY: event.clientY,
-      lastTime: event.timeStamp,
-      velocityY: 0,
-    };
+    this.#dragPointerId = event.pointerId;
   }
 
   @action
   async handleDrag(event: PointerEvent, info: DPointerDragInfo) {
-    const drag = this.#drag;
-    if (!drag || drag.pointerId !== event.pointerId || this.animating) {
+    if (this.#dragPointerId !== event.pointerId || this.animating) {
       return;
     }
-
-    const elapsed = event.timeStamp - drag.lastTime;
-    drag.velocityY = elapsed > 0 ? (event.clientY - drag.lastY) / elapsed : 0;
-    drag.lastY = event.clientY;
-    drag.lastTime = event.timeStamp;
 
     // applied instantly so the modal tracks the finger 1:1; easing only
     // happens when the gesture ends
@@ -369,11 +356,10 @@ export default class DModal extends Component<DModalSignature> {
 
   @action
   async handleDragEnd(event: PointerEvent, info: DPointerDragInfo) {
-    const drag = this.#drag;
-    if (!drag || drag.pointerId !== event.pointerId) {
+    if (this.#dragPointerId !== event.pointerId) {
       return;
     }
-    this.#drag = null;
+    this.#dragPointerId = null;
 
     if (!info.moved || this.animating) {
       return;
@@ -381,12 +367,11 @@ export default class DModal extends Component<DModalSignature> {
 
     const closeDistance =
       this.#modalContainer.clientHeight * SWIPE_CLOSE_DISTANCE_RATIO;
-    const idleMs = event.timeStamp - drag.lastTime;
-    const velocityY = idleMs > SWIPE_VELOCITY_EXPIRY_MS ? 0 : drag.velocityY;
 
     if (
       info.delta.y <= 0 ||
-      (velocityY < SWIPE_VELOCITY_THRESHOLD && info.delta.y < closeDistance)
+      (info.velocity.y < SWIPE_VELOCITY_THRESHOLD &&
+        info.delta.y < closeDistance)
     ) {
       return await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
     }
@@ -396,11 +381,10 @@ export default class DModal extends Component<DModalSignature> {
 
   @action
   async handleDragCancel(event: PointerEvent, info: DPointerDragInfo) {
-    const drag = this.#drag;
-    if (!drag || drag.pointerId !== event.pointerId) {
+    if (this.#dragPointerId !== event.pointerId) {
       return;
     }
-    this.#drag = null;
+    this.#dragPointerId = null;
 
     if (info.moved && !this.animating) {
       await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -14,7 +14,6 @@ import { lock, unlock } from "discourse/lib/body-scroll-lock";
 import {
   dampenedOverdrag,
   getMaxAnimationTimeMs,
-  shouldDeferSwipeToContent,
 } from "discourse/lib/swipe-events";
 import type Site from "discourse/models/site";
 import type AppEventsService from "discourse/services/app-events";
@@ -28,7 +27,9 @@ import DFlashMessage, {
 } from "discourse/ui-kit/d-flash-message";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dElement from "discourse/ui-kit/helpers/d-element";
-import dSwipe, { type SwipeState } from "discourse/ui-kit/modifiers/d-swipe";
+import dPointerDrag, {
+  type DPointerDragInfo,
+} from "discourse/ui-kit/modifiers/d-pointer-drag";
 import dTrapTab from "discourse/ui-kit/modifiers/d-trap-tab";
 
 export const CLOSE_INITIATED_BY_BUTTON = "initiatedByCloseButton";
@@ -224,6 +225,7 @@ export default class DModal extends Component<DModalSignature> {
   });
   #modalContainer: HTMLElement;
   #lockedScrollY?: number;
+  #drag: { lastY: number; lastTime: number; velocityY: number } | null = null;
   @tracked _wrapperElement?: HTMLElement;
 
   get autofocus() {
@@ -296,33 +298,45 @@ export default class DModal extends Component<DModalSignature> {
   }
 
   @action
-  handleSwipeStart(swipeState: SwipeState, event: Event) {
-    if (shouldDeferSwipeToContent(swipeState, this.#modalContainer)) {
-      event.preventDefault();
+  handleDragStart(event: PointerEvent) {
+    // pointer events unify mouse and touch, so the mobile gate is explicit
+    // where touch-only events used to imply it
+    if (!this.mobileDismissable || this.animating) {
+      return false;
     }
+    this.#drag = {
+      lastY: event.clientY,
+      lastTime: event.timeStamp,
+      velocityY: 0,
+    };
   }
 
   @action
-  async handleSwipe(swipeEvent: SwipeState) {
-    if (this.animating) {
+  async handleDrag(event: PointerEvent, info: DPointerDragInfo) {
+    const drag = this.#drag;
+    if (!drag || this.animating) {
       return;
     }
+
+    const elapsed = event.timeStamp - drag.lastTime;
+    drag.velocityY = elapsed > 0 ? (event.clientY - drag.lastY) / elapsed : 0;
+    drag.lastY = event.clientY;
+    drag.lastTime = event.timeStamp;
 
     // applied instantly so the modal tracks the finger 1:1; easing only
     // happens when the gesture ends
     const position =
-      swipeEvent.deltaY >= 0
-        ? swipeEvent.deltaY
-        : -dampenedOverdrag(-swipeEvent.deltaY);
+      info.delta.y >= 0 ? info.delta.y : -dampenedOverdrag(-info.delta.y);
 
     await this.#animateWrapperPosition(position, 0);
   }
 
   @action
-  async handleSwipeEnded(swipeEvent: SwipeState) {
-    if (this.animating) {
-      // if the modal is animating we don't want to risk resetting the position
-      // as the user releases the swipe at the same time
+  async handleDragEnd(event: PointerEvent, info: DPointerDragInfo) {
+    const drag = this.#drag;
+    this.#drag = null;
+
+    if (!drag || !info.moved || this.animating) {
       return;
     }
 
@@ -330,15 +344,41 @@ export default class DModal extends Component<DModalSignature> {
       this.#modalContainer.clientHeight * SWIPE_CLOSE_DISTANCE_RATIO;
 
     if (
-      swipeEvent.goingUp() ||
-      swipeEvent.deltaY <= 0 ||
-      (swipeEvent.velocityY < SWIPE_VELOCITY_THRESHOLD &&
-        swipeEvent.deltaY < closeDistance)
+      info.delta.y <= 0 ||
+      (drag.velocityY < SWIPE_VELOCITY_THRESHOLD &&
+        info.delta.y < closeDistance)
     ) {
       return await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
     }
 
     this.closeModal(CLOSE_INITIATED_BY_SWIPE_DOWN);
+  }
+
+  @action
+  async handleBackdropDragEnd(event: PointerEvent, info: DPointerDragInfo) {
+    if (!this.#drag) {
+      return;
+    }
+
+    // the gesture claims the press, so a motionless release is the backdrop tap
+    if (!info.moved) {
+      this.#drag = null;
+      return this.closeModal(CLOSE_INITIATED_BY_CLICK_OUTSIDE);
+    }
+
+    await this.handleDragEnd(event, info);
+  }
+
+  @action
+  async handleDragCancel(event: PointerEvent, info: DPointerDragInfo) {
+    const drag = this.#drag;
+    this.#drag = null;
+
+    // the browser claimed the touch, usually for the modal body's own scroll;
+    // a displaced modal settles back rather than staying where it was left
+    if (drag && info.moved && !this.animating) {
+      await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
+    }
   }
 
   @action
@@ -566,11 +606,14 @@ export default class DModal extends Component<DModalSignature> {
         <div
           class="d-modal__container"
           {{this.registerModalContainer}}
-          {{dSwipe
-            onDidStartSwipe=this.handleSwipeStart
-            onDidSwipe=this.handleSwipe
-            onDidEndSwipe=this.handleSwipeEnded
-            enabled=this.dismissable
+          {{dPointerDrag
+            onDragStart=this.handleDragStart
+            onDrag=this.handleDrag
+            onDragEnd=this.handleDragEnd
+            onDragCancel=this.handleDragCancel
+            threshold=5
+            touchAction="pan-x"
+            preservePress=true
           }}
         >
           {{yield to="aboveHeader"}}
@@ -682,10 +725,13 @@ export default class DModal extends Component<DModalSignature> {
         {{! eslint-disable ember/template-no-pointer-down-event-binding }}
         <div
           class="d-modal__backdrop"
-          {{dSwipe
-            onDidSwipe=this.handleSwipe
-            onDidEndSwipe=this.handleSwipeEnded
-            enabled=this.dismissable
+          {{dPointerDrag
+            onDragStart=this.handleDragStart
+            onDrag=this.handleDrag
+            onDragEnd=this.handleBackdropDragEnd
+            onDragCancel=this.handleDragCancel
+            threshold=5
+            touchAction="pan-x"
           }}
           {{on "click" this.handleWrapperClick}}
           {{on "pointerdown" this.handleWrapperPointerDown}}

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -73,6 +73,7 @@ const ENTER_HANDLING_CONTROLS = [
  */
 const UNAVAILABLE_PRIMARY = '[disabled], :disabled, [aria-disabled="true"]';
 
+const BODY_NO_SCROLL_CLASS = "--no-scroll";
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
 const SWIPE_VELOCITY_EXPIRY_MS = 100;
 const SWIPE_CLOSE_DISTANCE_RATIO = 0.25;
@@ -212,8 +213,29 @@ export default class DModal extends Component<DModalSignature> {
       );
     }
 
+    // the browser claims a vertical pan started here even with nothing to
+    // scroll, so the swipe only gets the axis back while that is true
+    const watched = new WeakSet<Element>();
+    const overflowObserver = new ResizeObserver((_entries, observer) => {
+      el.classList.toggle(
+        BODY_NO_SCROLL_CLASS,
+        el.scrollHeight <= el.clientHeight
+      );
+
+      // content can outgrow a body whose own box has stopped changing; the
+      // guard keeps re-observation from re-reporting on its own
+      for (const child of el.children) {
+        if (!watched.has(child)) {
+          watched.add(child);
+          observer.observe(child);
+        }
+      }
+    });
+    overflowObserver.observe(el);
+
     return () => {
       unlock(el, undefined);
+      overflowObserver.disconnect();
 
       if (this.capabilities.isIOS) {
         this.appEvents.off(

--- a/frontend/discourse/app/ui-kit/d-modal.gts
+++ b/frontend/discourse/app/ui-kit/d-modal.gts
@@ -73,7 +73,7 @@ const ENTER_HANDLING_CONTROLS = [
  */
 const UNAVAILABLE_PRIMARY = '[disabled], :disabled, [aria-disabled="true"]';
 
-const BODY_NO_SCROLL_CLASS = "--no-scroll";
+const BODY_NOT_SCROLLABLE_CLASS = "is-not-scrollable";
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
 const SWIPE_VELOCITY_EXPIRY_MS = 100;
 const SWIPE_CLOSE_DISTANCE_RATIO = 0.25;
@@ -218,7 +218,7 @@ export default class DModal extends Component<DModalSignature> {
     const watched = new WeakSet<Element>();
     const syncPannableAxis = () => {
       el.classList.toggle(
-        BODY_NO_SCROLL_CLASS,
+        BODY_NOT_SCROLLABLE_CLASS,
         el.scrollHeight <= el.clientHeight
       );
 

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -245,8 +245,7 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     );
     await open();
 
-    // the browser's own arbitration cannot be driven synthetically, so only the
-    // component's half of the wiring is observable
+    // the browser's arbitration cannot be driven synthetically
     assert
       .dom(".fk-d-menu-modal .d-modal__container")
       .hasAttribute(

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -22,6 +22,7 @@ import DTooltips from "discourse/float-kit/components/d-tooltips";
 import DMenuInstance from "discourse/float-kit/lib/d-menu-instance";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { stubPointerCapture } from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
 import DButton from "discourse/ui-kit/d-button";
 import dElement from "discourse/ui-kit/helpers/d-element";
 
@@ -37,18 +38,14 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
   }
 
   async function swipeDown(selector) {
-    await triggerEvent(selector, "touchstart", {
-      touches: [{ clientX: 0, clientY: 0 }],
-      changedTouches: [{ clientX: 0, clientY: 0 }],
+    stubPointerCapture(selector);
+    await triggerEvent(selector, "pointerdown", {
+      button: 0,
+      pointerId: 1,
+      clientY: 0,
     });
-    await triggerEvent(selector, "touchmove", {
-      touches: [{ clientX: 0, clientY: 200 }],
-      changedTouches: [{ clientX: 0, clientY: 200 }],
-    });
-    await triggerEvent(selector, "touchend", {
-      touches: [],
-      changedTouches: [{ clientX: 0, clientY: 200 }],
-    });
+    await triggerEvent(selector, "pointermove", { pointerId: 1, clientY: 200 });
+    await triggerEvent(selector, "pointerup", { pointerId: 1, clientY: 200 });
   }
 
   test("@label", async function (assert) {
@@ -234,7 +231,7 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     assert.dom(".fk-d-menu-modal").doesNotExist();
   });
 
-  test("@modalForMobile - swipe down defers to scrolled content", async function (assert) {
+  test("@modalForMobile - leaves content panning to the browser", async function (assert) {
     forceMobile();
 
     await render(
@@ -248,11 +245,15 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     );
     await open();
 
-    document.querySelector(".test-scroll-area").scrollTop = 100;
-
-    await swipeDown(".test-scroll-area");
-
-    assert.dom(".fk-d-menu-modal").exists();
+    // scroll deferral is the browser's own pan arbitration, which synthetic
+    // events cannot trigger; the touch-action wiring it rides on is observable
+    assert
+      .dom(".fk-d-menu-modal .d-modal__container")
+      .hasAttribute(
+        "data-pointer-drag",
+        "pan-x",
+        "vertical pans over scrollable content stay with the browser"
+      );
   });
 
   test("@onRegisterApi", async function (assert) {

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -246,7 +246,9 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     await open();
 
     // scroll deferral is the browser's own pan arbitration, which synthetic
-    // events cannot trigger; the touch-action wiring it rides on is observable
+    // events cannot trigger; only the component-owned half of the wiring is
+    // observable here — the body's own pan-y lives in modal.scss, which the
+    // qunit harness does not load
     assert
       .dom(".fk-d-menu-modal .d-modal__container")
       .hasAttribute(

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -245,10 +245,8 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     );
     await open();
 
-    // scroll deferral is the browser's own pan arbitration, which synthetic
-    // events cannot trigger; only the component-owned half of the wiring is
-    // observable here — the body's own pan-y lives in modal.scss, which the
-    // qunit harness does not load
+    // the browser's own arbitration cannot be driven synthetically, so only the
+    // component's half of the wiring is observable
     assert
       .dom(".fk-d-menu-modal .d-modal__container")
       .hasAttribute(

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -827,7 +827,7 @@ module("Integration | ui-kit | DModal", function (hooks) {
       assert
         .dom(body)
         .hasClass(
-          "--no-scroll",
+          "is-not-scrollable",
           "a body with nothing to scroll leaves vertical to the swipe"
         );
 
@@ -841,7 +841,7 @@ module("Integration | ui-kit | DModal", function (hooks) {
       assert
         .dom(body)
         .doesNotHaveClass(
-          "--no-scroll",
+          "is-not-scrollable",
           "and hands it back to the browser once there is"
         );
 
@@ -854,7 +854,7 @@ module("Integration | ui-kit | DModal", function (hooks) {
       assert
         .dom(body)
         .doesNotHaveClass(
-          "--no-scroll",
+          "is-not-scrollable",
           "content that grows in place is seen too"
         );
     });

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -725,8 +725,8 @@ module("Integration | ui-kit | DModal", function (hooks) {
       forceMobile();
     });
 
-    // `timeStamp` is a prototype accessor an own property shadows; the real
-    // spacing of synthetic events reads as a flick to the velocity rule
+    // synthetic events are milliseconds apart, which reads as a flick; an own
+    // `timeStamp` property shadows the prototype accessor
     function dispatchPointer(type, { y, time }) {
       const event = new PointerEvent(type, {
         bubbles: true,

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -7,12 +7,14 @@ import {
   focus,
   render,
   settled,
+  triggerEvent,
   triggerKeyEvent,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import noop from "discourse/helpers/noop";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { stubSharedPointerCapture } from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
 
@@ -716,5 +718,91 @@ module("Integration | ui-kit | DModal", function (hooks) {
       event.defaultPrevented,
       "the underlying modal does not preventDefault keystrokes aimed at the modal stacked above it"
     );
+  });
+
+  module("mobile swipe dismissal", function (innerHooks) {
+    innerHooks.beforeEach(function () {
+      forceMobile();
+    });
+
+    // `timeStamp` is a prototype accessor an own property shadows; the real
+    // spacing of synthetic events reads as a flick to the velocity rule
+    function dispatchPointer(type, { y, time }) {
+      const event = new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        pointerId: 1,
+        clientY: y,
+      });
+      Object.defineProperty(event, "timeStamp", { value: time });
+      find(".d-modal__container").dispatchEvent(event);
+    }
+
+    async function dragContainer({ by, overMs = 400 }) {
+      stubSharedPointerCapture([".d-modal__container"]);
+      dispatchPointer("pointerdown", { y: 100, time: 1000 });
+      dispatchPointer("pointermove", { y: 100 + by, time: 1000 + overMs });
+      dispatchPointer("pointerup", { y: 100 + by, time: 1000 + overMs + 16 });
+      await settled();
+    }
+
+    test("dragging down far enough closes the modal", async function (assert) {
+      const closeModal = () => assert.step("closeModal");
+      await render(
+        <template>
+          <DModal @inline={{true}} @closeModal={{closeModal}} />
+        </template>
+      );
+
+      const distance = find(".d-modal__container").clientHeight * 0.25 + 10;
+      await dragContainer({ by: distance });
+
+      assert.verifySteps(["closeModal"], "past a quarter height it dismisses");
+    });
+
+    test("a short drag settles the modal back", async function (assert) {
+      const closeModal = () => assert.step("closeModal");
+      await render(
+        <template>
+          <DModal @inline={{true}} @closeModal={{closeModal}} />
+        </template>
+      );
+
+      await dragContainer({ by: 10 });
+
+      assert.verifySteps([], "a short slow drag does not dismiss");
+      const { transform } = window.getComputedStyle(
+        find(".d-modal__container")
+      );
+      assert.strictEqual(
+        transform === "none" ? 0 : new DOMMatrixReadOnly(transform).m42,
+        0,
+        "and it settles back to resting position"
+      );
+    });
+
+    test("a press on a control hands it the pointer capture", async function (assert) {
+      await render(
+        <template>
+          <DModal @inline={{true}} @title="test" @closeModal={{noop}} />
+        </template>
+      );
+
+      const { ownerOf } = stubSharedPointerCapture([
+        ".d-modal__container",
+        ".modal-close",
+      ]);
+      await triggerEvent(".modal-close", "pointerdown", {
+        button: 0,
+        pointerId: 2,
+      });
+
+      assert
+        .dom(ownerOf(2))
+        .hasClass("modal-close", "a tap's click reaches the control");
+
+      await triggerEvent(".modal-close", "pointerup", { pointerId: 2 });
+    });
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -798,6 +798,40 @@ module("Integration | ui-kit | DModal", function (hooks) {
       assert.verifySteps([], "the flick's velocity expires while parked");
     });
 
+    test("the body keeps the vertical axis only while it can scroll", async function (assert) {
+      await render(
+        <template>
+          <DModal @inline={{true}} @closeModal={{noop}}>
+            <:body>short</:body>
+          </DModal>
+        </template>
+      );
+
+      const body = find(".d-modal__body");
+      // the measurement lands with the observer's first report, a frame in
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      assert
+        .dom(body)
+        .hasClass(
+          "--no-scroll",
+          "a body with nothing to scroll leaves vertical to the swipe"
+        );
+
+      // the stylesheet is absent here, so the scrolling box is set up by hand
+      body.style.height = "40px";
+      body.style.overflowY = "auto";
+      body.insertAdjacentHTML("beforeend", "<div style='height: 400px'></div>");
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await settled();
+
+      assert
+        .dom(body)
+        .doesNotHaveClass(
+          "--no-scroll",
+          "and hands it back to the browser once there is"
+        );
+    });
+
     test("a press on a control hands it the pointer capture", async function (assert) {
       await render(
         <template>

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -725,6 +725,14 @@ module("Integration | ui-kit | DModal", function (hooks) {
       forceMobile();
     });
 
+    // two frames: the first flushes any observation still in flight, so the
+    // second can only be reporting what the test just did
+    const settleObservers = async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await settled();
+    };
+
     // synthetic events are milliseconds apart, which reads as a flick; an own
     // `timeStamp` property shadows the prototype accessor
     function dispatchPointer(type, { y, time }) {
@@ -802,14 +810,20 @@ module("Integration | ui-kit | DModal", function (hooks) {
       await render(
         <template>
           <DModal @inline={{true}} @closeModal={{noop}}>
-            <:body>short</:body>
+            <:body><div class="body-content" style="height: 10px"></div></:body>
           </DModal>
         </template>
       );
 
+      // the stylesheet is absent here, so the capped box is set up by hand:
+      // measured against its own content, with the scrollbar space reserved so
+      // overflowing it later resizes nothing
       const body = find(".d-modal__body");
-      // the measurement lands with the observer's first report, a frame in
-      await new Promise((resolve) => requestAnimationFrame(resolve));
+      body.style.overflowY = "scroll";
+      body.style.scrollbarGutter = "stable";
+      body.style.height = `${body.scrollHeight + 20}px`;
+      await settleObservers();
+
       assert
         .dom(body)
         .hasClass(
@@ -817,18 +831,31 @@ module("Integration | ui-kit | DModal", function (hooks) {
           "a body with nothing to scroll leaves vertical to the swipe"
         );
 
-      // the stylesheet is absent here, so the scrolling box is set up by hand
-      body.style.height = "40px";
-      body.style.overflowY = "auto";
-      body.insertAdjacentHTML("beforeend", "<div style='height: 400px'></div>");
-      await new Promise((resolve) => requestAnimationFrame(resolve));
-      await settled();
+      // neither the capped body nor its existing child resizes here
+      find(".body-content").insertAdjacentHTML(
+        "afterend",
+        "<div style='height: 400px'></div>"
+      );
+      await settleObservers();
 
       assert
         .dom(body)
         .doesNotHaveClass(
           "--no-scroll",
           "and hands it back to the browser once there is"
+        );
+
+      // text grows in place: no child list changes and no element resizes
+      body.replaceChildren(document.createTextNode("short"));
+      await settleObservers();
+      body.firstChild.data = "long ".repeat(500);
+      await settleObservers();
+
+      assert
+        .dom(body)
+        .doesNotHaveClass(
+          "--no-scroll",
+          "content that grows in place is seen too"
         );
     });
 

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -739,11 +739,14 @@ module("Integration | ui-kit | DModal", function (hooks) {
       find(".d-modal__container").dispatchEvent(event);
     }
 
-    async function dragContainer({ by, overMs = 400 }) {
+    async function dragContainer({ by, overMs = 400, parkMs = 16 }) {
       stubSharedPointerCapture([".d-modal__container"]);
       dispatchPointer("pointerdown", { y: 100, time: 1000 });
       dispatchPointer("pointermove", { y: 100 + by, time: 1000 + overMs });
-      dispatchPointer("pointerup", { y: 100 + by, time: 1000 + overMs + 16 });
+      dispatchPointer("pointerup", {
+        y: 100 + by,
+        time: 1000 + overMs + parkMs,
+      });
       await settled();
     }
 
@@ -780,6 +783,19 @@ module("Integration | ui-kit | DModal", function (hooks) {
         0,
         "and it settles back to resting position"
       );
+    });
+
+    test("a flick parked before release settles instead of dismissing", async function (assert) {
+      const closeModal = () => assert.step("closeModal");
+      await render(
+        <template>
+          <DModal @inline={{true}} @closeModal={{closeModal}} />
+        </template>
+      );
+
+      await dragContainer({ by: 10, overMs: 8, parkMs: 250 });
+
+      assert.verifySteps([], "the flick's velocity expires while parked");
     });
 
     test("a press on a control hands it the pointer capture", async function (assert) {


### PR DESCRIPTION
Previously, the mobile modal's swipe-down dismissal ran on touch-only swipe events with hand-rolled content deferral, and a touch the browser claimed mid-drag left the modal displaced.

This change drives it with the shared pointer-drag gesture (`preservePress`, #42857): any pointer dismisses it, controls inside stay tappable, a claimed touch settles it back, velocity comes from the gesture rather than being tracked here, and `.d-modal__body` splits the pan axes so the browser keeps vertical scrolling while the swipe holds that axis whenever there is nothing to scroll.

One behaviour differs from before: in a body that can scroll, a downward drag always scrolls, including at the top edge where the old hit-testing dismissed instead. Built as the primitive's second consumer; the `touch-action` arbitration this rests on is described in the drag-and-gesture guide.
