### PR TITLE
FIX: scroll a sidebar row into view against the right scroller

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -11,6 +11,7 @@
   display: flex;
   align-items: center;
   position: relative;
+  scroll-margin-block: var(--space-6);
 
   &[data-list-item-name="all-categories"],
   &[data-list-item-name="all-tags"],

--- a/frontend/discourse/app/components/sidebar/section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-link.gjs
@@ -177,14 +177,13 @@ export default class SectionLink extends Component {
     }
 
     schedule("afterRender", () => {
-      const rect = element.getBoundingClientRect();
-      const alreadyVisible = rect.top <= window.innerHeight && rect.bottom >= 0;
-      if (alreadyVisible) {
+      if (isFullyScrolledIntoView(element)) {
         return;
       }
 
       element.scrollIntoView({
-        block: "center",
+        block: "nearest",
+        inline: "nearest",
       });
     });
   }
@@ -338,4 +337,34 @@ export default class SectionLink extends Component {
       </li>
     {{/if}}
   </template>
+}
+
+function isFullyScrolledIntoView(element) {
+  const rect = element.getBoundingClientRect();
+  let node = element.parentElement;
+  let scrolled = false;
+
+  while (node && node !== document.body) {
+    const { overflowY } = getComputedStyle(node);
+
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      scrolled = true;
+      const bounds = node.getBoundingClientRect();
+
+      if (rect.top < bounds.top || rect.bottom > bounds.bottom) {
+        return false;
+      }
+    }
+
+    node = node.parentElement;
+  }
+
+  if (scrolled) {
+    return true;
+  }
+
+  return rect.top >= 0 && rect.bottom <= window.innerHeight;
 }

--- a/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
@@ -107,4 +107,126 @@ module("Integration | Component | Sidebar | SectionLink", function (hooks) {
 
     assert.dom(".sidebar-section-link-wrapper").doesNotHaveClass("--hovering");
   });
+
+  test("scrollIntoView measures against the scrolling ancestor, not the window", async function (assert) {
+    // A scroller shorter than the window, with the link pushed below its
+    // visible area but still well inside the viewport.
+    await render(
+      <template>
+        <div
+          class="test-scroller"
+          style="height: 300px; overflow-y: auto; position: relative"
+        >
+          <div style="height: 600px"></div>
+          <SectionLink
+            @linkName="target"
+            @route="discovery.latest"
+            @scrollIntoView={{true}}
+          />
+          {{! trailing content, so centring the row is actually reachable }}
+          <div style="height: 600px"></div>
+        </div>
+      </template>
+    );
+
+    const scroller = document.querySelector(".test-scroller");
+    const link = document.querySelector("[data-list-item-name='target']");
+
+    assert.true(
+      link.getBoundingClientRect().top < window.innerHeight,
+      "precondition: the link is inside the viewport"
+    );
+    assert.true(
+      scroller.scrollTop > 0,
+      "the scroller was scrolled to bring the link into its own view"
+    );
+
+    const linkRect = link.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+
+    assert.true(
+      linkRect.top >= scrollerRect.top - 1,
+      "the link's top is inside the scroller"
+    );
+    assert.true(
+      linkRect.bottom <= scrollerRect.bottom + 1,
+      "the link's bottom is inside the scroller"
+    );
+
+    // centring would have scrolled roughly half a container further; the row is
+    // revealed near the edge instead, offset by its scroll-margin
+    const centeredScrollTop =
+      link.offsetTop - (scroller.clientHeight - link.offsetHeight) / 2;
+
+    assert.true(
+      scroller.scrollTop < centeredScrollTop,
+      "the scroller moved less than centring the row would have"
+    );
+  });
+
+  test("scrollIntoView accounts for an outer scroller too", async function (assert) {
+    // Visible inside its nearest scroller, but clipped by the one outside it.
+    await render(
+      <template>
+        <div
+          class="test-outer"
+          style="height: 100px; overflow-y: auto; position: relative"
+        >
+          <div style="height: 400px"></div>
+          <div
+            class="test-inner"
+            style="height: 60px; overflow-y: auto; position: relative"
+          >
+            <SectionLink
+              @linkName="target"
+              @route="discovery.latest"
+              @scrollIntoView={{true}}
+            />
+            {{! makes the inner scroller genuinely overflow }}
+            <div style="height: 300px"></div>
+          </div>
+          <div style="height: 400px"></div>
+        </div>
+      </template>
+    );
+
+    const outer = document.querySelector(".test-outer");
+    const link = document.querySelector("[data-list-item-name='target']");
+    const linkRect = link.getBoundingClientRect();
+    const outerRect = outer.getBoundingClientRect();
+
+    assert.true(outer.scrollTop > 0, "the outer scroller moved");
+    assert.true(
+      linkRect.top >= outerRect.top - 1,
+      "the link's top is inside the outer scroller"
+    );
+    assert.true(
+      linkRect.bottom <= outerRect.bottom + 1,
+      "the link's bottom is inside the outer scroller"
+    );
+  });
+
+  test("scrollIntoView leaves an already visible link alone", async function (assert) {
+    await render(
+      <template>
+        <div
+          class="test-scroller"
+          style="height: 300px; overflow-y: auto; position: relative"
+        >
+          <SectionLink
+            @linkName="target"
+            @route="discovery.latest"
+            @scrollIntoView={{true}}
+          />
+          <div style="height: 400px"></div>
+        </div>
+      </template>
+    );
+
+    assert.strictEqual(
+      document.querySelector(".test-scroller").scrollTop,
+      0,
+      "no scrolling happens when the link is already fully in view"
+    );
+  });
 });


### PR DESCRIPTION
We were actually checking if a sidebar row was rendered in the *window* rather than the container... so the active row wasn't properly scrolling into view in some cases because it's almost always in the window despite being scrolled out of view within its container.  

This also changes the behavior to be `nearest` rather than `center` which has a similar effect of keeping the active row in view, but reduces the movement required to do so. 

This change will allow us to utilize the scrollIntoView functionality for the sidebar in more places, not just the admin area. 