### PR TITLE
UX: scroll the open channel into view in the chat sidebar

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -265,6 +265,7 @@ export default {
             key = CHAT_PANEL;
             switchButtonLabel = i18n("sidebar.panels.chat.label");
             switchButtonIcon = "d-chat";
+            scrollActiveLinkIntoView = true;
 
             get switchButtonDefaultUrl() {
               return chatStateManager.lastKnownChatURL || "/chat";


### PR DESCRIPTION
This opts the full page chat sidebar into `scrollActiveLinkIntoView`, which will keep the current channel scrolled into view in cases of tall sidebars. This functionality was added for the admin sidebar and just never came over to chat. 