### PR TITLE
DEV: extract the sidebar's active link lookup

### DIFF
--- a/frontend/discourse/app/components/sidebar/api-sections.gjs
+++ b/frontend/discourse/app/components/sidebar/api-sections.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { getOwner, setOwner } from "@ember/owner";
 import { service } from "@ember/service";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import ApiSection from "./api-section";
 import PanelHeader from "./panel-header";
 
@@ -88,44 +89,9 @@ function prepareSidebarSectionClass(Section, routerService) {
       });
     }
 
+    @cached
     get activeLink() {
-      return this.filteredLinks.find((link) => {
-        try {
-          const currentWhen = link.currentWhen;
-
-          if (typeof currentWhen === "boolean") {
-            return currentWhen;
-          }
-
-          // TODO detect active links using the href field
-
-          const queryParams = link.query || {};
-          let models;
-
-          if (link.model) {
-            models = [link.model];
-          } else if (link.models) {
-            models = link.models;
-          } else {
-            models = [];
-          }
-
-          if (typeof currentWhen === "string") {
-            return currentWhen.split(" ").some((route) =>
-              routerService.isActive(route, ...models, {
-                queryParams,
-              })
-            );
-          }
-
-          return routerService.isActive(link.route, ...models, {
-            queryParams,
-          });
-        } catch {
-          // false if ember throws an exception while checking the routes
-          return false;
-        }
-      });
+      return findActiveLink(this.filteredLinks, routerService);
     }
 
     get filtered() {

--- a/frontend/discourse/app/lib/sidebar/active-link.js
+++ b/frontend/discourse/app/lib/sidebar/active-link.js
@@ -1,0 +1,56 @@
+/**
+ * Finds the link in a sidebar section that corresponds to the page being
+ * viewed. Sections use it to know whether they hold the current page, which
+ * drives expanding a collapsed section and scrolling the row into view.
+ *
+ * Route-backed links are matched through the router; links that only carry a
+ * URL — user-built custom sections store their links that way — are matched
+ * against the current URL instead.
+ *
+ * @param {Object[]} links - the section's links
+ * @param {RouterService} router
+ * @returns {Object|undefined} the matching link, if any
+ */
+export function findActiveLink(links, router) {
+  if (!links?.length) {
+    return;
+  }
+
+  return links.find((link) => {
+    try {
+      const currentWhen = link.currentWhen;
+
+      if (typeof currentWhen === "boolean") {
+        return currentWhen;
+      }
+
+      const href = link.href ?? link.value;
+
+      if (!link.route && href) {
+        return router.currentURL === href;
+      }
+
+      const queryParams = link.query || {};
+      let models;
+
+      if (link.model) {
+        models = [link.model];
+      } else if (link.models) {
+        models = link.models;
+      } else {
+        models = [];
+      }
+
+      if (typeof currentWhen === "string") {
+        return currentWhen
+          .split(" ")
+          .some((route) => router.isActive(route, ...models, { queryParams }));
+      }
+
+      return router.isActive(link.route, ...models, { queryParams });
+    } catch {
+      // false if ember throws an exception while checking the routes
+      return false;
+    }
+  });
+}

--- a/frontend/discourse/tests/unit/lib/sidebar/active-link-test.js
+++ b/frontend/discourse/tests/unit/lib/sidebar/active-link-test.js
@@ -1,0 +1,81 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
+
+module("Unit | Sidebar | active-link", function (hooks) {
+  setupTest(hooks);
+
+  function routerStub({ active = [], currentURL = "/" } = {}) {
+    return {
+      currentURL,
+      isActive(route) {
+        if (route === undefined) {
+          throw new Error("no route");
+        }
+        return active.includes(route);
+      },
+    };
+  }
+
+  test("returns undefined when there are no links", function (assert) {
+    assert.strictEqual(findActiveLink([], routerStub()), undefined);
+    assert.strictEqual(findActiveLink(undefined, routerStub()), undefined);
+  });
+
+  test("matches a route-backed link", function (assert) {
+    const links = [
+      { name: "one", route: "discovery.latest" },
+      { name: "two", route: "discovery.unread" },
+    ];
+
+    const result = findActiveLink(
+      links,
+      routerStub({ active: ["discovery.unread"] })
+    );
+
+    assert.strictEqual(result.name, "two");
+  });
+
+  test("matches a link that only carries a URL", function (assert) {
+    const links = [
+      { name: "one", value: "/somewhere" },
+      { name: "two", value: "/elsewhere" },
+    ];
+
+    const result = findActiveLink(
+      links,
+      routerStub({ currentURL: "/elsewhere" })
+    );
+
+    assert.strictEqual(result.name, "two", "user-built links match on href");
+  });
+
+  test("honours a boolean currentWhen", function (assert) {
+    const links = [
+      { name: "one", route: "discovery.latest", currentWhen: false },
+      { name: "two", route: "discovery.latest", currentWhen: true },
+    ];
+
+    assert.strictEqual(findActiveLink(links, routerStub()).name, "two");
+  });
+
+  test("honours a space separated currentWhen", function (assert) {
+    const links = [
+      { name: "one", route: "a", currentWhen: "x y" },
+      { name: "two", route: "b", currentWhen: "z discovery.latest" },
+    ];
+
+    const result = findActiveLink(
+      links,
+      routerStub({ active: ["discovery.latest"] })
+    );
+
+    assert.strictEqual(result.name, "two");
+  });
+
+  test("returns undefined when the router throws for every link", function (assert) {
+    const links = [{ name: "one" }, { name: "two" }];
+
+    assert.strictEqual(findActiveLink(links, routerStub()), undefined);
+  });
+});


### PR DESCRIPTION
This completes a TODO we were carrying here as a comment, and clears the way for some follow-ups. 

The lookup that decides which of a sidebar section's links is the current page was defined inline inside `prepareSidebarSectionClass`, so only sections rendered through `ApiSection` could use it... This means `expandActiveSection` and `scrollActiveLinkIntoView` were API-only features. Moving it lets us use it for the main sidebar sections too. 

Sections built by a site store their links as a `value` with no route, so they were never detected. They now match against `router.currentURL`.

Adds caching for the result, because otherwise it gets recomputed for every link in the section.

Behavior is unchanged otherwise. Tests cover route matching, hrefs, `currentWhen`, empty values, etc. 


