### PR TITLE
FEATURE: Add an AI automation review filter

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -626,7 +626,7 @@ class Reviewable < ActiveRecord::Base
           filter_query = filter.last
 
           next(memo) unless additional_filters[key]
-          filter_query.call(result, additional_filters[key])
+          filter_query.call(memo, additional_filters[key])
         end
     end
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/connectors/above-review-filters/ai-automation-filter.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/connectors/above-review-filters/ai-automation-filter.gjs
@@ -1,0 +1,37 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { action, set } from "@ember/object";
+import { service } from "@ember/service";
+import ComboBox from "discourse/select-kit/components/combo-box";
+import { i18n } from "discourse-i18n";
+
+export default class AiAutomationFilter extends Component {
+  static shouldRender(args, { currentUser }) {
+    return args.additionalFilters && currentUser?.ai_triage_automations?.length;
+  }
+
+  @service currentUser;
+
+  @action
+  updateAutomation(automationId) {
+    set(
+      this.args.outletArgs.additionalFilters,
+      "ai_triage_automation_id",
+      automationId
+    );
+  }
+
+  <template>
+    <div class="reviewable-filter ai-automation-filter" ...attributes>
+      <label class="filter-label">
+        {{i18n "discourse_ai.review_filters.ai_automation"}}
+      </label>
+      <ComboBox
+        @value={{@outletArgs.additionalFilters.ai_triage_automation_id}}
+        @content={{this.currentUser.ai_triage_automations}}
+        @onChange={{this.updateAutomation}}
+        @options={{hash none="discourse_ai.review_filters.all_ai_automations"}}
+      />
+    </div>
+  </template>
+}

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -231,6 +231,10 @@ en:
               description: "Allow tagging of posts created by the system user."
 
     discourse_ai:
+      review_filters:
+        ai_automation: "AI automation"
+        all_ai_automations: "(all AI automations)"
+
       title: "AI"
       copied: "Copied"
       view_raw: "View raw"

--- a/plugins/discourse-ai/lib/agents/tools/flag_post.rb
+++ b/plugins/discourse-ai/lib/agents/tools/flag_post.rb
@@ -82,6 +82,7 @@ module DiscourseAi
                 PostActionType.types[:spam],
                 message: spam_post_action_message,
                 reason: spam_score_reason,
+                context: triage_automation_context,
                 queue_for_review: true,
               ).perform
             flag_success = result.success?
@@ -106,6 +107,7 @@ module DiscourseAi
               Discourse.system_user,
               ReviewableScore.types[:needs_approval],
               reason: flag_reason,
+              context: triage_automation_context,
               force_review: true,
             )
 
@@ -183,6 +185,10 @@ module DiscourseAi
 
         def spam_flag?
           %w[spam spam_silence].include?(flag_type)
+        end
+
+        def triage_automation_context
+          DiscourseAi::Automation.triage_automation_context(feature_context[:automation_id])
         end
 
         def feature_context

--- a/plugins/discourse-ai/lib/automation.rb
+++ b/plugins/discourse-ai/lib/automation.rb
@@ -2,6 +2,14 @@
 
 module DiscourseAi
   module Automation
+    TRIAGE_AUTOMATION_CONTEXT_PREFIX = "discourse_ai:triage_automation:"
+
+    def self.triage_automation_context(automation_id)
+      return if automation_id.blank?
+
+      "#{TRIAGE_AUTOMATION_CONTEXT_PREFIX}#{automation_id}"
+    end
+
     def self.spam_based_flag_types
       %w[spam spam_silence]
     end

--- a/plugins/discourse-ai/lib/automation/llm_triage.rb
+++ b/plugins/discourse-ai/lib/automation/llm_triage.rb
@@ -263,6 +263,7 @@ module DiscourseAi
                     PostActionType.types[:spam],
                     message: spam_post_action_message,
                     reason: spam_score_reason,
+                    context: DiscourseAi::Automation.triage_automation_context(automation&.id),
                     queue_for_review: true,
                   ).perform
 
@@ -282,6 +283,7 @@ module DiscourseAi
                   Discourse.system_user,
                   ReviewableScore.types[:needs_approval],
                   reason: score_reason,
+                  context: DiscourseAi::Automation.triage_automation_context(automation&.id),
                   force_review: true,
                 )
 

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -90,6 +90,39 @@ DiscourseAi::Configuration::Module::NAMES.each do |module_name|
 end
 
 after_initialize do
+  add_to_serializer(
+    :current_user,
+    :ai_triage_automations,
+    include_condition: -> { scope.can_see_review_queue? },
+  ) do
+    DiscourseAutomation::Automation
+      .where(script: %w[llm_triage llm_agent_triage])
+      .order(:name)
+      .pluck(:id, :name)
+      .map { |id, name| { id: id, name: name } }
+  end
+
+  add_custom_reviewable_filter(
+    [
+      :ai_triage_automation_id,
+      Proc.new do |results, value|
+        value = value.to_s
+        if !value.match?(/\A[1-9]\d{0,18}\z/)
+          raise Discourse::InvalidParameters.new(:ai_triage_automation_id)
+        end
+
+        results.where(<<~SQL, context: DiscourseAi::Automation.triage_automation_context(value))
+            EXISTS (
+              SELECT 1
+              FROM reviewable_scores
+              WHERE reviewable_scores.reviewable_id = reviewables.id
+                AND reviewable_scores.context = :context
+            )
+          SQL
+      end,
+    ],
+  )
+
   if defined?(Rack::MiniProfiler)
     Rack::MiniProfiler.config.skip_paths << "/discourse-ai/ai-bot/artifacts"
   end

--- a/plugins/discourse-ai/spec/lib/agents/tools/flag_post_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/flag_post_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe DiscourseAi::Agents::Tools::FlagPost do
         reviewable_score_type: ReviewableScore.types[:needs_approval],
       )
     expect(score.reason).to include("Clear spam")
+    expect(score.context).to be_nil
   end
 
   it "skips when flag_post is false" do
@@ -132,5 +133,35 @@ RSpec.describe DiscourseAi::Agents::Tools::FlagPost do
       </p>
       <p>Response from the model: <img src=""></p>
     HTML
+    expect(score.context).to eq(DiscourseAi::Automation.triage_automation_context(123))
+  end
+
+  it "stores the automation context on spam scores while preserving their reason" do
+    automation = Fabricate(:automation, name: "Agent spam triage", script: "llm_agent_triage")
+    context =
+      DiscourseAi::Agents::BotContext.new(
+        post:,
+        feature_context: {
+          automation_id: automation.id,
+          automation_name: automation.name,
+        },
+      )
+
+    result =
+      described_class.new(
+        { flag_post: true, reason: "Spam links" },
+        bot_user: bot_user,
+        llm: llm,
+        context: context,
+        agent_options: {
+          flag_type: "spam",
+        },
+      ).invoke
+
+    score = ReviewableFlaggedPost.find_by(target: post).reviewable_scores.first
+
+    expect(result[:status]).to eq("flagged")
+    expect(score.context).to eq(DiscourseAi::Automation.triage_automation_context(automation.id))
+    expect(score.reason).to include(automation.name)
   end
 end

--- a/plugins/discourse-ai/spec/lib/modules/automation/llm_triage_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/automation/llm_triage_spec.rb
@@ -148,6 +148,37 @@ describe DiscourseAi::Automation::LlmTriage do
     )
   end
 
+  it "stores the automation context for review and spam scores without replacing their reasons" do
+    automation = Fabricate(:automation, name: "Unsafe content triage", script: "llm_triage")
+    spam_post = Fabricate(:post)
+
+    DiscourseAi::Completions::Llm.with_prepared_responses(%w[bad bad]) do
+      triage(
+        post: post,
+        triage_agent_id: ai_agent.id,
+        search_for_text: "bad",
+        flag_post: true,
+        flag_type: :review,
+        automation: automation,
+      )
+      triage(
+        post: spam_post,
+        triage_agent_id: ai_agent.id,
+        search_for_text: "bad",
+        flag_post: true,
+        flag_type: :spam,
+        automation: automation,
+      )
+    end
+
+    scores =
+      [post, spam_post].map { |target| Reviewable.find_by(target: target).reviewable_scores.first }
+    expected_context = DiscourseAi::Automation.triage_automation_context(automation.id)
+
+    expect(scores.map(&:context)).to contain_exactly(expected_context, expected_context)
+    expect(scores.map(&:reason)).to all(include(automation.name))
+  end
+
   it "keeps one reviewable when spam follows review" do
     DiscourseAi::Completions::Llm.with_prepared_responses(%w[bad bad]) do
       triage(

--- a/plugins/discourse-ai/spec/plugin_spec.rb
+++ b/plugins/discourse-ai/spec/plugin_spec.rb
@@ -30,4 +30,28 @@ describe Plugin::Instance do
       )
     end
   end
+
+  describe "current_user_serializer#ai_triage_automations" do
+    fab!(:moderator)
+
+    it "exposes classic and agent triage automations to reviewers" do
+      classic = Fabricate(:automation, name: "Classic triage", script: "llm_triage")
+      agent = Fabricate(:automation, name: "Agent triage", script: "llm_agent_triage")
+      Fabricate(:automation, name: "Report", script: "llm_report")
+
+      json = CurrentUserSerializer.new(moderator, scope: moderator.guardian, root: nil).as_json
+
+      expect(json[:ai_triage_automations]).to eq(
+        [{ id: agent.id, name: agent.name }, { id: classic.id, name: classic.name }],
+      )
+    end
+
+    it "does not expose triage automations to users without review access" do
+      user = Fabricate(:user)
+
+      json = CurrentUserSerializer.new(user, scope: user.guardian, root: nil).as_json
+
+      expect(json).not_to have_key(:ai_triage_automations)
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/requests/admin/reviewable_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/reviewable_controller_spec.rb
@@ -47,4 +47,36 @@ RSpec.describe ReviewablesController do
     json = JSON.parse(response.body)
     expect(json["reviewables"].length).to eq(2)
   end
+
+  it "filters by the stable AI triage automation score context" do
+    reviewable.add_score(
+      Discourse.system_user,
+      ReviewableScore.types[:needs_approval],
+      context: DiscourseAi::Automation.triage_automation_context(42),
+    )
+    reviewable2.add_score(
+      Discourse.system_user,
+      ReviewableScore.types[:needs_approval],
+      context: DiscourseAi::Automation.triage_automation_context(43),
+    )
+    sign_in(admin)
+
+    get "/review.json", params: { additional_filters: { ai_triage_automation_id: 42 }.to_json }
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["reviewables"].map { |item| item["id"] }).to contain_exactly(
+      reviewable.id,
+    )
+  end
+
+  it "rejects a malformed AI triage automation ID" do
+    sign_in(admin)
+
+    get "/review.json",
+        params: {
+          additional_filters: { ai_triage_automation_id: "1) OR TRUE--" }.to_json,
+        }
+
+    expect(response.status).to eq(400)
+  end
 end

--- a/plugins/discourse-ai/test/javascripts/integration/connectors/ai-automation-filter-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/connectors/ai-automation-filter-test.gjs
@@ -1,0 +1,53 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import AiAutomationFilter from "discourse/plugins/discourse-ai/discourse/connectors/above-review-filters/ai-automation-filter";
+
+module("Integration | Component | AiAutomationFilter", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("lists AI automations and updates the dedicated filter", async function (assert) {
+    this.currentUser.set("ai_triage_automations", [
+      { id: 21, name: "Classic triage" },
+      { id: 34, name: "Agent triage" },
+    ]);
+    const outletArgs = {
+      additionalFilters: { ai_triage_automation_id: 21 },
+    };
+
+    await render(
+      <template><AiAutomationFilter @outletArgs={{outletArgs}} /></template>
+    );
+
+    assert
+      .dom(".ai-automation-filter .filter-label")
+      .hasText("AI automation", "it labels the filter");
+
+    const automationSelector = selectKit(".ai-automation-filter .combo-box");
+    await automationSelector.expand();
+    assert.deepEqual(
+      automationSelector.noneRow().label(),
+      "(all AI automations)",
+      "it offers all AI automations"
+    );
+    assert.deepEqual(
+      automationSelector.rowByValue(21).label(),
+      "Classic triage",
+      "it lists the classic triage automation"
+    );
+    assert.deepEqual(
+      automationSelector.rowByValue(34).label(),
+      "Agent triage",
+      "it lists the agent triage automation"
+    );
+
+    await automationSelector.selectRowByValue(34);
+
+    assert.strictEqual(
+      outletArgs.additionalFilters.ai_triage_automation_id,
+      34,
+      "it writes the stable automation ID to the dedicated filter"
+    );
+  });
+});

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -812,9 +812,10 @@ RSpec.describe Reviewable, type: :model do
     after { Reviewable.clear_custom_filters! }
 
     it "correctly add a new filter" do
-      Reviewable.add_custom_filter([:assigned_to, Proc.new { |results, value| results }])
+      custom_filter = [:assigned_to, Proc.new { |results, value| results }]
+      Reviewable.add_custom_filter(custom_filter)
 
-      expect(Reviewable.custom_filters.size).to eq(1)
+      expect(Reviewable.custom_filters).to include(custom_filter)
     end
 
     it "applies the custom filter" do
@@ -829,6 +830,26 @@ RSpec.describe Reviewable, type: :model do
 
       expect(results.size).to eq(1)
       expect(results.first).to eq first_reviewable
+    end
+
+    it "composes multiple custom filters" do
+      admin = Fabricate(:admin)
+      matching_reviewable = Fabricate(:reviewable)
+      first_filter_reviewable = Fabricate(:reviewable)
+      second_filter_reviewable = Fabricate(:reviewable)
+      Reviewable.add_custom_filter([:first_ids, ->(results, value) { results.where(id: value) }])
+      Reviewable.add_custom_filter([:second_ids, ->(results, value) { results.where(id: value) }])
+
+      results =
+        Reviewable.list_for(
+          admin,
+          additional_filters: {
+            first_ids: [matching_reviewable.id, first_filter_reviewable.id],
+            second_ids: [matching_reviewable.id, second_filter_reviewable.id],
+          },
+        )
+
+      expect(results).to contain_exactly(matching_reviewable)
     end
 
     context "when listing for a moderator with a custom filter that joins tables with same named columns" do


### PR DESCRIPTION
Previously, staff could not identify which AI triage automation sent an item to the review queue.

This change records stable automation IDs on reviewable scores and adds a dedicated AI automation filter without changing the public `add_custom_reviewable_filter` API.

I have an automation that flags any post with the word `silly`:

<img width="970" height="525" alt="image" src="https://github.com/user-attachments/assets/f2efb310-37fe-479f-8e71-b11c042c81fa" />
