### PR TITLE
UX: scroll the current page into view in the main sidebar

### DIFF
--- a/frontend/discourse/app/components/sidebar/anonymous/categories-section.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/categories-section.gjs
@@ -1,5 +1,9 @@
+import { cached } from "@glimmer/tracking";
+import { service } from "@ember/service";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import Category from "discourse/models/category";
+import { and, eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import AllCategoriesSectionLink from "../common/all-categories-section-link";
 import SidebarCommonCategoriesSection from "../common/categories-section";
@@ -7,7 +11,14 @@ import Section from "../section";
 import SectionLink from "../section-link";
 
 export default class SidebarAnonymousCategoriesSection extends SidebarCommonCategoriesSection {
+  @service router;
+
   shouldSortCategoriesByDefault = this.#defaultCategoryIds().length > 0;
+
+  @cached
+  get activeLink() {
+    return findActiveLink(this.sectionLinks, this.router);
+  }
 
   get categories() {
     const ids = this.#defaultCategoryIds();
@@ -30,11 +41,17 @@ export default class SidebarAnonymousCategoriesSection extends SidebarCommonCate
   <template>
     <Section
       @sectionName="categories"
+      @activeLink={{this.activeLink}}
+      @expandWhenActive={{@expandActiveSection}}
       @headerLinkText={{i18n "sidebar.sections.categories.header_link_text"}}
       @collapsable={{@collapsable}}
     >
       {{#each this.sectionLinks as |sectionLink|}}
         <SectionLink
+          @scrollIntoView={{and
+            @scrollActiveLinkIntoView
+            (eq sectionLink.name this.activeLink.name)
+          }}
           @route={{sectionLink.route}}
           @title={{sectionLink.title}}
           @content={{sectionLink.text}}
@@ -47,7 +64,9 @@ export default class SidebarAnonymousCategoriesSection extends SidebarCommonCate
         />
       {{/each}}
 
-      <AllCategoriesSectionLink />
+      <AllCategoriesSectionLink
+        @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+      />
     </Section>
   </template>
 }

--- a/frontend/discourse/app/components/sidebar/anonymous/sections.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/sections.gjs
@@ -1,13 +1,19 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import BlockOutlet from "discourse/blocks/block-outlet";
+import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import ApiSections from "../api-sections";
 import CategoriesSection from "./categories-section";
 import CustomSections from "./custom-sections";
 import TagsSection from "./tags-section";
 
 export default class SidebarAnonymousSections extends Component {
+  @service sidebarState;
   @service siteSettings;
+
+  get mainPanel() {
+    return this.sidebarState.panels.find((panel) => panel.key === MAIN_PANEL);
+  }
 
   <template>
     <div class="sidebar-sections sidebar-sections-anonymous">
@@ -16,14 +22,28 @@ export default class SidebarAnonymousSections extends Component {
       <CustomSections
         @collapsable={{@collapsableSections}}
         @toggleNavigationMenu={{@toggleNavigationMenu}}
+        @expandActiveSection={{this.mainPanel.expandActiveSection}}
+        @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
       />
-      <CategoriesSection @collapsable={{@collapsableSections}} />
+      <CategoriesSection
+        @collapsable={{@collapsableSections}}
+        @expandActiveSection={{this.mainPanel.expandActiveSection}}
+        @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
+      />
 
       {{#if this.siteSettings.tagging_enabled}}
-        <TagsSection @collapsable={{@collapsableSections}} />
+        <TagsSection
+          @collapsable={{@collapsableSections}}
+          @expandActiveSection={{this.mainPanel.expandActiveSection}}
+          @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
+        />
       {{/if}}
 
-      <ApiSections @collapsable={{@collapsableSections}} />
+      <ApiSections
+        @collapsable={{@collapsableSections}}
+        @expandActiveSection={{this.mainPanel.expandActiveSection}}
+        @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
+      />
     </div>
   </template>
 }

--- a/frontend/discourse/app/components/sidebar/anonymous/tags-section.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/tags-section.gjs
@@ -1,15 +1,23 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { service } from "@ember/service";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import TagSectionLink from "discourse/lib/sidebar/user/tags-section/tag-section-link";
+import { and, eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import AllTagsSectionLink from "../common/all-tags-section-link";
 import Section from "../section";
 import SectionLink from "../section-link";
 
 export default class SidebarAnonymousTagsSection extends Component {
+  @service router;
   @service topicTrackingState;
   @service site;
+
+  @cached
+  get activeLink() {
+    return findActiveLink(this.sectionLinks, this.router);
+  }
 
   get displaySection() {
     return (
@@ -37,10 +45,16 @@ export default class SidebarAnonymousTagsSection extends Component {
         @sectionName="tags"
         @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
         @collapsable={{@collapsable}}
+        @activeLink={{this.activeLink}}
+        @expandWhenActive={{@expandActiveSection}}
       >
 
         {{#each this.sectionLinks as |sectionLink|}}
           <SectionLink
+            @scrollIntoView={{and
+              @scrollActiveLinkIntoView
+              (eq sectionLink.name this.activeLink.name)
+            }}
             @route={{sectionLink.route}}
             @content={{sectionLink.text}}
             @title={{sectionLink.title}}
@@ -53,7 +67,9 @@ export default class SidebarAnonymousTagsSection extends Component {
           />
         {{/each}}
 
-        <AllTagsSectionLink />
+        <AllTagsSectionLink
+          @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+        />
       </Section>
     {{/if}}
   </template>

--- a/frontend/discourse/app/components/sidebar/common/all-categories-section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/common/all-categories-section-link.gjs
@@ -1,14 +1,26 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import { i18n } from "discourse-i18n";
 import SectionLink from "../section-link";
 
-const SidebarCommonAllCategoriesSectionLink = <template>
-  <SectionLink
-    @linkName="all-categories"
-    @content={{i18n "sidebar.all_categories"}}
-    @route="discovery.categories"
-    @prefixType="icon"
-    @prefixValue="sidebar.all_categories"
-  />
-</template>;
+export default class SidebarCommonAllCategoriesSectionLink extends Component {
+  @service router;
 
-export default SidebarCommonAllCategoriesSectionLink;
+  get scrollIntoView() {
+    return (
+      this.args.scrollActiveLinkIntoView &&
+      this.router.isActive("discovery.categories")
+    );
+  }
+
+  <template>
+    <SectionLink
+      @linkName="all-categories"
+      @content={{i18n "sidebar.all_categories"}}
+      @route="discovery.categories"
+      @prefixType="icon"
+      @prefixValue="sidebar.all_categories"
+      @scrollIntoView={{this.scrollIntoView}}
+    />
+  </template>
+}

--- a/frontend/discourse/app/components/sidebar/common/all-categories-section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/common/all-categories-section-link.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import { isActiveLink } from "discourse/lib/sidebar/active-link";
 import { i18n } from "discourse-i18n";
 import SectionLink from "../section-link";
 
@@ -9,7 +10,7 @@ export default class SidebarCommonAllCategoriesSectionLink extends Component {
   get scrollIntoView() {
     return (
       this.args.scrollActiveLinkIntoView &&
-      this.router.isActive("discovery.categories")
+      isActiveLink({ route: "discovery.categories" }, this.router)
     );
   }
 

--- a/frontend/discourse/app/components/sidebar/common/all-tags-section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/common/all-tags-section-link.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import { isActiveLink } from "discourse/lib/sidebar/active-link";
 import { i18n } from "discourse-i18n";
 import SectionLink from "../section-link";
 
@@ -7,7 +8,10 @@ export default class SidebarCommonAllTagsSectionLink extends Component {
   @service router;
 
   get scrollIntoView() {
-    return this.args.scrollActiveLinkIntoView && this.router.isActive("tags");
+    return (
+      this.args.scrollActiveLinkIntoView &&
+      isActiveLink({ route: "tags" }, this.router)
+    );
   }
 
   <template>

--- a/frontend/discourse/app/components/sidebar/common/all-tags-section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/common/all-tags-section-link.gjs
@@ -1,14 +1,23 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import { i18n } from "discourse-i18n";
 import SectionLink from "../section-link";
 
-const SidebarCommonAllTagsSectionLink = <template>
-  <SectionLink
-    @linkName="all-tags"
-    @content={{i18n "sidebar.all_tags"}}
-    @route="tags"
-    @prefixType="icon"
-    @prefixValue="list"
-  />
-</template>;
+export default class SidebarCommonAllTagsSectionLink extends Component {
+  @service router;
 
-export default SidebarCommonAllTagsSectionLink;
+  get scrollIntoView() {
+    return this.args.scrollActiveLinkIntoView && this.router.isActive("tags");
+  }
+
+  <template>
+    <SectionLink
+      @linkName="all-tags"
+      @content={{i18n "sidebar.all_tags"}}
+      @route="tags"
+      @prefixType="icon"
+      @prefixValue="list"
+      @scrollIntoView={{this.scrollIntoView}}
+    />
+  </template>
+}

--- a/frontend/discourse/app/components/sidebar/common/custom-section.gjs
+++ b/frontend/discourse/app/components/sidebar/common/custom-section.gjs
@@ -1,6 +1,8 @@
 import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
 import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import CommonCommunitySection from "discourse/lib/sidebar/common/community-section/section";
 import Section from "discourse/lib/sidebar/section";
 import AdminCommunitySection from "discourse/lib/sidebar/user/community-section/admin-section";
@@ -39,6 +41,11 @@ export default class SidebarCustomSection extends Component {
     }
   }
 
+  @cached
+  get activeLink() {
+    return findActiveLink(this.section.links, this.router);
+  }
+
   get exactUrlMatch() {
     return this.section.links.find((link) => {
       return this.router.currentURL === link.value;
@@ -48,6 +55,8 @@ export default class SidebarCustomSection extends Component {
   <template>
     <SectionComponent
       @sectionName={{this.section.slug}}
+      @activeLink={{this.activeLink}}
+      @expandWhenActive={{@expandActiveSection}}
       @headerLinkText={{this.section.decoratedTitle}}
       @indicatePublic={{this.section.indicatePublic}}
       @collapsable={{@collapsable}}
@@ -63,6 +72,10 @@ export default class SidebarCustomSection extends Component {
         <SectionLink
           data-sidebar-custom-link="true"
           class={{if (eq linkDrop.linkDropIndex index) "is-link-drop-before"}}
+          @scrollIntoView={{and
+            @scrollActiveLinkIntoView
+            (eq link.name this.activeLink.name)
+          }}
           @badgeText={{link.badgeText}}
           @content={{dReplaceEmoji link.text}}
           @currentWhen={{link.currentWhen}}

--- a/frontend/discourse/app/components/sidebar/common/custom-sections.gjs
+++ b/frontend/discourse/app/components/sidebar/common/custom-sections.gjs
@@ -24,6 +24,8 @@ export default class SidebarCustomSections extends Component {
           @collapsable={{@collapsable}}
           @enableLinkDrop={{@enableLinkDrop}}
           @toggleNavigationMenu={{@toggleNavigationMenu}}
+          @expandActiveSection={{@expandActiveSection}}
+          @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
         />
       {{/each}}
     </div>

--- a/frontend/discourse/app/components/sidebar/user/categories-section.gjs
+++ b/frontend/discourse/app/components/sidebar/user/categories-section.gjs
@@ -2,8 +2,10 @@ import { cached } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { debounce } from "discourse/lib/decorators";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import { hasDefaultSidebarCategories } from "discourse/lib/sidebar/helpers";
 import Category from "discourse/models/category";
+import { and, eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import AllCategoriesSectionLink from "../common/all-categories-section-link";
 import CommonCategoriesSection from "../common/categories-section";
@@ -20,6 +22,7 @@ export default class SidebarUserCategoriesSection extends CommonCategoriesSectio
   @service currentUser;
   @service modal;
   @service navigationMenu;
+  @service router;
   @service siteSettings;
 
   constructor() {
@@ -42,6 +45,11 @@ export default class SidebarUserCategoriesSection extends CommonCategoriesSectio
       this,
       this._refreshCounts
     );
+  }
+
+  @cached
+  get activeLink() {
+    return findActiveLink(this.sectionLinks, this.router);
   }
 
   // TopicTrackingState changes or plugins can trigger this function so we debounce to ensure we're not refreshing
@@ -102,6 +110,8 @@ export default class SidebarUserCategoriesSection extends CommonCategoriesSectio
   <template>
     <Section
       @sectionName="categories"
+      @activeLink={{this.activeLink}}
+      @expandWhenActive={{@expandActiveSection}}
       @headerLinkText={{i18n "sidebar.sections.categories.header_link_text"}}
       @headerActions={{this.headerActions}}
       @headerActionsIcon={{this.headerActionsIcon}}
@@ -111,6 +121,10 @@ export default class SidebarUserCategoriesSection extends CommonCategoriesSectio
 
       {{#each this.sectionLinks as |sectionLink|}}
         <SectionLink
+          @scrollIntoView={{and
+            @scrollActiveLinkIntoView
+            (eq sectionLink.name this.activeLink.name)
+          }}
           @route={{sectionLink.route}}
           @query={{sectionLink.query}}
           @title={{sectionLink.title}}
@@ -129,7 +143,9 @@ export default class SidebarUserCategoriesSection extends CommonCategoriesSectio
         />
       {{/each}}
 
-      <AllCategoriesSectionLink />
+      <AllCategoriesSectionLink
+        @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+      />
 
       {{#if this.shouldDisplayDefaultConfig}}
         <SectionLink

--- a/frontend/discourse/app/components/sidebar/user/sections.gjs
+++ b/frontend/discourse/app/components/sidebar/user/sections.gjs
@@ -12,6 +12,7 @@ import {
   WEB_LINK_KINDS,
   webLinkPayload,
 } from "discourse/lib/sidebar/link-drop";
+import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dDragAndDropAutoScroll from "discourse/ui-kit/modifiers/d-drag-and-drop-auto-scroll";
@@ -32,6 +33,7 @@ import TagsSection from "./tags-section";
 const ZONE_ARM_DELAY = 250;
 
 export default class SidebarUserSections extends Component {
+  @service sidebarState;
   @service currentUser;
   @service modal;
 
@@ -122,6 +124,10 @@ export default class SidebarUserSections extends Component {
     });
   }
 
+  get mainPanel() {
+    return this.sidebarState.panels.find((panel) => panel.key === MAIN_PANEL);
+  }
+
   <template>
     {{! This is the element that scrolls, so a link dragged in can only reach a
         section below the fold if the scrolling happens here. Both origins are
@@ -146,6 +152,8 @@ export default class SidebarUserSections extends Component {
         @collapsable={{@collapsableSections}}
         @enableLinkDrop={{@enableLinkDrop}}
         @toggleNavigationMenu={{@toggleNavigationMenu}}
+        @expandActiveSection={{this.mainPanel.expandActiveSection}}
+        @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
       />
 
       {{#if this.zoneRevealed}}
@@ -188,14 +196,24 @@ export default class SidebarUserSections extends Component {
       <CategoriesSection
         @collapsable={{@collapsableSections}}
         @toggleNavigationMenu={{@toggleNavigationMenu}}
+        @expandActiveSection={{this.mainPanel.expandActiveSection}}
+        @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
       />
 
       {{#if this.currentUser.display_sidebar_tags}}
-        <TagsSection @collapsable={{@collapsableSections}} />
+        <TagsSection
+          @collapsable={{@collapsableSections}}
+          @expandActiveSection={{this.mainPanel.expandActiveSection}}
+          @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
+        />
       {{/if}}
 
       {{#unless @hideApiSections}}
-        <ApiSections @collapsable={{@collapsableSections}} />
+        <ApiSections
+          @collapsable={{@collapsableSections}}
+          @expandActiveSection={{this.mainPanel.expandActiveSection}}
+          @scrollActiveLinkIntoView={{this.mainPanel.scrollActiveLinkIntoView}}
+        />
       {{/unless}}
     </div>
   </template>

--- a/frontend/discourse/app/components/sidebar/user/tags-section.gjs
+++ b/frontend/discourse/app/components/sidebar/user/tags-section.gjs
@@ -4,15 +4,18 @@ import { array, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import SidebarEditNavigationMenuTagsModal from "discourse/components/sidebar/edit-navigation-menu/tags-modal";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import { hasDefaultSidebarTags } from "discourse/lib/sidebar/helpers";
 import PMTagSectionLink from "discourse/lib/sidebar/user/tags-section/pm-tag-section-link";
 import TagSectionLink from "discourse/lib/sidebar/user/tags-section/tag-section-link";
+import { and, eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import AllTagsSectionLink from "../common/all-tags-section-link";
 import Section from "../section";
 import SectionLink from "../section-link";
 
 export default class SidebarUserTagsSection extends Component {
+  @service router;
   @service currentUser;
   @service modal;
   @service site;
@@ -34,6 +37,11 @@ export default class SidebarUserTagsSection extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.topicTrackingState.offStateChange(this.callbackId);
+  }
+
+  @cached
+  get activeLink() {
+    return findActiveLink(this.sectionLinks, this.router);
   }
 
   @cached
@@ -85,6 +93,8 @@ export default class SidebarUserTagsSection extends Component {
   <template>
     <Section
       @sectionName="tags"
+      @activeLink={{this.activeLink}}
+      @expandWhenActive={{@expandActiveSection}}
       @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
       @headerActions={{array
         (hash
@@ -97,6 +107,10 @@ export default class SidebarUserTagsSection extends Component {
     >
       {{#each this.sectionLinks as |sectionLink|}}
         <SectionLink
+          @scrollIntoView={{and
+            @scrollActiveLinkIntoView
+            (eq sectionLink.name this.activeLink.name)
+          }}
           @route={{sectionLink.route}}
           @title={{sectionLink.title}}
           @content={{sectionLink.text}}
@@ -113,7 +127,9 @@ export default class SidebarUserTagsSection extends Component {
         />
       {{/each}}
 
-      <AllTagsSectionLink />
+      <AllTagsSectionLink
+        @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+      />
 
       {{#if this.shouldDisplayDefaultConfig}}
         <SectionLink

--- a/frontend/discourse/app/lib/sidebar/active-link.js
+++ b/frontend/discourse/app/lib/sidebar/active-link.js
@@ -11,46 +11,57 @@
  * @param {RouterService} router
  * @returns {Object|undefined} the matching link, if any
  */
+/**
+ * Whether one link corresponds to the page being viewed. The router throws for
+ * a route it does not know, and is not always a full router service — in
+ * rendering tests it is a stand-in — so every lookup goes through here.
+ *
+ * @param {Object} link
+ * @param {RouterService} router
+ * @returns {boolean}
+ */
+export function isActiveLink(link, router) {
+  try {
+    const currentWhen = link.currentWhen;
+
+    if (typeof currentWhen === "boolean") {
+      return currentWhen;
+    }
+
+    const href = link.href ?? link.value;
+
+    if (!link.route && href) {
+      return router.currentURL === href;
+    }
+
+    const queryParams = link.query || {};
+    let models;
+
+    if (link.model) {
+      models = [link.model];
+    } else if (link.models) {
+      models = link.models;
+    } else {
+      models = [];
+    }
+
+    if (typeof currentWhen === "string") {
+      return currentWhen
+        .split(" ")
+        .some((route) => router.isActive(route, ...models, { queryParams }));
+    }
+
+    return router.isActive(link.route, ...models, { queryParams });
+  } catch {
+    // false if ember throws an exception while checking the routes
+    return false;
+  }
+}
+
 export function findActiveLink(links, router) {
   if (!links?.length) {
     return;
   }
 
-  return links.find((link) => {
-    try {
-      const currentWhen = link.currentWhen;
-
-      if (typeof currentWhen === "boolean") {
-        return currentWhen;
-      }
-
-      const href = link.href ?? link.value;
-
-      if (!link.route && href) {
-        return router.currentURL === href;
-      }
-
-      const queryParams = link.query || {};
-      let models;
-
-      if (link.model) {
-        models = [link.model];
-      } else if (link.models) {
-        models = link.models;
-      } else {
-        models = [];
-      }
-
-      if (typeof currentWhen === "string") {
-        return currentWhen
-          .split(" ")
-          .some((route) => router.isActive(route, ...models, { queryParams }));
-      }
-
-      return router.isActive(link.route, ...models, { queryParams });
-    } catch {
-      // false if ember throws an exception while checking the routes
-      return false;
-    }
-  });
+  return links.find((link) => isActiveLink(link, router));
 }

--- a/frontend/discourse/app/lib/sidebar/custom-sections.js
+++ b/frontend/discourse/app/lib/sidebar/custom-sections.js
@@ -5,8 +5,9 @@ import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import { i18n } from "discourse-i18n";
 import AdminSidebarPanel from "./admin-sidebar";
 
-class MainSidebarPanel {
-  sections = [];
+class MainSidebarPanel extends BaseCustomSidebarPanel {
+  scrollActiveLinkIntoView = true;
+  expandActiveSection = false;
 
   get key() {
     return "main";

--- a/frontend/discourse/tests/acceptance/sidebar-plugin-api-test.gjs
+++ b/frontend/discourse/tests/acceptance/sidebar-plugin-api-test.gjs
@@ -854,6 +854,149 @@ acceptance("Sidebar - Plugin API", function (needs) {
       .exists({ count: 1 });
   });
 
+  test("Scroll active link into view on first load, for a short section below long ones", async function (assert) {
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-long-section";
+            text = "Long";
+            collapsedByDefault = false;
+
+            get links() {
+              return [...Array(100)].map(
+                (_, i) =>
+                  new (class extends BaseCustomSidebarSectionLink {
+                    get name() {
+                      return `filler-${i}`;
+                    }
+
+                    get href() {
+                      return `/filler${i}`;
+                    }
+
+                    get title() {
+                      return `Filler ${i}`;
+                    }
+
+                    get text() {
+                      return `Filler ${i}`;
+                    }
+                  })()
+              );
+            }
+          };
+        }
+      );
+
+      // its own single-link section, rendered after the long one
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-trailing-section";
+            hideSectionHeader = true;
+            text = null;
+
+            get links() {
+              return [
+                new (class extends BaseCustomSidebarSectionLink {
+                  name = "trailing-search";
+                  route = "full-page-search";
+                  title = "Search";
+                  text = "Search";
+                })(),
+              ];
+            }
+          };
+        }
+      );
+    });
+
+    // land on the page directly rather than transitioning to it
+    await visit("/search");
+
+    assert
+      .dom(
+        ".sidebar-section-link-wrapper[data-list-item-name='trailing-search'] > a.active"
+      )
+      .exists("precondition: the link is detected as active");
+
+    assert.true(
+      document.querySelector(".sidebar-sections").scrollTop > 0,
+      "the sidebar scrolled the trailing section's link into view on load"
+    );
+  });
+
+  test("Scroll active link into view for a section in the main sidebar", async function (assert) {
+    // Sections can be appended to the main sidebar rather than living in a
+    // panel of their own; those render through ApiSections inside the main
+    // panel, so the main panel's flag has to reach them.
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-appended-section";
+            text = "Appended";
+            collapsedByDefault = false;
+
+            get links() {
+              const values = [...Array(100)].map(
+                (_, i) =>
+                  new (class extends BaseCustomSidebarSectionLink {
+                    get name() {
+                      return `appended-link-${i}`;
+                    }
+
+                    get href() {
+                      return `/appended${i}`;
+                    }
+
+                    get title() {
+                      return `Appended Link ${i}`;
+                    }
+
+                    get text() {
+                      return `Appended Link ${i}`;
+                    }
+                  })()
+              );
+
+              values.push(
+                new (class extends BaseCustomSidebarSectionLink {
+                  name = "appended-search";
+                  route = "full-page-search";
+                  title = "Search";
+                  text = "Search";
+                })()
+              );
+
+              return values;
+            }
+          };
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(".sidebar-sections")
+      .hasProperty("scrollTop", 0, "the sidebar is not scrolled initially");
+
+    await visit("/search");
+
+    assert
+      .dom(
+        ".sidebar-section-link-wrapper[data-list-item-name='appended-search'] > a.active"
+      )
+      .exists();
+
+    assert.true(
+      document.querySelector(".sidebar-sections").scrollTop > 0,
+      "the main sidebar scrolled the appended section's active link into view"
+    );
+  });
+
   test("Scroll active link into view", async function (assert) {
     withPluginApi((api) => {
       api.addSidebarPanel((BaseCustomSidebarPanel) => {


### PR DESCRIPTION
depends on https://github.com/discourse/discourse/pull/42866

this adds the functionality of scrolling the active sidebar link into view to the main navigation sidebar, previously this feature only worked for API-added sidebars 

this turns on scrolling into view, but specifically does not expand collapsed sections, which would be overriding the user's preferred state 

the tag and categories sections needed a little separate handling due to the special "view all" links 