### PR TITLE
FIX: Identify tags by a stable key rather than their display name

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -103,9 +103,13 @@ class TagsController < ::ApplicationController
 
   def list
     offset = params[:offset].to_i || 0
-    only_tags = params[:only_tags]
 
-    tags = only_tags.present? ? Tag.visible(guardian) : Tag.browsable(guardian)
+    # Callers holding tag records filter by id; callers holding user input, such
+    # as a tag name typed into a composer preset, filter by name.
+    only_tag_ids = params[:only_tag_ids].presence
+    only_tags = params[:only_tags].presence
+
+    tags = (only_tag_ids || only_tags) ? Tag.visible(guardian) : Tag.browsable(guardian)
     tags = tags.without_pm_only_tags(guardian) unless show_all_tags?
 
     load_more_query_params = { offset: offset + 1 }
@@ -115,12 +119,18 @@ class TagsController < ::ApplicationController
       load_more_query_params[:filter] = filter
     end
 
-    if only_tags
-      tags = tags.where("LOWER(tags.name) IN (?)", only_tags.split(",").map(&:downcase))
+    if only_tag_ids
+      tags = tags.where(id: only_tag_ids.split(","))
+      load_more_query_params[:only_tag_ids] = only_tag_ids
+    elsif only_tags
+      tags = tags.where_name(only_tags.split(","))
       load_more_query_params[:only_tags] = only_tags
     end
 
-    if exclude_tags = params[:exclude_tags]
+    if exclude_tag_ids = params[:exclude_tag_ids].presence
+      tags = tags.where.not(id: exclude_tag_ids.split(","))
+      load_more_query_params[:exclude_tag_ids] = exclude_tag_ids
+    elsif exclude_tags = params[:exclude_tags].presence
       tags = tags.where("LOWER(tags.name) NOT IN (?)", exclude_tags.split(",").map(&:downcase))
       load_more_query_params[:exclude_tags] = exclude_tags
     end
@@ -604,6 +614,10 @@ class TagsController < ::ApplicationController
             target ? { id: target.id, name: target.name, slug: target.slug } : nil
           end,
       }
+
+      # Customizations are keyed on the untranslated name, which is otherwise
+      # unrecoverable from a localized payload.
+      attrs[:original_name] = t.name if tag_name != t.name
 
       if show_pm_tags && SiteSetting.display_personal_messages_tag_counts
         attrs[:pm_count] = t.pm_topic_count

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2216,18 +2216,13 @@ class UsersController < ApplicationController
     permitted.concat UserUpdater::TAG_NAMES.keys
     permitted << UserUpdater::NOTIFICATION_SCHEDULE_ATTRS
 
-    if params.has_key?(:sidebar_category_ids) && params[:sidebar_category_ids].blank?
-      params[:sidebar_category_ids] = []
-    end
+    sidebar_keys = [:sidebar_category_ids]
+    # `sidebar_tag_names` is deprecated in favour of `sidebar_tag_ids`.
+    sidebar_keys.concat(%i[sidebar_tag_ids sidebar_tag_names]) if SiteSetting.tagging_enabled
 
-    permitted << { sidebar_category_ids: [] }
-
-    if SiteSetting.tagging_enabled
-      if params.has_key?(:sidebar_tag_names) && params[:sidebar_tag_names].blank?
-        params[:sidebar_tag_names] = []
-      end
-
-      permitted << { sidebar_tag_names: [] }
+    sidebar_keys.each do |key|
+      params[key] = [] if params.has_key?(key) && params[key].blank?
+      permitted << { key => [] }
     end
 
     if SiteSetting.enable_user_status

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -269,6 +269,22 @@ class Tag < ActiveRecord::Base
     slug.presence || "#{id}-tag"
   end
 
+  def localization_for(scope)
+    get_localization if ContentLocalization.show_translated_tag?(self, scope)
+  end
+
+  def display_name(scope)
+    localization_for(scope)&.name || name
+  end
+
+  def display_description(scope)
+    localization_for(scope)&.description || description
+  end
+
+  def display_description_cooked(scope)
+    localization_for(scope)&.description_cooked || description_cooked
+  end
+
   def index_search
     SearchIndexer.index(self)
   end

--- a/app/serializers/concerns/localized_tag_mixin.rb
+++ b/app/serializers/concerns/localized_tag_mixin.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# `name` is a display string and holds a localization when one applies, so the
+# untranslated name rides along whenever the two differ.
+module LocalizedTagMixin
+  def self.included(klass)
+    klass.attributes :name, :original_name, :description
+  end
+
+  def name
+    @name ||= object.display_name(scope)
+  end
+
+  def description
+    object.display_description(scope)
+  end
+
+  def original_name
+    object.name
+  end
+
+  def include_original_name?
+    name != object.name
+  end
+end

--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -17,14 +17,23 @@ module TopicTagsMixin
   end
 
   def tags
-    all_tags.map { |tag| { id: tag.id, name: localized_tag_name(tag), slug: tag.slug_for_url } }
+    all_tags.map do |tag|
+      display_name = tag.display_name(scope)
+
+      {
+        id: tag.id,
+        name: display_name,
+        slug: tag.slug_for_url,
+        original_name: (tag.name if display_name != tag.name),
+      }.compact
+    end
   end
 
   def tags_descriptions
     all_tags
       .each
       .with_object({}) do |tag, acc|
-        acc[localized_tag_name(tag)] = localized_tag_description(tag)&.truncate(DESCRIPTION_LIMIT)
+        acc[tag.display_name(scope)] = tag.display_description(scope)&.truncate(DESCRIPTION_LIMIT)
       end
       .compact
   end
@@ -34,22 +43,6 @@ module TopicTagsMixin
   end
 
   private
-
-  def localized_tag_name(tag)
-    if ContentLocalization.show_translated_tag?(tag, scope)
-      tag.get_localization&.name || tag.name
-    else
-      tag.name
-    end
-  end
-
-  def localized_tag_description(tag)
-    if ContentLocalization.show_translated_tag?(tag, scope)
-      tag.get_localization&.description || tag.description
-    else
-      tag.description
-    end
-  end
 
   def all_tags
     return @tags if defined?(@tags)

--- a/app/serializers/sidebar_tag_serializer.rb
+++ b/app/serializers/sidebar_tag_serializer.rb
@@ -1,24 +1,12 @@
 # frozen_string_literal: true
 
 class SidebarTagSerializer < ApplicationSerializer
-  attributes :id, :name, :slug, :description, :pm_only
+  include LocalizedTagMixin
+
+  attributes :id, :slug, :pm_only
 
   def slug
     object.slug_for_url
-  end
-
-  def name
-    translated =
-      (object.get_localization&.name if ContentLocalization.show_translated_tag?(object, scope))
-    translated || object.name
-  end
-
-  def description
-    translated =
-      if ContentLocalization.show_translated_tag?(object, scope)
-        object.get_localization&.description
-      end
-    translated || object.description
   end
 
   def pm_only

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class TagSerializer < ApplicationSerializer
-  attributes :id, :name, :slug, :topic_count, :staff, :description, :description_cooked
+  include LocalizedTagMixin
+
+  attributes :id, :slug, :topic_count, :staff, :description_cooked
 
   has_many :localizations, serializer: TagLocalizationSerializer, embed: :objects
 
@@ -9,26 +11,8 @@ class TagSerializer < ApplicationSerializer
     object.slug_for_url
   end
 
-  def name
-    translated =
-      (object.get_localization&.name if ContentLocalization.show_translated_tag?(object, scope))
-    translated || object.name
-  end
-
-  def description
-    translated =
-      if ContentLocalization.show_translated_tag?(object, scope)
-        object.get_localization&.description
-      end
-    translated || object.description
-  end
-
   def description_cooked
-    translated =
-      if ContentLocalization.show_translated_tag?(object, scope)
-        object.get_localization&.description_cooked
-      end
-    translated || object.description_cooked
+    object.display_description_cooked(scope)
   end
 
   def topic_count

--- a/app/services/tag_hashtag_data_source.rb
+++ b/app/services/tag_hashtag_data_source.rb
@@ -23,16 +23,20 @@ class TagHashtagDataSource
   def self.tag_to_hashtag_item(tag, guardian)
     topic_count_column = Tag.topic_count_column(guardian)
 
-    tag =
-      Tag.new(
-        tag.slice(:id, :name, :slug, :description).merge(topic_count_column => tag[:count]),
-      ) if tag.is_a?(Hash)
+    # `name` may hold a localization, but hashtags are looked up by the real name.
+    if tag.is_a?(Hash)
+      lookup_name = tag[:original_name] || tag[:name]
+      tag =
+        Tag.new(tag.slice(:id, :name, :slug, :description).merge(topic_count_column => tag[:count]))
+    else
+      lookup_name = tag.name
+    end
 
     HashtagAutocompleteService::HashtagItem.new.tap do |item|
       item.text = tag.name
       item.secondary_text = "x#{tag.public_send(topic_count_column)}"
       item.description = tag.description
-      item.slug = tag.name
+      item.slug = lookup_name
       item.relative_url = tag.url
       item.icon = icon
       item.style_type = style_type

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -241,12 +241,23 @@ class UserUpdater
         )
       end
 
-      if attributes.key?(:sidebar_tag_names) && SiteSetting.tagging_enabled
-        SidebarSectionLinksUpdater.update_tag_section_links(
-          user,
-          tag_ids:
-            Tag.browsable(@user_guardian).where(name: attributes[:sidebar_tag_names]).pluck(:id),
-        )
+      if SiteSetting.tagging_enabled
+        browsable = Tag.browsable(@user_guardian)
+
+        tags =
+          if attributes.key?(:sidebar_tag_ids)
+            browsable.where(id: attributes[:sidebar_tag_ids])
+          elsif attributes.key?(:sidebar_tag_names)
+            Discourse.deprecate(
+              "`sidebar_tag_names` is deprecated. Use `sidebar_tag_ids` instead.",
+              since: "2026.9.0-latest",
+              drop_from: "2027.3.0-latest",
+            )
+
+            browsable.where_name(attributes[:sidebar_tag_names])
+          end
+
+        SidebarSectionLinksUpdater.update_tag_section_links(user, tag_ids: tags.pluck(:id)) if tags
       end
 
       if SiteSetting.enable_user_status?

--- a/frontend/discourse/app/components/discourse-tag-bound.gjs
+++ b/frontend/discourse/app/components/discourse-tag-bound.gjs
@@ -2,24 +2,19 @@
 import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { tagName } from "@ember-decorators/component";
-import getURL from "discourse/lib/get-url";
+import { originalTagName, tagUrl } from "discourse/lib/tag-identity";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 @tagName("")
 export default class DiscourseTagBound extends Component {
-  @computed("tagRecord.name")
+  @computed("tagRecord.name", "tagRecord.original_name")
   get tagClass() {
-    return "tag-" + this.tagRecord?.name;
+    return "tag-" + originalTagName(this.tagRecord);
   }
 
-  @computed("tagRecord.slug", "tagRecord.id")
+  @computed("tagRecord.slug", "tagRecord.id", "tagRecord.name")
   get href() {
-    if (this.tagRecord?.id) {
-      const slugForUrl = this.tagRecord?.slug || `${this.tagRecord?.id}-tag`;
-      return getURL(`/tag/${slugForUrl}/${this.tagRecord?.id}`);
-    }
-    // fallback for tags without id
-    return getURL("/tag/" + this.tagRecord.name);
+    return tagUrl(this.tagRecord);
   }
 
   <template>

--- a/frontend/discourse/app/components/search-menu/results/assistant-item.gjs
+++ b/frontend/discourse/app/components/search-menu/results/assistant-item.gjs
@@ -6,7 +6,7 @@ import Category from "discourse/components/search-menu/results/type/category";
 import Tag from "discourse/components/search-menu/results/type/tag";
 import User from "discourse/components/search-menu/results/type/user";
 import { debounce } from "discourse/lib/decorators";
-import getURL from "discourse/lib/get-url";
+import { tagUrl } from "discourse/lib/tag-identity";
 import { and, or } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -33,14 +33,14 @@ export default class AssistantItem extends Component {
       href = this.args.category.url;
 
       if (this.args.tags && this.args.isIntersection) {
-        href = getURL(`/tag/${this.args.tag}`);
+        href = tagUrl(this.args.tag);
       }
     } else if (
       this.args.tags &&
       this.args.isIntersection &&
       this.args.additionalTags?.length
     ) {
-      href = getURL(`/tag/${this.args.tag}`);
+      href = tagUrl(this.args.tag);
     }
 
     return href;

--- a/frontend/discourse/app/components/sidebar/anonymous/tags-section.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/tags-section.gjs
@@ -63,7 +63,7 @@ export default class SidebarAnonymousTagsSection extends Component {
             @prefixValue={{sectionLink.prefixValue}}
             @prefixColor={{sectionLink.prefixColor}}
             @models={{sectionLink.models}}
-            data-tag-name={{sectionLink.tagName}}
+            data-tag-name={{sectionLink.originalName}}
           />
         {{/each}}
 

--- a/frontend/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.gjs
+++ b/frontend/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.gjs
@@ -22,7 +22,7 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
 
   @tracked disableFiltering = false;
   @tracked saving = false;
-  @tracked selectedTags = trackedSet([...this.currentUser.sidebarTagNames]);
+  @tracked selectedTagIds = trackedSet([...this.currentUser.sidebarTagIds]);
   @tracked tags = [];
   @tracked tagsLoading = false;
   observer;
@@ -45,14 +45,14 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
       }
 
       if (this.onlySelected) {
-        if (this.selectedTags.size === 0) {
+        if (this.selectedTagIds.size === 0) {
           this.tags = [];
           return;
         }
 
-        findArgs.only_tags = [...this.selectedTags].join(",");
+        findArgs.only_tag_ids = [...this.selectedTagIds].join(",");
       } else if (this.onlyUnselected) {
-        findArgs.exclude_tags = [...this.selectedTags].join(",");
+        findArgs.exclude_tag_ids = [...this.selectedTagIds].join(",");
       }
 
       try {
@@ -68,11 +68,8 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
   }
 
   @action
-  didInsertTag(element) {
-    const tagName = element.dataset.tagName;
-    const lastTagName = this.tags.content.at(-1).name;
-
-    if (tagName === lastTagName) {
+  didInsertTag(element, [tagId]) {
+    if (tagId === this.tags.content.at(-1).id) {
       if (this.observer) {
         this.observer.disconnect();
       } else {
@@ -135,22 +132,33 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
 
   @action
   deselectAll() {
-    this.selectedTags.clear();
+    this.selectedTagIds.clear();
   }
 
   @action
-  resetToDefaults() {
-    this.selectedTags = trackedSet(
-      this.siteSettings.default_navigation_menu_tags.split("|")
-    );
+  async resetToDefaults() {
+    // The setting stores tag names, and the ids they resolve to are only known
+    // to the server.
+    try {
+      const tags = await this.store.findAll("listTag", {
+        only_tags: this.siteSettings.default_navigation_menu_tags.replaceAll(
+          "|",
+          ","
+        ),
+      });
+
+      this.selectedTagIds = trackedSet(tags.content.map((tag) => tag.id));
+    } catch (error) {
+      popupAjaxError(error);
+    }
   }
 
   @action
-  toggleTag(tag) {
-    if (this.selectedTags.has(tag)) {
-      this.selectedTags.delete(tag);
+  toggleTag(tagId) {
+    if (this.selectedTagIds.has(tagId)) {
+      this.selectedTagIds.delete(tagId);
     } else {
-      this.selectedTags.add(tag);
+      this.selectedTagIds.add(tagId);
     }
   }
 
@@ -158,10 +166,10 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
   async save() {
     this.saving = true;
     const initialSidebarTags = this.currentUser.sidebar_tags;
-    this.currentUser.set("sidebar_tag_names", [...this.selectedTags]);
+    this.currentUser.set("sidebar_tag_ids", [...this.selectedTagIds]);
 
     try {
-      const result = await this.currentUser.save(["sidebar_tag_names"]);
+      const result = await this.currentUser.save(["sidebar_tag_ids"]);
       this.currentUser.set("sidebar_tags", result.user.sidebar_tags);
       this.args.closeModal();
     } catch (error) {
@@ -201,20 +209,20 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
         <form class="sidebar-tags-form">
           {{#each this.tags.content as |tag|}}
             <div
-              {{didInsert this.didInsertTag}}
-              data-tag-name={{tag.name}}
+              {{didInsert this.didInsertTag tag.id}}
+              data-tag-id={{tag.id}}
               class="sidebar-tags-form__tag"
             >
               <input
-                {{on "click" (fn this.toggleTag tag.name)}}
+                {{on "click" (fn this.toggleTag tag.id)}}
                 type="checkbox"
-                checked={{has this.selectedTags tag.name}}
-                id={{concat "sidebar-tags-form__input--" tag.name}}
+                checked={{has this.selectedTagIds tag.id}}
+                id={{concat "sidebar-tags-form__input--" tag.id}}
                 class="sidebar-tags-form__input"
               />
 
               <label
-                for={{concat "sidebar-tags-form__input--" tag.name}}
+                for={{concat "sidebar-tags-form__input--" tag.id}}
                 class="sidebar-tags-form__tag-label"
               >
                 <p>

--- a/frontend/discourse/app/components/sidebar/user/tags-section.gjs
+++ b/frontend/discourse/app/components/sidebar/user/tags-section.gjs
@@ -123,7 +123,7 @@ export default class SidebarUserTagsSection extends Component {
           @suffixCSSClass={{sectionLink.suffixCSSClass}}
           @suffixValue={{sectionLink.suffixValue}}
           @suffixType={{sectionLink.suffixType}}
-          data-tag-name={{sectionLink.tagName}}
+          data-tag-name={{sectionLink.originalName}}
         />
       {{/each}}
 

--- a/frontend/discourse/app/components/topic-list/item.gjs
+++ b/frontend/discourse/app/components/topic-list/item.gjs
@@ -19,6 +19,7 @@ import {
   removeValueFromArray,
 } from "discourse/lib/array-tools";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
+import { originalTagName } from "discourse/lib/tag-identity";
 import {
   applyBehaviorTransformer,
   applyValueTransformer,
@@ -61,10 +62,7 @@ export default class Item extends Component {
   }
 
   get tagClassNames() {
-    return this.args.topic.tags?.map((tag) => {
-      const tagName = typeof tag === "string" ? tag : tag.name;
-      return `tag-${tagName}`;
-    });
+    return this.args.topic.tags?.map((tag) => `tag-${originalTagName(tag)}`);
   }
 
   get #transformerContext() {

--- a/frontend/discourse/app/components/topic-list/latest-topic-list-item.gjs
+++ b/frontend/discourse/app/components/topic-list/latest-topic-list-item.gjs
@@ -6,6 +6,7 @@ import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
 import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
+import { originalTagName } from "discourse/lib/tag-identity";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import DUserAvatarFlair from "discourse/ui-kit/d-user-avatar-flair";
 import DUserLink from "discourse/ui-kit/d-user-link";
@@ -18,10 +19,7 @@ import dTopicLink from "discourse/ui-kit/helpers/d-topic-link";
 
 export default class LatestTopicListItem extends Component {
   get tagClassNames() {
-    return this.args.topic.tags?.map((tag) => {
-      const tagName = typeof tag === "string" ? tag : tag.name;
-      return `tag-${tagName}`;
-    });
+    return this.args.topic.tags?.map((tag) => `tag-${originalTagName(tag)}`);
   }
 
   get additionalClasses() {

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -2955,7 +2955,9 @@ class _PluginApi {
    * ```
    *
    * @param {Object} arg - An object
-   * @param {string} arg.tagName - The name of the tag
+   * @param {string} arg.tagName - The name or the slug of the tag. A tag's name
+   *   and slug differ as soon as the name contains an underscore, uppercase or
+   *   non-ASCII character, and either identifies the tag here.
    * @param {string} arg.prefixValue - The name of a FontAwesome icon.
    * @param {string} arg.prefixColor - The color represented using hexadecimal to use for the prefix. Example: "#FF0000" or "#FFF".
    */

--- a/frontend/discourse/app/lib/render-tag.js
+++ b/frontend/discourse/app/lib/render-tag.js
@@ -1,6 +1,11 @@
 import escape from "discourse/lib/escape";
 import getURL from "discourse/lib/get-url";
 import { helperContext } from "discourse/lib/helpers";
+import {
+  originalTagName,
+  tagPath,
+  tagRouteName,
+} from "discourse/lib/tag-identity";
 import { escapeExpression } from "discourse/lib/utilities";
 import User from "discourse/models/user";
 
@@ -15,10 +20,9 @@ export function defaultRenderTag(tag, params) {
   let siteSettings = helperContext().siteSettings;
 
   params = params || {};
-  const tagName = typeof tag === "string" ? tag : tag.name;
-  const visibleName = escapeExpression(tagName);
-  const tagNameLower = visibleName.toLowerCase();
-  const tagPathName = tagNameLower.replaceAll(".", "%2E");
+  const visibleName = escapeExpression(
+    typeof tag === "string" ? tag : tag.name
+  );
 
   const classes = ["discourse-tag"];
   const htmlTag = params.tagName || "a";
@@ -29,15 +33,12 @@ export function defaultRenderTag(tag, params) {
       const username = params.tagsForUser
         ? params.tagsForUser
         : User.current().username;
-      path = `/u/${username}/messages/tags/${tagPathName}`;
-    } else if (typeof tag === "object" && tag.id) {
-      const slugForUrl = tag.slug || `${tag.id}-tag`;
-      path = `/tag/${slugForUrl}/${tag.id}`;
+      path = `/u/${username}/messages/tags/${tagRouteName(tag)}`;
     } else {
-      path = `/tag/${tagPathName}`;
+      path = tagPath(tag);
     }
   }
-  const href = path ? ` href='${getURL(path)}' ` : "";
+  const href = path ? ` href='${escapeExpression(getURL(path))}' ` : "";
 
   if (siteSettings.tag_style || params.style) {
     classes.push(params.style || siteSettings.tag_style);
@@ -53,8 +54,9 @@ export function defaultRenderTag(tag, params) {
     "<" +
     htmlTag +
     href +
-    " data-tag-name=" +
-    tagNameLower +
+    " data-tag-name='" +
+    escapeExpression(originalTagName(tag).toLowerCase()) +
+    "'" +
     " class='" +
     classes.join(" ") +
     "'>" +

--- a/frontend/discourse/app/lib/search.js
+++ b/frontend/discourse/app/lib/search.js
@@ -6,6 +6,7 @@ import UserAutocompleteResults from "discourse/components/user-autocomplete-resu
 import { ajax } from "discourse/lib/ajax";
 import { search as searchCategoryTag } from "discourse/lib/category-tag-search";
 import getURL from "discourse/lib/get-url";
+import { tagUrl } from "discourse/lib/tag-identity";
 import { emojiUnescape } from "discourse/lib/text";
 import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipulation";
 import { userPath } from "discourse/lib/url";
@@ -101,18 +102,13 @@ export function translateResults(results, opts) {
     })
     .filter((item) => item != null);
 
-  results.tags = results.tags
-    .map(function (tag) {
-      const id = tag.id;
-      const name = escapeExpression(tag.name);
-      const slug = tag.slug || `${id}-tag`;
-      return EmberObject.create({
-        id,
-        name,
-        url: getURL(`/tag/${slug}/${id}`),
-      });
+  results.tags = results.tags.map((tag) =>
+    EmberObject.create({
+      id: tag.id,
+      name: escapeExpression(tag.name),
+      url: tagUrl(tag),
     })
-    .filter((item) => item != null);
+  );
 
   return translateResultsCallbacks
     .reduce(

--- a/frontend/discourse/app/lib/sidebar/user/tags-section/base-tag-section-link.js
+++ b/frontend/discourse/app/lib/sidebar/user/tags-section/base-tag-section-link.js
@@ -1,3 +1,5 @@
+import { originalTagName, tagIdentifiers } from "discourse/lib/tag-identity";
+
 let customTagSectionLinkPrefixIcons = {};
 
 export function registerCustomTagSectionLinkPrefixIcon({
@@ -30,6 +32,11 @@ export default class BaseTagSectionLink {
     return this.tagName;
   }
 
+  // `tagName` is a display string and holds a localization when one applies.
+  get originalName() {
+    return originalTagName(this.tag);
+  }
+
   get text() {
     return this.tagName;
   }
@@ -45,10 +52,18 @@ export default class BaseTagSectionLink {
   }
 
   get prefixValue() {
-    return customTagSectionLinkPrefixIcons[this.tagName]?.prefixValue || "tag";
+    return this.#customPrefixIcon?.prefixValue || "tag";
   }
 
   get prefixColor() {
-    return customTagSectionLinkPrefixIcons[this.tagName]?.prefixColor;
+    return this.#customPrefixIcon?.prefixColor;
+  }
+
+  get #customPrefixIcon() {
+    const identifier = tagIdentifiers(this.tag).find(
+      (candidate) => customTagSectionLinkPrefixIcons[candidate]
+    );
+
+    return customTagSectionLinkPrefixIcons[identifier];
   }
 }

--- a/frontend/discourse/app/lib/sidebar/user/tags-section/pm-tag-section-link.js
+++ b/frontend/discourse/app/lib/sidebar/user/tags-section/pm-tag-section-link.js
@@ -2,7 +2,7 @@ import BaseTagSectionLink from "discourse/lib/sidebar/user/tags-section/base-tag
 
 export default class PMTagSectionLink extends BaseTagSectionLink {
   get models() {
-    return [this.currentUser, this.tagName];
+    return [this.currentUser, this.originalName];
   }
 
   get route() {

--- a/frontend/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
+++ b/frontend/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
@@ -1,6 +1,7 @@
 import { tracked } from "@glimmer/tracking";
 import { bind } from "discourse/lib/decorators";
 import BaseTagSectionLink from "discourse/lib/sidebar/user/tags-section/base-tag-section-link";
+import { tagRouteModels } from "discourse/lib/tag-identity";
 import { i18n } from "discourse-i18n";
 
 export default class TagSectionLink extends BaseTagSectionLink {
@@ -31,7 +32,7 @@ export default class TagSectionLink extends BaseTagSectionLink {
   }
 
   get models() {
-    return [this.tag.slug, this.tag.id];
+    return tagRouteModels(this.tag);
   }
 
   get route() {

--- a/frontend/discourse/app/lib/tag-identity.ts
+++ b/frontend/discourse/app/lib/tag-identity.ts
@@ -1,0 +1,69 @@
+import getURL from "discourse/lib/get-url";
+
+/**
+ * The subset of a tag needed to identify it. Matches the shape serialized by
+ * the server, and is also satisfied by `Tag` models. `original_name` is only
+ * sent when `name` holds a localization.
+ */
+export interface TagLike {
+  name: string;
+  id?: number;
+  slug?: string;
+  original_name?: string;
+}
+
+/**
+ * A tag can be referred to by its slug or by its name, and the two differ once
+ * the name isn't already slug-shaped. Never by its localized name: that would
+ * only match for readers of one language.
+ *
+ * @returns Every string that refers to `tag`, most stable first.
+ */
+export function tagIdentifiers(tag: TagLike): string[] {
+  const name = originalTagName(tag);
+
+  return tag.slug && tag.slug !== name ? [tag.slug, name] : [name];
+}
+
+/**
+ * The untranslated name. Tag routes are filtered on it server-side, so a
+ * localized `name` cannot be used to build them.
+ */
+export function originalTagName(tag: string | TagLike): string {
+  return typeof tag === "string" ? tag : tag.original_name || tag.name;
+}
+
+/** The name as it appears in the routes that look tags up by name. */
+export function tagRouteName(tag: string | TagLike): string {
+  // A dot would be read as a format separator.
+  return originalTagName(tag).toLowerCase().replaceAll(".", "%2E");
+}
+
+/**
+ * The canonical path to a tag's topic list. Tags without an id — legacy
+ * payloads which serialize to a bare name — fall back to the name-only route.
+ */
+export function tagPath(tag: string | TagLike): string {
+  if (typeof tag !== "string" && tag.id) {
+    return `/tag/${slugForUrl(tag.slug, tag.id)}/${tag.id}`;
+  }
+
+  return `/tag/${tagRouteName(tag)}`;
+}
+
+/** The dynamic segments of the `tag.show` route, matching {@link tagPath}. */
+export function tagRouteModels(
+  tag: TagLike & { id: number }
+): [string, number] {
+  return [slugForUrl(tag.slug, tag.id), tag.id];
+}
+
+/** The placeholder the server falls back to for tags without a slug. */
+function slugForUrl(slug: string | undefined, id: number): string {
+  return slug || `${id}-tag`;
+}
+
+/** {@link tagPath}, prefixed with the site's base path. */
+export function tagUrl(tag: string | TagLike): string {
+  return getURL(tagPath(tag));
+}

--- a/frontend/discourse/app/models/tag.js
+++ b/frontend/discourse/app/models/tag.js
@@ -1,5 +1,5 @@
 import { computed } from "@ember/object";
-import getURL from "discourse/lib/get-url";
+import { tagUrl } from "discourse/lib/tag-identity";
 import RestModel from "discourse/models/rest";
 
 export default class Tag extends RestModel {
@@ -8,14 +8,9 @@ export default class Tag extends RestModel {
     return this.pm_only;
   }
 
-  @computed("slug", "id")
+  @computed("slug", "id", "name")
   get url() {
-    if (this.id) {
-      const slugForUrl = this.slug || `${this.id}-tag`;
-      return getURL(`/tag/${slugForUrl}/${this.id}`);
-    }
-    // fallback for tags without id (legacy)
-    return getURL(`/tag/${this.name.replaceAll(".", "%2E")}`);
+    return tagUrl(this);
   }
 
   @computed("count", "pm_count")

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -32,6 +32,7 @@ import discourseLater from "discourse/lib/later";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import PreloadStore from "discourse/lib/preload-store";
 import singleton from "discourse/lib/singleton";
+import { originalTagName } from "discourse/lib/tag-identity";
 import { emojiUnescape } from "discourse/lib/text";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
 import {
@@ -94,6 +95,7 @@ let userFields = [
   "primary_group_id",
   "profile_background_upload_url",
   "sidebar_category_ids",
+  "sidebar_tag_ids",
   "sidebar_tag_names",
   "status",
   "title",
@@ -339,9 +341,20 @@ export default class User extends RestModel.extend(Evented) {
     this._location = value;
   }
 
+  @computed("sidebarTags.@each.id")
+  get sidebarTagIds() {
+    return this.sidebarTags?.map?.((item) => item.id) ?? [];
+  }
+
   @computed("sidebarTags.@each.name")
   get sidebarTagNames() {
-    return this.sidebarTags?.map?.((item) => item.name) ?? [];
+    deprecated("sidebarTagNames is deprecated. Use sidebarTagIds instead.", {
+      id: "discourse.user.sidebar-tag-names",
+      since: "2026.9.0-latest",
+      dropFrom: "2027.3.0-latest",
+    });
+
+    return this.sidebarTags?.map?.((item) => originalTagName(item)) ?? [];
   }
 
   @computed("groups.@each.has_messages")
@@ -702,7 +715,7 @@ export default class User extends RestModel.extend(Evented) {
       }
     });
 
-    ["sidebar_category_ids", "sidebar_tag_names"].forEach((prop) => {
+    ["sidebar_category_ids", "sidebar_tag_ids"].forEach((prop) => {
       if (data[prop]?.length === 0) {
         data[prop] = null;
       }

--- a/frontend/discourse/app/routes/preferences/navigation-menu.js
+++ b/frontend/discourse/app/routes/preferences/navigation-menu.js
@@ -3,17 +3,11 @@ import RestrictedUserRoute from "discourse/routes/restricted-user";
 
 export default class PreferencesNavigationMenu extends RestrictedUserRoute {
   setupController(controller, user) {
-    const props = {
+    controller.setProperties({
       model: user,
       selectedSidebarCategories: Category.findByIds(user.sidebarCategoryIds),
       newSidebarLinkToFilteredList: user.sidebarLinkToFilteredList,
       newSidebarShowCountOfNewItems: user.sidebarShowCountOfNewItems,
-    };
-
-    if (this.siteSettings.tagging_enabled) {
-      props.selectedSidebarTagNames = user.sidebarTagNames;
-    }
-
-    controller.setProperties(props);
+    });
   }
 }

--- a/frontend/discourse/select-kit/components/tags-intersection-chooser.js
+++ b/frontend/discourse/select-kit/components/tags-intersection-chooser.js
@@ -1,6 +1,7 @@
 import { action } from "@ember/object";
 import { attributeBindings, classNames } from "@ember-decorators/component";
 import { makeArray } from "discourse/lib/helpers";
+import { originalTagName, tagPath } from "discourse/lib/tag-identity";
 import DiscourseURL from "discourse/lib/url";
 import MiniTagChooser from "discourse/select-kit/components/mini-tag-chooser";
 import { pluginApiIdentifiers } from "discourse/select-kit/components/select-kit";
@@ -24,8 +25,10 @@ export default class TagsIntersectionChooser extends MiniTagChooser {
   @action
   onChange(tags) {
     const mainTag = this.mainTag;
-    const mainTagName = mainTag?.name;
-    const tagNames = tags.map((t) => t.name ?? t);
+    // Intersection routes are filtered by name server-side, so a localized
+    // `name` cannot be used to build them.
+    const mainTagName = mainTag && originalTagName(mainTag);
+    const tagNames = tags.map((t) => originalTagName(t));
 
     if (mainTagName && tagNames.includes(mainTagName)) {
       const remainingTags = tagNames.filter((t) => t !== mainTagName);
@@ -34,17 +37,14 @@ export default class TagsIntersectionChooser extends MiniTagChooser {
         DiscourseURL.routeTo(
           `/tags/intersection/${mainTagName}/${remainingTags.join("/")}`
         );
-      } else if (mainTag.id) {
-        const slug = mainTag.slug || `${mainTag.id}-tag`;
-        DiscourseURL.routeTo(`/tag/${slug}/${mainTag.id}`);
       } else {
-        DiscourseURL.routeTo(`/tag/${mainTagName}`);
+        DiscourseURL.routeTo(tagPath(mainTag));
       }
     } else {
       if (tagNames.length >= 2) {
         DiscourseURL.routeTo(`/tags/intersection/${tagNames.join("/")}`);
       } else if (tagNames.length === 1) {
-        DiscourseURL.routeTo(`/tag/${tagNames[0]}`);
+        DiscourseURL.routeTo(tagPath(tags[0]));
       } else {
         DiscourseURL.routeTo("/tags");
       }

--- a/frontend/discourse/tests/acceptance/sidebar-plugin-api-test.gjs
+++ b/frontend/discourse/tests/acceptance/sidebar-plugin-api-test.gjs
@@ -864,6 +864,77 @@ acceptance("Sidebar - Plugin API", function (needs) {
     }
   });
 
+  test("Customizing the prefix icon used in a tag section link by tag slug", async function (assert) {
+    try {
+      return await withPluginApi(async (api) => {
+        updateCurrentUser({
+          display_sidebar_tags: true,
+          sidebar_tags: [
+            { id: 1, name: "tag_1", slug: "tag-1", pm_only: false },
+            { id: 2, name: "tag_2", slug: "tag-2", pm_only: false },
+          ],
+        });
+
+        api.registerCustomTagSectionLinkPrefixIcon({
+          tagName: "tag-1",
+          prefixValue: "wrench",
+        });
+
+        await visit("/");
+
+        assert
+          .dom(
+            `.sidebar-section-link-wrapper[data-tag-name="tag_1"] .prefix-icon.d-icon-wrench`
+          )
+          .exists("wrench icon is displayed when matching on the tag's slug");
+
+        assert
+          .dom(
+            `.sidebar-section-link-wrapper[data-tag-name="tag_2"] .prefix-icon.d-icon-tag`
+          )
+          .exists("default tag icon is displayed for the unconfigured tag");
+      });
+    } finally {
+      resetCustomTagSectionLinkPrefixIcons();
+    }
+  });
+
+  test("Customizing the prefix icon used in a tag section link by untranslated tag name", async function (assert) {
+    try {
+      return await withPluginApi(async (api) => {
+        updateCurrentUser({
+          display_sidebar_tags: true,
+          sidebar_tags: [
+            {
+              id: 1,
+              name: "戦略",
+              slug: "strategic-access",
+              original_name: "strategic_access",
+              pm_only: false,
+            },
+          ],
+        });
+
+        api.registerCustomTagSectionLinkPrefixIcon({
+          tagName: "strategic_access",
+          prefixValue: "wrench",
+        });
+
+        await visit("/");
+
+        assert
+          .dom(
+            `.sidebar-section-link-wrapper[data-tag-name="strategic_access"] .prefix-icon.d-icon-wrench`
+          )
+          .exists(
+            "wrench icon is displayed when matching on the tag's untranslated name"
+          );
+      });
+    } finally {
+      resetCustomTagSectionLinkPrefixIcons();
+    }
+  });
+
   test("New custom sidebar panel and option to set default and show/hide switch buttons", async function (assert) {
     withPluginApi((api) => {
       api.addSidebarPanel((BaseCustomSidebarPanel) => {

--- a/frontend/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -257,6 +257,30 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
       .exists("the tag4 section link is marked as active");
   });
 
+  test("private message tag section link for a localized tag", async function (assert) {
+    updateCurrentUser({
+      sidebar_tags: [
+        {
+          id: 5,
+          name: "戦略",
+          slug: "strategic-access",
+          original_name: "strategic_access",
+          pm_only: true,
+        },
+      ],
+    });
+
+    await visit("/");
+
+    assert
+      .dom(`.sidebar-section-link-wrapper[data-tag-name=strategic_access] a`)
+      .hasAttribute(
+        "href",
+        "/u/eviltrout/messages/tags/strategic_access",
+        "the link filters on the untranslated tag name"
+      );
+  });
+
   test("visiting tag discovery top route", async function (assert) {
     await visit(`/tag/tag1/1/l/top`);
 

--- a/frontend/discourse/tests/unit/lib/render-tag-test.js
+++ b/frontend/discourse/tests/unit/lib/render-tag-test.js
@@ -1,14 +1,32 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import renderTag from "discourse/lib/render-tag";
+import User from "discourse/models/user";
 
 module("Unit | Utility | render-tag", function (hooks) {
   setupTest(hooks);
 
+  test("defaultRenderTag links private message tags by their untranslated name", function (assert) {
+    User.resetCurrent(User.create({ id: 1, username: "eviltrout" }));
+
+    assert.strictEqual(
+      renderTag(
+        {
+          id: 1,
+          name: "戦略",
+          slug: "strategic-access",
+          original_name: "strategic_access",
+        },
+        { isPrivateMessage: true }
+      ),
+      "<a href='/u/eviltrout/messages/tags/strategic_access'  data-tag-name='strategic_access' class='discourse-tag simple'>戦略</a>"
+    );
+  });
+
   test("defaultRenderTag", function (assert) {
     assert.strictEqual(
       renderTag("foo", { description: "foo description" }),
-      "<a href='/tag/foo'  data-tag-name=foo class='discourse-tag simple'>foo</a>",
+      "<a href='/tag/foo'  data-tag-name='foo' class='discourse-tag simple'>foo</a>",
       "does not expose the description as a tooltip"
     );
   });
@@ -16,7 +34,7 @@ module("Unit | Utility | render-tag", function (hooks) {
   test("defaultRenderTag encodes legacy tag links with periods", function (assert) {
     assert.strictEqual(
       renderTag("node.js"),
-      "<a href='/tag/node%2Ejs'  data-tag-name=node.js class='discourse-tag simple'>node.js</a>"
+      "<a href='/tag/node%2Ejs'  data-tag-name='node.js' class='discourse-tag simple'>node.js</a>"
     );
   });
 

--- a/frontend/discourse/tests/unit/lib/tag-identity-test.js
+++ b/frontend/discourse/tests/unit/lib/tag-identity-test.js
@@ -1,0 +1,56 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { tagIdentifiers, tagPath } from "discourse/lib/tag-identity";
+
+module("Unit | Utility | tag-identity", function (hooks) {
+  setupTest(hooks);
+
+  test("tagIdentifiers returns the slug and the name", function (assert) {
+    assert.deepEqual(
+      tagIdentifiers({
+        id: 1,
+        name: "strategic_access",
+        slug: "strategic-access",
+      }),
+      ["strategic-access", "strategic_access"]
+    );
+  });
+
+  test("tagIdentifiers never matches on the localized name", function (assert) {
+    assert.deepEqual(
+      tagIdentifiers({
+        id: 1,
+        name: "戦略",
+        slug: "strategic-access",
+        original_name: "strategic_access",
+      }),
+      ["strategic-access", "strategic_access"]
+    );
+  });
+
+  test("tagIdentifiers deduplicates and drops blanks", function (assert) {
+    assert.deepEqual(tagIdentifiers({ id: 1, name: "foo", slug: "foo" }), [
+      "foo",
+    ]);
+    assert.deepEqual(tagIdentifiers({ id: 1, name: "foo", slug: "" }), ["foo"]);
+  });
+
+  test("tagPath uses the slug and the id", function (assert) {
+    assert.strictEqual(
+      tagPath({ id: 1, name: "strategic_access", slug: "strategic-access" }),
+      "/tag/strategic-access/1"
+    );
+  });
+
+  test("tagPath falls back to the id placeholder for unslugged tags", function (assert) {
+    assert.strictEqual(
+      tagPath({ id: 1, name: "サポート", slug: "" }),
+      "/tag/1-tag/1"
+    );
+  });
+
+  test("tagPath falls back to the name route without an id", function (assert) {
+    assert.strictEqual(tagPath({ name: "Node.js" }), "/tag/node%2Ejs");
+    assert.strictEqual(tagPath("Node.js"), "/tag/node%2Ejs");
+  });
+});

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -577,6 +577,47 @@ RSpec.describe Tag do
     end
   end
 
+  describe "#display_name and #display_description" do
+    fab!(:localized_tag, :tag) do
+      Fabricate(:tag, name: "strategic_access", description: "About access", locale: "en")
+    end
+    fab!(:localization) do
+      Fabricate(
+        :tag_localization,
+        tag: localized_tag,
+        locale: "ja",
+        name: "戦略",
+        description: "アクセスについて",
+      )
+    end
+
+    let(:guardian) { Guardian.new(Fabricate(:user)) }
+
+    it "returns the localization when the tag is not in the user's locale" do
+      SiteSetting.content_localization_enabled = true
+      I18n.locale = "ja"
+
+      expect(localized_tag.display_name(guardian)).to eq("戦略")
+      expect(localized_tag.display_description(guardian)).to eq("アクセスについて")
+    end
+
+    it "returns the original values when localization is disabled" do
+      SiteSetting.content_localization_enabled = false
+      I18n.locale = "ja"
+
+      expect(localized_tag.display_name(guardian)).to eq("strategic_access")
+      expect(localized_tag.display_description(guardian)).to eq("About access")
+    end
+
+    it "returns the original values when the tag is already in the user's locale" do
+      SiteSetting.content_localization_enabled = true
+      I18n.locale = "en"
+
+      expect(localized_tag.display_name(guardian)).to eq("strategic_access")
+      expect(localized_tag.display_description(guardian)).to eq("About access")
+    end
+  end
+
   describe ".with_localizations" do
     fab!(:tag1) { Fabricate(:tag, name: "strategy", locale: "en") }
     fab!(:tag2) { Fabricate(:tag, name: "design", locale: "en") }

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -2192,7 +2192,7 @@ RSpec.describe TagsController do
 
           expect(response.status).to eq(200)
           expect(response.parsed_body["results"]).to include(
-            include("name" => "戦略", "id" => tag.id),
+            include("name" => "戦略", "original_name" => "strategy", "id" => tag.id),
           )
         end
 
@@ -2766,6 +2766,34 @@ RSpec.describe TagsController do
       expect(response.parsed_body["meta"]["load_more_list_tags"]).to eq(
         "/tags/list.json?offset=1&filter=3",
       )
+    end
+
+    it "accepts a `only_tag_ids` param and filters the tags by the given tags" do
+      sign_in(user)
+
+      get "/tags/list.json", params: { only_tag_ids: "#{tag1.id},#{tag3.id}" }
+
+      expect(response.status).to eq(200)
+
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq(
+        [tag1.name, tag3.name],
+      )
+
+      expect(response.parsed_body["meta"]["total_rows_list_tags"]).to eq(2)
+
+      expect(response.parsed_body["meta"]["load_more_list_tags"]).to eq(
+        "/tags/list.json?offset=1&only_tag_ids=#{tag1.id}%2C#{tag3.id}",
+      )
+    end
+
+    it "accepts an `exclude_tag_ids` param and filters tags excluding the given tags" do
+      sign_in(user)
+
+      get "/tags/list.json", params: { exclude_tag_ids: "#{tag1.id}" }
+
+      expect(response.status).to eq(200)
+
+      expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).not_to include(tag1.name)
     end
 
     it "accepts a `only_tags` param and filters the tags by the given tags" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3103,6 +3103,42 @@ RSpec.describe UsersController do
             )
           end
 
+          it "should allow user to add tag sidebar section links by id" do
+            SiteSetting.tagging_enabled = true
+
+            tag = Fabricate(:tag)
+            hidden_tag = Fabricate(:tag)
+            Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
+
+            put "/u/#{user.username}.json", params: { sidebar_tag_ids: [tag.id, hidden_tag.id, -1] }
+
+            expect(response.status).to eq(200)
+            expect(user.sidebar_section_links.map(&:linkable)).to eq([tag])
+          end
+
+          it "should allow user to remove all tag sidebar section links by id" do
+            SiteSetting.tagging_enabled = true
+
+            Fabricate(:tag_sidebar_section_link, user: user)
+
+            expect do
+              put "/u/#{user.username}.json", params: { sidebar_tag_ids: nil }
+
+              expect(response.status).to eq(200)
+            end.to change { user.sidebar_section_links.count }.from(1).to(0)
+          end
+
+          it "should not allow user to add tag sidebar section links by id when tagging is disabled" do
+            SiteSetting.tagging_enabled = false
+
+            tag = Fabricate(:tag)
+
+            put "/u/#{user.username}.json", params: { sidebar_tag_ids: [tag.id] }
+
+            expect(response.status).to eq(200)
+            expect(user.reload.sidebar_section_links.count).to eq(0)
+          end
+
           it "should allow user to remove all tag sidebar section links" do
             SiteSetting.tagging_enabled = true
 

--- a/spec/serializers/sidebar_tag_serializer_spec.rb
+++ b/spec/serializers/sidebar_tag_serializer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe SidebarTagSerializer do
+  fab!(:user)
+  fab!(:localized_tag, :tag) { Fabricate(:tag, name: "strategic_access", locale: "en") }
+  fab!(:localization) { Fabricate(:tag_localization, tag: localized_tag, locale: "ja", name: "戦略") }
+
+  def serialize(tag)
+    described_class.new(tag, scope: Guardian.new(user), root: false).as_json
+  end
+
+  describe "#original_name" do
+    it "is included alongside the localized name" do
+      SiteSetting.content_localization_enabled = true
+      I18n.locale = "ja"
+
+      serialized = serialize(localized_tag)
+
+      expect(serialized[:name]).to eq("戦略")
+      expect(serialized[:original_name]).to eq("strategic_access")
+    end
+
+    it "is omitted when the name is not localized" do
+      SiteSetting.content_localization_enabled = false
+      I18n.locale = "ja"
+
+      serialized = serialize(localized_tag)
+
+      expect(serialized[:name]).to eq("strategic_access")
+      expect(serialized).not_to have_key(:original_name)
+    end
+  end
+end

--- a/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/spec/serializers/topic_list_item_serializer_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe TopicListItemSerializer do
       I18n.locale = "ja"
 
       expect(serialize[:tags]).to include(
-        { id: localized_tag.id, name: "猫", slug: localized_tag.slug },
+        { id: localized_tag.id, name: "猫", slug: localized_tag.slug, original_name: "cats" },
       )
     end
 

--- a/spec/services/tag_hashtag_data_source_spec.rb
+++ b/spec/services/tag_hashtag_data_source_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe TagHashtagDataSource do
       end
     end
 
+    describe "#search" do
+      it "returns the untranslated tag name as the slug" do
+        tag2.update!(locale: "en")
+        Fabricate(:tag_localization, tag: tag2, locale: "ja", name: "要因")
+
+        I18n.with_locale(:ja) do
+          factor_result =
+            described_class.search(ja_guardian, "fact", 5).find { |r| r.id == tag2.id }
+
+          expect(factor_result.text).to eq("要因")
+          expect(factor_result.slug).to eq(tag2.name)
+        end
+      end
+    end
+
     describe "#search_without_term" do
       it "returns localized tag names" do
         tag2.update!(locale: "en")

--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -25,6 +25,40 @@ RSpec.describe "Editing sidebar tags navigation" do
 
   before { sign_in(user) }
 
+  context "with a localized tag" do
+    fab!(:localized_tag) do
+      Fabricate(:tag, name: "strategic_access", locale: "en").tap do |tag|
+        Fabricate(:topic, tags: [tag])
+      end
+    end
+
+    fab!(:localization) do
+      Fabricate(:tag_localization, tag: localized_tag, locale: "ja", name: "戦略")
+    end
+
+    fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
+
+    before do
+      SiteSetting.allow_user_locale = true
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_supported_locales = "en|ja"
+
+      sign_in(japanese_user)
+    end
+
+    it "adds the tag under its untranslated name" do
+      visit "/latest"
+
+      modal = sidebar.click_edit_tags_button
+      modal.toggle_tag_checkbox(localized_tag).save
+
+      expect(modal).to be_closed
+      expect(sidebar).to have_section_link("戦略")
+
+      expect(japanese_user.reload.visible_sidebar_tags.pluck(:id)).to eq([localized_tag.id])
+    end
+  end
+
   shared_examples "a user can edit the sidebar tags navigation" do |mobile|
     it "allows a user to edit the sidebar tags navigation", mobile: mobile do
       visit "/latest"

--- a/spec/system/page_objects/modals/sidebar_edit_tags.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_tags.rb
@@ -22,7 +22,7 @@ module PageObjects
 
       def toggle_tag_checkbox(tag)
         find(
-          ".sidebar-tags-form .sidebar-tags-form__tag[data-tag-name='#{tag.name}'] .sidebar-tags-form__input",
+          ".sidebar-tags-form .sidebar-tags-form__tag[data-tag-id='#{tag.id}'] .sidebar-tags-form__input",
         ).click
 
         self
@@ -30,7 +30,7 @@ module PageObjects
 
       def scroll_to_tag(tag)
         page.execute_script(
-          "document.querySelector('.sidebar-tags-form__tag[data-tag-name=\"#{tag.name}\"]').scrollIntoView()",
+          "document.querySelector('.sidebar-tags-form__tag[data-tag-id=\"#{tag.id}\"]').scrollIntoView()",
         )
       end
 


### PR DESCRIPTION
Previously, tags were identified by their `name` on some surfaces and their `slug` on others, so anything keyed on a tag — a sidebar prefix icon, say — only worked where the two happened to agree, and stopped working altogether once content localization translated the name.

This change gives a tag one identity: every surface resolves it through `discourse/lib/tag-identity`, matching on the slug or the untranslated name, and serializers send `original_name` alongside a localized `name` so the real name survives translation.

### Why the two keys diverge

`Slug.for` rewrites `_` to `-` and drops non-ASCII, so a tag named `strategic_access` has the slug `strategic-access`, and `2026` or `サポート` have no slug at all. Once `Tag` gained a slug ([#36985](https://github.com/discourse/discourse/pull/36985)) and tag payloads started carrying it, surfaces silently split over which key they used.

Ids can't replace this: the key is typed by a human into a theme setting, written into post markdown as `#tag`, or stored by name in a site setting. But where core owns both ends of the wire it now uses ids — hence `sidebar_tag_ids`.

### Bugs this fixes

- Sidebar prefix icons matched `tag.name` while the tag renderer matched `tag.slug`, so a tag whose name and slug differ could only show its icon in one place, never both.
- Saving the sidebar tags modal on a localized site posted **translated** names to `sidebar_tag_names`, which matched no tag and deleted every sidebar tag the user had.
- Private message tag links were built from the localized name, and `list_private_messages_tag` filters on the real one, so those links returned an empty list.
- Hashtag autocomplete inserted the localized name, which then cooked to nothing.
- Tag intersection routes were built from localized names and are filtered by name server-side.

### Notes

- `sidebar_tag_names` and `only_tags`/`exclude_tags` still work; the first is deprecated with a removal window, the others remain supported for callers that only have names.
- `data-tag-name` and the `tag-*` class now carry the untranslated name. Byte-identical on sites without content localization; on localized sites they stop varying per viewer, which is what CSS needs.
