### PR TITLE
DEV: allow custom sidebar sections to use the "more" links menu

### DIFF
--- a/frontend/discourse/app/components/sidebar/api-section.gjs
+++ b/frontend/discourse/app/components/sidebar/api-section.gjs
@@ -1,76 +1,143 @@
-import { hash } from "@ember/helper";
+import Component from "@glimmer/component";
+import { concat, hash } from "@ember/helper";
 import curryComponent from "ember-curry-component";
 import { and, eq, not } from "discourse/truth-helpers";
+import MoreSectionLink from "./more-section-link";
+import MoreSectionLinks from "./more-section-links";
 import Section from "./section";
 import SectionLink from "./section-link";
 
-const SidebarApiSection = <template>
-  {{#if @section.filtered}}
-    <Section
-      @sectionName={{@section.name}}
-      @headerLinkText={{@section.text}}
-      @headerLinkTitle={{@section.title}}
-      @headerActionsIcon={{@section.actionsIcon}}
-      @headerActions={{@section.actions}}
-      @willDestroy={{@section.willDestroy}}
-      @collapsable={{@collapsable}}
-      @displaySection={{@section.displaySection}}
-      @hideSectionHeader={{@section.hideSectionHeader}}
-      @collapsedByDefault={{@section.collapsedByDefault}}
-      @activeLink={{@section.activeLink}}
-      @expandWhenActive={{@expandWhenActive}}
-      @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
-    >
-      {{#if
-        (and @section.emptyStateComponent (not @section.filteredLinks.length))
-      }}
-        <@section.emptyStateComponent />
-      {{/if}}
+export default class SidebarApiSection extends Component {
+  get moreLinks() {
+    return this.args.section.filteredMoreLinks ?? [];
+  }
 
-      {{#each @section.filteredLinks key="name" as |link|}}
-        <SectionLink
-          @linkName={{link.name}}
-          @linkClass={{link.classNames}}
-          @route={{link.route}}
-          @model={{link.model}}
-          @query={{link.query}}
-          @models={{link.models}}
-          @currentWhen={{link.currentWhen}}
-          @href={{link.href}}
-          @title={{link.title}}
-          @badgeText={{link.badgeText}}
-          @contentCSSClass={{link.contentCSSClass}}
-          @prefixColor={{link.prefixColor}}
-          @prefixBadge={{link.prefixBadge}}
-          @prefixType={{link.prefixType}}
-          @prefixValue={{link.prefixValue}}
-          @prefixCSSClass={{link.prefixCSSClass}}
-          @suffixType={{link.suffixType}}
-          @suffixValue={{link.suffixValue}}
-          @suffixCSSClass={{link.suffixCSSClass}}
-          @hoverType={{link.hoverType}}
-          @hoverValue={{link.hoverValue}}
-          @hoverAction={{link.hoverAction}}
-          @hoverTitle={{link.hoverTitle}}
-          @didInsert={{link.didInsert}}
-          @willDestroy={{link.willDestroy}}
-          @content={{link.text}}
-          @contentComponent={{if
-            link.contentComponent
-            (curryComponent
-              link.contentComponent (hash status=link.contentComponentArgs)
-            )
-          }}
-          @suffixComponent={{link.suffixComponent}}
-          @suffixArgs={{link.suffixArgs}}
-          @scrollIntoView={{and
-            @scrollActiveLinkIntoView
-            (eq link.name @section.activeLink.name)
-          }}
-        />
-      {{/each}}
-    </Section>
-  {{/if}}
-</template>;
+  get moreLinksAtStart() {
+    return this.args.section.moreLinksPosition === "start";
+  }
 
-export default SidebarApiSection;
+  <template>
+    {{#if @section.filtered}}
+      <Section
+        @sectionName={{@section.name}}
+        @headerLinkText={{@section.text}}
+        @headerLinkTitle={{@section.title}}
+        @headerActionsIcon={{@section.actionsIcon}}
+        @headerActions={{@section.actions}}
+        @willDestroy={{@section.willDestroy}}
+        @collapsable={{@collapsable}}
+        @displaySection={{@section.displaySection}}
+        @hideSectionHeader={{@section.hideSectionHeader}}
+        @collapsedByDefault={{@section.collapsedByDefault}}
+        @activeLink={{@section.activeLink}}
+        @expandWhenActive={{@expandWhenActive}}
+        @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+      >
+        {{#if
+          (and @section.emptyStateComponent (not @section.filteredLinks.length))
+        }}
+          <@section.emptyStateComponent />
+        {{/if}}
+
+        {{#if this.moreLinksAtStart}}
+          {{#if this.moreLinks}}
+            {{#if @section.moreLinksInline}}
+              {{#each this.moreLinks as |sectionLink|}}
+                <MoreSectionLink
+                  @sectionLink={{sectionLink}}
+                  @scrollIntoView={{and
+                    @scrollActiveLinkIntoView
+                    (eq sectionLink.name @section.activeLink.name)
+                  }}
+                />
+              {{/each}}
+            {{else}}
+              <MoreSectionLinks
+                @sectionLinks={{this.moreLinks}}
+                @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+                @identifier={{concat "sidebar-more-" @section.name}}
+                @triggerText={{@section.moreLinksTriggerText}}
+                @triggerPrefixType={{@section.moreLinksTriggerPrefixType}}
+                @triggerPrefixValue={{@section.moreLinksTriggerPrefixValue}}
+                @triggerSuffixType={{@section.moreLinksTriggerSuffixType}}
+                @triggerSuffixValue={{@section.moreLinksTriggerSuffixValue}}
+                @hoistActiveLink={{@section.moreLinksHoistActiveLink}}
+              />
+            {{/if}}
+          {{/if}}
+        {{/if}}
+
+        {{#each @section.filteredLinks key="name" as |link|}}
+          <SectionLink
+            @linkName={{link.name}}
+            @linkClass={{link.classNames}}
+            @route={{link.route}}
+            @model={{link.model}}
+            @query={{link.query}}
+            @models={{link.models}}
+            @currentWhen={{link.currentWhen}}
+            @href={{link.href}}
+            @title={{link.title}}
+            @badgeText={{link.badgeText}}
+            @contentCSSClass={{link.contentCSSClass}}
+            @prefixColor={{link.prefixColor}}
+            @prefixBadge={{link.prefixBadge}}
+            @prefixType={{link.prefixType}}
+            @prefixValue={{link.prefixValue}}
+            @prefixCSSClass={{link.prefixCSSClass}}
+            @suffixType={{link.suffixType}}
+            @suffixValue={{link.suffixValue}}
+            @suffixCSSClass={{link.suffixCSSClass}}
+            @hoverType={{link.hoverType}}
+            @hoverValue={{link.hoverValue}}
+            @hoverAction={{link.hoverAction}}
+            @hoverTitle={{link.hoverTitle}}
+            @didInsert={{link.didInsert}}
+            @willDestroy={{link.willDestroy}}
+            @content={{link.text}}
+            @contentComponent={{if
+              link.contentComponent
+              (curryComponent
+                link.contentComponent (hash status=link.contentComponentArgs)
+              )
+            }}
+            @suffixComponent={{link.suffixComponent}}
+            @suffixArgs={{link.suffixArgs}}
+            @scrollIntoView={{and
+              @scrollActiveLinkIntoView
+              (eq link.name @section.activeLink.name)
+            }}
+          />
+        {{/each}}
+
+        {{#unless this.moreLinksAtStart}}
+          {{#if this.moreLinks}}
+            {{#if @section.moreLinksInline}}
+              {{#each this.moreLinks as |sectionLink|}}
+                <MoreSectionLink
+                  @sectionLink={{sectionLink}}
+                  @scrollIntoView={{and
+                    @scrollActiveLinkIntoView
+                    (eq sectionLink.name @section.activeLink.name)
+                  }}
+                />
+              {{/each}}
+            {{else}}
+              <MoreSectionLinks
+                @sectionLinks={{this.moreLinks}}
+                @scrollActiveLinkIntoView={{@scrollActiveLinkIntoView}}
+                @identifier={{concat "sidebar-more-" @section.name}}
+                @triggerText={{@section.moreLinksTriggerText}}
+                @triggerPrefixType={{@section.moreLinksTriggerPrefixType}}
+                @triggerPrefixValue={{@section.moreLinksTriggerPrefixValue}}
+                @triggerSuffixType={{@section.moreLinksTriggerSuffixType}}
+                @triggerSuffixValue={{@section.moreLinksTriggerSuffixValue}}
+                @hoistActiveLink={{@section.moreLinksHoistActiveLink}}
+              />
+            {{/if}}
+          {{/if}}
+        {{/unless}}
+      </Section>
+    {{/if}}
+  </template>
+}

--- a/frontend/discourse/app/components/sidebar/api-sections.gjs
+++ b/frontend/discourse/app/components/sidebar/api-sections.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { getOwner, setOwner } from "@ember/owner";
 import { service } from "@ember/service";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import ApiSection from "./api-section";
 import PanelHeader from "./panel-header";
 
@@ -67,15 +68,28 @@ function prepareSidebarSectionClass(Section, routerService) {
 
     @cached
     get filteredLinks() {
+      return this.#applyFilter(this.links);
+    }
+
+    @cached
+    get filteredMoreLinks() {
+      return this.#applyFilter(this.moreLinks);
+    }
+
+    #applyFilter(links) {
+      if (!links?.length) {
+        return links;
+      }
+
       if (!this.filterable || !this.sidebarState.filter) {
-        return this.links;
+        return links;
       }
 
       if (this.text?.toLowerCase()?.match(this.sidebarState.sanitizedFilter)) {
-        return this.links;
+        return links;
       }
 
-      return this.links.filter((link) => {
+      return links.filter((link) => {
         return (
           link.text
             .toString()
@@ -88,48 +102,20 @@ function prepareSidebarSectionClass(Section, routerService) {
       });
     }
 
+    @cached
     get activeLink() {
-      return this.filteredLinks.find((link) => {
-        try {
-          const currentWhen = link.currentWhen;
-
-          if (typeof currentWhen === "boolean") {
-            return currentWhen;
-          }
-
-          // TODO detect active links using the href field
-
-          const queryParams = link.query || {};
-          let models;
-
-          if (link.model) {
-            models = [link.model];
-          } else if (link.models) {
-            models = link.models;
-          } else {
-            models = [];
-          }
-
-          if (typeof currentWhen === "string") {
-            return currentWhen.split(" ").some((route) =>
-              routerService.isActive(route, ...models, {
-                queryParams,
-              })
-            );
-          }
-
-          return routerService.isActive(link.route, ...models, {
-            queryParams,
-          });
-        } catch {
-          // false if ember throws an exception while checking the routes
-          return false;
-        }
-      });
+      return findActiveLink(
+        [...this.filteredLinks, ...(this.filteredMoreLinks || [])],
+        routerService
+      );
     }
 
     get filtered() {
-      return !this.filterable || this.filteredLinks?.length > 0;
+      return (
+        !this.filterable ||
+        this.filteredLinks?.length > 0 ||
+        this.filteredMoreLinks?.length > 0
+      );
     }
   };
 }

--- a/frontend/discourse/app/components/sidebar/common/custom-section.gjs
+++ b/frontend/discourse/app/components/sidebar/common/custom-section.gjs
@@ -1,6 +1,8 @@
 import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
 import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
 import CommonCommunitySection from "discourse/lib/sidebar/common/community-section/section";
 import Section from "discourse/lib/sidebar/section";
 import AdminCommunitySection from "discourse/lib/sidebar/user/community-section/admin-section";
@@ -39,6 +41,14 @@ export default class SidebarCustomSection extends Component {
     }
   }
 
+  @cached
+  get activeLink() {
+    return findActiveLink(
+      [...this.section.links, ...(this.section.moreLinks || [])],
+      this.router
+    );
+  }
+
   get exactUrlMatch() {
     return this.section.links.find((link) => {
       return this.router.currentURL === link.value;
@@ -48,6 +58,8 @@ export default class SidebarCustomSection extends Component {
   <template>
     <SectionComponent
       @sectionName={{this.section.slug}}
+      @activeLink={{this.activeLink}}
+      @expandWhenActive={{@expandActiveSection}}
       @headerLinkText={{this.section.decoratedTitle}}
       @indicatePublic={{this.section.indicatePublic}}
       @collapsable={{@collapsable}}
@@ -63,6 +75,10 @@ export default class SidebarCustomSection extends Component {
         <SectionLink
           data-sidebar-custom-link="true"
           class={{if (eq linkDrop.linkDropIndex index) "is-link-drop-before"}}
+          @scrollIntoView={{and
+            @scrollActiveLinkIntoView
+            (eq link.name this.activeLink.name)
+          }}
           @badgeText={{link.badgeText}}
           @content={{dReplaceEmoji link.text}}
           @currentWhen={{link.currentWhen}}

--- a/frontend/discourse/app/components/sidebar/more-section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/more-section-link.gjs
@@ -15,6 +15,7 @@ const SidebarMoreSectionLink = <template>
     @prefixValue={{@sectionLink.prefixValue}}
     @query={{@sectionLink.query}}
     @route={{@sectionLink.route}}
+    @scrollIntoView={{@scrollIntoView}}
     @shouldDisplay={{@sectionLink.shouldDisplay}}
     @suffixCSSClass={{@sectionLink.suffixCSSClass}}
     @suffixType={{@sectionLink.suffixType}}

--- a/frontend/discourse/app/components/sidebar/more-section-links.gjs
+++ b/frontend/discourse/app/components/sidebar/more-section-links.gjs
@@ -1,11 +1,14 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
-import { isEmpty } from "@ember/utils";
+import curryComponent from "ember-curry-component";
 import DMenu from "discourse/float-kit/components/d-menu";
+import { findActiveLink } from "discourse/lib/sidebar/active-link";
+import { and } from "discourse/truth-helpers";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import MoreSectionLink from "./more-section-link";
 import MoreSectionTrigger from "./more-section-trigger";
@@ -27,8 +30,12 @@ export default class SidebarMoreSectionLinks extends Component {
     this.router.off("routeDidChange", this, this.#setActiveSectionLink);
   }
 
+  get hoistActiveLink() {
+    return this.args.hoistActiveLink ?? true;
+  }
+
   get sectionLinks() {
-    if (this.activeSectionLink) {
+    if (this.hoistActiveLink && this.activeSectionLink) {
       return this.#filterActiveSectionLink(this.args.sectionLinks);
     } else {
       return this.args.sectionLinks;
@@ -36,7 +43,7 @@ export default class SidebarMoreSectionLinks extends Component {
   }
 
   get secondarySectionLinks() {
-    if (this.activeSectionLink) {
+    if (this.hoistActiveLink && this.activeSectionLink) {
       return this.#filterActiveSectionLink(this.args.secondarySectionLinks);
     } else {
       return this.args.secondarySectionLinks;
@@ -50,21 +57,25 @@ export default class SidebarMoreSectionLinks extends Component {
   }
 
   #setActiveSectionLink() {
-    this.activeSectionLink = this.args.sectionLinks.find((sectionLink) => {
-      const args = [sectionLink.route];
+    this.activeSectionLink = findActiveLink(
+      this.args.sectionLinks,
+      this.router
+    );
+  }
 
-      if (sectionLink.model) {
-        args.push(sectionLink.model);
-      } else if (sectionLink.models) {
-        args.push(...sectionLink.models);
-      }
-
-      if (!isEmpty(sectionLink.query)) {
-        args.push({ queryParams: sectionLink.query });
-      }
-
-      return this.router.isActive(...args) && sectionLink;
-    });
+  @cached
+  get triggerComponent() {
+    return curryComponent(
+      MoreSectionTrigger,
+      {
+        text: this.args.triggerText,
+        prefixType: this.args.triggerPrefixType,
+        prefixValue: this.args.triggerPrefixValue,
+        suffixType: this.args.triggerSuffixType,
+        suffixValue: this.args.triggerSuffixValue,
+      },
+      getOwner(this)
+    );
   }
 
   @action
@@ -77,8 +88,11 @@ export default class SidebarMoreSectionLinks extends Component {
   }
 
   <template>
-    {{#if this.activeSectionLink}}
-      <MoreSectionLink @sectionLink={{this.activeSectionLink}} />
+    {{#if (and this.hoistActiveLink this.activeSectionLink)}}
+      <MoreSectionLink
+        @sectionLink={{this.activeSectionLink}}
+        @scrollIntoView={{@scrollActiveLinkIntoView}}
+      />
     {{/if}}
 
     <li class="sidebar-section-link-wrapper">
@@ -88,8 +102,8 @@ export default class SidebarMoreSectionLinks extends Component {
         @autofocus={{true}}
         @placement="bottom"
         @inline={{true}}
-        @identifier="sidebar-more-section"
-        @triggerComponent={{MoreSectionTrigger}}
+        @identifier={{if @identifier @identifier "sidebar-more-section"}}
+        @triggerComponent={{this.triggerComponent}}
       >
 
         <:content as |menu|>

--- a/frontend/discourse/app/components/sidebar/more-section-trigger.gjs
+++ b/frontend/discourse/app/components/sidebar/more-section-trigger.gjs
@@ -1,14 +1,34 @@
+import { eq, or } from "discourse/truth-helpers";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import SectionLinkPrefix from "./section-link-prefix";
 
 const MoreSectionTrigger = <template>
   <button ...attributes type="button" class="sidebar-section-link sidebar-row">
-    <span class="sidebar-section-link-prefix icon">
-      {{dIcon "ellipsis-vertical"}}
-    </span>
+    <SectionLinkPrefix
+      @prefixType={{or @prefixType "icon"}}
+      @prefixValue={{or @prefixValue "ellipsis-vertical"}}
+      @prefixCSSClass={{@prefixCSSClass}}
+    />
+
     <span class="sidebar-section-link-content-text">
-      {{i18n "sidebar.more"}}
+      {{or @text (i18n "sidebar.more")}}
     </span>
+
+    {{#if @suffixValue}}
+      <span
+        class={{dConcatClass
+          "sidebar-section-link-suffix"
+          @suffixType
+          @suffixCSSClass
+        }}
+      >
+        {{#if (eq @suffixType "icon")}}
+          {{dIcon @suffixValue}}
+        {{/if}}
+      </span>
+    {{/if}}
   </button>
 </template>;
 

--- a/frontend/discourse/app/lib/sidebar/base-custom-sidebar-section.js
+++ b/frontend/discourse/app/lib/sidebar/base-custom-sidebar-section.js
@@ -32,6 +32,73 @@ export default class BaseCustomSidebarSection {
   get links() {}
 
   /**
+   * Links rendered behind a "more" drawer instead of directly in the section,
+   * matching the drawer the community section uses.
+   *
+   * @returns {BaseCustomSidebarSectionLink[]} Links for the drawer
+   */
+  get moreLinks() {
+    return [];
+  }
+
+  /**
+   * @returns {string} Text for the drawer trigger. Defaults to "More…".
+   */
+  get moreLinksTriggerText() {}
+
+  /**
+   * @returns {string} Prefix type for the drawer trigger, matching a section
+   * link's. Accepted values: icon, image, text, emoji, square.
+   */
+  get moreLinksTriggerPrefixType() {}
+
+  /**
+   * @returns {string} Prefix value for the drawer trigger. Defaults to an
+   * ellipsis icon.
+   */
+  get moreLinksTriggerPrefixValue() {}
+
+  /**
+   * @returns {string} Suffix type for the drawer trigger. Accepted value: icon.
+   */
+  get moreLinksTriggerSuffixType() {}
+
+  /**
+   * @returns {string} Suffix value for the drawer trigger, e.g. a chevron when
+   * the trigger reads as a picker.
+   */
+  get moreLinksTriggerSuffixValue() {}
+
+  /**
+   * Renders the drawer's links directly in the section instead of behind the
+   * trigger, for a section that wants them listed but kept apart from its own
+   * links.
+   *
+   * @returns {boolean} Defaults to false.
+   */
+  get moreLinksInline() {
+    return false;
+  }
+
+  /**
+   * Whether the drawer's active link is lifted out and rendered above the
+   * trigger. Turn this off when the trigger itself names the current choice.
+   *
+   * @returns {boolean} Defaults to true.
+   */
+  get moreLinksHoistActiveLink() {
+    return true;
+  }
+
+  /**
+   * @returns {"start"|"end"} Whether the drawer leads or trails the section's
+   * own links. Defaults to "end".
+   */
+  get moreLinksPosition() {
+    return "end";
+  }
+
+  /**
    * @returns {Boolean} Whether or not to show the entire section including heading.
    */
   get displaySection() {

--- a/frontend/discourse/tests/acceptance/sidebar-plugin-api-test.gjs
+++ b/frontend/discourse/tests/acceptance/sidebar-plugin-api-test.gjs
@@ -284,6 +284,249 @@ acceptance("Sidebar - Plugin API", function (needs) {
     );
   });
 
+  test("A section without moreLinks renders no drawer", async function (assert) {
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-plain-section";
+            text = "plain section text";
+
+            links = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "plain-link";
+                route = "discovery.latest";
+                title = "plain link title";
+                text = "plain link text";
+              })(),
+            ];
+          };
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(".sidebar-section[data-section-name='test-plain-section']")
+      .exists();
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-plain-section'] .sidebar-more-section-links-details-summary"
+      )
+      .doesNotExist("no drawer trigger is added to sections that opt out");
+  });
+
+  test("Links behind a more drawer", async function (assert) {
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-inboxes";
+            text = "inboxes text";
+            moreLinksTriggerText = "Pick an inbox";
+            moreLinksTriggerPrefixType = "icon";
+            moreLinksTriggerPrefixValue = "inbox";
+            moreLinksTriggerSuffixType = "icon";
+            moreLinksTriggerSuffixValue = "chevron-down";
+
+            links = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "always-shown";
+                route = "discovery.latest";
+                title = "always shown title";
+                text = "always shown text";
+              })(),
+            ];
+
+            moreLinks = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "tucked-away";
+                route = "discovery.unread";
+                title = "tucked away title";
+                text = "tucked away text";
+              })(),
+            ];
+          };
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(".sidebar-section[data-section-name='test-inboxes']")
+      .exists("the section is rendered");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-inboxes'] [data-link-name='tucked-away']"
+      )
+      .doesNotExist("drawer links are not rendered inline");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-inboxes'] .sidebar-more-section-links-details-summary"
+      )
+      .hasText("Pick an inbox", "the trigger uses the section's text");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-inboxes'] .sidebar-section-link-prefix .d-icon-inbox"
+      )
+      .exists("the trigger takes a prefix like a section link does");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-inboxes'] .sidebar-section-link-suffix .d-icon-chevron-down"
+      )
+      .exists("and a suffix");
+
+    await click(
+      ".sidebar-section[data-section-name='test-inboxes'] .sidebar-more-section-links-details-summary"
+    );
+
+    assert
+      .dom("[data-link-name='tucked-away']")
+      .exists("the drawer reveals its links");
+  });
+
+  test("A more drawer copes with links that only carry an href", async function (assert) {
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-href-drawer";
+            text = "href drawer text";
+
+            links = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "always-shown";
+                route = "discovery.latest";
+                title = "always shown title";
+                text = "always shown text";
+              })(),
+            ];
+
+            moreLinks = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "external";
+                href = "https://www.discourse.org";
+                title = "External";
+                text = "External";
+              })(),
+            ];
+          };
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-href-drawer'] .sidebar-more-section-links-details-summary"
+      )
+      .exists("the section renders rather than throwing");
+
+    await click(
+      ".sidebar-section[data-section-name='test-href-drawer'] .sidebar-more-section-links-details-summary"
+    );
+
+    assert
+      .dom("[data-link-name='external']")
+      .exists("and the href-only link is listed");
+  });
+
+  test("A more drawer can be inlined by the section", async function (assert) {
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-inlined-drawer";
+            text = "inlined drawer text";
+            moreLinksInline = true;
+
+            links = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "always-shown";
+                route = "discovery.latest";
+                title = "always shown title";
+                text = "always shown text";
+              })(),
+            ];
+
+            moreLinks = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "listed-inline";
+                route = "discovery.unread";
+                title = "listed inline title";
+                text = "listed inline text";
+              })(),
+            ];
+          };
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-inlined-drawer'] [data-link-name='listed-inline']"
+      )
+      .exists("the links are rendered in the section");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='test-inlined-drawer'] .sidebar-more-section-links-details-summary"
+      )
+      .doesNotExist("and there is no trigger to open");
+  });
+
+  test("A more drawer can lead the section", async function (assert) {
+    withPluginApi((api) => {
+      api.addSidebarSection(
+        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          return class extends BaseCustomSidebarSection {
+            name = "test-leading-drawer";
+            text = "leading drawer text";
+            moreLinksPosition = "start";
+
+            links = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "second-item";
+                route = "discovery.latest";
+                title = "second item title";
+                text = "second item text";
+              })(),
+            ];
+
+            moreLinks = [
+              new (class extends BaseCustomSidebarSectionLink {
+                name = "in-the-drawer";
+                route = "discovery.unread";
+                title = "in the drawer title";
+                text = "in the drawer text";
+              })(),
+            ];
+          };
+        }
+      );
+    });
+
+    await visit("/");
+
+    const rows = [
+      ...document.querySelectorAll(
+        ".sidebar-section[data-section-name='test-leading-drawer'] .sidebar-section-link-wrapper"
+      ),
+    ];
+
+    assert.dom(rows[0]).hasText("More", "the drawer trigger is the first row");
+  });
+
   test("Single header action and no links", async function (assert) {
     withPluginApi((api) => {
       api.addSidebarSection((BaseCustomSidebarSection) => {


### PR DESCRIPTION
Depends on https://github.com/discourse/discourse/pull/42866 and https://github.com/discourse/discourse/pull/42868

The community section of the main sidebar can put links behind a "more" menu, but that's built inside `custom-section.gjs`... sections added through `addSidebarSection` render via `ApiSection` and had no way to do this.

With this API built sections can with `moreLinks` with some options that follow how we do things in the community sidebar: 

* `moreLinksPosition` - start or end 
* `moreLinksTriggerText` - label for the trigger
* `moreLinksTriggerPrefixType` & `moreLinksTriggerPrefixValue` following the section-link convention
* `moreLinksTriggerSuffixType` & `moreLinksTriggerSuffixValue` following the section-link convention
* `moreLinksHoistActiveLink` - if the active link should be moved out and placed above the trigger (how the main sidebar functions, defaults `true`)
* `moreLinksInline` – lists the links inline instead of showing them behind the dropdown, useful for a case like header dropdown mode, where you may not want to use a drawer 
