### PR TITLE
DEV: Fix jemalloc preload path in CI

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -125,9 +125,10 @@ jobs:
 
       - name: RSpec (Rails integration)
         env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
           MIGRATIONS_RAILS: "1"
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
+            (cd "migrations/$gem" && BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
           done

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -129,5 +129,5 @@ jobs:
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && LD_PRELOAD=/usr/lib/libjemalloc.so BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
+            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
           done

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -125,10 +125,9 @@ jobs:
 
       - name: RSpec (Rails integration)
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
           MIGRATIONS_RAILS: "1"
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
+            (cd "migrations/$gem" && LD_PRELOAD=/usr/lib/libjemalloc.so BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
           done

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -125,10 +125,9 @@ jobs:
 
       - name: RSpec (Rails integration)
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
           MIGRATIONS_RAILS: "1"
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
+            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
           done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,7 +256,9 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: LD_PRELOAD="$RUBY_ALLOCATOR" bin/turbo_rspec --use-runtime-info --format=progress
+        env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
+        run: bin/turbo_rspec --use-runtime-info --format=progress
 
       - name: Ember Build
         if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
@@ -281,8 +283,10 @@ jobs:
 
       - name: Plugins RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
+        env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
         run: |
-          LD_PRELOAD="$RUBY_ALLOCATOR" bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
+          bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
 
       - name: Plugins QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -301,34 +305,39 @@ jobs:
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
-        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
+        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
 
       - name: Core Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core-plugins'
         env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
         run: |
-          LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
+          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Official Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'official-plugins'
         env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
         run: |
-          LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
+          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Chat System Tests
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
-        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
+        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
 
       - name: Theme System Tests
         if: matrix.build_type == 'system' && matrix.target == 'themes'
         env:
+          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
-        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
+        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
 
       - name: Upload failed system test artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,9 +256,7 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
-        run: bin/turbo_rspec --use-runtime-info --format=progress
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" bin/turbo_rspec --use-runtime-info --format=progress
 
       - name: Ember Build
         if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
@@ -283,10 +281,8 @@ jobs:
 
       - name: Plugins RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
         run: |
-          bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
+          LD_PRELOAD="$RUBY_ALLOCATOR" bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
 
       - name: Plugins QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -305,39 +301,34 @@ jobs:
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
 
       - name: Core Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core-plugins'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
           CHECKOUT_TIMEOUT: 10
         run: |
-          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
+          LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Official Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'official-plugins'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
           CHECKOUT_TIMEOUT: 10
         run: |
-          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
+          LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Chat System Tests
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
 
       - name: Theme System Tests
         if: matrix.build_type == 'system' && matrix.target == 'themes'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so.1
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
 
       - name: Upload failed system test artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,7 +256,7 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: LD_PRELOAD=/usr/lib/libjemalloc.so bin/turbo_rspec --use-runtime-info --format=progress
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" bin/turbo_rspec --use-runtime-info --format=progress
 
       - name: Ember Build
         if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
@@ -282,7 +282,7 @@ jobs:
       - name: Plugins RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
         run: |
-          LD_PRELOAD=/usr/lib/libjemalloc.so bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
+          LD_PRELOAD="$RUBY_ALLOCATOR" bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
 
       - name: Plugins QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -302,33 +302,33 @@ jobs:
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
 
       - name: Core Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core-plugins'
         env:
           CHECKOUT_TIMEOUT: 10
         run: |
-          LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
+          LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Official Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'official-plugins'
         env:
           CHECKOUT_TIMEOUT: 10
         run: |
-          LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
+          LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Chat System Tests
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
 
       - name: Theme System Tests
         if: matrix.build_type == 'system' && matrix.target == 'themes'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
+        run: LD_PRELOAD="$RUBY_ALLOCATOR" RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
 
       - name: Upload failed system test artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,9 +256,7 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
-        run: bin/turbo_rspec --use-runtime-info --format=progress
+        run: LD_PRELOAD=/usr/lib/libjemalloc.so bin/turbo_rspec --use-runtime-info --format=progress
 
       - name: Ember Build
         if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
@@ -283,10 +281,8 @@ jobs:
 
       - name: Plugins RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
         run: |
-          bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
+          LD_PRELOAD=/usr/lib/libjemalloc.so bin/rake plugin:turbo_spec['*','--format=progress --use-runtime-info']
 
       - name: Plugins QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -305,39 +301,34 @@ jobs:
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
+        run: LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation spec/system
 
       - name: Core Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core-plugins'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
         run: |
-          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
+          LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Official Plugins System Tests
         if: matrix.build_type == 'system' && matrix.target == 'official-plugins'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
         run: |
-          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
+          LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="$(script/list_bundled_plugins '/*' | paste -sd, -)" --use-runtime-info --format documentation plugins/*/spec/system
 
       - name: Chat System Tests
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
+        run: LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --format documentation plugins/chat/spec/system
 
       - name: Theme System Tests
         if: matrix.build_type == 'system' && matrix.target == 'themes'
         env:
-          LD_PRELOAD: /usr/lib/libjemalloc.so
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
+        run: LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --format documentation tmp/themes/*/spec/system themes/*/spec/system
 
       - name: Upload failed system test artifacts
         uses: actions/upload-artifact@v7

--- a/migrations/tooling/config/schema/intermediate_db/ignored.rb
+++ b/migrations/tooling/config/schema/intermediate_db/ignored.rb
@@ -152,6 +152,7 @@ Migrations::Tooling::Schema.ignored do
   tables :admin_dashboard_reports,
          :admin_dashboard_sections,
          :browser_pageview_country_daily_rollups,
+         :browser_pageview_entry_url_daily_rollups,
          :browser_pageview_referrer_daily_rollups,
          :category_activity_daily_rollups,
          :user_visit_daily_rollups


### PR DESCRIPTION
Resolve the following warning from [this CI build](https://github.com/discourse/discourse/actions/runs/32791428738/job/97633588472?pr=42854):

> ERROR: ld.so: object '/usr/lib/libjemalloc.so.1' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.