### PR TITLE
FIX: Uploads Restorer -- Remap Safety

### DIFF
--- a/lib/backup_restore/uploads_restorer.rb
+++ b/lib/backup_restore/uploads_restorer.rb
@@ -131,7 +131,13 @@ module BackupRestore
 
     def remap(from, to)
       log "Remapping '#{from}' to '#{to}'"
-      DbHelper.remap(from, to, verbose: true, excluded_tables: ["backup_metadata"])
+      DbHelper.remap(
+        from,
+        to,
+        verbose: true,
+        excluded_tables: ["backup_metadata"],
+        skip_max_length_violations: true,
+      )
     end
 
     def remap_s3(old_s3_base_url, uploads_folder)
@@ -143,6 +149,7 @@ module BackupRestore
           uploads_folder,
           verbose: true,
           excluded_tables: ["backup_metadata"],
+          skip_max_length_violations: true,
         )
       else
         remap(old_s3_base_url, uploads_folder)

--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -190,13 +190,21 @@ class DbHelper
         parts[:length_constrained_columns] << "#{column[:name]}(#{column[:max_length]})"
       end
 
-      # Build SQL update statements for each column
-      parts[:updates] << %|"#{column[:name]}" = #{replace}|
-
       # Build the base SQL condition clause for each column
       basic_condition = transforms[:condition].call(column[:name])
 
       if skip_max_length_violations && column[:max_length].present?
+        # Per-column protection: preserve the original value when the transformed
+        # value would exceed the column length limit. Without this, a row that
+        # matches on any short column still assigns overflowing values to its
+        # other constrained columns and triggers PG::StringDataRightTruncation.
+        parts[:updates] << <<~SQL.strip
+          "#{column[:name]}" = CASE
+            WHEN LENGTH(#{replace}) <= #{column[:max_length]} THEN #{replace}
+            ELSE "#{column[:name]}"
+          END
+        SQL
+
         # Extend base condition to skip updates that would violate the column length constraint
         parts[
           :conditions
@@ -213,6 +221,7 @@ class DbHelper
           ) AS #{column[:name]}_skipped
         SQL
       else
+        parts[:updates] << %|"#{column[:name]}" = #{replace}|
         parts[:conditions] << "(#{basic_condition})"
       end
     end

--- a/spec/lib/backup_restore/uploads_restorer_spec.rb
+++ b/spec/lib/backup_restore/uploads_restorer_spec.rb
@@ -636,4 +636,36 @@ RSpec.describe BackupRestore::UploadsRestorer do
       FileUtils.mkdir_p(File.join(directory, "uploads", ".hidden"))
     end
   end
+
+  describe "length-constrained columns during remap" do
+    it "passes skip_max_length_violations to DbHelper.remap" do
+      DbHelper
+        .expects(:remap)
+        .with { |_from, _to, args| args[:skip_max_length_violations] == true }
+        .at_least_once
+
+      with_temp_uploads_directory(name: "foo") do |directory|
+        Discourse.store.class.any_instance.stubs(:copy_from)
+        BackupMetadata.create!(name: "db_name", value: "foo")
+        restorer.restore(directory)
+      end
+    end
+
+    it "passes skip_max_length_violations to DbHelper.regexp_replace" do
+      DbHelper.stubs(:remap)
+      DbHelper
+        .expects(:regexp_replace)
+        .with { |_from, _to, args| args[:skip_max_length_violations] == true }
+        .at_least_once
+
+      with_temp_uploads_directory(name: "default") do |directory|
+        Discourse.store.class.any_instance.stubs(:copy_from)
+        BackupMetadata.create!(
+          name: "s3_base_url",
+          value: "//old-bucket.s3.dualstack.us-west-2.amazonaws.com",
+        )
+        restorer.restore(directory)
+      end
+    end
+  end
 end

--- a/spec/lib/db_helper_spec.rb
+++ b/spec/lib/db_helper_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe DbHelper do
         expect(sidebar_url1.name).to eq("short-sidebar-url")
         expect(sidebar_url2.name).to eq("another-sidebar-url")
       end
+
+      it "protects each length-constrained column independently on the same row" do
+        value_limit = SidebarUrl.columns_hash["value"].limit
+        # name(80) will fit after remap, value(1000) will overflow.
+        row =
+          SidebarUrl.create!(
+            icon: "link",
+            name: "TOK-name",
+            value: "TOK" + ("x" * (value_limit - 3)),
+          )
+
+        expect {
+          DbHelper.remap("TOK", "TOKENEXPANDED", skip_max_length_violations: true)
+        }.not_to raise_error
+
+        row.reload
+        expect(row.name).to eq("TOKENEXPANDED-name")
+        expect(row.value).to eq("TOK" + ("x" * (value_limit - 3)))
+      end
     end
   end
 
@@ -137,6 +156,24 @@ RSpec.describe DbHelper do
 
         expect(sidebar_url1.name).to eq("short-sidebar-url")
         expect(sidebar_url2.name).to eq("another-sidebar-url")
+      end
+
+      it "protects each length-constrained column independently on the same row" do
+        value_limit = SidebarUrl.columns_hash["value"].limit
+        row =
+          SidebarUrl.create!(
+            icon: "link",
+            name: "TOK-name",
+            value: "TOK" + ("x" * (value_limit - 3)),
+          )
+
+        expect {
+          DbHelper.regexp_replace("TOK", "TOKENEXPANDED", skip_max_length_violations: true)
+        }.not_to raise_error
+
+        row.reload
+        expect(row.name).to eq("TOKENEXPANDED-name")
+        expect(row.value).to eq("TOK" + ("x" * (value_limit - 3)))
       end
     end
   end


### PR DESCRIPTION
Previously, when a remapping failed on an upload restore, the entire job would fail gracefully and rollback. There were some scenarios where the column length was almost at the max and remapping to a longer base_url would cause the entire job to fail.

DbHelper has an included flag for `skip_max_length_violations` that can help here, with the addition of a conditional update statement per column instead of mapping all of the columns.