### PR TITLE
FIX: Preserve list markers when replacing placeholder

### DIFF
--- a/frontend/discourse/app/lib/textarea-text-manipulation.ts
+++ b/frontend/discourse/app/lib/textarea-text-manipulation.ts
@@ -973,11 +973,22 @@ export default class TextareaTextManipulation implements TextManipulation {
     exampleKey: string,
     opts?: SurroundOptions
   ): void {
+    const collapsedSelection = sel.start === sel.end;
+
     if (sel.value.includes("\n")) {
       this.applySurround(sel, head, "", exampleKey, opts);
     } else {
       const [hval, hlen] = getHead(head);
-      if (sel.start === sel.end) {
+
+      let absorbedHead = false;
+      if (hlen > 0 && sel.pre.slice(sel.pre.lastIndexOf("\n") + 1) === hval) {
+        sel.start -= hlen;
+        sel.pre = sel.pre.slice(0, -hlen);
+        sel.value = `${hval}${sel.value}`;
+        absorbedHead = true;
+      }
+
+      if (collapsedSelection && !absorbedHead) {
         sel.value = i18n(`composer.${exampleKey}`);
       }
 
@@ -985,6 +996,7 @@ export default class TextareaTextManipulation implements TextManipulation {
       // they are "list-like" in that they have a character at
       // the start and a level, rather than having a surrounding format.
       let number;
+      let removedHead = false;
       if (hval.includes("#")) {
         const currentHeadingLevel = sel.value.search(/[^#]/);
 
@@ -992,6 +1004,7 @@ export default class TextareaTextManipulation implements TextManipulation {
         // mirrors list behavior.
         if (sel.value.startsWith(hval) && currentHeadingLevel + 1 === hlen) {
           number = sel.value.slice(hlen);
+          removedHead = true;
         } else {
           // Replace the existing heading level with the new one, or
           // if there is no heading level, add the new one.
@@ -1009,6 +1022,7 @@ export default class TextareaTextManipulation implements TextManipulation {
         // it to "list item"
         if (sel.value.startsWith(hval)) {
           number = sel.value.slice(hlen);
+          removedHead = true;
         } else {
           number = `${hval}${sel.value}`;
         }
@@ -1024,17 +1038,14 @@ export default class TextareaTextManipulation implements TextManipulation {
 
       this._insertAt(sel.start - preChars, sel.end + postChars, textToInsert);
 
-      if (opts?.excludeHeadInSelection) {
-        this.selectText(
-          sel.start + (preNewlines.length - preChars) + hval.length,
-          number.length - hval.length
-        );
-      } else {
-        this.selectText(
-          sel.start + (preNewlines.length - preChars),
-          number.length
-        );
-      }
+      const headSelectionOffset =
+        (opts?.excludeHeadInSelection || collapsedSelection) && !removedHead
+          ? hval.length
+          : 0;
+      this.selectText(
+        sel.start + (preNewlines.length - preChars) + headSelectionOffset,
+        number.length - headSelectionOffset
+      );
     }
   }
 

--- a/frontend/discourse/tests/integration/ui-kit/d-editor-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-editor-test.gjs
@@ -573,12 +573,32 @@ third line`
       await click(`button.list`);
       await click('.btn[data-name="list-bullet"]');
       assert.strictEqual(this.value, `hello world.\n\n* ${example}`);
-      assert.strictEqual(textarea.selectionStart, 14);
+      assert.strictEqual(textarea.selectionStart, 16);
       assert.strictEqual(textarea.selectionEnd, 16 + example.length);
 
       await click(`button.list`);
       await click('.btn[data-name="list-bullet"]');
       assert.strictEqual(this.value, `hello world.\n\n${example}`);
+      assert.strictEqual(textarea.selectionStart, 14);
+      assert.strictEqual(textarea.selectionEnd, 14 + example.length);
+
+      this.set("value", "hello world.");
+      await settled();
+      jumpEnd(textarea);
+      await click(`button.list`);
+      await click('.btn[data-name="list-bullet"]');
+
+      textarea.setRangeText(
+        "First item",
+        textarea.selectionStart,
+        textarea.selectionEnd,
+        "end"
+      );
+      await triggerEvent(textarea, "input", {
+        inputType: "insertText",
+        data: "First item",
+      });
+      assert.strictEqual(this.value, "hello world.\n\n* First item");
     }
   );
 
@@ -632,7 +652,7 @@ third line`
       await click(`button.list`);
       await click('.btn[data-name="list-ordered"]');
       assert.strictEqual(this.value, `hello world.\n\n1. ${example}`);
-      assert.strictEqual(textarea.selectionStart, 14);
+      assert.strictEqual(textarea.selectionStart, 17);
       assert.strictEqual(textarea.selectionEnd, 17 + example.length);
 
       await click(`button.list`);

--- a/frontend/discourse/tests/unit/lib/text-area-manipulaton-test.js
+++ b/frontend/discourse/tests/unit/lib/text-area-manipulaton-test.js
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import TextareaTextManipulation from "discourse/lib/textarea-text-manipulation";
+import { i18n } from "discourse-i18n";
 
 module("Unit | Utility | text-area-manipulation", function (hooks) {
   setupTest(hooks);
@@ -50,6 +51,26 @@ module("Unit | Utility | text-area-manipulation", function (hooks) {
     textarea.select();
     manipulation.applySurroundSelection("**", "**", "example");
     assert.strictEqual(textarea.value, "****Hello World**");
+  });
+
+  test("applyList selects a placeholder without its checklist marker", function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.setSelectionRange(0, 0);
+    manipulation.applyList(
+      manipulation.getSelected(false, { lineVal: true }),
+      "- [ ] ",
+      "list_item"
+    );
+
+    const example = i18n("composer.list_item");
+    assert.strictEqual(textarea.value, `- [ ] ${example}`);
+    assert.strictEqual(textarea.selectionStart, 6);
+    assert.strictEqual(textarea.selectionEnd, 6 + example.length);
   });
 
   test("emojiSelected - replaces ASCII partial term", async function (assert) {


### PR DESCRIPTION
Select only the placeholder text when inserting list formatting so typing
replaces the example without removing the marker. Absorb adjacent markers
when toggling formatting to keep list and heading behavior consistent.
