### PR TITLE
DEV: Add user locale to post serializer for admins

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -93,6 +93,7 @@ class PostSerializer < BasicPostSerializer
              :reviewable_score_count,
              :reviewable_score_pending_count,
              :user_suspended,
+             :user_locale,
              :user_status,
              :mentioned_users,
              :post_url,
@@ -652,6 +653,14 @@ class PostSerializer < BasicPostSerializer
 
   def include_user_suspended?
     object.user&.suspended?
+  end
+
+  def user_locale
+    object.user&.locale
+  end
+
+  def include_user_locale?
+    SiteSetting.allow_user_locale && scope.is_admin? && user_locale.present?
   end
 
   def include_user_status?

--- a/frontend/discourse/app/models/post.js
+++ b/frontend/discourse/app/models/post.js
@@ -196,6 +196,7 @@ export default class Post extends RestModel {
   @tracked user_custom_fields;
   @tracked user_deleted;
   @tracked user_id;
+  @tracked user_locale;
   @tracked user_suspended;
   @tracked user_title;
   @tracked username;
@@ -521,6 +522,7 @@ export default class Post extends RestModel {
       flair_group_id: this.flair_group_id,
       flair_name: this.flair_name,
       flair_url: this.flair_url,
+      locale: this.user_locale,
       moderator: this.moderator,
       primary_group_name: this.primary_group_name,
       status: this.user_status,

--- a/frontend/discourse/tests/unit/models/post-test.js
+++ b/frontend/discourse/tests/unit/models/post-test.js
@@ -25,6 +25,21 @@ module("Unit | Model | post", function (hooks) {
     assert.false(post.new_user, "post is no longer from a new user");
   });
 
+  test("user includes user_locale from the post payload", function (assert) {
+    const post = this.store.createRecord("post", {
+      id: 1,
+      user_id: 2,
+      username: "author",
+      user_locale: "ja",
+    });
+
+    assert.strictEqual(
+      post.user.locale,
+      "ja",
+      "maps user_locale to user.locale"
+    );
+  });
+
   test("firstPost", function (assert) {
     const post = this.store.createRecord("post", { post_number: 1 });
     assert.true(post.firstPost, "is the first post");

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -192,6 +192,41 @@ RSpec.describe PostSerializer do
     end
   end
 
+  describe "#user_locale" do
+    fab!(:admin)
+    fab!(:moderator)
+
+    before { post.user.update!(locale: "ja") }
+
+    it "includes the author's locale for admins only when user locale is enabled" do
+      SiteSetting.allow_user_locale = true
+
+      expect(described_class.new(post, scope: Guardian.new(admin), root: false).as_json).to include(
+        user_locale: "ja",
+      )
+
+      expect(
+        described_class.new(post, scope: Guardian.new(moderator), root: false).as_json,
+      ).not_to have_key(:user_locale)
+
+      expect(described_class.new(post, scope: Guardian.new(post.user), root: false).as_json).not_to(
+        have_key(:user_locale),
+      )
+
+      expect(described_class.new(post, scope: Guardian.new, root: false).as_json).not_to have_key(
+        :user_locale,
+      )
+    end
+
+    it "omits the author's locale when user locale is disabled" do
+      SiteSetting.allow_user_locale = false
+
+      expect(described_class.new(post, scope: Guardian.new(admin), root: false).as_json).not_to(
+        have_key(:user_locale),
+      )
+    end
+  end
+
   describe "#display_username" do
     let(:user) { post.user }
     let(:serializer) { PostSerializer.new(post, scope: Guardian.new, root: false) }


### PR DESCRIPTION
This allows admins in topics to know if a user is viewing their site in a different language.