### PR TITLE
FIX: Clear report group filters

### DIFF
--- a/frontend/discourse/admin/components/admin-report.gjs
+++ b/frontend/discourse/admin/components/admin-report.gjs
@@ -44,6 +44,18 @@ const TABLE_OPTIONS = {
 
 const CHART_OPTIONS = {};
 
+export function updateReportFilters(filters, id, value) {
+  const customFilters = { ...filters };
+
+  if (value === null || typeof value === "undefined") {
+    delete customFilters[id];
+  } else {
+    customFilters[id] = value;
+  }
+
+  return customFilters;
+}
+
 export default class AdminReport extends Component {
   @service siteSettings;
 
@@ -352,15 +364,9 @@ export default class AdminReport extends Component {
 
   @action
   applyFilter(id, value) {
-    let customFilters = this.args.filters?.customFilters || {};
-
-    if (typeof value === "undefined") {
-      delete customFilters[id];
-    } else {
-      customFilters[id] = value;
-    }
-
-    this.refreshReport({ filters: customFilters });
+    this.refreshReport({
+      filters: updateReportFilters(this.args.filters?.customFilters, id, value),
+    });
   }
 
   @action

--- a/frontend/discourse/tests/integration/components/admin-report-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-report-test.gjs
@@ -1,11 +1,21 @@
 import { click, fillIn, render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import AdminReport from "discourse/admin/components/admin-report";
+import AdminReport, {
+  updateReportFilters,
+} from "discourse/admin/components/admin-report";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module("Integration | Component | AdminReport", function (hooks) {
   setupRenderingTest(hooks);
+
+  test("clearing a group filter removes it", function (assert) {
+    assert.deepEqual(
+      updateReportFilters({ group: 88 }, "group", null),
+      {},
+      "omits the group filter"
+    );
+  });
 
   test("default", async function (assert) {
     await render(


### PR DESCRIPTION
Previously, selecting All groups left the selected report group active because a null value remained in the filter state.

This change removes cleared filter values before the report refreshes, allowing unfiltered data to render.

https://github.com/user-attachments/assets/0e60c21e-6247-4a76-ba1b-7e16f6aebca9

