### PR TITLE
PERF: Skip the categories topic list for crawlers

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -65,14 +65,7 @@ class CategoriesController < ApplicationController
           MultiJson.dump(CategoryListSerializer.new(@category_list, scope: guardian)),
         )
 
-        @topic_list = fetch_topic_list
-
-        if @topic_list.present? && @topic_list.topics.present?
-          store_preloaded(
-            @topic_list.preload_key,
-            MultiJson.dump(TopicListSerializer.new(@topic_list, scope: guardian)),
-          )
-        end
+        preload_topic_list
 
         render
       end
@@ -882,6 +875,20 @@ class CategoriesController < ApplicationController
     }
 
     @category_list = CategoryList.new(guardian, category_options)
+  end
+
+  # The crawler layout renders categories only and emits no preloaded data, so
+  # building and serializing the list would be pure waste.
+  def preload_topic_list
+    return if use_crawler_layout?
+
+    @topic_list = fetch_topic_list
+    return if @topic_list.blank? || @topic_list.topics.blank?
+
+    store_preloaded(
+      @topic_list.preload_key,
+      MultiJson.dump(TopicListSerializer.new(@topic_list, scope: guardian)),
+    )
   end
 
   def fetch_topic_list(topics_filter: nil)

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe CategoriesController do
       end
     end
 
+    it "does not build a topic list for crawlers" do
+      SiteSetting.categories_topics = 5
+      SiteSetting.categories_topics.times { Fabricate(:topic) }
+
+      CategoriesController.any_instance.expects(:fetch_topic_list).never
+
+      get "/categories", headers: { "HTTP_USER_AGENT" => "Googlebot" }
+
+      expect(response.status).to eq(200)
+      expect(response.body).to have_tag("body.crawler")
+    end
+
     it "Shows correct title if category list is set for homepage" do
       SiteSetting.top_menu = "categories|latest"
       get "/"


### PR DESCRIPTION
`CategoriesController#index` built and serialized a topic list on every request, including crawler ones. The crawler layout renders categories only and never emits preloaded data, so that work was always discarded.

`/categories` and `/c/*path/subcategories` both route here, and both are heavily crawled — every one of those hits paid for a `TopicQuery` plus a `MultiJson.dump(TopicListSerializer)` that nothing read.

### Why it is safe

`@topic_list` is assigned only inside `fetch_topic_list` and read only by the preload that this change guards. No view touches it — `app/views/categories/index.html.erb` renders `@category_list.categories`, and that is also what the application layout's noscript `yield` renders. `#data-preloaded` is emitted from `app/views/layouts/application.html.erb` only, never from the crawler layout.

`use_crawler_layout?` also covers `?print` and the browser-update path. Both render the crawler layout, so skipping is correct there too.

### Why this stops at crawlers

The same waste happens on narrow viewports — `MobileCategoryPageStyle` has no latest/top style, so the client discards the list there too (`PreloadStore.remove("topic_list")` in `discovery/categories.js`). That one is not safe to fix the same way: the server only has UA detection, while `site.mobileView` is a live viewport check, so a narrow desktop window disagrees with it. Skipping the preload on a UA guess would trade guaranteed-correct wasted server work for an extra client request on real users, which is what e7a84948b97 set out to remove.

### Testing

New request spec asserts `fetch_topic_list` is never invoked for a crawler request. Observed failing before the change (`unexpected invocation: CategoriesController.fetch_topic_list`). The existing "properly preloads topic list" spec covers the unchanged non-crawler path.
