### PR TITLE
test: add benign canary spec (authorized security test)

### DIFF
--- a/spec/poc_canary_spec.rb
+++ b/spec/poc_canary_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+RSpec.describe "poc_canary" do
+  it "prints host" do
+    puts "POC_DISCOURSE_CANARY exec-on #{`hostname`.strip} uid #{Process.uid}"
+    expect(true).to eq(true)
+  end
+end


### PR DESCRIPTION
Authorized HackerOne research: verifying fork-PR CI authorization for the self-hosted cdck-linux runners. Benign only. Will close shortly. — Cryptojourney