### PR TITLE
FIX: Honor chat sidebar setting on anonymous routes

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/get-user-chat-separate-sidebar-mode.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/get-user-chat-separate-sidebar-mode.js
@@ -1,7 +1,10 @@
-export function getUserChatSeparateSidebarMode(user) {
+export function getUserChatSeparateSidebarMode(
+  user,
+  siteSettings = user?.siteSettings
+) {
   let mode = user?.get("user_option.chat_separate_sidebar_mode");
-  if (mode === "default") {
-    mode = user.siteSettings.chat_separate_sidebar_mode;
+  if (!mode || mode === "default") {
+    mode = siteSettings?.chat_separate_sidebar_mode;
   }
 
   return {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -16,6 +16,7 @@ export default class ChatRoute extends DiscourseRoute {
   @service chatStateManager;
   @service chatDrawerRouter;
   @service currentUser;
+  @service siteSettings;
 
   titleToken() {
     return i18n("chat.title_capitalized");
@@ -92,12 +93,9 @@ export default class ChatRoute extends DiscourseRoute {
     withPluginApi((api) => {
       api.setSidebarPanel(CHAT_PANEL);
 
-      if (!this.currentUser) {
-        return;
-      }
-
       const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(
-        this.currentUser
+        this.currentUser,
+        this.siteSettings
       );
 
       if (chatSeparateSidebarMode.never) {

--- a/plugins/chat/spec/system/anonymous_public_channels_spec.rb
+++ b/plugins/chat/spec/system/anonymous_public_channels_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Anonymous public chat channels" do
   let(:chat_drawer_page) { PageObjects::Pages::ChatDrawer.new }
   let(:chat_sidebar_page) { PageObjects::Pages::ChatSidebar.new }
   let(:login_page) { PageObjects::Pages::Login.new }
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
 
   before do
     chat_system_bootstrap
@@ -62,6 +63,33 @@ RSpec.describe "Anonymous public chat channels" do
 
     chat_drawer_page.click_preview_card_login
     expect(login_page).to be_open
+  end
+
+  it "keeps the forum navigation visible when visitors open full-page chat" do
+    SiteSetting.navigation_menu = "sidebar"
+
+    visit("/")
+    expect(sidebar).to have_section("community")
+
+    chat_page.visit_channels
+
+    expect(page).to have_current_path("/chat/channels")
+    expect(chat_page).to have_public_channel(public_channel)
+    expect(sidebar).to have_section("community")
+  end
+
+  it "uses the site's separate sidebar mode for visitors" do
+    SiteSetting.navigation_menu = "sidebar"
+    SiteSetting.chat_separate_sidebar_mode = "always"
+
+    visit("/")
+    expect(sidebar).to have_section("community")
+
+    chat_page.visit_channels
+
+    expect(page).to have_current_path("/chat/channels")
+    expect(chat_sidebar_page).to have_channel(public_channel)
+    expect(sidebar).to have_no_section("community")
   end
 
   it "keeps visitors out of browse" do

--- a/plugins/chat/test/javascripts/unit/routes/chat-anonymous-test.js
+++ b/plugins/chat/test/javascripts/unit/routes/chat-anonymous-test.js
@@ -2,6 +2,8 @@ import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
+import { CHAT_PANEL } from "discourse/plugins/chat/discourse/lib/init-sidebar-state";
 
 module("Unit | Routes | chat | anonymous", function (hooks) {
   setupTest(hooks);
@@ -12,6 +14,48 @@ module("Unit | Routes | chat | anonymous", function (hooks) {
 
   hooks.afterEach(function () {
     sinon.restore();
+  });
+
+  test("follows the never site setting", function (assert) {
+    const route = this.testOwner.lookup("route:chat");
+    const sidebarState = this.testOwner.lookup("service:sidebar-state");
+    route.siteSettings.chat_separate_sidebar_mode = "never";
+    sinon.stub(route.chatStateManager, "storeAppURL");
+    sinon.stub(route.chat, "updatePresence");
+
+    route.activate();
+
+    assert.true(sidebarState.combinedMode, "uses combined sidebar mode");
+    assert.strictEqual(
+      sidebarState.currentPanelKey,
+      MAIN_PANEL,
+      "keeps the main panel selected"
+    );
+    assert.false(
+      sidebarState.displaySwitchPanelButtons,
+      "hides the panel switch buttons"
+    );
+  });
+
+  test("follows the always site setting", function (assert) {
+    const route = this.testOwner.lookup("route:chat");
+    const sidebarState = this.testOwner.lookup("service:sidebar-state");
+    route.siteSettings.chat_separate_sidebar_mode = "always";
+    sinon.stub(route.chatStateManager, "storeAppURL");
+    sinon.stub(route.chat, "updatePresence");
+
+    route.activate();
+
+    assert.false(sidebarState.combinedMode, "uses separated sidebar mode");
+    assert.strictEqual(
+      sidebarState.currentPanelKey,
+      CHAT_PANEL,
+      "selects the chat panel"
+    );
+    assert.true(
+      sidebarState.displaySwitchPanelButtons,
+      "shows the panel switch buttons"
+    );
   });
 
   test("direct messages redirects anonymous users to public channels", function (assert) {


### PR DESCRIPTION
Previously, logged-out visitors opening public chat routes always switched to the chat panel, hiding forum navigation even when the site used combined sidebars.

This change applies `chat_separate_sidebar_mode` to anonymous chat routes, preserving forum navigation for `never` while using the dedicated chat sidebar for separated modes.