### PR TITLE
UX: Move invite domain restriction behind advanced mode

### DIFF
--- a/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
+++ b/frontend/discourse/app/components/modal/create-invite-with-roles.gjs
@@ -641,29 +641,31 @@ export default class CreateInviteWithRoles extends Component {
 
                 <conditional.Contents as |Content|>
                   <Content @name="link">
-                    <form.Field
-                      @name="domain"
-                      @type="input"
-                      @title={{i18n
-                        "user.invited.invite_roles.restrict_domain"
-                      }}
-                      @description={{i18n
-                        "user.invited.invite_roles.restrict_domain_help"
-                      }}
-                      @validate={{if
-                        (eq this.delivery "link")
-                        this.validateDomain
-                      }}
-                      @format="full"
-                      as |field|
-                    >
-                      <field.Control
-                        autofocus="autofocus"
-                        placeholder={{i18n
-                          "user.invited.invite_roles.domain_placeholder"
+                    {{#if this.showAdvanced}}
+                      <form.Field
+                        @name="domain"
+                        @type="input"
+                        @title={{i18n
+                          "user.invited.invite_roles.restrict_domain"
                         }}
-                      />
-                    </form.Field>
+                        @description={{i18n
+                          "user.invited.invite_roles.restrict_domain_help"
+                        }}
+                        @validate={{if
+                          (eq this.delivery "link")
+                          this.validateDomain
+                        }}
+                        @format="full"
+                        as |field|
+                      >
+                        <field.Control
+                          autofocus="autofocus"
+                          placeholder={{i18n
+                            "user.invited.invite_roles.domain_placeholder"
+                          }}
+                        />
+                      </form.Field>
+                    {{/if}}
                   </Content>
 
                   <Content @name="email">
@@ -767,29 +769,31 @@ export default class CreateInviteWithRoles extends Component {
 
                 <conditional.Contents as |Content|>
                   <Content @name="link">
-                    <form.Field
-                      @name="domain"
-                      @type="input"
-                      @title={{i18n
-                        "user.invited.invite_roles.restrict_domain"
-                      }}
-                      @description={{i18n
-                        "user.invited.invite_roles.restrict_domain_help"
-                      }}
-                      @validate={{if
-                        (eq this.delivery "link")
-                        this.validateDomain
-                      }}
-                      @format="full"
-                      as |field|
-                    >
-                      <field.Control
-                        autofocus="autofocus"
-                        placeholder={{i18n
-                          "user.invited.invite_roles.domain_placeholder"
+                    {{#if this.showAdvanced}}
+                      <form.Field
+                        @name="domain"
+                        @type="input"
+                        @title={{i18n
+                          "user.invited.invite_roles.restrict_domain"
                         }}
-                      />
-                    </form.Field>
+                        @description={{i18n
+                          "user.invited.invite_roles.restrict_domain_help"
+                        }}
+                        @validate={{if
+                          (eq this.delivery "link")
+                          this.validateDomain
+                        }}
+                        @format="full"
+                        as |field|
+                      >
+                        <field.Control
+                          autofocus="autofocus"
+                          placeholder={{i18n
+                            "user.invited.invite_roles.domain_placeholder"
+                          }}
+                        />
+                      </form.Field>
+                    {{/if}}
                   </Content>
 
                   <Content @name="email">

--- a/frontend/discourse/tests/integration/components/create-invite-with-roles-test.gjs
+++ b/frontend/discourse/tests/integration/components/create-invite-with-roles-test.gjs
@@ -25,6 +25,7 @@ module("Integration | Component | CreateInviteWithRoles", function (hooks) {
     assert
       .dom("input[name='invite-role']")
       .doesNotExist("role toggle is not shown");
+    await click(".advanced-mode-btn");
     assert.true(formKit().hasField("domain"), "defaults to member link mode");
   });
 
@@ -62,6 +63,12 @@ module("Integration | Component | CreateInviteWithRoles", function (hooks) {
       .isChecked("defaults to link delivery");
     assert
       .dom("[data-name='domain']")
+      .doesNotExist("hides the domain field until advanced mode is on");
+
+    await click(".advanced-mode-btn");
+
+    assert
+      .dom("[data-name='domain']")
       .isVisible("shows the domain field in link mode");
     assert
       .dom("[data-name='email']")
@@ -89,6 +96,7 @@ module("Integration | Component | CreateInviteWithRoles", function (hooks) {
       </template>
     );
 
+    await click(".advanced-mode-btn");
     assert.true(formKit().hasField("domain"), "stays in member mode");
   });
 
@@ -231,6 +239,7 @@ module("Integration | Component | CreateInviteWithRoles", function (hooks) {
       </template>
     );
 
+    await click(".advanced-mode-btn");
     await formKit().field("domain").fillIn("example.com");
     await click(".save-invite");
 
@@ -431,6 +440,7 @@ module("Integration | Component | CreateInviteWithRoles", function (hooks) {
       </template>
     );
 
+    await click(".advanced-mode-btn");
     await formKit().field("domain").fillIn("");
     await click(".save-invite");
 
@@ -478,6 +488,8 @@ module("Integration | Component | CreateInviteWithRoles", function (hooks) {
         <CreateInviteWithRoles @inline={{true}} @model={{model}} />
       </template>
     );
+
+    await click(".advanced-mode-btn");
 
     assert
       .form()

--- a/spec/system/create_invite_with_roles_spec.rb
+++ b/spec/system/create_invite_with_roles_spec.rb
@@ -101,6 +101,7 @@ describe "Creating invites with roles" do
       open_invite_modal_for(admin)
 
       modal.select_role("admin")
+      modal.toggle_advanced_options
       modal.form.field("domain").fill_in("example.com")
       modal.save_button.click
 
@@ -124,7 +125,6 @@ describe "Creating invites with roles" do
 
       modal.toggle_advanced_options
       screenshot_marker(label: "invite-members-advanced", only: :desktop)
-      modal.toggle_advanced_options
 
       modal.form.field("domain").fill_in("example.com")
       modal.save_button.click


### PR DESCRIPTION
**Previously**, the "Restrict to domain" field was shown by default in both the members and staff invite modals, adding a step most people skip.

**In this update**, the field only appears when advanced mode is enabled.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-members-v2.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-members-v2.png) |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-staff-v2.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-staff-v2.png) |