### PR TITLE
FIX: Authorize topic recovery against the post it actually recovers

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -145,6 +145,10 @@ class Topic < ActiveRecord::Base
     @featured_users ||= TopicFeaturedUsers.new(self)
   end
 
+  def first_post_with_deleted
+    posts.with_deleted.find_by(post_number: 1)
+  end
+
   def trash!(trashed_by = nil)
     trigger_event = false
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -151,7 +151,10 @@ module TopicGuardian
     if is_category_group_moderator?(topic.category) || can_delete_all_posts_and_topics?
       topic.deleted_at?
     else
-      can_recover_post?(topic.ordered_posts.first)
+      original_post = topic.first_post_with_deleted
+      return false if original_post&.trashed? && !can_see_deleted_post?(original_post)
+
+      can_recover_post?(original_post)
     end
   end
 

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -121,7 +121,9 @@ class PostDestroyer
     user_recovered if user_recovery
 
     @topic.update_column(:user_id, Discourse::SYSTEM_USER_ID) if !@topic.user_id
-    @topic.recover!(@user) if (staff_recovery || user_recovery) && @post.is_first_post?
+    if (staff_recovery || user_recovery) && @post.is_first_post? && @post.deleted_at.nil?
+      @topic.recover!(@user)
+    end
     @topic.update_statistics!
     Topic.publish_stats_to_clients!(@topic.id, :recovered)
 

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -150,6 +150,55 @@ RSpec.describe TopicGuardian do
       SiteSetting.delete_all_posts_and_topics_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
       expect(Guardian.new.can_recover_topic?(Topic.with_deleted.last)).to eq(false)
     end
+
+    it "returns false when the user only owns a surviving reply and staff trashed the first post" do
+      trashed_topic = Fabricate(:topic, category: category, user: user)
+      Fabricate(
+        :post,
+        topic: trashed_topic,
+        user: user,
+        post_number: 1,
+        deleted_at: 1.day.ago,
+        deleted_by: admin,
+      )
+      Fabricate(:post, topic: trashed_topic, user: user, post_number: 2, user_deleted: true)
+      trashed_topic.trash!(admin)
+
+      expect(Guardian.new(user).can_recover_topic?(trashed_topic)).to eq(false)
+    end
+
+    it "returns true for the author of a topic they deleted themselves" do
+      own_topic = Fabricate(:topic, category: category, user: user)
+      Fabricate(:post, topic: own_topic, user: user, post_number: 1, user_deleted: true)
+
+      expect(Guardian.new(user).can_recover_topic?(own_topic)).to eq(true)
+    end
+
+    it "returns false for tl4 when someone else trashed the first post of a live topic" do
+      live_topic = Fabricate(:topic, category: category)
+      Fabricate(
+        :post,
+        topic: live_topic,
+        post_number: 1,
+        deleted_at: 1.day.ago,
+        deleted_by: moderator,
+      )
+
+      expect(Guardian.new(tl4_user).can_recover_topic?(live_topic)).to eq(false)
+    end
+
+    it "returns true for tl4 when they trashed the first post of a live topic themselves" do
+      live_topic = Fabricate(:topic, category: category)
+      Fabricate(
+        :post,
+        topic: live_topic,
+        post_number: 1,
+        deleted_at: 1.day.ago,
+        deleted_by: tl4_user,
+      )
+
+      expect(Guardian.new(tl4_user).can_recover_topic?(live_topic)).to eq(true)
+    end
   end
 
   describe "#can_edit_topic?" do

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -1633,4 +1633,13 @@ RSpec.describe PostDestroyer do
     expect(post.reload.deleted_at).to be_present
     expect(Topic.with_deleted.find(post.topic_id).deleted_at).to be_present
   end
+
+  it "leaves the topic deleted when its author recovers a first post staff trashed" do
+    PostDestroyer.new(moderator, post).destroy
+
+    PostDestroyer.new(post.user, post.reload).recover
+
+    expect(post.reload.deleted_at).to be_present
+    expect(Topic.with_deleted.find(post.topic_id).deleted_at).to be_present
+  end
 end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1992,6 +1992,16 @@ RSpec.describe TopicsController do
           put "/t/#{topic.id}/recover.json"
           expect(response).to be_forbidden
         end
+
+        it "raises an exception when only the user's own deleted reply survives" do
+          Fabricate(:post, topic: topic, user: user, post_number: 2, user_deleted: true)
+          sign_in(user)
+
+          put "/t/#{topic.id}/recover.json"
+
+          expect(response).to be_forbidden
+          expect(topic.reload).to be_trashed
+        end
       end
 
       context "with permission" do


### PR DESCRIPTION
`TopicGuardian#can_recover_topic?` asked `can_recover_post?` about `topic.ordered_posts.first`, but `ordered_posts` is trashable-scoped, so once the first post is deleted that query can never return it — it returns the earliest *surviving* post instead. `TopicsController#recover` meanwhile acts on `posts.with_deleted.order(:post_number).first`, the real first post. The guardian was answering a question about one record while the controller acted on another.

### Reproduction

On a default install:

1. Alice (TL1) creates a topic, replies to it, and deletes her own reply.
2. A moderator deletes the topic.
3. Alice sends `PUT /t/:id/recover.json` → **200**.

Her self-deleted reply is `user_deleted` with `deleted_at` unset, which is exactly the shape `can_recover_post?` approves — so the guardian approved recovering the topic on the strength of a reply.

### Why the state it leaves behind is worse than the permission slip

`user_recovered` bails out on a post staff trashed, since `user_deleted` is false. `@topic.recover!` ran anyway, keyed on which branch was *selected* rather than on whether it did anything. The topic came back listed with no opening post, and Alice could not repair it — `can_recover_post?` on the real first post is false for her.

That state is also load-bearing elsewhere: `Jobs::DeleteTopic`, `DestroyTask` and `PostMover` all reach for `ordered_posts.first` and hand the result to `PostDestroyer`, so on an affected topic they delete a reply and leave the topic alive, reporting success. Those call sites are left for a follow-up — `PostDestroyer#destroy` is not idempotent on an already-trashed post, so converting them needs its own change.

### The guard

Pointing the guardian at the real first post would, on its own, hand TL4 a recover button for an opening post a moderator deleted on a live topic — `can_recover_post?` grants that through `can_moderate_topic?`, and `details.can_recover` flips with it. `posts#recover` refuses that same request through `ensure_can_see!` → `can_see_deleted_post?`, so the guard keeps both routes to one answer. A TL4 recovering a post they trashed themselves stays allowed, exactly as `posts#recover` already allowed.

`first_post_with_deleted` reads `post_number: 1` rather than the lowest surviving number, so it agrees with `Post#is_first_post?` and cannot substitute a reply the way the code it replaces did.

### No backfill

A live topic whose first post is trashed is also a legitimate state — a moderator deleting the opening post of a live multi-post topic produces it. Nothing can tell that apart from the corruption, so existing rows are left alone.
