### PR TITLE
SECURITY: Require acting policy editors to manage newly added policy target groups in p...

### DIFF
--- a/plugins/discourse-policy/lib/post_validator.rb
+++ b/plugins/discourse-policy/lib/post_validator.rb
@@ -17,7 +17,8 @@ module DiscoursePolicy
 
       return true if old_policies == new_policies
 
-      if !user_allowed?(@post.acting_user) || !user_allowed?(@post.user)
+      if !user_allowed?(@post.acting_user) || !user_allowed?(@post.user) ||
+           !acting_user_can_manage_target_groups?(old_policies, new_policies)
         @post.errors.add(:base, I18n.t("discourse_policy.errors.no_policy_permission"))
         return false
       end
@@ -35,6 +36,24 @@ module DiscoursePolicy
         .css("div.policy")
         .reject { |p| p.ancestors("blockquote").any? }
         .map(&:to_html)
+    end
+
+    def acting_user_can_manage_target_groups?(old_policies, new_policies)
+      old_target_group_names = old_policies.map { |policy| policy_target_group_name(policy) }
+
+      new_policies.each_with_index.all? do |policy, index|
+        target_group_name = policy_target_group_name(policy)
+        next true if target_group_name.blank? || target_group_name == old_target_group_names[index]
+
+        target_group = Group.find_by_name(target_group_name)
+
+        !target_group || !Guardian.new(@post.user).can_edit_group?(target_group) ||
+          Guardian.new(@post.acting_user).can_edit_group?(target_group)
+      end
+    end
+
+    def policy_target_group_name(policy)
+      Nokogiri::HTML5.fragment(policy).at_css("div.policy")["data-add-users-to-group"]
     end
 
     def user_allowed?(user)

--- a/plugins/discourse-policy/plugin.rb
+++ b/plugins/discourse-policy/plugin.rb
@@ -72,7 +72,8 @@ after_initialize do
     has_group = false
 
     if post&.user&.in_any_groups?(SiteSetting.create_policy_allowed_groups_map)
-      if policy = doc.search(".policy")&.first
+      policy = doc.search(".policy").find { |node| node.ancestors("blockquote").none? }
+      if policy
         post_policy = post.post_policy || post.build_post_policy
 
         group_names = []

--- a/plugins/discourse-policy/spec/plugin_spec.rb
+++ b/plugins/discourse-policy/spec/plugin_spec.rb
@@ -61,6 +61,24 @@ describe DiscoursePolicy do
       expect(policy.next_renew_at).to be_nil
     end
 
+    context "when a policy is inside a blockquote" do
+      fab!(:target_group, :group)
+
+      it "does not persist a policy placed inside a blockquote" do
+        raw = <<~MD
+          [quote="someone, post:1, topic:1"]
+          [policy group=#{group.name} add-users-to-group=#{target_group.name}]
+            Here's the new policy
+          [/policy]
+          [/quote]
+        MD
+
+        post = create_post(raw: raw, user: moderator)
+
+        expect(PostPolicy.find_by(post: post)).to be_nil
+      end
+    end
+
     context "with add_users_to_group present" do
       fab!(:group2, :group)
       fab!(:post) { Fabricate(:post, user: moderator) }

--- a/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
+++ b/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
@@ -395,6 +395,31 @@ describe DiscoursePolicy::PolicyController do
       end
     end
 
+    it "does not grant wiki editors access through a blockquoted policy" do
+      sign_in(editor)
+      put "/posts/#{policy_post.id}.json", params: { post: { raw: <<~MD } }
+                [quote="someone, post:1, topic:1"]
+                [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
+                Accept this policy
+                [/policy]
+                [/quote]
+              MD
+
+      expect(response.status).to eq(200)
+
+      put "/policy/accept.json", params: { post_id: policy_post.id }
+      accept_status = response.status
+
+      get "/posts/#{private_post.id}.json"
+      restricted_status = response.status
+
+      aggregate_failures do
+        expect(target_group.user_ids).not_to include(editor.id)
+        expect(accept_status).not_to eq(200)
+        expect(restricted_status).to eq(403)
+      end
+    end
+
     it "allows wiki editors to modify policy text without changing an inaccessible target group" do
       policy_post_with_target_group.update!(wiki: true)
       sign_in(editor)

--- a/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
+++ b/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
@@ -327,4 +327,88 @@ describe DiscoursePolicy::PolicyController do
       )
     end
   end
+
+  describe "wiki policy edits" do
+    fab!(:admin)
+    fab!(:editor, :user)
+    fab!(:policy_group, :group)
+    fab!(:policy_creator_group, :group)
+    fab!(:target_group, :group)
+    fab!(:private_category) { Fabricate(:private_category, group: target_group) }
+    fab!(:private_topic) { Fabricate(:topic, category: private_category, user: admin) }
+    fab!(:private_post) do
+      Fabricate(:post, topic: private_topic, user: admin, raw: "Restricted group content")
+    end
+    let(:policy_post) { create_post(user: admin, raw: <<~MD) }
+          [policy group=#{policy_group.name}]
+          Accept this policy
+          [/policy]
+        MD
+    let(:policy_post_with_target_group) { create_post(user: admin, raw: <<~MD) }
+          [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
+          Accept this policy
+          [/policy]
+        MD
+
+    before do
+      policy_group.add(editor)
+      policy_creator_group.add(editor)
+      SiteSetting.policy_enabled = true
+      SiteSetting.create_policy_allowed_groups = "1|2|#{policy_creator_group.id}"
+      editor.change_trust_level!(TrustLevel[1])
+      SiteSetting.edit_wiki_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
+      policy_post.update!(wiki: true)
+    end
+
+    it "prevents wiki editors from granting themselves access through a policy target group" do
+      sign_in(editor)
+      get "/posts/#{private_post.id}.json"
+      inaccessible_status = response.status
+      inaccessible_body = response.body
+
+      put "/posts/#{policy_post.id}.json", params: { post: { raw: <<~MD } }
+                [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
+                Accept this policy
+                [/policy]
+              MD
+
+      edit_status = response.status
+      edit_errors = response.parsed_body["errors"]
+
+      put "/policy/accept.json", params: { post_id: policy_post.id }
+      accept_status = response.status
+      accept_body = response.body
+
+      get "/posts/#{private_post.id}.json"
+      restricted_status = response.status
+      restricted_body = response.body
+
+      aggregate_failures do
+        expect(inaccessible_status).to eq(403)
+        expect(inaccessible_body).not_to include(private_post.raw)
+        expect(edit_status).to eq(422)
+        expect(edit_errors).to include(I18n.t("discourse_policy.errors.no_policy_permission"))
+        expect(accept_status).to eq(200), accept_body
+        expect(target_group.user_ids).not_to include(editor.id)
+        expect(restricted_status).to eq(403)
+        expect(restricted_body).not_to include(private_post.raw)
+      end
+    end
+
+    it "allows wiki editors to modify policy text without changing an inaccessible target group" do
+      policy_post_with_target_group.update!(wiki: true)
+      sign_in(editor)
+
+      put "/posts/#{policy_post_with_target_group.id}.json", params: { post: { raw: <<~MD } }
+                [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
+                Updated policy text
+                [/policy]
+              MD
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["post"]["raw"]).to include("Updated policy text")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Restrict policy wiki edits so an acting editor must manage any newly introduced or changed `add-users-to-group` target that the post author can persist. The validator now compares the previous and updated policy target assignments and rejects edits that add or retarget a group without the editor's group-management authority, while allowing unrelated text changes to existing policies.

Also updates the `on(:post_process_cooked)` callback so that it won't save a policy included in a blockquote as a PostPolicy, [mirroring the validator](https://github.com/discourse/discourse/blob/2c98a078cfd70853ee549cc003b52e5c6d52afc8/plugins/discourse-policy/lib/post_validator.rb#L36), otherwise the editor could bypass the added check by placing the policy inside a blockquote.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1824

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>