### PR TITLE
UX: Improvements to the design wizard

### DIFF
--- a/app/assets/stylesheets/common/components/design-wizard.scss
+++ b/app/assets/stylesheets/common/components/design-wizard.scss
@@ -77,6 +77,10 @@ $dw-button-default-border: #d3d3d3;
   --d-button-transparent-text-color--hover: #{$dw-tertiary-hover};
   --d-button-transparent-icon-color: #{$dw-primary-high};
   --d-button-transparent-icon-color--hover: #{$dw-tertiary-hover};
+
+  // rem-based, so the previewed theme's root font size would otherwise rescale
+  // the tool's spacing despite the pinned font-size below
+  --space: 4px;
   color: var(--primary);
   color-scheme: light;
   font-family:
@@ -115,7 +119,7 @@ $dw-button-default-border: #d3d3d3;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  width: min(24em, 100vw);
+  width: min(27em, 100vw);
   background: var(--secondary);
   border: 1px solid var(--content-border-color);
   border-inline-end: none;
@@ -147,6 +151,12 @@ $dw-button-default-border: #d3d3d3;
     animation: none;
   }
 
+  // a theme preview replaces the page; the panel is waiting for that to land
+  &.--busy .design-wizard__sections {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
   &__close {
     position: absolute;
     inset-block-start: var(--space-2);
@@ -156,12 +166,22 @@ $dw-button-default-border: #d3d3d3;
   &__content {
     display: flex;
     flex-direction: column;
-    gap: var(--space-4);
+    gap: var(--space-5);
     height: 100%;
 
     // so the sections scroll rather than pushing the footer actions out
     min-height: 0;
-    padding: var(--space-4);
+    padding: var(--space-5);
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+
+    h2 {
+      margin: 0;
+    }
   }
 
   &__subtitle {
@@ -171,16 +191,24 @@ $dw-button-default-border: #d3d3d3;
 
   &__sections {
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
-    align-items: center;
-    gap: var(--space-4);
+    gap: var(--space-6);
     min-height: 0;
+
+    // so a selected control's box-shadow isn't clipped by the scroll container
+    padding: 2px;
+    margin: -2px;
     overflow-y: auto;
     overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: var(--primary-low-mid) transparent;
   }
 
   &__section {
-    width: calc(100% - 2px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
   }
 
   &__section-title {
@@ -191,7 +219,7 @@ $dw-button-default-border: #d3d3d3;
   &__section-body {
     display: flex;
     flex-direction: column;
-    gap: var(--space-2);
+    gap: var(--space-3);
   }
 
   &__custom-theme-notice {
@@ -206,7 +234,7 @@ $dw-button-default-border: #d3d3d3;
   &__theme-cards {
     display: flex;
     flex-direction: column;
-    gap: var(--space-2);
+    gap: var(--space-3);
     min-width: 0;
     padding: 0;
     margin: 0;
@@ -243,9 +271,32 @@ $dw-button-default-border: #d3d3d3;
     position: relative;
     display: flex;
     align-items: center;
+
+    // matches the serialized screenshot size, so the box is reserved at the
+    // right shape before the image lands and the card never reflows
+    aspect-ratio: 16 / 9;
     overflow: hidden;
+    background: var(--primary-very-low);
     border: 1px solid var(--content-border-color);
     border-radius: var(--d-border-radius);
+
+    &.--loading::after {
+      position: absolute;
+      inset: 0;
+      content: "";
+      background: linear-gradient(
+        90deg,
+        var(--primary-very-low) 25%,
+        var(--primary-low) 37%,
+        var(--primary-very-low) 63%
+      );
+      background-size: 400% 100%;
+      animation: design-wizard-shimmer 1.4s ease infinite;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
   }
 
   &__theme-screenshot-image {
@@ -268,6 +319,13 @@ $dw-button-default-border: #d3d3d3;
     display: block;
     margin: 0;
     font-weight: normal;
+  }
+
+  &__theme-spinner.spinner {
+    margin: 0;
+    border-width: 2px;
+    border-color: currentcolor;
+    border-right-color: transparent;
   }
 
   &__theme-enabled-badge {
@@ -302,7 +360,7 @@ $dw-button-default-border: #d3d3d3;
   }
 
   &__color-mode {
-    padding: var(--space-1) var(--space-2);
+    padding: var(--space-2);
     font-size: var(--font-down-2);
     font-weight: 600;
     background: none;
@@ -359,13 +417,13 @@ $dw-button-default-border: #d3d3d3;
   }
 
   &__swatch {
-    padding: var(--space-1);
+    padding: var(--space-2);
     text-align: center;
   }
 
   &__swatch-preview {
     display: block;
-    height: 1.25em;
+    height: 2.5em;
     border-radius: var(--token-radius-small);
   }
 
@@ -373,8 +431,8 @@ $dw-button-default-border: #d3d3d3;
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
-    margin-block-start: var(--space-1);
-    font-size: var(--font-down-2);
+    margin-block-start: var(--space-2);
+    font-size: var(--font-down-1);
 
     .d-icon {
       font-size: var(--font-down-3);
@@ -388,21 +446,22 @@ $dw-button-default-border: #d3d3d3;
     color: var(--primary-medium);
   }
 
-  &__user-selectable {
+  &__switch-row {
     display: flex;
-    gap: var(--space-2);
-    padding: var(--space-2);
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-3);
     border: 1px solid var(--content-border-color);
     border-radius: var(--d-border-radius);
   }
 
-  &__user-selectable-title {
+  &__switch-row-title {
     display: block;
     font-size: var(--font-down-1);
     font-weight: 600;
   }
 
-  &__user-selectable-description {
+  &__switch-row-description {
     display: block;
     font-size: var(--font-down-2);
     color: var(--primary-medium);
@@ -416,7 +475,7 @@ $dw-button-default-border: #d3d3d3;
 
   &__label {
     display: block;
-    font-size: var(--font-down-1-rem);
+    font-size: var(--font-down-1);
     font-weight: 600;
     color: var(--primary);
   }
@@ -424,6 +483,7 @@ $dw-button-default-border: #d3d3d3;
   &__font-select.btn-default.btn {
     justify-content: space-between;
     width: 100%;
+    padding-block: var(--space-2);
     border-radius: var(--d-border-radius);
     background: var(--content-background);
 
@@ -440,7 +500,7 @@ $dw-button-default-border: #d3d3d3;
   &__homepage-cards {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: var(--space-2);
+    gap: var(--space-3);
   }
 
   &__homepage-card {
@@ -456,7 +516,7 @@ $dw-button-default-border: #d3d3d3;
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
-    height: 4.5em;
+    height: 5.5em;
     padding: var(--space-1);
     overflow: hidden;
     background: var(--secondary);
@@ -474,14 +534,14 @@ $dw-button-default-border: #d3d3d3;
     }
   }
 
-  &__homepage-detail {
+  &__detail-group {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
 
   &__style-blocks,
-  &__topic-page-options {
+  &__option-rows {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -500,7 +560,7 @@ $dw-button-default-border: #d3d3d3;
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
-    height: 4.5em;
+    height: 5.5em;
     padding: var(--space-2);
     overflow: hidden;
     background: var(--secondary);
@@ -669,7 +729,7 @@ $dw-button-default-border: #d3d3d3;
   }
 
   // Rendered inline like the notification tracking menu's selectable rows.
-  &__topic-page-option {
+  &__option-row {
     display: flex;
     box-sizing: border-box;
     align-items: center;
@@ -691,7 +751,7 @@ $dw-button-default-border: #d3d3d3;
     }
   }
 
-  &__topic-page-option-texts {
+  &__option-row-texts {
     display: flex;
     flex: 1 1 0%;
     flex-direction: column;
@@ -700,7 +760,7 @@ $dw-button-default-border: #d3d3d3;
     line-height: var(--line-height-medium);
   }
 
-  &__topic-page-option-label {
+  &__option-row-label {
     flex: 1 1 auto;
     max-width: 100%;
     font-size: var(--font-0);
@@ -710,7 +770,7 @@ $dw-button-default-border: #d3d3d3;
     @include ellipsis;
   }
 
-  &__topic-page-option-description {
+  &__option-row-description {
     flex: 1 1 auto;
     font-size: var(--font-down-1);
     color: var(--primary-medium);
@@ -722,7 +782,8 @@ $dw-button-default-border: #d3d3d3;
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    margin-block-start: auto;
+    padding-block-start: var(--space-4);
+    border-block-start: 1px solid var(--content-border-color);
   }
 
   &__step-dots {
@@ -766,6 +827,16 @@ $dw-button-default-border: #d3d3d3;
   overscroll-behavior: contain;
   scrollbar-width: thin;
   scrollbar-color: var(--primary-low-mid) transparent;
+}
+
+@keyframes design-wizard-shimmer {
+  from {
+    background-position: 100% 50%;
+  }
+
+  to {
+    background-position: 0 50%;
+  }
 }
 
 @keyframes design-wizard-slide-in {

--- a/app/controllers/admin/config/design_wizard_controller.rb
+++ b/app/controllers/admin/config/design_wizard_controller.rb
@@ -32,6 +32,13 @@ class Admin::Config::DesignWizardController < Admin::AdminController
                  ),
                status: :unprocessable_entity
       end
+      on_failed_step(:update_themeable_site_settings) do
+        render json:
+                 failed_json.merge(
+                   errors: [I18n.t("design_wizard.errors.site_settings_update_failed")],
+                 ),
+               status: :unprocessable_entity
+      end
       on_failure { render json: failed_json, status: :unprocessable_entity }
     end
   end

--- a/app/jobs/regular/generate_theme_screenshot_thumbnails.rb
+++ b/app/jobs/regular/generate_theme_screenshot_thumbnails.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Jobs
+  class GenerateThemeScreenshotThumbnails < ::Jobs::Base
+    sidekiq_options queue: "low"
+
+    def execute(args)
+      theme_id = args[:theme_id]
+      raise Discourse::InvalidParameters.new(:theme_id) if theme_id.blank?
+
+      return if !(theme = Theme.find_by(id: theme_id))
+
+      ThemeScreenshotThumbnails.generate!(theme)
+    end
+  end
+end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -410,22 +410,20 @@ class Theme < ActiveRecord::Base
     end
   end
 
-  def screenshot_dark_url
+  def screenshot_upload(name)
     theme_fields
       .find do |field|
-        field.type_id == ThemeField.types[:theme_screenshot_upload_var] &&
-          field.name == "screenshot_dark"
+        field.type_id == ThemeField.types[:theme_screenshot_upload_var] && field.name == name
       end
-      &.upload_url
+      &.upload
+  end
+
+  def screenshot_dark_url
+    screenshot_upload("screenshot_dark")&.url
   end
 
   def screenshot_light_url
-    theme_fields
-      .find do |field|
-        field.type_id == ThemeField.types[:theme_screenshot_upload_var] &&
-          field.name == "screenshot_light"
-      end
-      &.upload_url
+    screenshot_upload("screenshot_light")&.url
   end
 
   def switch_to_component!

--- a/app/serializers/design_wizard_theme_serializer.rb
+++ b/app/serializers/design_wizard_theme_serializer.rb
@@ -19,6 +19,14 @@ class DesignWizardThemeSerializer < ApplicationSerializer
     object.default?
   end
 
+  def screenshot_light_url
+    ThemeScreenshotThumbnails.url_for(object, "screenshot_light") || object.screenshot_light_url
+  end
+
+  def screenshot_dark_url
+    ThemeScreenshotThumbnails.url_for(object, "screenshot_dark") || object.screenshot_dark_url
+  end
+
   def palette_pairs
     DesignWizard::PalettePairs.for_theme(object)
   end

--- a/app/services/design_wizard/apply.rb
+++ b/app/services/design_wizard/apply.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
-# Applies the design choices made in the admin design wizard in one atomic
-# operation: default theme, the theme's light/dark palettes, fonts, homepage
-# and whether members can switch between the offered palettes.
+# Applies the design choices made in the admin design wizard: default theme,
+# the theme's light/dark palettes, fonts, homepage, welcome banner and search
+# presentation, and whether members can switch between the offered palettes.
+# The palette work is transactional; the site settings are applied after it,
+# the same way the rest of the admin config writes them.
 class DesignWizard::Apply
   include Service::Base
 
   BASE_LIGHT_PALETTE_ID = ColorScheme::NAMES_TO_ID_MAP[ColorScheme::LIGHT_PALETTE_NAME]
+
+  # these are resolved per theme rather than site wide, so they cannot go
+  # through SiteSetting::Update
+  THEMEABLE_SETTINGS = %i[enable_welcome_banner search_experience].freeze
 
   params do
     attribute :theme_id, :integer
@@ -17,11 +23,16 @@ class DesignWizard::Apply
     attribute :heading_font, :string
     attribute :homepage, :string
     attribute :category_page_style, :string
+    attribute :enable_welcome_banner, :boolean
+    attribute :welcome_banner_location, :string
+    attribute :search_experience, :string
 
     before_validation do
       # the built-in light palette is represented by a theme without an
       # assigned light palette
       self.light_palette_id = nil if light_palette_id == BASE_LIGHT_PALETTE_ID
+      self.welcome_banner_location = welcome_banner_location.presence
+      self.search_experience = search_experience.presence
     end
 
     validates :theme_id, presence: true, inclusion: { in: Theme::CORE_THEMES.values }
@@ -37,6 +48,16 @@ class DesignWizard::Apply
                 in: CategoryPageStyle.values.map { |style| style[:value] },
               },
               allow_blank: true
+    validates :welcome_banner_location,
+              inclusion: {
+                in: WelcomeBannerLocation.values.map { |location| location[:value] },
+              },
+              allow_blank: true
+    validates :search_experience,
+              inclusion: {
+                in: SearchExperienceSiteSetting.values.map { |experience| experience[:value] },
+              },
+              allow_blank: true
     validate :built_in_palettes_exist
 
     def site_settings(theme_id:)
@@ -46,7 +67,18 @@ class DesignWizard::Apply
         heading_font: heading_font.presence,
         default_homepage: homepage.presence,
         desktop_category_page_style: category_page_style.presence,
+        welcome_banner_location: welcome_banner_location.presence,
       }.compact.map { |setting_name, value| { setting_name:, value: } }
+    end
+
+    # the wizard re-sends every selection on each step, so skip the settings
+    # that would be written back unchanged and audit-logged again
+    def themeable_site_settings(theme_id:)
+      THEMEABLE_SETTINGS
+        .index_with { |setting_name| public_send(setting_name) }
+        .reject do |setting_name, value|
+          value.nil? || SiteSetting.public_send(setting_name, theme_id:) == value
+        end
     end
 
     private
@@ -75,6 +107,7 @@ class DesignWizard::Apply
   end
 
   step :update_site_settings
+  step :update_themeable_site_settings
   step :expire_user_color_schemes_cache
 
   private
@@ -139,6 +172,21 @@ class DesignWizard::Apply
       },
       guardian:,
     ) { on_failure { fail!("failed to update site settings") } }
+  end
+
+  def update_themeable_site_settings(params:, theme:, guardian:)
+    params
+      .themeable_site_settings(theme_id: theme.id)
+      .each do |setting_name, value|
+        Themes::ThemeSiteSettingManager.call(
+          params: {
+            theme_id: theme.id,
+            name: setting_name,
+            value:,
+          },
+          guardian:,
+        ) { on_failure { fail!("failed to update themeable site settings") } }
+      end
   end
 
   def expire_user_color_schemes_cache

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -572,7 +572,7 @@ en:
       dismiss: "Dismiss setup"
       select_theme:
         title: "Customize your site"
-        description: "Choose colors, fonts, and a homepage."
+        description: "Choose colors, fonts, and how your site is laid out."
         action: "See options"
         completed: "Change options"
         show_light_screenshot: "Show light screenshot"
@@ -609,7 +609,7 @@ en:
 
     design_wizard:
       title: "Customize your site"
-      subtitle: "Choose colors, fonts, and a homepage."
+      subtitle: "Choose colors, fonts, and how your site is laid out."
       step_label: "Go to step %{index}"
       save: "Save and finish"
       back: "Back"
@@ -619,8 +619,11 @@ en:
         colors: "Default color"
         fonts: "Fonts"
         homepage: "Homepage"
+        welcome_banner: "Welcome banner"
+        search: "Search"
       theme:
         selected: "Selected"
+        applying: "Applying…"
         custom_theme_notice: "Your site currently uses %{name} as its default theme. Choose a theme below to preview it. Saving will replace your current theme."
       colors:
         light: "Light"
@@ -645,6 +648,21 @@ en:
           boxes: "Boxes"
           with_topics: "Categories with topics"
           only: "Categories only"
+      welcome_banner:
+        enable: "Show a welcome banner"
+        enable_description: "Greet visitors with your site name and a search box"
+        location: "Banner location"
+        locations:
+          below_site_header: "Below the site header"
+          above_topic_content: "Above the topic list"
+      search:
+        experiences:
+          search_icon:
+            title: "Search icon"
+            description: "A magnifying glass in the header that opens search."
+          search_field:
+            title: "Search field"
+            description: "A full search field in the header, always visible."
 
     about:
       edit: "Edit this page"

--- a/frontend/discourse/app/components/admin-onboarding/banner.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/banner.gjs
@@ -41,6 +41,11 @@ const STEPS = [
     }
 
     @action
+    prefetch() {
+      this.designWizard.prefetch();
+    }
+
+    @action
     performAction() {
       this.designWizard.start({ onComplete: this.#onComplete });
     }

--- a/frontend/discourse/app/components/admin-onboarding/step.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/step.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { concat } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { logOnboardingEvent } from "discourse/lib/admin-onboarding";
@@ -40,6 +41,11 @@ export default class OnboardingStep extends Component {
   performAction() {
     throw new Error("performAction is required for OnboardingStep");
   }
+
+  // Steps whose action needs slow-to-arrive data can warm it up here, so the
+  // work overlaps with the admin reaching for the button.
+  @action
+  prefetch() {}
 
   // Awaits the audit write so callers that reload the page on completion can't
   // cancel it in flight.
@@ -88,6 +94,8 @@ export default class OnboardingStep extends Component {
             "btn-transparent btn-small btn-link"
             (if this.completed "--completed")
           }}
+          {{on "pointerenter" this.prefetch}}
+          {{on "focus" this.prefetch}}
         />
 
       </div>

--- a/frontend/discourse/app/components/design-wizard-panel.gjs
+++ b/frontend/discourse/app/components/design-wizard-panel.gjs
@@ -41,7 +41,8 @@ export default class DesignWizardPanel extends Component {
     {{#if this.designWizard.active}}
       <aside
         class="design-wizard
-          {{unless this.designWizard.animateEntrance '--no-entrance'}}"
+          {{unless this.designWizard.animateEntrance '--no-entrance'}}
+          {{if this.designWizard.applyingTheme '--busy'}}"
         aria-labelledby="design-wizard-title"
         {{didInsert this.registerElement}}
         ...attributes

--- a/frontend/discourse/app/components/design-wizard/colors-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/colors-section.gjs
@@ -63,17 +63,17 @@ const DesignWizardColorsSection = <template>
     </p>
   </div>
 
-  <div class="design-wizard__user-selectable">
+  <div class="design-wizard__switch-row">
     <div>
       <span
         id="design-wizard-user-selectable-title"
-        class="design-wizard__user-selectable-title"
+        class="design-wizard__switch-row-title"
       >
         {{i18n "design_wizard.colors.user_selectable"}}
       </span>
       <span
         id="design-wizard-user-selectable-description"
-        class="design-wizard__user-selectable-description"
+        class="design-wizard__switch-row-description"
       >
         {{i18n "design_wizard.colors.user_selectable_description"}}
       </span>

--- a/frontend/discourse/app/components/design-wizard/controls.gjs
+++ b/frontend/discourse/app/components/design-wizard/controls.gjs
@@ -6,8 +6,10 @@ import { service } from "@ember/service";
 import ColorsSection from "discourse/components/design-wizard/colors-section";
 import FontsSection from "discourse/components/design-wizard/fonts-section";
 import HomepageSection from "discourse/components/design-wizard/homepage-section";
+import SearchSection from "discourse/components/design-wizard/search-section";
 import Section from "discourse/components/design-wizard/section";
 import ThemeSection from "discourse/components/design-wizard/theme-section";
+import WelcomeBannerSection from "discourse/components/design-wizard/welcome-banner-section";
 import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
@@ -39,9 +41,15 @@ export default class DesignWizardControls extends Component {
     return this.currentStep === "theme" && !this.designWizard.themeId;
   }
 
+  // a theme preview replaces the page, so anything else clicked in the meantime
+  // would either be lost or save selections the reload is about to discard
+  get busy() {
+    return this.designWizard.applyingTheme;
+  }
+
   @action
   async goToStep(index) {
-    if (index === this.designWizard.stepIndex) {
+    if (index === this.designWizard.stepIndex || this.busy) {
       return;
     }
 
@@ -59,6 +67,10 @@ export default class DesignWizardControls extends Component {
 
   @action
   back() {
+    if (this.busy) {
+      return;
+    }
+
     this.designWizard.setStepIndex(
       Math.max(this.designWizard.stepIndex - 1, 0)
     );
@@ -66,6 +78,10 @@ export default class DesignWizardControls extends Component {
 
   @action
   async next() {
+    if (this.busy) {
+      return;
+    }
+
     if (await this.designWizard.saveProgress()) {
       this.designWizard.setStepIndex(
         Math.min(this.designWizard.stepIndex + 1, STEPS.length - 1)
@@ -114,6 +130,21 @@ export default class DesignWizardControls extends Component {
   }
 
   @action
+  toggleWelcomeBanner() {
+    this.designWizard.selectWelcomeBanner(!this.designWizard.welcomeBanner);
+  }
+
+  @action
+  selectWelcomeBannerLocation(location) {
+    this.designWizard.selectWelcomeBannerLocation(location);
+  }
+
+  @action
+  selectSearchExperience(experience) {
+    this.designWizard.selectSearchExperience(experience);
+  }
+
+  @action
   save() {
     this.designWizard.save();
   }
@@ -136,6 +167,7 @@ export default class DesignWizardControls extends Component {
               @themes={{this.designWizard.data.themes}}
               @currentTheme={{this.designWizard.data.current_theme}}
               @selectedThemeId={{this.designWizard.themeId}}
+              @applying={{this.busy}}
               @onSelect={{this.selectTheme}}
             />
           </Section>
@@ -172,6 +204,22 @@ export default class DesignWizardControls extends Component {
               @onSelectCategoryPageStyle={{this.selectCategoryPageStyle}}
             />
           </Section>
+
+          <Section @title={{i18n "design_wizard.sections.welcome_banner"}}>
+            <WelcomeBannerSection
+              @enabled={{this.designWizard.welcomeBanner}}
+              @location={{this.designWizard.welcomeBannerLocation}}
+              @onToggle={{this.toggleWelcomeBanner}}
+              @onSelectLocation={{this.selectWelcomeBannerLocation}}
+            />
+          </Section>
+
+          <Section @title={{i18n "design_wizard.sections.search"}}>
+            <SearchSection
+              @searchExperience={{this.designWizard.searchExperience}}
+              @onSelect={{this.selectSearchExperience}}
+            />
+          </Section>
         {{/if}}
       </div>
 
@@ -184,6 +232,7 @@ export default class DesignWizardControls extends Component {
                 {{if (eq step this.currentStep) '--active'}}"
               aria-label={{this.goToStepLabel index}}
               aria-current={{if (eq step this.currentStep) "true"}}
+              disabled={{this.busy}}
               {{on "click" (fn this.goToStep index)}}
             ></button>
           {{/each}}
@@ -191,7 +240,7 @@ export default class DesignWizardControls extends Component {
         <DButton
           @action={{this.back}}
           @label="design_wizard.back"
-          @disabled={{this.isFirstStep}}
+          @disabled={{if this.busy true this.isFirstStep}}
           class="btn-flat design-wizard__back"
         />
         {{#if this.isLastStep}}
@@ -199,6 +248,7 @@ export default class DesignWizardControls extends Component {
             @action={{this.save}}
             @label="design_wizard.save"
             @isLoading={{this.designWizard.saving}}
+            @disabled={{this.busy}}
             class="btn-primary design-wizard__save"
           />
         {{else}}
@@ -206,7 +256,7 @@ export default class DesignWizardControls extends Component {
             @action={{this.next}}
             @label="design_wizard.next"
             @isLoading={{this.designWizard.saving}}
-            @disabled={{this.needsThemeChoice}}
+            @disabled={{if this.busy true this.needsThemeChoice}}
             class="btn-primary design-wizard__next"
           />
         {{/if}}

--- a/frontend/discourse/app/components/design-wizard/homepage-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/homepage-section.gjs
@@ -1,5 +1,6 @@
 import { array, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
+import OptionRow from "discourse/components/design-wizard/option-row";
 import { HORIZON_THEME_ID } from "discourse/lib/theme-selector";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
@@ -138,7 +139,7 @@ const DesignWizardHomepageSection = <template>
   </div>
 
   {{#if (eq @homepage "categories")}}
-    <div class="design-wizard__homepage-detail">
+    <div class="design-wizard__detail-group">
       <span class="design-wizard__label">
         {{i18n "design_wizard.homepage.category_page_style"}}
       </span>
@@ -166,29 +167,19 @@ const DesignWizardHomepageSection = <template>
       </div>
     </div>
   {{else}}
-    <div class="design-wizard__homepage-detail">
+    <div class="design-wizard__detail-group">
       <span class="design-wizard__label">
         {{i18n "design_wizard.homepage.topic_page_type"}}
       </span>
-      <div class="design-wizard__topic-page-options">
+      <div class="design-wizard__option-rows">
         {{#each TOPIC_PAGES as |page|}}
-          <button
-            type="button"
-            class="design-wizard__topic-page-option
-              {{if (eq page @homepage) '--selected'}}"
-            aria-pressed={{if (eq page @homepage) "true" "false"}}
+          <OptionRow
+            @label={{topicPageLabel page}}
+            @description={{topicPageDescription page}}
+            @selected={{eq page @homepage}}
+            @onSelect={{fn @onSelectHomepage page}}
             data-topic-page={{page}}
-            {{on "click" (fn @onSelectHomepage page)}}
-          >
-            <span class="design-wizard__topic-page-option-texts">
-              <span class="design-wizard__topic-page-option-label">
-                {{topicPageLabel page}}
-              </span>
-              <span class="design-wizard__topic-page-option-description">
-                {{topicPageDescription page}}
-              </span>
-            </span>
-          </button>
+          />
         {{/each}}
       </div>
     </div>

--- a/frontend/discourse/app/components/design-wizard/option-row.gjs
+++ b/frontend/discourse/app/components/design-wizard/option-row.gjs
@@ -1,0 +1,23 @@
+import { on } from "@ember/modifier";
+
+// A selectable row, rendered like the notification tracking menu's options.
+const DesignWizardOptionRow = <template>
+  <button
+    type="button"
+    class="design-wizard__option-row {{if @selected '--selected'}}"
+    aria-pressed={{if @selected "true" "false"}}
+    ...attributes
+    {{on "click" @onSelect}}
+  >
+    <span class="design-wizard__option-row-texts">
+      <span class="design-wizard__option-row-label">{{@label}}</span>
+      {{#if @description}}
+        <span class="design-wizard__option-row-description">
+          {{@description}}
+        </span>
+      {{/if}}
+    </span>
+  </button>
+</template>;
+
+export default DesignWizardOptionRow;

--- a/frontend/discourse/app/components/design-wizard/search-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/search-section.gjs
@@ -1,0 +1,30 @@
+import { fn } from "@ember/helper";
+import OptionRow from "discourse/components/design-wizard/option-row";
+import { eq } from "discourse/truth-helpers";
+import { i18n } from "discourse-i18n";
+
+const EXPERIENCES = ["search_icon", "search_field"];
+
+function experienceLabel(experience) {
+  return i18n(`design_wizard.search.experiences.${experience}.title`);
+}
+
+function experienceDescription(experience) {
+  return i18n(`design_wizard.search.experiences.${experience}.description`);
+}
+
+const DesignWizardSearchSection = <template>
+  <div class="design-wizard__option-rows">
+    {{#each EXPERIENCES as |experience|}}
+      <OptionRow
+        @label={{experienceLabel experience}}
+        @description={{experienceDescription experience}}
+        @selected={{eq experience @searchExperience}}
+        @onSelect={{fn @onSelect experience}}
+        data-search-experience={{experience}}
+      />
+    {{/each}}
+  </div>
+</template>;
+
+export default DesignWizardSearchSection;

--- a/frontend/discourse/app/components/design-wizard/theme-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/theme-section.gjs
@@ -1,20 +1,37 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { eq } from "discourse/truth-helpers";
+import { and } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+
+// matches ThemeScreenshotThumbnails, so the card reserves the right box
+// before the image arrives
+const SCREENSHOT_WIDTH = 800;
+const SCREENSHOT_HEIGHT = 450;
 
 class ThemeCard extends Component {
   @service interfaceColor;
   @service session;
+
+  @tracked screenshotLoaded = false;
 
   get currentScreenshotUrl() {
     const { screenshot_dark_url, screenshot_light_url } = this.args.theme;
     return this.#showDarkScreenshot
       ? screenshot_dark_url || screenshot_light_url
       : screenshot_light_url || screenshot_dark_url;
+  }
+
+  get selected() {
+    return this.args.theme.id === this.args.selectedThemeId;
+  }
+
+  get showSkeleton() {
+    return !!this.currentScreenshotUrl && !this.screenshotLoaded;
   }
 
   get #showDarkScreenshot() {
@@ -25,33 +42,53 @@ class ThemeCard extends Component {
     );
   }
 
+  // a broken screenshot should still clear the skeleton
+  @action
+  screenshotSettled() {
+    this.screenshotLoaded = true;
+  }
+
   <template>
     <div class="design-wizard__theme-card-wrapper">
       <label
-        class="design-wizard__theme-card
-          {{if (eq @theme.id @selectedThemeId) '--selected'}}"
+        class="design-wizard__theme-card {{if this.selected '--selected'}}"
         data-theme-id={{@theme.id}}
       >
         <input
           type="radio"
           name="design-wizard-theme"
           value={{@theme.id}}
-          checked={{eq @theme.id @selectedThemeId}}
+          checked={{this.selected}}
+          disabled={{@applying}}
           class="sr-only"
           {{on "change" (fn @onSelect @theme.id)}}
         />
-        {{#if (eq @theme.id @selectedThemeId)}}
+        {{#if (and this.selected @applying)}}
+          <span class="design-wizard__theme-enabled-badge">
+            <span class="spinner small design-wizard__theme-spinner"></span>
+            {{i18n "design_wizard.theme.applying"}}
+          </span>
+        {{else if this.selected}}
           <span class="design-wizard__theme-enabled-badge">
             {{dIcon "check"}}
             {{i18n "design_wizard.theme.selected"}}
           </span>
         {{/if}}
-        <span class="design-wizard__theme-screenshot">
+        <span
+          class="design-wizard__theme-screenshot
+            {{if this.showSkeleton '--loading'}}"
+        >
           {{#if this.currentScreenshotUrl}}
             <img
               class="design-wizard__theme-screenshot-image"
               src={{this.currentScreenshotUrl}}
+              width={{SCREENSHOT_WIDTH}}
+              height={{SCREENSHOT_HEIGHT}}
+              decoding="async"
+              fetchpriority="high"
               alt=""
+              {{on "load" this.screenshotSettled}}
+              {{on "error" this.screenshotSettled}}
             />
           {{/if}}
         </span>
@@ -70,7 +107,10 @@ const DesignWizardThemeSection = <template>
       {{i18n "design_wizard.theme.custom_theme_notice" name=@currentTheme.name}}
     </p>
   {{/if}}
-  <fieldset class="design-wizard__theme-cards">
+  <fieldset
+    class="design-wizard__theme-cards"
+    aria-busy={{if @applying "true"}}
+  >
     <legend class="sr-only">
       {{i18n "design_wizard.sections.theme"}}
     </legend>
@@ -78,6 +118,7 @@ const DesignWizardThemeSection = <template>
       <ThemeCard
         @theme={{theme}}
         @selectedThemeId={{@selectedThemeId}}
+        @applying={{@applying}}
         @onSelect={{@onSelect}}
       />
     {{/each}}

--- a/frontend/discourse/app/components/design-wizard/welcome-banner-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/welcome-banner-section.gjs
@@ -1,0 +1,57 @@
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import OptionRow from "discourse/components/design-wizard/option-row";
+import { eq } from "discourse/truth-helpers";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
+import { i18n } from "discourse-i18n";
+
+const LOCATIONS = ["below_site_header", "above_topic_content"];
+
+function locationLabel(location) {
+  return i18n(`design_wizard.welcome_banner.locations.${location}`);
+}
+
+const DesignWizardWelcomeBannerSection = <template>
+  <div class="design-wizard__switch-row">
+    <div>
+      <span
+        id="design-wizard-welcome-banner-title"
+        class="design-wizard__switch-row-title"
+      >
+        {{i18n "design_wizard.welcome_banner.enable"}}
+      </span>
+      <span
+        id="design-wizard-welcome-banner-description"
+        class="design-wizard__switch-row-description"
+      >
+        {{i18n "design_wizard.welcome_banner.enable_description"}}
+      </span>
+    </div>
+    <DToggleSwitch
+      @state={{@enabled}}
+      aria-labelledby="design-wizard-welcome-banner-title"
+      aria-describedby="design-wizard-welcome-banner-description"
+      {{on "click" @onToggle}}
+    />
+  </div>
+
+  {{#if @enabled}}
+    <div class="design-wizard__detail-group">
+      <span class="design-wizard__label">
+        {{i18n "design_wizard.welcome_banner.location"}}
+      </span>
+      <div class="design-wizard__option-rows">
+        {{#each LOCATIONS as |location|}}
+          <OptionRow
+            @label={{locationLabel location}}
+            @selected={{eq location @location}}
+            @onSelect={{fn @onSelectLocation location}}
+            data-welcome-banner-location={{location}}
+          />
+        {{/each}}
+      </div>
+    </div>
+  {{/if}}
+</template>;
+
+export default DesignWizardWelcomeBannerSection;

--- a/frontend/discourse/app/services/design-wizard.js
+++ b/frontend/discourse/app/services/design-wizard.js
@@ -20,6 +20,14 @@ import discourseLater from "discourse/lib/later";
 import { HORIZON_THEME_ID, setLocalTheme } from "discourse/lib/theme-selector";
 
 const STATE_KEY = "design_wizard_panel_state";
+// site settings the wizard mutates locally to preview a selection, and which
+// have to be put back when the wizard is closed without saving
+const PREVIEWED_SITE_SETTINGS = [
+  "desktop_category_page_style",
+  "enable_welcome_banner",
+  "welcome_banner_location",
+  "search_experience",
+];
 const SELECT_THEME_STEP = "select_theme";
 // mirrors the onboarding step's own completion key so a wizard finished
 // after its caller was torn down still marks the step complete
@@ -44,7 +52,12 @@ export default class DesignWizardService extends Service {
   @tracked headingFont;
   @tracked homepage;
   @tracked categoryPageStyle;
+  @tracked welcomeBanner;
+  @tracked welcomeBannerLocation;
+  @tracked searchExperience;
   @tracked saving = false;
+  // a theme preview replaces the whole page, so the panel stays busy until it does
+  @tracked applyingTheme = false;
   @tracked selectedPairKeys = new Map();
   @tracked stepIndex = 0;
   // resuming an in-progress wizard (e.g. after a theme-preview reload)
@@ -52,13 +65,40 @@ export default class DesignWizardService extends Service {
   @tracked animateEntrance = true;
 
   #onComplete;
-  #originalCategoryPageStyle;
+  #originalSiteSettings;
   #originalColorSchemeLinks;
+  #prefetched = false;
+
+  // warms the browser cache for the theme screenshots, which dominate the
+  // panel's first paint on a slow connection
+  async prefetch() {
+    if (this.#prefetched || this.active || isTesting()) {
+      return;
+    }
+    this.#prefetched = true;
+
+    try {
+      const data = await ajax("/admin/config/design-wizard.json");
+      for (const theme of data.themes) {
+        for (const url of [
+          theme.screenshot_light_url,
+          theme.screenshot_dark_url,
+        ]) {
+          if (url) {
+            new Image().src = url;
+          }
+        }
+      }
+    } catch {
+      // a failed warm-up is not worth surfacing, `start` reports its own errors
+    }
+  }
 
   async start({ onComplete } = {}) {
     this.#onComplete = onComplete;
-    this.#originalCategoryPageStyle ??=
-      this.siteSettings.desktop_category_page_style;
+    this.#originalSiteSettings ??= Object.fromEntries(
+      PREVIEWED_SITE_SETTINGS.map((name) => [name, this.siteSettings[name]])
+    );
 
     // always fetch fresh: progress saves change the settings this payload
     // reflects, so a cached copy would preview stale selections
@@ -80,10 +120,7 @@ export default class DesignWizardService extends Service {
     this.active = true;
     this.#originalColorSchemeLinks = captureColorSchemeLinks();
 
-    if (stored && this.homepage === "categories") {
-      this.siteSettings.desktop_category_page_style = this.categoryPageStyle;
-    }
-
+    this.#previewSiteSettings();
     await this.#previewSelections();
   }
 
@@ -142,11 +179,16 @@ export default class DesignWizardService extends Service {
   }
 
   selectTheme(themeId) {
-    if (themeId === this.themeId) {
+    if (themeId === this.themeId || this.applyingTheme) {
       return;
     }
 
+    this.applyingTheme = true;
     this.themeId = themeId;
+    // these are resolved per theme, so let the reloaded page re-seed them from
+    // the theme being previewed rather than carrying the old theme's values
+    this.welcomeBanner = undefined;
+    this.searchExperience = undefined;
     this.#persistState();
 
     // a different theme is a different asset build, so previewing it means
@@ -222,15 +264,34 @@ export default class DesignWizardService extends Service {
     this.#refreshCategoriesPage();
   }
 
+  selectWelcomeBanner(enabled) {
+    this.welcomeBanner = enabled;
+    this.siteSettings.enable_welcome_banner = enabled;
+    this.#persistState();
+  }
+
+  selectWelcomeBannerLocation(location) {
+    this.welcomeBannerLocation = location;
+    this.siteSettings.welcome_banner_location = location;
+    this.#persistState();
+  }
+
+  selectSearchExperience(experience) {
+    this.searchExperience = experience;
+    this.siteSettings.search_experience = experience;
+    this.#persistState();
+  }
+
   stop() {
     this.active = false;
     this.#onComplete = undefined;
     this.keyValueStore.remove(STATE_KEY);
     clearPreview(document);
 
-    if (this.#originalCategoryPageStyle) {
-      this.siteSettings.desktop_category_page_style =
-        this.#originalCategoryPageStyle;
+    if (this.#originalSiteSettings) {
+      for (const [name, value] of Object.entries(this.#originalSiteSettings)) {
+        this.siteSettings[name] = value;
+      }
       this.#refreshCategoriesPage();
     }
     restoreColorSchemeLinks(this.#originalColorSchemeLinks);
@@ -319,6 +380,9 @@ export default class DesignWizardService extends Service {
       homepage: this.homepage,
       category_page_style:
         this.homepage === "categories" ? this.categoryPageStyle : null,
+      enable_welcome_banner: this.welcomeBanner,
+      welcome_banner_location: this.welcomeBannerLocation,
+      search_experience: this.searchExperience,
     };
   }
 
@@ -357,6 +421,9 @@ export default class DesignWizardService extends Service {
     this.colorMode = renderedColorMode();
     this.homepage = this.#supportedHomepage(this.data.homepage);
     this.categoryPageStyle = this.siteSettings.desktop_category_page_style;
+    this.welcomeBanner = this.siteSettings.enable_welcome_banner;
+    this.welcomeBannerLocation = this.siteSettings.welcome_banner_location;
+    this.searchExperience = this.siteSettings.search_experience;
     this.stepIndex = 0;
   }
 
@@ -371,6 +438,12 @@ export default class DesignWizardService extends Service {
       stored.homepage ?? this.#supportedHomepage(this.data.homepage);
     this.categoryPageStyle =
       stored.categoryPageStyle ?? this.siteSettings.desktop_category_page_style;
+    this.welcomeBanner =
+      stored.welcomeBanner ?? this.siteSettings.enable_welcome_banner;
+    this.welcomeBannerLocation =
+      stored.welcomeBannerLocation ?? this.siteSettings.welcome_banner_location;
+    this.searchExperience =
+      stored.searchExperience ?? this.siteSettings.search_experience;
     // selections are restored but the flow always restarts from the first
     // step, so a resumed wizard walks the same path as a fresh one
     this.stepIndex = 0;
@@ -388,8 +461,22 @@ export default class DesignWizardService extends Service {
         headingFont: this.headingFont,
         homepage: this.homepage,
         categoryPageStyle: this.categoryPageStyle,
+        welcomeBanner: this.welcomeBanner,
+        welcomeBannerLocation: this.welcomeBannerLocation,
+        searchExperience: this.searchExperience,
       }),
     });
+  }
+
+  // the page behind the sheet renders from the client copy of these settings,
+  // so assigning them previews the restored selections live
+  #previewSiteSettings() {
+    if (this.homepage === "categories") {
+      this.siteSettings.desktop_category_page_style = this.categoryPageStyle;
+    }
+    this.siteSettings.enable_welcome_banner = this.welcomeBanner;
+    this.siteSettings.welcome_banner_location = this.welcomeBannerLocation;
+    this.siteSettings.search_experience = this.searchExperience;
   }
 
   #refreshCategoriesPage() {

--- a/frontend/discourse/tests/acceptance/admin-onboarding-banner-test.gjs
+++ b/frontend/discourse/tests/acceptance/admin-onboarding-banner-test.gjs
@@ -431,11 +431,20 @@ acceptance("Admin - Onboarding Banner", function (needs) {
       .dom(".design-wizard__homepage-card.--selected")
       .hasAttribute("data-homepage", "topics", "defaults to a topics homepage");
     assert
-      .dom(".design-wizard__topic-page-option")
+      .dom(".design-wizard__option-row[data-topic-page]")
       .exists({ count: 3 }, "a topics homepage offers the topic page types");
     assert
-      .dom(".design-wizard__topic-page-option.--selected")
+      .dom(".design-wizard__option-row[data-topic-page].--selected")
       .hasAttribute("data-topic-page", "latest", "defaults to latest");
+    assert
+      .dom(".design-wizard__switch-row [role='switch']")
+      .exists(
+        { count: 1 },
+        "the homepage step offers the welcome banner switch"
+      );
+    assert
+      .dom(".design-wizard__option-row[data-search-experience]")
+      .exists({ count: 2 }, "the homepage step offers the search experiences");
 
     await click(".design-wizard__homepage-card[data-homepage='categories']");
     assert
@@ -449,7 +458,7 @@ acceptance("Admin - Onboarding Banner", function (needs) {
         "defaults to boxes with subcategories"
       );
     assert
-      .dom(".design-wizard__topic-page-option")
+      .dom(".design-wizard__option-row[data-topic-page]")
       .doesNotExist("the topic page types are hidden for categories");
 
     assert.dom(".design-wizard__next").doesNotExist("no next on the last step");

--- a/frontend/discourse/tests/integration/components/design-wizard-sections-test.gjs
+++ b/frontend/discourse/tests/integration/components/design-wizard-sections-test.gjs
@@ -3,7 +3,9 @@ import { click, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import ColorsSection from "discourse/components/design-wizard/colors-section";
 import HomepageSection from "discourse/components/design-wizard/homepage-section";
+import SearchSection from "discourse/components/design-wizard/search-section";
 import ThemeSection from "discourse/components/design-wizard/theme-section";
+import WelcomeBannerSection from "discourse/components/design-wizard/welcome-banner-section";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 const SCREENSHOT = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
@@ -71,6 +73,44 @@ module(
           ".design-wizard__theme-card[data-theme-id='-2'] input[type='radio']"
         )
         .isNotChecked("leaves the other theme unchecked");
+      assert
+        .dom(
+          ".design-wizard__theme-card[data-theme-id='-2'] .design-wizard__theme-screenshot"
+        )
+        .doesNotHaveClass(
+          "--loading",
+          "does not leave a skeleton running for a theme with no screenshot"
+        );
+    });
+
+    test("applying a theme locks the choices while the preview loads", async function (assert) {
+      const themes = [
+        { id: -1, name: "Foundation", screenshot_light_url: SCREENSHOT },
+        { id: -2, name: "Horizon", screenshot_light_url: SCREENSHOT },
+      ];
+
+      await render(
+        <template>
+          <ThemeSection
+            @themes={{themes}}
+            @selectedThemeId={{-1}}
+            @applying={{true}}
+            @onSelect={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".design-wizard__theme-cards")
+        .hasAttribute("aria-busy", "true", "marks the choices as busy");
+      assert
+        .dom(".design-wizard__theme-card input[type='radio']")
+        .isDisabled("stops a second theme being picked mid-preview");
+      assert
+        .dom(
+          ".design-wizard__theme-card[data-theme-id='-1'] .design-wizard__theme-spinner"
+        )
+        .exists("shows progress on the theme being applied");
     });
   }
 );
@@ -107,7 +147,7 @@ module(
         .dom(".design-wizard__swatch[data-pair-key='alternate']")
         .hasAria("pressed", "false", "exposes the unselected palette");
       assert
-        .dom(".design-wizard__user-selectable [role='switch']")
+        .dom(".design-wizard__switch-row [role='switch']")
         .hasAria("checked", "false", "exposes the switch state")
         .hasAria(
           "labelledby",
@@ -143,7 +183,7 @@ module(
         </template>
       );
 
-      const SWITCH = ".design-wizard__user-selectable [role='switch']";
+      const SWITCH = ".design-wizard__switch-row [role='switch']";
       assert.dom(SWITCH).hasAria("checked", "false", "starts off");
 
       await click(SWITCH);
@@ -188,10 +228,10 @@ module(
         .dom(".design-wizard__homepage-card[data-homepage='topics']")
         .hasAria("pressed", "true", "exposes the selected homepage type");
       assert
-        .dom(".design-wizard__topic-page-option[data-topic-page='latest']")
+        .dom(".design-wizard__option-row[data-topic-page='latest']")
         .hasAria("pressed", "true", "exposes the selected topic page");
       assert
-        .dom(".design-wizard__topic-page-option[data-topic-page='new']")
+        .dom(".design-wizard__option-row[data-topic-page='new']")
         .hasAria("pressed", "false", "exposes an unselected topic page");
 
       state.homepage = "categories";
@@ -204,8 +244,90 @@ module(
         .dom(".design-wizard__style-block[data-style='categories_boxes']")
         .hasAria("pressed", "true", "exposes the selected category style");
       assert
-        .dom(".design-wizard__topic-page-option")
+        .dom(".design-wizard__option-row")
         .doesNotExist("hides the topic page types for a categories homepage");
+    });
+  }
+);
+
+module(
+  "Integration | Component | DesignWizard | WelcomeBannerSection",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("the location choices only appear once the banner is enabled", async function (assert) {
+      const state = new (class {
+        @tracked enabled = false;
+      })();
+      const toggle = () => (state.enabled = !state.enabled);
+
+      await render(
+        <template>
+          <WelcomeBannerSection
+            @enabled={{state.enabled}}
+            @location="above_topic_content"
+            @onToggle={{toggle}}
+            @onSelectLocation={{noop}}
+          />
+        </template>
+      );
+
+      const SWITCH = ".design-wizard__switch-row [role='switch']";
+      assert.dom(SWITCH).hasAria("checked", "false", "starts off");
+      assert
+        .dom(".design-wizard__option-row[data-welcome-banner-location]")
+        .doesNotExist("hides the locations while the banner is off");
+
+      await click(SWITCH);
+
+      assert.true(state.enabled, "clicking the switch notifies the caller");
+      assert
+        .dom(
+          ".design-wizard__option-row[data-welcome-banner-location='above_topic_content']"
+        )
+        .hasAria("pressed", "true", "exposes the selected location");
+      assert
+        .dom(
+          ".design-wizard__option-row[data-welcome-banner-location='below_site_header']"
+        )
+        .hasAria("pressed", "false", "exposes an unselected location");
+    });
+  }
+);
+
+module(
+  "Integration | Component | DesignWizard | SearchSection",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("search controls expose their selected state", async function (assert) {
+      const selected = [];
+      const select = (experience) => selected.push(experience);
+
+      await render(
+        <template>
+          <SearchSection @searchExperience="search_icon" @onSelect={{select}} />
+        </template>
+      );
+
+      assert
+        .dom(".design-wizard__option-row[data-search-experience='search_icon']")
+        .hasAria("pressed", "true", "exposes the selected experience");
+      assert
+        .dom(
+          ".design-wizard__option-row[data-search-experience='search_field']"
+        )
+        .hasAria("pressed", "false", "exposes an unselected experience");
+
+      await click(
+        ".design-wizard__option-row[data-search-experience='search_field']"
+      );
+
+      assert.deepEqual(
+        selected,
+        ["search_field"],
+        "notifies the caller of the chosen experience"
+      );
     });
   }
 );

--- a/lib/theme_screenshot_thumbnails.rb
+++ b/lib/theme_screenshot_thumbnails.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# The design wizard renders theme screenshots into a narrow rail, where the
+# full-size images a theme ships are an order of magnitude larger than the slot
+# needs. Producing a resized copy is a synchronous ImageMagick convert behind a
+# host-wide mutex, so generation always happens in a job and callers serve the
+# full-size screenshot until the resized one lands.
+class ThemeScreenshotThumbnails
+  WIDTH = 800
+  HEIGHT = 450
+  FORMAT = "webp"
+  NAMES = %w[screenshot_light screenshot_dark].freeze
+
+  # an install that cannot produce the format would otherwise re-enqueue on
+  # every request, since a failed conversion leaves nothing behind
+  RETRY_INTERVAL = 1.hour
+
+  def self.url_for(theme, name)
+    upload = theme.screenshot_upload(name)
+    return if upload.blank?
+
+    existing =
+      upload.optimized_images.find_by(width: WIDTH, height: HEIGHT, extension: ".#{FORMAT}")
+    return existing.url if existing
+
+    enqueue_generation(theme)
+    nil
+  end
+
+  def self.generate!(theme)
+    NAMES.each do |name|
+      upload = theme.screenshot_upload(name)
+      next if upload.blank?
+
+      upload.get_optimized_image(WIDTH, HEIGHT, format: FORMAT)
+    end
+  end
+
+  def self.enqueue_generation(theme)
+    key = "theme_screenshot_thumbnails_#{theme.id}"
+    return if !Discourse.redis.set(key, "1", ex: RETRY_INTERVAL.to_i, nx: true)
+
+    Jobs.enqueue(:generate_theme_screenshot_thumbnails, theme_id: theme.id)
+  end
+  private_class_method :enqueue_generation
+end

--- a/spec/jobs/regular/generate_theme_screenshot_thumbnails_spec.rb
+++ b/spec/jobs/regular/generate_theme_screenshot_thumbnails_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::GenerateThemeScreenshotThumbnails do
+  fab!(:upload, :image_upload)
+  fab!(:theme) { Theme.horizon_theme }
+
+  before do
+    theme.set_field(
+      target: :common,
+      name: "screenshot_light",
+      type: :theme_screenshot_upload_var,
+      upload_id: upload.id,
+    )
+    theme.save!
+  end
+
+  it "raises when no theme is given" do
+    expect { described_class.new.execute({}) }.to raise_error(Discourse::InvalidParameters)
+  end
+
+  it "does nothing for a theme that no longer exists" do
+    expect { described_class.new.execute(theme_id: -99_999) }.not_to change { OptimizedImage.count }
+  end
+
+  it "resizes the theme's screenshots" do
+    described_class.new.execute(theme_id: theme.id)
+
+    expect(OptimizedImage.find_by(upload_id: upload.id)).to have_attributes(
+      width: ThemeScreenshotThumbnails::WIDTH,
+      height: ThemeScreenshotThumbnails::HEIGHT,
+      extension: ".webp",
+    )
+  end
+
+  it "reuses an already generated thumbnail" do
+    described_class.new.execute(theme_id: theme.id)
+
+    expect { described_class.new.execute(theme_id: theme.id) }.not_to change {
+      OptimizedImage.count
+    }
+  end
+end

--- a/spec/requests/admin/config/design_wizard_controller_spec.rb
+++ b/spec/requests/admin/config/design_wizard_controller_spec.rb
@@ -55,6 +55,61 @@ RSpec.describe Admin::Config::DesignWizardController do
         expect(dracula["light"]).to be_nil
       end
 
+      context "with a theme screenshot" do
+        fab!(:upload, :image_upload)
+
+        before do
+          horizon = Theme.horizon_theme
+          horizon.set_field(
+            target: :common,
+            name: "screenshot_light",
+            type: :theme_screenshot_upload_var,
+            upload_id: upload.id,
+          )
+          horizon.save!
+        end
+
+        def serialized_horizon
+          get "/admin/config/design-wizard.json"
+          response.parsed_body["themes"].find do |theme|
+            theme["id"] == Theme::CORE_THEMES["horizon"]
+          end
+        end
+
+        it "serves the full-size screenshot and schedules a resize when none exists yet" do
+          expect_enqueued_with(
+            job: :generate_theme_screenshot_thumbnails,
+            args: {
+              theme_id: Theme::CORE_THEMES["horizon"],
+            },
+          ) { expect(serialized_horizon["screenshot_light_url"]).to eq(upload.url) }
+        end
+
+        it "only schedules the resize once while it is outstanding" do
+          serialized_horizon
+
+          expect { serialized_horizon }.not_to change {
+            Jobs::GenerateThemeScreenshotThumbnails.jobs.size
+          }
+        end
+
+        it "serves the resized screenshot once it has been generated" do
+          Jobs::GenerateThemeScreenshotThumbnails.new.execute(
+            theme_id: Theme::CORE_THEMES["horizon"],
+          )
+
+          url = serialized_horizon["screenshot_light_url"]
+
+          expect(url).not_to eq(upload.url)
+          expect(OptimizedImage.find_by(upload_id: upload.id)).to have_attributes(
+            url:,
+            width: ThemeScreenshotThumbnails::WIDTH,
+            height: ThemeScreenshotThumbnails::HEIGHT,
+            extension: ".webp",
+          )
+        end
+      end
+
       it "returns the current fonts and homepage" do
         SiteSetting.base_font = "lato"
         SiteSetting.heading_font = "merriweather"
@@ -158,6 +213,7 @@ RSpec.describe Admin::Config::DesignWizardController do
               heading_font: "merriweather",
               homepage: "categories",
               category_page_style: "categories_boxes",
+              welcome_banner_location: "below_site_header",
             }
 
         expect(response.status).to eq(200)
@@ -168,7 +224,34 @@ RSpec.describe Admin::Config::DesignWizardController do
         expect(SiteSetting.heading_font).to eq("merriweather")
         expect(SiteSetting.default_homepage).to eq("categories")
         expect(SiteSetting.desktop_category_page_style).to eq("categories_boxes")
+        expect(SiteSetting.welcome_banner_location).to eq("below_site_header")
         expect(light.reload.user_selectable).to eq(true)
+      end
+
+      it "applies the welcome banner and search choices to the chosen theme" do
+        horizon = Theme.horizon_theme
+
+        put "/admin/config/design-wizard.json",
+            params: {
+              theme_id: horizon.id,
+              enable_welcome_banner: false,
+              search_experience: "search_field",
+            }
+
+        expect(response.status).to eq(200)
+        expect(SiteSetting.enable_welcome_banner(theme_id: horizon.id)).to eq(false)
+        expect(SiteSetting.search_experience(theme_id: horizon.id)).to eq("search_field")
+      end
+
+      it "returns a 400 for an unsupported search experience" do
+        put "/admin/config/design-wizard.json",
+            params: {
+              theme_id: Theme::CORE_THEMES["horizon"],
+              search_experience: "not_an_experience",
+            }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["errors"]).to be_present
       end
 
       it "returns a 400 with errors for an invalid contract" do

--- a/spec/services/design_wizard/apply_spec.rb
+++ b/spec/services/design_wizard/apply_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe DesignWizard::Apply do
+  # the service reaches these through SiteSetting.public_send(name, theme_id:),
+  # which only exists while they are themeable
+  it "only treats genuinely themeable settings as themeable" do
+    expect(described_class::THEMEABLE_SETTINGS.select { |name| SiteSetting.themeable[name] }).to eq(
+      described_class::THEMEABLE_SETTINGS,
+    )
+  end
+
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:theme_id) }
     it { is_expected.to validate_inclusion_of(:theme_id).in_array(Theme::CORE_THEMES.values) }
@@ -22,6 +30,16 @@ RSpec.describe DesignWizard::Apply do
     it do
       is_expected.to validate_inclusion_of(:category_page_style).in_array(
         CategoryPageStyle.values.map { |style| style[:value] },
+      ).allow_nil
+    end
+    it do
+      is_expected.to validate_inclusion_of(:welcome_banner_location).in_array(
+        WelcomeBannerLocation.values.map { |location| location[:value] },
+      ).allow_nil
+    end
+    it do
+      is_expected.to validate_inclusion_of(:search_experience).in_array(
+        SearchExperienceSiteSetting.values.map { |experience| experience[:value] },
       ).allow_nil
     end
 
@@ -283,6 +301,51 @@ RSpec.describe DesignWizard::Apply do
         expect { described_class.call(params:, **dependencies) }.not_to change {
           ColorScheme.where(via_wizard: true).count
         }
+      end
+    end
+
+    context "with welcome banner and search choices" do
+      let(:theme_id) { Theme::CORE_THEMES["horizon"] }
+      let(:params) do
+        {
+          theme_id:,
+          enable_welcome_banner: false,
+          search_experience: "search_field",
+          welcome_banner_location: "below_site_header",
+        }
+      end
+
+      it { is_expected.to run_successfully }
+
+      it "scopes the themeable settings to the chosen theme and leaves the others alone" do
+        result
+
+        expect(SiteSetting.enable_welcome_banner(theme_id: horizon_theme.id)).to eq(false)
+        expect(SiteSetting.search_experience(theme_id: horizon_theme.id)).to eq("search_field")
+        expect(SiteSetting.enable_welcome_banner(theme_id: foundation_theme.id)).to eq(true)
+        expect(SiteSetting.welcome_banner_location).to eq("below_site_header")
+      end
+
+      it "audits each themeable change once" do
+        expect { result }.to change {
+          UserHistory.where(action: UserHistory.actions[:change_theme_site_setting]).count
+        }.by(2)
+      end
+
+      # the wizard resends every selection on each step, so an unchanged value
+      # must not be written back and audited again
+      it "does not re-audit settings that are already at the chosen value" do
+        result
+
+        expect { described_class.call(params:, **dependencies) }.not_to change {
+          UserHistory.where(action: UserHistory.actions[:change_theme_site_setting]).count
+        }
+      end
+
+      context "when a themeable setting cannot be written" do
+        before { SiteSetting.stubs(:themeable).returns({}) }
+
+        it { is_expected.to fail_a_step(:update_themeable_site_settings) }
       end
     end
 

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -199,6 +199,30 @@ describe "Admin Onboarding Banner" do
       expect(ColorScheme.where(theme_id: horizon.id).pluck(:user_selectable)).to all(eq(false))
     end
 
+    it "reverts a previewed welcome banner when closed without saving" do
+      visit("/")
+      banner.click_step_action("select_theme")
+
+      expect(design_wizard_panel).to be_visible
+
+      design_wizard_panel.next_step
+      design_wizard_panel.next_step
+
+      expect(design_wizard_panel).to have_welcome_banner_enabled
+      expect(page).to have_css(".welcome-banner")
+
+      design_wizard_panel.toggle_welcome_banner
+
+      expect(design_wizard_panel).to have_no_welcome_banner_enabled
+      expect(page).to have_no_css(".welcome-banner")
+
+      design_wizard_panel.close
+
+      expect(design_wizard_panel).to be_hidden
+      expect(page).to have_css(".welcome-banner")
+      expect(SiteSetting.enable_welcome_banner(theme_id: Theme.find_default.id)).to eq(true)
+    end
+
     it "previews and applies the design choices and marks step complete" do
       visit("/")
       banner.click_step_action("select_theme")
@@ -219,6 +243,13 @@ describe "Admin Onboarding Banner" do
 
       design_wizard_panel.next_step
       design_wizard_panel.select_homepage("categories")
+      design_wizard_panel.select_search_experience("search_icon")
+
+      expect(design_wizard_panel).to have_welcome_banner_enabled
+      expect(page).to have_css(".welcome-banner")
+      design_wizard_panel.select_welcome_banner_location("below_site_header")
+      design_wizard_panel.toggle_welcome_banner
+      expect(page).to have_no_css(".welcome-banner")
 
       design_wizard_panel.save
 
@@ -234,6 +265,9 @@ describe "Admin Onboarding Banner" do
       expect(SiteSetting.base_font).to eq("lato")
       expect(SiteSetting.default_homepage).to eq("categories")
       expect(SiteSetting.desktop_category_page_style).to eq("categories_boxes")
+      expect(SiteSetting.enable_welcome_banner(theme_id: horizon.id)).to eq(false)
+      expect(SiteSetting.welcome_banner_location).to eq("below_site_header")
+      expect(SiteSetting.search_experience(theme_id: horizon.id)).to eq("search_icon")
 
       # the reload must not cancel the in-flight audit write
       expect(

--- a/spec/system/page_objects/components/design_wizard_panel.rb
+++ b/spec/system/page_objects/components/design_wizard_panel.rb
@@ -55,6 +55,26 @@ module PageObjects
         find("#{WIZARD_SELECTOR}__homepage-card[data-homepage='#{key}']").click
       end
 
+      def toggle_welcome_banner
+        welcome_banner_switch.toggle
+      end
+
+      def has_welcome_banner_enabled?
+        welcome_banner_switch.checked?
+      end
+
+      def has_no_welcome_banner_enabled?
+        welcome_banner_switch.unchecked?
+      end
+
+      def select_welcome_banner_location(key)
+        find("#{WIZARD_SELECTOR}__option-row[data-welcome-banner-location='#{key}']").click
+      end
+
+      def select_search_experience(key)
+        find("#{WIZARD_SELECTOR}__option-row[data-search-experience='#{key}']").click
+      end
+
       def select_body_font(font_key)
         groups = all("#{WIZARD_SELECTOR}__font-group")
         groups[0].find("#{WIZARD_SELECTOR}__font-select").click
@@ -105,7 +125,13 @@ module PageObjects
 
       def user_selectable_switch
         PageObjects::Components::DToggleSwitch.new(
-          "#{WIZARD_SELECTOR}__user-selectable [role='switch']",
+          "#{WIZARD_SELECTOR}__switch-row [aria-labelledby='design-wizard-user-selectable-title']",
+        )
+      end
+
+      def welcome_banner_switch
+        PageObjects::Components::DToggleSwitch.new(
+          "#{WIZARD_SELECTOR}__switch-row [aria-labelledby='design-wizard-welcome-banner-title']",
         )
       end
     end


### PR DESCRIPTION
**Previously**, the design wizard served full-size theme screenshots into a narrow rail with no loading feedback, gave no sign that picking a theme triggers a page reload, limited its third step to the homepage, and left content cramped with a large empty gap above the footer.

**In this update**, theme screenshots are resized to WebP in a background job and rendered in a reserved 16:9 box with a skeleton, picking a theme puts the panel in an explicit busy state, the third step also exposes the welcome banner and search settings, and the panel's width and spacing were reworked.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-theme.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-theme.png) |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-homepage.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-homepage.png) |