### PR TITLE
FIX: Enforce category posting rights on chat message mutations

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channel_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_messages_controller.rb
@@ -85,6 +85,7 @@ class Chat::Api::ChannelMessagesController < Chat::ApiController
       end
       on_failure { render(json: failed_json, status: :unprocessable_entity) }
       on_failed_policy(:no_silenced_user) { raise Discourse::InvalidAccess }
+      on_failed_policy(:can_post_in_channel) { raise Discourse::InvalidAccess }
       on_model_not_found(:channel) { raise Discourse::NotFound }
       on_failed_policy(:accept_blocks) { raise Discourse::InvalidAccess }
       on_model_not_found(:membership) { raise Discourse::NotFound }

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -64,6 +64,7 @@ module Chat
     end
 
     model :channel
+    policy :can_post_in_channel
     step :enforce_membership
     model :membership
     policy :channel_allows_message_creation, class_name: Chat::Channel::Policy::MessageCreation
@@ -100,6 +101,10 @@ module Chat
 
     def no_silenced_user(guardian:)
       !guardian.is_silenced?
+    end
+
+    def can_post_in_channel(guardian:, channel:)
+      guardian.can_post_in_chatable?(channel.chatable)
     end
 
     def fetch_channel(params:)

--- a/plugins/chat/app/services/chat/restore_message.rb
+++ b/plugins/chat/app/services/chat/restore_message.rb
@@ -47,7 +47,10 @@ module Chat
     end
 
     def invalid_access(guardian:, message:)
-      guardian.can_restore_chat?(message, message.chat_channel.chatable)
+      (
+        guardian.can_post_in_chatable?(message.chat_channel.chatable) ||
+          guardian.can_moderate_chat?(message.chat_channel.chatable)
+      ) && guardian.can_restore_chat?(message, message.chat_channel.chatable)
     end
 
     def restore_message(message:)

--- a/plugins/chat/app/services/chat/update_message.rb
+++ b/plugins/chat/app/services/chat/update_message.rb
@@ -105,7 +105,8 @@ module Chat
     end
 
     def can_edit_message(guardian:, message:)
-      guardian.can_edit_chat?(message)
+      guardian.can_post_in_chatable?(message.chat_channel.chatable) &&
+        guardian.can_edit_chat?(message)
     end
 
     def modify_message(params:, message:, guardian:, uploads:)

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -238,10 +238,9 @@ module Chat
     def can_delete_chat?(message, chatable)
       return false if @user.silenced?
       return false if !can_modify_channel_message?(message.chat_channel)
+      return false if !can_preview_chat_channel?(message.chat_channel)
 
       if message.user_id == current_user.id
-        return false if !can_preview_chat_channel?(message.chat_channel)
-
         can_delete_own_chats?(chatable)
       else
         can_delete_other_chats?(chatable)
@@ -263,10 +262,9 @@ module Chat
 
     def can_restore_chat?(message, chatable)
       return false if !can_modify_channel_message?(message.chat_channel)
+      return false if !can_preview_chat_channel?(message.chat_channel)
 
       if message.user_id == current_user.id
-        return false if !can_preview_chat_channel?(message.chat_channel)
-
         case chatable
         when Category
           return message.deleted_by_id == current_user.id || can_moderate_chat?(chatable)

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -238,7 +238,7 @@ module Chat
     def can_delete_chat?(message, chatable)
       return false if @user.silenced?
       return false if !can_modify_channel_message?(message.chat_channel)
-      return false if !can_preview_chat_channel?(message.chat_channel)
+      return false if !is_admin? && !can_preview_chat_channel?(message.chat_channel)
 
       if message.user_id == current_user.id
         can_delete_own_chats?(chatable)
@@ -262,7 +262,7 @@ module Chat
 
     def can_restore_chat?(message, chatable)
       return false if !can_modify_channel_message?(message.chat_channel)
-      return false if !can_preview_chat_channel?(message.chat_channel)
+      return false if !is_admin? && !can_preview_chat_channel?(message.chat_channel)
 
       if message.user_id == current_user.id
         case chatable

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -332,6 +332,94 @@ RSpec.describe Chat::Api::ChannelMessagesController do
     end
   end
 
+  describe "category posting permissions" do
+    fab!(:posting_group, :group)
+    fab!(:public_category) do
+      Fabricate(:category).tap do |category|
+        category.set_permissions(:everyone => :readonly, posting_group => :full)
+        category.save!
+      end
+    end
+    fab!(:restricted_channel) { Fabricate(:chat_channel, chatable: public_category) }
+
+    before do
+      posting_group.add(current_user)
+      restricted_channel.add(current_user)
+      sign_in(current_user)
+    end
+
+    it "blocks a former posting-group member from creating, editing and restoring" do
+      message_to_edit =
+        Fabricate(
+          :chat_message,
+          chat_channel: restricted_channel,
+          user: current_user,
+          message: "original",
+        )
+      message_to_restore =
+        Fabricate(:chat_message, chat_channel: restricted_channel, user: current_user)
+      message_to_restore.trash!(current_user)
+      posting_group.remove(current_user)
+
+      expect(restricted_channel.membership_for(current_user)).to be_present
+
+      aggregate_failures do
+        expect {
+          post "/chat/#{restricted_channel.id}.json", params: { message: "new message" }
+        }.not_to change { restricted_channel.chat_messages.count }
+        expect(response).to have_http_status(:forbidden)
+
+        put "/chat/api/channels/#{restricted_channel.id}/messages/#{message_to_edit.id}",
+            params: {
+              message: "edited",
+            }
+        expect(response).to have_http_status(:forbidden)
+        expect(message_to_edit.reload.message).to eq("original")
+
+        put "/chat/api/channels/#{restricted_channel.id}/messages/#{message_to_restore.id}/restore"
+        expect(response).to have_http_status(:forbidden)
+        expect(message_to_restore.reload).to be_trashed
+      end
+    end
+
+    it "lets a moderator who can see the channel delete and restore others' messages" do
+      moderator = Fabricate(:moderator)
+      posting_group.add(moderator)
+      restricted_channel.add(moderator)
+      posting_group.remove(moderator)
+      sign_in(moderator)
+
+      others_message = Fabricate(:chat_message, chat_channel: restricted_channel)
+
+      delete "/chat/api/channels/#{restricted_channel.id}/messages/#{others_message.id}"
+      expect(response).to have_http_status(:success)
+      expect(others_message.reload).to be_trashed
+
+      put "/chat/api/channels/#{restricted_channel.id}/messages/#{others_message.id}/restore"
+      expect(response).to have_http_status(:success)
+      expect(others_message.reload).not_to be_trashed
+    end
+
+    it "blocks a moderator who cannot see the channel from deleting or restoring via API" do
+      moderator = Fabricate(:moderator)
+      hidden_category = Fabricate(:category, read_restricted: true)
+      hidden_channel = Fabricate(:chat_channel, chatable: hidden_category)
+      message = Fabricate(:chat_message, chat_channel: hidden_channel)
+      sign_in(moderator)
+
+      expect(moderator.guardian.can_preview_chat_channel?(hidden_channel)).to eq(false)
+      expect(moderator.guardian.can_moderate_chat?(hidden_category)).to eq(true)
+
+      delete "/chat/api/channels/#{hidden_channel.id}/messages/#{message.id}"
+      expect(response).to have_http_status(:forbidden)
+      expect(message.reload).not_to be_trashed
+
+      put "/chat/api/channels/#{hidden_channel.id}/messages/#{message.id}/restore"
+      expect(response).to have_http_status(:forbidden)
+      expect(message.reload).not_to be_trashed
+    end
+  end
+
   describe "#bulk_destroy" do
     fab!(:other_user, :user)
     fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel, user: other_user) }


### PR DESCRIPTION
### Description 

Previously, a user who lost category posting rights could still create, edit, or restore messages in a category chat channel, because `Chat::CreateMessage`, `Chat::UpdateMessage`, and `Chat::RestoreMessage` relied on stale channel membership instead of re-checking the actor's current category permission.

This change re-evaluates `can_post_in_chatable?` at the create, update, and restore boundaries (with a moderator carve-out on restore) and requires `can_preview_chat_channel?` for delete and restore, returning `403` when posting or visibility permission is missing.


Context: [Patch](https://patch.discourse.org/patch-triage/1769)
