### PR TITLE
FIX: pass all five arguments to replace_internal_link in Discuz import

### DIFF
--- a/script/import_scripts/discuz_x.rb
+++ b/script/import_scripts/discuz_x.rb
@@ -810,7 +810,7 @@ class ImportScripts::DiscuzX < ImportScripts::Base
 
     # Discuz can create PM out of a post, which will generates like
     # [url=http://example.com/forum.php?mod=redirect&goto=findpost&pid=111&ptid=11][b]关于您在“主题名称”的帖子[/b][/url]
-    s.gsub!(pm_url_regexp) { |discuzx_link| replace_internal_link(discuzx_link, $1) }
+    s.gsub!(pm_url_regexp) { |discuzx_link| replace_internal_link(discuzx_link, $1, nil, nil, nil) }
 
     # [url][b]text[/b][/url] to **[url]text[/url]**
     s.gsub!(%r{(\[url=[^\[\]]*?\])\[b\](\S*)\[/b\](\[/url\])}, '**\1\2\3**')


### PR DESCRIPTION
The private-message branch of `process_discuzx_post` calls `replace_internal_link` with two arguments, but the method takes five required positionals, so importing any post whose raw body matches `pm_url_regexp` aborts with `ArgumentError: wrong number of arguments (given 2, expected 5)`. The link format that triggers it is the one documented in the comment right above the call, which Discuz generates when a post is turned into a private message.

`pm_url_regexp` has a single capture group, the `ptid`, so `$1` is the topic id. This passes it in the `import_topic_id` position and `nil` for the other three, matching what the sibling call site a few lines below does when a named capture is missing.

The URL also carries an uncaptured `pid`, and capturing it would resolve to the exact post instead of the topic's first post. I left that alone deliberately: it changes which URL the importer produces, which is a behavior change rather than a crash fix, and I have no Discuz database to check it against.

I could not run the suite locally, and `script/import_scripts/discuz_x.rb` has no spec (it needs a live MySQL source), so there is nothing to add here on the test side.

To verify the arity mismatch I extracted the real regexp, the real method signature and the real call line from the file and executed them:

```
before: ArgumentError: wrong number of arguments (given 2, expected 5)
after:  replace_internal_link reached, topic id "11", link substituted
```

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
