### PR TITLE
FIX: forward force as a keyword argument in the TopicAssigner shim

### DIFF
--- a/plugins/discourse-assign/lib/topic_assigner.rb
+++ b/plugins/discourse-assign/lib/topic_assigner.rb
@@ -13,7 +13,7 @@ class ::TopicAssigner
 
   def self.auto_assign(post, force: false)
     deprecation_note
-    Assigner.auto_assign(post, force)
+    Assigner.auto_assign(post, force: force)
   end
 
   def self.is_last_staff_post?(post)

--- a/plugins/discourse-assign/spec/lib/topic_assigner_spec.rb
+++ b/plugins/discourse-assign/spec/lib/topic_assigner_spec.rb
@@ -4,16 +4,18 @@ RSpec.describe TopicAssigner do
   describe ".auto_assign" do
     let(:post) { instance_double(Post) }
 
-    it "forwards force to Assigner as a keyword argument" do
-      expect(Assigner).to receive(:auto_assign).with(post, force: true)
+    before { allow(Assigner).to receive(:auto_assign) }
 
+    it "forwards force to Assigner as a keyword argument" do
       described_class.auto_assign(post, force: true)
+
+      expect(Assigner).to have_received(:auto_assign).with(post, force: true)
     end
 
     it "forwards the default force value as a keyword argument" do
-      expect(Assigner).to receive(:auto_assign).with(post, force: false)
-
       described_class.auto_assign(post)
+
+      expect(Assigner).to have_received(:auto_assign).with(post, force: false)
     end
   end
 end

--- a/plugins/discourse-assign/spec/lib/topic_assigner_spec.rb
+++ b/plugins/discourse-assign/spec/lib/topic_assigner_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe TopicAssigner do
+  describe ".auto_assign" do
+    let(:post) { instance_double(Post) }
+
+    it "forwards force to Assigner as a keyword argument" do
+      expect(Assigner).to receive(:auto_assign).with(post, force: true)
+
+      described_class.auto_assign(post, force: true)
+    end
+
+    it "forwards the default force value as a keyword argument" do
+      expect(Assigner).to receive(:auto_assign).with(post, force: false)
+
+      described_class.auto_assign(post)
+    end
+  end
+end


### PR DESCRIPTION
`TopicAssigner.auto_assign` accepts `force:` as a keyword argument and forwards it positionally to `Assigner.auto_assign`, which takes a single positional argument. Every call raises `ArgumentError: wrong number of arguments (given 2, expected 1)`, including the plain `TopicAssigner.auto_assign(post)` form, since the default is forwarded the same way.

`TopicAssigner` is the deprecated shim kept for third party plugins, and the plugin engine puts its directory on `autoload_paths`, so referencing the constant is enough to reach it. The breakage lands on exactly the callers the shim exists to serve. The other six methods in the class forward their arguments correctly.

The second commit adds the spec the class was missing, which is why this survived. With `verify_partial_doubles` on, the message expectation is checked against the real `Assigner.auto_assign` signature, so forwarding `force` positionally again fails the spec.

I could not run the suite locally, so CI is the real check on that spec. The fix itself I verified by loading the real shim with `load` and defining `Assigner` from the real signature in `assigner.rb`:

```
before: TopicAssigner.auto_assign(post, force: true) -> ArgumentError (given 2, expected 1)
        TopicAssigner.auto_assign(post)              -> ArgumentError (given 2, expected 1)
after:  both reach Assigner.auto_assign with force: true and force: false
```

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
