### PR TITLE
FIX: two crashes in the Lithium import script

### DIFF
--- a/script/import_scripts/lithium.rb
+++ b/script/import_scripts/lithium.rb
@@ -937,8 +937,7 @@ SQL
         unless post.raw == new_raw
           post.raw = new_raw
           post.cooked = post.cook(new_raw)
-          cpp = CookedPostProcessor.new(post)
-          cpp.link_post_uploads
+          post.link_post_uploads
           post.custom_fields["import_post_process"] = true
           post.save
         end

--- a/script/import_scripts/lithium.rb
+++ b/script/import_scripts/lithium.rb
@@ -272,7 +272,7 @@ class ImportScripts::Lithium < ImportScripts::Base
       nil
     end
     begin
-      file.unlind
+      file.unlink
     rescue StandardError
       nil
     end


### PR DESCRIPTION
Two independent crashes in the Lithium importer, one commit each. They share a file, so they go in one PR rather than two conflicting ones.

**`file.unlind` in `import_profile_picture`**

The `ensure` block calls `file.unlind`. `Tempfile` has no such method, so the call raises `NoMethodError`, and the surrounding `rescue StandardError` swallows it since `NoMethodError` descends from `StandardError`. The temp file is never removed, leaking one file per imported avatar. The twin method `import_profile_background` has the same ensure shape and already calls `file.unlink`.

**`cpp.link_post_uploads` in the attachment post-processing step**

`link_post_uploads` is defined in the `HasPostUploadReferences` concern, which `Post` includes. `CookedPostProcessor` does not define it, and it has no `method_missing` or `delegate`, so the call raises `NoMethodError`. Here the surrounding rescue only catches `PrettyText::JavaScriptError`, so this one is not swallowed: it aborts the whole `import_attachments` post-processing pass. The fix calls it on the post and drops the `CookedPostProcessor` instance, which existed only to receive that call.

**Verification**

`Tempfile` is stdlib, so that one I could exercise directly:

```
Tempfile#unlind -> NoMethodError: undefined method 'unlind' for an instance of Tempfile
Tempfile#unlink -> file removed
```

The `link_post_uploads` receiver cannot be exercised without booting the app, so that one rests on ownership, which is checkable from the tree: `def link_post_uploads` exists only in `app/models/concerns/has_post_upload_references.rb`, `app/models/post.rb` includes the concern, and `lib/cooked_post_processor.rb` has no matching definition and no dynamic dispatch. `lithium.rb` is the only caller in `script/`.

I could not run the suite locally, and these import scripts have no spec (they need a live MySQL source), so there is nothing to add on the test side.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
