### PR TITLE
FIX: Let AI agents inherit the site LLM

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_agents_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_agents_controller.rb
@@ -232,7 +232,7 @@ module DiscourseAi
 
         return render_json_error(I18n.t("discourse_ai.errors.agent_disabled")) if !agent.enabled
 
-        if agent.default_llm.blank?
+        if agent.default_llm.blank? && SiteSetting.ai_default_llm_model.blank?
           return render_json_error(I18n.t("discourse_ai.errors.no_default_llm"))
         end
 

--- a/plugins/discourse-ai/app/models/ai_agent.rb
+++ b/plugins/discourse-ai/app/models/ai_agent.rb
@@ -27,7 +27,7 @@ class AiAgent < ActiveRecord::Base
   validates :description, presence: true, length: { maximum: 2000 }
   validates :system_prompt, presence: true, length: { maximum: 10_000_000 }
   validate :system_agent_unchangeable, on: :update, if: :system
-  validate :chat_preconditions
+  validate :forced_default_llm_preconditions
   validate :well_formated_examples
   validates :max_turn_tokens,
             numericality: {
@@ -576,12 +576,9 @@ class AiAgent < ActiveRecord::Base
     errors.add(:base, I18n.t("discourse_ai.ai_bot.agents.bot_user_unsupported"))
   end
 
-  def chat_preconditions
-    if (
-         allow_chat_channel_mentions || allow_chat_direct_messages || allow_topic_mentions ||
-           force_default_llm
-       ) && !default_llm_id
-      errors.add(:base, I18n.t("discourse_ai.ai_bot.agents.default_llm_required"))
+  def forced_default_llm_preconditions
+    if force_default_llm && default_llm_id.blank?
+      errors.add(:base, I18n.t("discourse_ai.ai_bot.agents.forced_default_llm_required"))
     end
   end
 

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -829,7 +829,7 @@ en:
         create_user: Create user
         create_user_help: You can optionally attach a user to this agent. If you do, the AI will use this user to respond to requests.
         default_llm: Default language model
-        default_llm_help: The default language model to use for this agent. Required if you wish to mention the agent on public posts.
+        default_llm_help: The default language model to use for this agent. When blank, the site default language model is used.
         system_prompt: System prompt
         forced_tool_strategy: Forced tool strategy
         allow_chat_direct_messages: "Allow chat direct messages"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -471,7 +471,7 @@ en:
         failed: "Could not complete the action: %{error}"
         unexpected_error: "an unexpected error occurred"
       agents:
-        default_llm_required: "Default LLM model is required prior to enabling Chat"
+        forced_default_llm_required: "Select a default language model before requiring this agent to always use it."
         bot_user_unsupported: "This agent is used internally by a feature and cannot have a bot user"
         cannot_delete_system_agent: "System agents cannot be deleted, please disable it instead"
         cannot_edit_system_agent: "System agents can only be renamed, you may not edit tools or system prompt, instead disable and make a copy"
@@ -1176,7 +1176,7 @@ en:
       no_user_specified: The username or the user_unique_id parameter is required, please specify it.
       user_not_found: The user specified does not exist. Check the username param.
       agent_disabled: "The agent specified is disabled. Check the agent_name or agent_id params (legacy: persona_name or persona_id)."
-      no_default_llm: The agent must have a default_llm defined.
+      no_default_llm: No default language model is available. Configure a model for the agent or site.
       user_not_allowed: The user is not allowed to participate in the topic.
       invalid_stream_resume_token: The resume_token is invalid or has expired.
       no_tool_results_specified: The tool_results parameter is required when resuming a stream.

--- a/plugins/discourse-ai/lib/ai_bot/entry_point.rb
+++ b/plugins/discourse-ai/lib/ai_bot/entry_point.rb
@@ -246,7 +246,9 @@ module DiscourseAi
                 {
                   "id" => agent_user[:user_id],
                   "username" => agent_user[:username],
-                  "has_default_llm" => agent_user[:default_llm_id].present?,
+                  "has_default_llm" =>
+                    agent_user[:default_llm_id].present? ||
+                      SiteSetting.ai_default_llm_model.present?,
                   "force_default_llm" => agent_user[:force_default_llm],
                   "is_agent" => true,
                 }

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/entry_point_spec.rb
@@ -74,10 +74,17 @@ RSpec.describe DiscourseAi::AiBot::EntryPoint do
         expect(agent_bot["force_default_llm"]).to eq(true)
       end
 
-      it "includes user ids for all agents in the serializer" do
+      it "includes agents using the site default LLM in the serializer" do
         Group.refresh_automatic_groups!
+        assign_fake_provider_to(:ai_default_llm_model)
 
-        agent = Fabricate(:ai_agent, enabled: true, allowed_group_ids: [bot_allowed_group.id])
+        agent =
+          Fabricate(
+            :ai_agent,
+            enabled: true,
+            allowed_group_ids: [bot_allowed_group.id],
+            default_llm: nil,
+          )
         agent.create_user!
 
         serializer = CurrentUserSerializer.new(admin, scope: Guardian.new(admin))
@@ -86,6 +93,7 @@ RSpec.describe DiscourseAi::AiBot::EntryPoint do
 
         agent_bot = bots.find { |bot| bot["id"] == agent.user_id }
         expect(agent_bot["username"]).to eq(agent.user.username)
+        expect(agent_bot["has_default_llm"]).to eq(true)
         expect(agent_bot["force_default_llm"]).to eq(false)
       end
 

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
@@ -876,14 +876,15 @@ RSpec.describe DiscourseAi::AiBot::Playground do
       expect(last_post.post_type).to eq(Post.types[:whisper])
     end
 
-    it "allows mentioning a agent" do
+    it "allows mentioning an agent that inherits the site default LLM" do
       # we still should be able to mention with no bots
       toggle_enabled_bots(bots: [])
 
-      agent.update!(allow_topic_mentions: true)
+      global_llm = assign_fake_provider_to(:ai_default_llm_model)
+      agent.update!(allow_topic_mentions: true, default_llm: nil)
 
       post = nil
-      DiscourseAi::Completions::Llm.with_prepared_responses(["Yes I can"]) do
+      DiscourseAi::Completions::Llm.with_prepared_responses(["Yes I can"], llm: global_llm) do
         post =
           create_post(
             user: admin,

--- a/plugins/discourse-ai/spec/models/ai_agent_spec.rb
+++ b/plugins/discourse-ai/spec/models/ai_agent_spec.rb
@@ -504,51 +504,33 @@ RSpec.describe AiAgent do
     agent.class_instance
   end
 
-  it "does not allow setting allowing chat without a default_llm" do
-    agent =
-      AiAgent.create(
-        name: "test",
-        description: "test",
-        system_prompt: "test",
-        allowed_group_ids: [],
-        default_llm: nil,
-        allow_chat_channel_mentions: true,
-      )
+  it "allows mention modalities without a per-agent LLM" do
+    assign_fake_provider_to(:ai_default_llm_model)
 
-    expect(agent.valid?).to eq(false)
+    %i[
+      allow_chat_channel_mentions
+      allow_chat_direct_messages
+      allow_topic_mentions
+    ].each do |modality|
+      agent = Fabricate.build(:ai_agent, name: "test_#{modality}", default_llm: nil)
+      agent.public_send("#{modality}=", true)
+
+      expect(agent).to be_valid,
+      "expected #{modality} to be valid without a per-agent language model"
+    end
+  end
+
+  it "requires a per-agent default LLM when it is forced" do
+    agent = Fabricate.build(:ai_agent, default_llm: nil, force_default_llm: true)
+
+    expect(agent).not_to be_valid
     expect(agent.errors[:base]).to include(
-      I18n.t("discourse_ai.ai_bot.agents.default_llm_required"),
+      I18n.t("discourse_ai.ai_bot.agents.forced_default_llm_required"),
     )
 
-    agent =
-      AiAgent.create(
-        name: "test",
-        description: "test",
-        system_prompt: "test",
-        allowed_group_ids: [],
-        default_llm: nil,
-        allow_chat_direct_messages: true,
-      )
+    agent.default_llm = llm_model
 
-    expect(agent.valid?).to eq(false)
-    expect(agent.errors[:base]).to include(
-      I18n.t("discourse_ai.ai_bot.agents.default_llm_required"),
-    )
-
-    agent =
-      AiAgent.create(
-        name: "test",
-        description: "test",
-        system_prompt: "test",
-        allowed_group_ids: [],
-        default_llm: nil,
-        allow_topic_mentions: true,
-      )
-
-    expect(agent.valid?).to eq(false)
-    expect(agent.errors[:base]).to include(
-      I18n.t("discourse_ai.ai_bot.agents.default_llm_required"),
-    )
+    expect(agent).to be_valid
   end
 
   it "does not leak caches between sites" do

--- a/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
@@ -1466,12 +1466,13 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
       # trust level 0
       SiteSetting.ai_bot_allowed_groups = "10"
 
+      SiteSetting.ai_default_llm_model = llm.id
       fake_endpoint.fake_content = ["This is a test! Testing!", "An amazing title"]
 
       ai_agent.create_user!
       ai_agent.update!(
         allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
-        default_llm_id: llm.id,
+        default_llm: nil,
         allow_personal_messages: true,
         system_prompt: "you are a helpful bot",
       )


### PR DESCRIPTION
Allow agents without a model override to use the site default for mentions, serialization, and admin tests. Only require an agent-specific model when force_default_llm is enabled, while still rejecting test runs when no model is available.
