### PR TITLE
FIX: Align Site Traffic cutoff with chart dates

### DIFF
--- a/frontend/discourse/admin/components/site-traffic-explorer.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer.gjs
@@ -174,7 +174,7 @@ export default class SiteTrafficExplorer extends Component {
       ? moment(partial.available_start_date).format("ll")
       : null;
 
-    const pageviewLimitStart = moment(partial.pageview_limit_start_at);
+    const pageviewLimitStart = moment.utc(partial.pageview_limit_start_at);
     const pageviewLimitDate = pageviewLimitStart.format("ll");
     const pageviewLimitTime = pageviewLimitStart.format("LT");
 

--- a/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
@@ -552,15 +552,15 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
   end
 
   it "warns an admin when the selected range has incomplete traffic data",
-     time: Time.zone.local(2026, 5, 14, 12, 0, 0),
-     timezone: "UTC" do
+     time: Time.zone.local(2026, 8, 20, 12, 0, 0),
+     timezone: "Asia/Singapore" do
     sign_in(admin)
     SiteSetting.site_traffic_explorer_event_limit = 2
 
     [
-      ["/first-retained", "2026-02-15 09:00:00"],
-      ["/middle-retained", "2026-05-10 10:00:00"],
-      ["/latest-retained", "2026-05-12 10:00:00"],
+      ["/first-retained", "2026-08-17 21:00:00"],
+      ["/middle-retained", "2026-08-17 22:27:00"],
+      ["/latest-retained", "2026-08-17 23:00:00"],
     ].each do |url, created_at|
       Fabricate(
         :browser_pageview_event,
@@ -571,11 +571,11 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
       )
     end
 
-    traffic.visit(start_date: "2026-01-01", end_date: "2026-05-12")
+    traffic.visit(start_date: "2026-05-01", end_date: "2026-08-17")
 
     expect(traffic).to have_partial_data_warning(
       reason:
-        "Results include the most recent 2 pageviews, beginning May 10, 2026 at 10:00 AM. Earlier pageviews in the selected date range are not included; pageview data before Feb 14, 2026 is no longer available.",
+        "Results include the most recent 2 pageviews, beginning Aug 17, 2026 at 10:27 PM. Earlier pageviews in the selected date range are not included; pageview data before May 20, 2026 is no longer available.",
     )
   end
 


### PR DESCRIPTION
The Site Traffic Explorer groups chart series into UTC dates, but the pageview-limit warning formatted its cutoff in the browser timezone. Near a UTC day boundary, the warning and first chart bucket could show different dates.

This change formats the cutoff timestamp in UTC on the client, using the same date basis as the chart. It does not add request parameters, alter date bounds, validate timezones, or change the SQL query.

## Before

The browser formats the Aug 17 at 10:27 PM UTC cutoff as Aug 18 at 6:27 AM, while the chart contains the UTC Aug 17 bucket.

![Before: warning begins Aug 18 while the chart shows Aug 17](https://gist.githubusercontent.com/tgxworld/31b8a094f2a8736495771ea7d5d90f58/raw/0116bcd8f2c8bf1962f007e685d3b023f6162e88/before-cutoff-warning.png)

## After

The warning and chart both use Aug 17 because they now use the same UTC date basis.

![After: warning and chart both use Aug 17](https://gist.githubusercontent.com/tgxworld/31b8a094f2a8736495771ea7d5d90f58/raw/0116bcd8f2c8bf1962f007e685d3b023f6162e88/after-cutoff-warning.png)

Both screenshots come from the same focused system-test scenario with the same fabricated pageviews, browser timezone, date range, KPI values, and chart.