### PR TITLE
FEATURE: Link activity-by-category counts to topic lists

### DIFF
--- a/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
@@ -7,6 +7,7 @@ import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+import moment from "moment";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { number } from "discourse/lib/formatter";
@@ -47,16 +48,27 @@ export default class ActivityByCategory extends Component {
 
   get rows() {
     const rows = this.activity?.rows ?? [];
-    const decorated = rows.map((row) => ({
-      ...row,
-      category: Category.findById(row.category_id),
-      topicsFormatted: I18n.toNumber(row.topics, { precision: 0 }),
-      postsFormatted: I18n.toNumber(row.posts, { precision: 0 }),
-      pageViewsFormatted: number(row.page_views),
-      changeClass:
-        row.share_change > 0 ? "--pos" : row.share_change < 0 ? "--neg" : "",
-      swatchStyle: trustHTML(`background-color: #${this.#safeHex(row.color)}`),
-    }));
+    const decorated = rows.map((row) => {
+      const category = Category.findById(row.category_id);
+      const categorySlug = category
+        ? Category.slugFor(category, ":")
+        : row.slug;
+
+      return {
+        ...row,
+        category,
+        topicsFormatted: I18n.toNumber(row.topics, { precision: 0 }),
+        postsFormatted: I18n.toNumber(row.posts, { precision: 0 }),
+        pageViewsFormatted: number(row.page_views),
+        topicsQuery: this.#topicQuery(categorySlug, "created"),
+        postsQuery: this.#topicQuery(categorySlug, "activity"),
+        changeClass:
+          row.share_change > 0 ? "--pos" : row.share_change < 0 ? "--neg" : "",
+        swatchStyle: trustHTML(
+          `background-color: #${this.#safeHex(row.color)}`
+        ),
+      };
+    });
 
     const direction = this.sortDir === "asc" ? 1 : -1;
     return decorated.sort((a, b) => {
@@ -72,6 +84,26 @@ export default class ActivityByCategory extends Component {
 
   #safeHex(color) {
     return /^[0-9a-fA-F]{6}$/.test(color) ? color : "cccccc";
+  }
+
+  #topicQuery(categorySlug, dateFilter) {
+    const terms = [];
+
+    if (this.args.startDate) {
+      terms.push(
+        `${dateFilter}-after:${moment(this.args.startDate).format("YYYY-MM-DD")}`
+      );
+    }
+    if (this.args.endDate) {
+      terms.push(
+        `${dateFilter}-before:${moment(this.args.endDate)
+          .add(1, "day")
+          .format("YYYY-MM-DD")}`
+      );
+    }
+    terms.push(`=category:${categorySlug}`);
+
+    return { q: terms.join(" ") };
   }
 
   @action
@@ -314,12 +346,19 @@ export default class ActivityByCategory extends Component {
                       {{row.name}}
                     {{/if}}
                   </td>
-                  <td
-                    class="db-activity-table__cell-number"
-                  >{{row.topicsFormatted}}</td>
-                  <td
-                    class="db-activity-table__cell-number"
-                  >{{row.postsFormatted}}</td>
+                  <td class="db-activity-table__cell-number">
+                    <LinkTo
+                      @route="discovery.filter"
+                      @query={{row.topicsQuery}}
+                    >
+                      {{row.topicsFormatted}}
+                    </LinkTo>
+                  </td>
+                  <td class="db-activity-table__cell-number">
+                    <LinkTo @route="discovery.filter" @query={{row.postsQuery}}>
+                      {{row.postsFormatted}}
+                    </LinkTo>
+                  </td>
                   <td
                     class="db-activity-table__cell-number"
                   >{{row.pageViewsFormatted}}</td>

--- a/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
@@ -16,7 +16,7 @@ module(
       total: 100,
       rows: [
         {
-          category_id: 1,
+          category_id: 3,
           name: "Support & Help",
           color: "0088CC",
           topics: 412,
@@ -28,7 +28,7 @@ module(
           share_change_formatted: "+12%",
         },
         {
-          category_id: 2,
+          category_id: 6,
           name: "General",
           color: "009C00",
           topics: 231,
@@ -40,7 +40,7 @@ module(
           share_change_formatted: "+5%",
         },
         {
-          category_id: 3,
+          category_id: 7,
           name: "Bug Reports",
           color: "E45735",
           topics: 61,
@@ -99,6 +99,43 @@ module(
       assert.dom(".db-delta.--pos").exists({ count: 2 });
       assert.dom(".db-delta.--neg").exists({ count: 1 });
       assert.dom(".db-delta.--neg").hasText("-8%");
+    });
+
+    test("links topic and post counts to the category's filtered topic list", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".db-activity-table tbody td:nth-child(2) a")
+        .exists({ count: 3 }, "every topic count is linked");
+      assert
+        .dom(".db-activity-table tbody td:nth-child(3) a")
+        .exists({ count: 3 }, "every post count is linked");
+      assert
+        .dom(".db-activity-table tbody tr:nth-child(1) td:nth-child(2) a")
+        .hasAttribute(
+          "href",
+          `/filter?q=${encodeURIComponent(
+            "created-after:2026-04-01 created-before:2026-05-01 =category:meta"
+          )}`,
+          "the topic count filters new topics by category and date range"
+        );
+      assert
+        .dom(".db-activity-table tbody tr:nth-child(1) td:nth-child(3) a")
+        .hasAttribute(
+          "href",
+          `/filter?q=${encodeURIComponent(
+            "activity-after:2026-04-01 activity-before:2026-05-01 =category:meta"
+          )}`,
+          "the post count filters activity by category and date range"
+        );
     });
 
     test("formats page views with k suffix when over 1000", async function (assert) {
@@ -164,7 +201,7 @@ module(
 
       assert.strictEqual(
         selectKit(".multiple-categories-selector").header().value(),
-        "1,2,3"
+        "3,6,7"
       );
     });
 


### PR DESCRIPTION
Previously, admins could see category topic and post counts but not the topics behind them.

This change links each count to a date- and category-filtered topic list.

<img width="1080" height="562" alt="Screenshot 2026-08-26 at 2 17 04 pm" src="https://github.com/user-attachments/assets/5776e0e1-c60b-4c24-bc74-732cc8f526de" />
