### PR TITLE
UX: Align site traffic metric labels on site traffic explorer

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -222,7 +222,6 @@
     display: flex;
     align-items: center;
     gap: var(--space-1);
-    min-height: 1.625em;
   }
 
   .db-section__row-block {

--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -218,6 +218,13 @@
     }
   }
 
+  .db-section__metric-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    min-height: 1.625em;
+  }
+
   .db-section__row-block {
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
+++ b/app/assets/stylesheets/admin/dashboard/site-traffic-explorer.scss
@@ -222,6 +222,10 @@
     display: flex;
     align-items: center;
     gap: var(--space-1);
+
+    .db-section__info {
+      font-size: inherit;
+    }
   }
 
   .db-section__row-block {


### PR DESCRIPTION
## Before

![Before: the tooltip label's larger line box misaligns KPI labels](https://gist.githubusercontent.com/tgxworld/f8b147303fa29e04f7c65eedfa215bdd/raw/9d7a9966b510801ad545e21830b4e73e29547601/before-kpi-label-alignment.png)

## After

![After: all KPI labels use the same line box](https://gist.githubusercontent.com/tgxworld/f8b147303fa29e04f7c65eedfa215bdd/raw/853c8ca444c13149a271c038fbc1afd6cfe70ac1/after-kpi-label-alignment.png)
