### PR TITLE
DEV: update Events plugin key names for settings and i18n

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1078,8 +1078,8 @@ class Plugin::Instance
   # Example:
   #   register_calendar_subscription_feed(
   #     name: "all_events",
-  #     scope: "discourse-calendar:events_calendar",
-  #     description_key: "discourse_calendar.preferences.all_events_description",
+  #     scope: "my-plugin:events_calendar",
+  #     description_key: "my_plugin.preferences.all_events_description",
   #     url: ->(base_url, user, key) { "#{base_url}/events.ics?user_api_key=#{key}" }
   #   )
   def register_calendar_subscription_feed(name:, scope:, description_key:, url:)

--- a/plugins/discourse-events/app/controllers/admin/discourse_events/holidays_controller.rb
+++ b/plugins/discourse-events/app/controllers/admin/discourse_events/holidays_controller.rb
@@ -11,10 +11,7 @@ module Admin::DiscourseEvents
         holidays = DiscourseEvents::Holidays::Finder.find_holidays_for(region_code: region_code)
       rescue ::Holidays::InvalidRegion
         return(
-          render_json_error(
-            I18n.t("system_messages.discourse_calendar_holiday_region_invalid"),
-            422,
-          )
+          render_json_error(I18n.t("system_messages.discourse_events_holiday_region_invalid"), 422)
         )
       end
 
@@ -35,7 +32,7 @@ module Admin::DiscourseEvents
       if DiscourseEvents::Holidays::DisabledHoliday.destroy_by(disabled_holiday_params).present?
         render json: success_json
       else
-        render_json_error(I18n.t("system_messages.discourse_calendar_enable_holiday_failed"), 422)
+        render_json_error(I18n.t("system_messages.discourse_events_enable_holiday_failed"), 422)
       end
     end
 

--- a/plugins/discourse-events/app/controllers/discourse_events/events_controller.rb
+++ b/plugins/discourse-events/app/controllers/discourse_events/events_controller.rb
@@ -228,7 +228,7 @@ module DiscourseEvents
         end
 
       I18n.t(
-        "discourse_calendar.calendar_subscriptions.#{translation_key}",
+        "discourse_events.calendar_subscriptions.#{translation_key}",
         site_title: SiteSetting.title,
       )
     end

--- a/plugins/discourse-events/app/services/discourse_events/categories/types/events.rb
+++ b/plugins/discourse-events/app/services/discourse_events/categories/types/events.rb
@@ -102,28 +102,28 @@ module DiscourseEvents
                   required: true,
                   choices: [
                     {
-                      name: I18n.t("discourse_calendar.category_type.default_calendar_view.day"),
+                      name: I18n.t("discourse_events.category_type.default_calendar_view.day"),
                       value: "day",
                     },
                     {
-                      name: I18n.t("discourse_calendar.category_type.default_calendar_view.week"),
+                      name: I18n.t("discourse_events.category_type.default_calendar_view.week"),
                       value: "week",
                     },
                     {
-                      name: I18n.t("discourse_calendar.category_type.default_calendar_view.month"),
+                      name: I18n.t("discourse_events.category_type.default_calendar_view.month"),
                       value: "month",
                     },
                     {
-                      name: I18n.t("discourse_calendar.category_type.default_calendar_view.year"),
+                      name: I18n.t("discourse_events.category_type.default_calendar_view.year"),
                       value: "year",
                     },
                   ],
-                  label: I18n.t("discourse_calendar.category_type.default_calendar_view.label"),
+                  label: I18n.t("discourse_events.category_type.default_calendar_view.label"),
                 },
                 events_calendar_display_weekends: {
                   default: true,
                   type: :bool,
-                  label: I18n.t("discourse_calendar.category_type.display_weekends.label"),
+                  label: I18n.t("discourse_events.category_type.display_weekends.label"),
                 },
               },
               site_settings: {
@@ -132,7 +132,7 @@ module DiscourseEvents
                   type: :group_list,
                   label:
                     I18n.t(
-                      "discourse_calendar.category_type.discourse_post_event_allowed_on_groups.label",
+                      "discourse_events.category_type.discourse_post_event_allowed_on_groups.label",
                     ),
                 },
                 use_local_event_date: {
@@ -141,16 +141,15 @@ module DiscourseEvents
                   required: true,
                   choices: [
                     {
-                      name: I18n.t("discourse_calendar.category_type.use_local_event_date.local"),
+                      name: I18n.t("discourse_events.category_type.use_local_event_date.local"),
                       value: true,
                     },
                     {
-                      name:
-                        I18n.t("discourse_calendar.category_type.use_local_event_date.relative"),
+                      name: I18n.t("discourse_events.category_type.use_local_event_date.relative"),
                       value: false,
                     },
                   ],
-                  label: I18n.t("discourse_calendar.category_type.use_local_event_date.label"),
+                  label: I18n.t("discourse_events.category_type.use_local_event_date.label"),
                 },
                 sort_categories_by_event_start_date_enabled: {
                   default: true,
@@ -160,28 +159,28 @@ module DiscourseEvents
                     {
                       name:
                         I18n.t(
-                          "discourse_calendar.category_type.sort_categories_by_event_start_date_enabled.event_date",
+                          "discourse_events.category_type.sort_categories_by_event_start_date_enabled.event_date",
                         ),
                       value: true,
                     },
                     {
                       name:
                         I18n.t(
-                          "discourse_calendar.category_type.sort_categories_by_event_start_date_enabled.latest_post",
+                          "discourse_events.category_type.sort_categories_by_event_start_date_enabled.latest_post",
                         ),
                       value: false,
                     },
                   ],
                   label:
                     I18n.t(
-                      "discourse_calendar.category_type.sort_categories_by_event_start_date_enabled.label",
+                      "discourse_events.category_type.sort_categories_by_event_start_date_enabled.label",
                     ),
                 },
                 sidebar_show_upcoming_events: {
                   default: true,
                   type: :bool,
                   label:
-                    I18n.t("discourse_calendar.category_type.sidebar_show_upcoming_events.label"),
+                    I18n.t("discourse_events.category_type.sidebar_show_upcoming_events.label"),
                 },
               },
             }

--- a/plugins/discourse-events/app/views/discourse_events/livestream/zoom_frame.html.erb
+++ b/plugins/discourse-events/app/views/discourse_events/livestream/zoom_frame.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="robots" content="noindex">
-    <title><%= t("discourse_calendar.livestream.zoom.frame_title") %></title>
+    <title><%= t("discourse_events.livestream.zoom.frame_title") %></title>
     <style>
       html,
       body {
@@ -80,13 +80,13 @@
     <button id="join" type="button">
       <span>
         <svg viewBox="0 0 576 512" aria-hidden="true"><path d="M336 64H48C21.5 64 0 85.5 0 112v288c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48V112c0-26.5-21.5-48-48-48zm212.2 25.7L416 181.8v148.4l132.2 92.1c15.9 11 37.8-.2 37.8-19.7V109.4c0-19.5-21.9-30.7-37.8-19.7z"/></svg>
-        <%= t("discourse_calendar.livestream.zoom.frame_join") %>
+        <%= t("discourse_events.livestream.zoom.frame_join") %>
       </span>
     </button>
 
     <script nonce="<%= csp_nonce_placeholder %>">
       window.zoomFrameConfig = <%= raw @config.to_json %>;
-      window.zoomFrameConfig.joiningLabel = "<%= j t("discourse_calendar.livestream.zoom.frame_joining") %>";
+      window.zoomFrameConfig.joiningLabel = "<%= j t("discourse_events.livestream.zoom.frame_joining") %>";
     </script>
     <script nonce="<%= csp_nonce_placeholder %>">
       (function () {

--- a/plugins/discourse-events/assets/javascripts/discourse/components/admin-holidays-list-item.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/admin-holidays-list-item.gjs
@@ -56,8 +56,8 @@ export default class AdminHolidaysListItem extends Component {
             @action={{this.toggleEnableHoliday}}
             @label={{if
               this.isHolidayDisabled
-              "discourse_calendar.enable_holiday"
-              "discourse_calendar.disable_holiday"
+              "discourse_events.enable_holiday"
+              "discourse_events.disable_holiday"
             }}
             @isLoading={{this.loading}}
             class="btn-default btn-small"

--- a/plugins/discourse-events/assets/javascripts/discourse/components/admin-holidays-list.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/admin-holidays-list.gjs
@@ -5,9 +5,9 @@ const AdminHolidaysList = <template>
   <table class="d-table admin-holidays-list">
     <thead class="d-table__header">
       <tr class="d-table__row">
-        <th class="d-table__header-cell">{{i18n "discourse_calendar.date"}}</th>
+        <th class="d-table__header-cell">{{i18n "discourse_events.date"}}</th>
         <th class="d-table__header-cell">{{i18n
-            "discourse_calendar.holiday"
+            "discourse_events.holiday"
           }}</th>
         <th></th>
       </tr>

--- a/plugins/discourse-events/assets/javascripts/discourse/components/livestream/zoom-entry.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/livestream/zoom-entry.gjs
@@ -69,7 +69,7 @@ export default class LivestreamZoomEntry extends Component {
         <div class="discourse-calendar-livestream-zoom-entry__actions">
           <DButton
             @href={{this.joinHref}}
-            @label="discourse_calendar.livestream.zoom.join"
+            @label="discourse_events.livestream.zoom.join"
             @icon="video"
             class="discourse-calendar-livestream-zoom-entry__join btn-primary"
             @disabled={{this.joinDisabled}}
@@ -78,7 +78,7 @@ export default class LivestreamZoomEntry extends Component {
 
           {{#unless this.canJoinNow}}
             <p class="discourse-calendar-livestream-zoom-entry__waiting">
-              {{i18n "discourse_calendar.livestream.zoom.too_early"}}
+              {{i18n "discourse_events.livestream.zoom.too_early"}}
             </p>
           {{/unless}}
         </div>

--- a/plugins/discourse-events/assets/javascripts/discourse/components/livestream/zoom-page.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/livestream/zoom-page.gjs
@@ -143,7 +143,7 @@ export default class LivestreamZoomPage extends Component {
       // nowhere to go but back to the topic the webinar belongs to.
       window.location.assign(this.topicUrl);
     } else if (event.data.state === "error") {
-      this.errorMessage = i18n("discourse_calendar.livestream.zoom.load_error");
+      this.errorMessage = i18n("discourse_events.livestream.zoom.load_error");
     }
   }
 
@@ -211,13 +211,13 @@ export default class LivestreamZoomPage extends Component {
 
             <DButton
               @href={{this.zoomUrl}}
-              @label="discourse_calendar.livestream.zoom.open_in_zoom"
+              @label="discourse_events.livestream.zoom.open_in_zoom"
               @icon="up-right-from-square"
             />
 
             <DButton
               @action={{this.retryZoom}}
-              @label="discourse_calendar.livestream.zoom.join"
+              @label="discourse_events.livestream.zoom.join"
               @icon="video"
               class="btn-primary"
             />
@@ -227,20 +227,20 @@ export default class LivestreamZoomPage extends Component {
         <iframe
           class="discourse-calendar-livestream-zoom-page__frame"
           src={{this.frameUrl}}
-          title={{i18n "discourse_calendar.livestream.zoom.frame_title"}}
+          title={{i18n "discourse_events.livestream.zoom.frame_title"}}
           allow="camera; microphone; autoplay; display-capture; fullscreen"
           {{this.listenForFrame}}
         ></iframe>
       {{else}}
         <div class="discourse-calendar-livestream-zoom-page__waiting-wrapper">
           <p class="discourse-calendar-livestream-zoom-page__waiting">
-            {{i18n "discourse_calendar.livestream.zoom.too_early"}}
+            {{i18n "discourse_events.livestream.zoom.too_early"}}
             <a
               href={{this.topicUrl}}
               class="raw-link"
               {{on "click" this.viewTopic}}
             >
-              {{i18n "discourse_calendar.livestream.zoom.view_topic"}}
+              {{i18n "discourse_events.livestream.zoom.view_topic"}}
             </a>
           </p>
 

--- a/plugins/discourse-events/assets/javascripts/discourse/components/region-input.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/region-input.js
@@ -11,7 +11,7 @@ import { HOLIDAY_REGIONS } from "../lib/regions";
 @selectKitOptions({
   filterable: true,
   allowAny: false,
-  none: "discourse_calendar.region.select_region",
+  none: "discourse_events.region.select_region",
 })
 @pluginApiIdentifiers("timezone-input")
 @classNames("timezone-input", "region-input")
@@ -29,14 +29,14 @@ export default class RegionInput extends ComboBoxComponent {
 
     if (this.allowNoneRegion === true) {
       regions.push({
-        name: i18n("discourse_calendar.region.none"),
+        name: i18n("discourse_events.region.none"),
         id: null,
       });
     }
 
     regions = regions.concat(
       HOLIDAY_REGIONS.map((region) => ({
-        name: i18n(`discourse_calendar.region.names.${region}`),
+        name: i18n(`discourse_events.region.names.${region}`),
         id: region,
       })).sort((a, b) => a.name.localeCompare(b.name))
     );

--- a/plugins/discourse-events/assets/javascripts/discourse/connectors/calendar-subscriptions-feeds/event-feeds.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/connectors/calendar-subscriptions-feeds/event-feeds.gjs
@@ -4,9 +4,9 @@ import { i18n } from "discourse-i18n";
 export default <template>
   {{#if @outletArgs.urls.all_events}}
     <CalendarSubscriptionUrl
-      @label={{i18n "discourse_calendar.preferences.all_events"}}
+      @label={{i18n "discourse_events.preferences.all_events"}}
       @description={{i18n
-        "discourse_calendar.preferences.all_events_description"
+        "discourse_events.preferences.all_events_description"
       }}
       @url={{@outletArgs.urls.all_events}}
     />
@@ -14,10 +14,8 @@ export default <template>
 
   {{#if @outletArgs.urls.my_events}}
     <CalendarSubscriptionUrl
-      @label={{i18n "discourse_calendar.preferences.my_events"}}
-      @description={{i18n
-        "discourse_calendar.preferences.my_events_description"
-      }}
+      @label={{i18n "discourse_events.preferences.my_events"}}
+      @description={{i18n "discourse_events.preferences.my_events_description"}}
       @url={{@outletArgs.urls.my_events}}
     />
   {{/if}}

--- a/plugins/discourse-events/assets/javascripts/discourse/connectors/chat-channel-preview-card-content/livestream-rsvp.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/connectors/chat-channel-preview-card-content/livestream-rsvp.gjs
@@ -14,11 +14,11 @@ export default class LivestreamRsvpPreviewCard extends LivestreamRsvp {
     // when the chat renders within the livestream topic, there is no point
     // linking to the topic the user is already on
     if (this.isOnTopic) {
-      return i18n("discourse_calendar.livestream.chat.rsvp_to_event");
+      return i18n("discourse_events.livestream.chat.rsvp_to_event");
     }
 
     return trustHTML(
-      i18n("discourse_calendar.livestream.chat.rsvp_to_event_with_link", {
+      i18n("discourse_events.livestream.chat.rsvp_to_event_with_link", {
         url: this.livestreamTopic.url,
       })
     );
@@ -35,7 +35,7 @@ export default class LivestreamRsvpPreviewCard extends LivestreamRsvp {
       </div>
 
       <div class="chat-channel-preview-card__body">
-        {{i18n "discourse_calendar.livestream.chat.rsvp_body"}}
+        {{i18n "discourse_events.livestream.chat.rsvp_body"}}
       </div>
 
       <div class="chat-channel-preview-card__actions">

--- a/plugins/discourse-events/assets/javascripts/discourse/connectors/user-custom-preferences/region.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/connectors/user-custom-preferences/region.gjs
@@ -26,7 +26,7 @@ export default class Region extends Component {
   <template>
     <div class="control-group region">
       <label class="control-label">
-        {{i18n "discourse_calendar.region.title"}}
+        {{i18n "discourse_events.region.title"}}
       </label>
 
       <div class="controls">
@@ -39,7 +39,7 @@ export default class Region extends Component {
 
       <DButton
         @icon="globe"
-        @label="discourse_calendar.region.use_current_region"
+        @label="discourse_events.region.use_current_region"
         @action={{this.useCurrentRegion}}
         class="btn-default"
       />

--- a/plugins/discourse-events/assets/javascripts/discourse/helpers/format-event-name.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/helpers/format-event-name.js
@@ -18,7 +18,7 @@ export function formatEventName(event, userTimezone) {
     event.timezone &&
     !sameTimezoneOffset(event.timezone, userTimezone)
   ) {
-    output += ` (${i18n("discourse_calendar.local_time")})`;
+    output += ` (${i18n("discourse_events.local_time")})`;
   }
 
   return output;

--- a/plugins/discourse-events/assets/javascripts/discourse/initializers/calendar-admin-plugin-configuration-nav.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/initializers/calendar-admin-plugin-configuration-nav.js
@@ -16,10 +16,10 @@ export default {
 
       api.addAdminPluginConfigurationNav(PLUGIN_ID, [
         {
-          label: "discourse_calendar.holidays.header_title",
+          label: "discourse_events.holidays.header_title",
           route: "adminPlugins.show.discourse-events-holidays",
           description:
-            "discourse_calendar.holidays.disabled_holidays_description",
+            "discourse_events.holidays.disabled_holidays_description",
         },
       ]);
     });

--- a/plugins/discourse-events/assets/javascripts/discourse/lib/calendar-locale.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/lib/calendar-locale.js
@@ -6,10 +6,10 @@ export function getCurrentBcp47Locale() {
 
 export function getCalendarButtonsText() {
   return {
-    today: i18n("discourse_calendar.toolbar_button.today"),
-    month: i18n("discourse_calendar.toolbar_button.month"),
-    week: i18n("discourse_calendar.toolbar_button.week"),
-    day: i18n("discourse_calendar.toolbar_button.day"),
-    list: i18n("discourse_calendar.toolbar_button.year"),
+    today: i18n("discourse_events.toolbar_button.today"),
+    month: i18n("discourse_events.toolbar_button.month"),
+    week: i18n("discourse_events.toolbar_button.week"),
+    day: i18n("discourse_events.toolbar_button.day"),
+    list: i18n("discourse_events.toolbar_button.year"),
   };
 }

--- a/plugins/discourse-events/assets/javascripts/discourse/templates/admin-plugins/show/discourse-events-holidays.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/templates/admin-plugins/show/discourse-events-holidays.gjs
@@ -8,15 +8,13 @@ import RegionInput from "discourse/plugins/discourse-events/discourse/components
 export default <template>
   <DBreadcrumbsItem
     @path="/admin/plugins/discourse-events/holidays"
-    @label={{i18n "discourse_calendar.holidays.header_title"}}
+    @label={{i18n "discourse_events.holidays.header_title"}}
   />
 
   <div class="calendar-admin-holidays admin-detail">
     <DPageSubheader
-      @titleLabel={{i18n "discourse_calendar.holidays.header_title"}}
-      @descriptionLabel={{i18n
-        "discourse_calendar.holidays.header_description"
-      }}
+      @titleLabel={{i18n "discourse_events.holidays.header_title"}}
+      @descriptionLabel={{i18n "discourse_events.holidays.header_description"}}
     />
 
     <RegionInput

--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -5,7 +5,7 @@ en:
       site_settings:
         categories:
           discourse_post_event: "Discourse Event"
-          discourse_calendar: "Events"
+          discourse_events: "Events"
       web_hooks:
         calendar_event:
           group_name: "Calendar Event"
@@ -26,7 +26,7 @@ en:
           fields:
             topic_id:
               label: Topic ID
-    discourse_calendar:
+    discourse_events:
       livestream:
         zoom:
           join: "Join Zoom"
@@ -39,7 +39,6 @@ en:
           rsvp_to_event: "RSVP to the event to start chatting"
           rsvp_to_event_with_link: "RSVP to <a href='%{url}'>the event</a> to start chatting"
           rsvp_body: "Connect with other attendees before, during, and after the event."
-      invite_user_notification: "%{username} invited you to: %{description}"
       preferences:
         all_events: "Discourse Events - All events"
         all_events_description: "All forum events"
@@ -335,6 +334,10 @@ en:
         week: "Week"
         day: "Day"
         year: "Year"
+    # Persisted verbatim in notifications.data.message on existing sites, so this key
+    # cannot move with the rest of the namespace without blanking historic notifications.
+    discourse_calendar:
+      invite_user_notification: "%{username} invited you to: %{description}"
     group_timezones:
       search: "Search..."
       group_availability: "%{group} availability"

--- a/plugins/discourse-events/config/locales/server.en.yml
+++ b/plugins/discourse-events/config/locales/server.en.yml
@@ -21,8 +21,8 @@ en:
       event_started:
         title: Event started
   system_messages:
-    discourse_calendar_holiday_region_invalid: "The holiday region you provided does not exist."
-    discourse_calendar_enable_holiday_failed: "This holiday could not be enabled, it's already enabled or it's not disabled."
+    discourse_events_holiday_region_invalid: "The holiday region you provided does not exist."
+    discourse_events_enable_holiday_failed: "This holiday could not be enabled, it's already enabled or it's not disabled."
     discourse_post_event_bulk_invite_succeeded:
       title: "Event - Bulk Invite Succeeded"
       subject_template: "Bulk invite processed successfully"
@@ -81,7 +81,7 @@ en:
     livestream_embeddable_chat_allowed_paths: "Allowed paths for the embeddable livestream chat."
     livestream_enable_modal_chat_on_mobile: "Show livestream chat in a modal on mobile."
 
-  discourse_calendar:
+  discourse_events:
     category_type:
       default_calendar_view:
         label: "Default calendar view"

--- a/plugins/discourse-events/config/settings.yml
+++ b/plugins/discourse-events/config/settings.yml
@@ -1,4 +1,4 @@
-discourse_calendar:
+discourse_events:
   discourse_events_enabled:
     default: false
     client: true

--- a/plugins/discourse-events/jobs/scheduled/delete_expired_event_posts.rb
+++ b/plugins/discourse-events/jobs/scheduled/delete_expired_event_posts.rb
@@ -46,7 +46,7 @@ module Jobs
         PostDestroyer.new(
           Discourse.system_user,
           post,
-          context: I18n.t("discourse_calendar.event_expired"),
+          context: I18n.t("discourse_events.event_expired"),
         ).destroy
       end
 

--- a/plugins/discourse-events/lib/discourse_events/calendar/event_validator.rb
+++ b/plugins/discourse-events/lib/discourse_events/calendar/event_validator.rb
@@ -13,12 +13,12 @@ module DiscourseEvents
         calendar_type = @first_post.custom_fields[DiscourseEvents::CALENDAR_CUSTOM_FIELD]
 
         if @post.whisper? && dates_count > 0
-          @post.errors.add(:base, I18n.t("discourse_calendar.whisper_not_allowed"))
+          @post.errors.add(:base, I18n.t("discourse_events.whisper_not_allowed"))
           return false
         end
 
         if calendar_type == "dynamic" && dates_count > 2
-          @post.errors.add(:base, I18n.t("discourse_calendar.more_than_two_dates"))
+          @post.errors.add(:base, I18n.t("discourse_events.more_than_two_dates"))
           return false
         end
 

--- a/plugins/discourse-events/lib/discourse_events/calendar/validator.rb
+++ b/plugins/discourse-events/lib/discourse_events/calendar/validator.rb
@@ -13,12 +13,12 @@ module DiscourseEvents
         return false if extracted_calendars.count == 0
 
         if extracted_calendars.count > 1
-          @post.errors.add(:base, I18n.t("discourse_calendar.more_than_one_calendar"))
+          @post.errors.add(:base, I18n.t("discourse_events.more_than_one_calendar"))
           return false
         end
 
         if !@post.is_first_post?
-          @post.errors.add(:base, I18n.t("discourse_calendar.calendar_must_be_in_first_post"))
+          @post.errors.add(:base, I18n.t("discourse_events.calendar_must_be_in_first_post"))
           return false
         end
 

--- a/plugins/discourse-events/lib/discourse_events/configuration/upcoming_events_default_view.rb
+++ b/plugins/discourse-events/lib/discourse_events/configuration/upcoming_events_default_view.rb
@@ -11,10 +11,10 @@ module DiscourseEvents
 
       def self.values
         @values ||= [
-          { name: "discourse_calendar.toolbar_button.day", value: "day" },
-          { name: "discourse_calendar.toolbar_button.week", value: "week" },
-          { name: "discourse_calendar.toolbar_button.month", value: "month" },
-          { name: "discourse_calendar.toolbar_button.year", value: "year" },
+          { name: "discourse_events.toolbar_button.day", value: "day" },
+          { name: "discourse_events.toolbar_button.week", value: "week" },
+          { name: "discourse_events.toolbar_button.month", value: "month" },
+          { name: "discourse_events.toolbar_button.year", value: "year" },
         ]
       end
 

--- a/plugins/discourse-events/lib/discourse_events/holidays/status.rb
+++ b/plugins/discourse-events/lib/discourse_events/holidays/status.rb
@@ -8,7 +8,7 @@ module DiscourseEvents
         if status.blank? || status.expired? ||
              (is_holiday_status?(status) && status.ends_at != ends_at)
           user.set_status!(
-            I18n.t("discourse_calendar.holiday_status.description"),
+            I18n.t("discourse_events.holiday_status.description"),
             emoji_name,
             ends_at,
           )
@@ -23,7 +23,7 @@ module DiscourseEvents
 
       def self.is_holiday_status?(status)
         status.emoji == emoji_name &&
-          status.description == I18n.t("discourse_calendar.holiday_status.description")
+          status.description == I18n.t("discourse_events.holiday_status.description")
       end
 
       def self.emoji_name

--- a/plugins/discourse-events/plugin.rb
+++ b/plugins/discourse-events/plugin.rb
@@ -108,7 +108,7 @@ module ::DiscourseEvents
           chat_channel_id: channel.id,
           message:
             I18n.t(
-              "discourse_calendar.livestream.chat.topic_reference_message",
+              "discourse_events.livestream.chat.topic_reference_message",
               title: topic.markdown_link_title,
               url: topic.relative_url,
             ),
@@ -318,7 +318,7 @@ after_initialize do
   register_calendar_subscription_feed(
     name: "all_events",
     scope: DiscourseEvents::EVENTS_CALENDAR_SCOPE,
-    description_key: "discourse_calendar.preferences.all_events_description",
+    description_key: "discourse_events.preferences.all_events_description",
     url: ->(base_url, _user, key) do
       "#{base_url}/discourse-post-event/events.ics?user_api_key=#{key}"
     end,
@@ -327,7 +327,7 @@ after_initialize do
   register_calendar_subscription_feed(
     name: "my_events",
     scope: DiscourseEvents::EVENTS_CALENDAR_SCOPE,
-    description_key: "discourse_calendar.preferences.my_events_description",
+    description_key: "discourse_events.preferences.my_events_description",
     url: ->(base_url, user, key) do
       "#{base_url}/discourse-post-event/events.ics?attending_user=#{user.username_lower}&include_interested=true&user_api_key=#{key}"
     end,

--- a/plugins/discourse-events/spec/integration/post_spec.rb
+++ b/plugins/discourse-events/spec/integration/post_spec.rb
@@ -562,7 +562,7 @@ describe Post do
 
         status = post.user.user_status
         expect(status).to be_present
-        expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+        expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
         expect(status.emoji).to eq(SiteSetting.holiday_status_emoji)
         expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 10, 20))
       end
@@ -612,7 +612,7 @@ describe Post do
 
           status = post.user.user_status
           expect(status).to be_present
-          expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+          expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
           expect(status.emoji).to eq(custom_emoji)
           expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 10, 20))
         end
@@ -630,7 +630,7 @@ describe Post do
 
           status = post.user.user_status
           expect(status).to be_present
-          expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+          expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
           expect(status.emoji).to eq("date")
           expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 10, 20))
         end
@@ -652,7 +652,7 @@ describe Post do
 
         status = post.user.user_status
         expect(status).to be_present
-        expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+        expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
         expect(status.emoji).to eq(SiteSetting.holiday_status_emoji)
         expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 0, 0))
       end
@@ -692,7 +692,7 @@ describe Post do
         # the job has set the holiday status:
         status = post.user.user_status
         expect(status).to be_present
-        expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+        expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
         expect(status.emoji).to eq(SiteSetting.holiday_status_emoji)
         expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 10, 20))
 
@@ -713,7 +713,7 @@ describe Post do
         # the job has set the holiday status:
         status = post.user.user_status
         expect(status).to be_present
-        expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+        expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
         expect(status.emoji).to eq(SiteSetting.holiday_status_emoji)
         expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 10, 20))
 

--- a/plugins/discourse-events/spec/jobs/scheduled/delete_expired_event_posts_spec.rb
+++ b/plugins/discourse-events/spec/jobs/scheduled/delete_expired_event_posts_spec.rb
@@ -40,7 +40,7 @@ describe Jobs::DiscourseCalendar::DeleteExpiredEventPosts do
     expect(DiscourseEvents::Calendar::Event.exists?(post: post_in_the_future)).to eq(true)
 
     expect(UserHistory.find_by(post_id: post_with_one_date.id).context).to eq(
-      I18n.t("discourse_calendar.event_expired"),
+      I18n.t("discourse_events.event_expired"),
     )
   end
 

--- a/plugins/discourse-events/spec/jobs/scheduled/update_holiday_usernames_spec.rb
+++ b/plugins/discourse-events/spec/jobs/scheduled/update_holiday_usernames_spec.rb
@@ -75,7 +75,7 @@ describe Jobs::DiscourseCalendar::UpdateHolidayUsernames do
     post.user.reload
     status = post.user.user_status
     expect(status).to be_present
-    expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+    expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
     expect(status.emoji).to eq(SiteSetting.holiday_status_emoji)
     expect(status.ends_at).to eq_time(Time.utc(2018, 6, 6, 10, 20))
   end
@@ -138,7 +138,7 @@ describe Jobs::DiscourseCalendar::UpdateHolidayUsernames do
     post.user.reload
     status = post.user.user_status
     expect(status).to be_present
-    expect(status.description).to eq(I18n.t("discourse_calendar.holiday_status.description"))
+    expect(status.description).to eq(I18n.t("discourse_events.holiday_status.description"))
     expect(status.emoji).to eq(SiteSetting.holiday_status_emoji)
     expect(status.ends_at).to eq_time(Time.utc(2018, 6, 8, 10, 20))
   end

--- a/plugins/discourse-events/spec/lib/discourse_events/calendar/extractor_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_events/calendar/extractor_spec.rb
@@ -60,20 +60,20 @@ describe DiscourseEvents::Calendar::Extractor do
         topic: calendar_post.topic,
         raw: 'Rome [date="2018-06-05"] → [date="2018-06-08"] [date="2018-06-09"]',
       )
-    }.to raise_error(StandardError, I18n.t("discourse_calendar.more_than_two_dates"))
+    }.to raise_error(StandardError, I18n.t("discourse_events.more_than_two_dates"))
   end
 
   it "raises an error when the calendar is not in first post" do
     expect { create_post(topic: calendar_post.topic, raw: raw) }.to raise_error(
       StandardError,
-      I18n.t("discourse_calendar.calendar_must_be_in_first_post"),
+      I18n.t("discourse_events.calendar_must_be_in_first_post"),
     )
   end
 
   it "raises an error when there are more than 1 calendar" do
     expect { create_post(raw: "#{raw}\n#{raw}") }.to raise_error(
       StandardError,
-      I18n.t("discourse_calendar.more_than_one_calendar"),
+      I18n.t("discourse_events.more_than_one_calendar"),
     )
   end
 

--- a/plugins/discourse-events/spec/requests/admin/holidays_controller_spec.rb
+++ b/plugins/discourse-events/spec/requests/admin/holidays_controller_spec.rb
@@ -40,7 +40,7 @@ module Admin::DiscourseEvents
 
             expect(response.status).to eq(422)
             expect(response.parsed_body["errors"]).to include(
-              I18n.t("system_messages.discourse_calendar_holiday_region_invalid"),
+              I18n.t("system_messages.discourse_events_holiday_region_invalid"),
             )
           end
         end

--- a/plugins/discourse-events/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-events/spec/requests/events_controller_spec.rb
@@ -96,7 +96,7 @@ module DiscourseEvents::Events
         body = response.body
         calendar_name =
           I18n.t(
-            "discourse_calendar.calendar_subscriptions.all_events_feed_name",
+            "discourse_events.calendar_subscriptions.all_events_feed_name",
             site_title: SiteSetting.title,
           )
         expect(body).to include("BEGIN:VCALENDAR")
@@ -387,7 +387,7 @@ module DiscourseEvents::Events
           expect(response.status).to eq(200)
           calendar_name =
             I18n.t(
-              "discourse_calendar.calendar_subscriptions.my_events_feed_name",
+              "discourse_events.calendar_subscriptions.my_events_feed_name",
               site_title: SiteSetting.title,
             )
           expect(response.body).to include("X-WR-CALNAME:#{IcalEncoder.encode(calendar_name)}")

--- a/plugins/discourse-events/spec/system/desktop_topic_livestream_authenticated_spec.rb
+++ b/plugins/discourse-events/spec/system/desktop_topic_livestream_authenticated_spec.rb
@@ -22,7 +22,7 @@ describe "Discourse Livestream - Topic Livestream - Desktop - Authenticated" do
 
       expect(topic_page).to have_css("#custom-chat-container")
       expect(topic_page).to have_css("#custom-chat-container .chat-channel-preview-card")
-      expect(topic_page).to have_text(I18n.t("js.discourse_calendar.livestream.chat.rsvp_to_event"))
+      expect(topic_page).to have_text(I18n.t("js.discourse_events.livestream.chat.rsvp_to_event"))
     end
 
     it "does not create a chat channel for regular topics" do
@@ -30,7 +30,7 @@ describe "Discourse Livestream - Topic Livestream - Desktop - Authenticated" do
 
       expect(topic_page).not_to have_css("#custom-chat-container")
       expect(topic_page).not_to have_text(
-        I18n.t("js.discourse_calendar.livestream.chat.rsvp_to_event"),
+        I18n.t("js.discourse_events.livestream.chat.rsvp_to_event"),
       )
     end
   end

--- a/plugins/discourse-events/spec/system/livestream_zoom_webinar_spec.rb
+++ b/plugins/discourse-events/spec/system/livestream_zoom_webinar_spec.rb
@@ -30,7 +30,7 @@ describe "Discourse Livestream - Livestream with Zoom webinar" do
 
       expect(page).to have_css(
         ".discourse-calendar-livestream-zoom-entry__actions .btn",
-        text: I18n.t("js.discourse_calendar.livestream.zoom.join"),
+        text: I18n.t("js.discourse_events.livestream.zoom.join"),
       )
     end
 
@@ -45,9 +45,9 @@ describe "Discourse Livestream - Livestream with Zoom webinar" do
 
         expect(page).to have_css(
           ".discourse-calendar-livestream-zoom-entry__actions .btn[disabled]",
-          text: I18n.t("js.discourse_calendar.livestream.zoom.join"),
+          text: I18n.t("js.discourse_events.livestream.zoom.join"),
         )
-        expect(page).to have_content(I18n.t("js.discourse_calendar.livestream.zoom.too_early"))
+        expect(page).to have_content(I18n.t("js.discourse_events.livestream.zoom.too_early"))
       end
     end
   end

--- a/plugins/discourse-events/test/javascripts/components/livestream-rsvp-test.gjs
+++ b/plugins/discourse-events/test/javascripts/components/livestream-rsvp-test.gjs
@@ -64,7 +64,7 @@ module("Events | Component | LivestreamRsvp", function (hooks) {
 
     assert
       .dom(".livestream-rsvp__message")
-      .hasText(i18n("discourse_calendar.livestream.chat.rsvp_to_event"));
+      .hasText(i18n("discourse_events.livestream.chat.rsvp_to_event"));
     assert.dom(".livestream-rsvp__message a").doesNotExist();
   });
 


### PR DESCRIPTION
As a follow up to the Calendar -> Events rename this change updates the keys to align with the new namespace.