### PR TITLE
FIX: Remap hashtags everywhere when a category or tag is renamed

### DIFF
--- a/app/jobs/regular/remap_category_hashtag.rb
+++ b/app/jobs/regular/remap_category_hashtag.rb
@@ -6,64 +6,11 @@ module Jobs
     cluster_concurrency 1
 
     def execute(args)
-      return if args[:category_id].blank?
-      category = category_from(args)
-      return if category.blank?
-
-      old_ref = args[:old_ref].presence
-      new_ref = category&.slug_ref.presence || args[:new_ref].presence
-      return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
-
-      posts_matching(old_ref, category.id).find_each { |post| update_post(post, old_ref, new_ref) }
-    end
-
-    private
-
-    def category_from(args)
-      Category.find_by(id: args[:category_id])
-    end
-
-    def posts_matching(old_ref, category_id)
-      posts =
-        Post
-          .joins(:topic)
-          .where("topics.deleted_at IS NULL")
-          .where("posts.raw ~* ?", "(?n)#{raw_hashtag_pattern(old_ref)}")
-
-      # More accurate way to find matching hashtags than looking
-      # at raw since we can have tags/chat channels with the same
-      # hashtag ref
-      if category_id.present?
-        posts =
-          posts.where(
-            "posts.cooked LIKE ? AND posts.cooked LIKE ?",
-            '%data-type="category"%',
-            "%data-id=\"#{category_id}\"%",
-          )
-      end
-
-      posts
-    end
-
-    def update_post(post, old_ref, new_ref)
-      new_raw = post.raw.gsub(raw_hashtag_regex(old_ref), "##{new_ref}")
-      return if new_raw == post.raw
-
-      post.revise(Discourse.system_user, { raw: new_raw }, bypass_bump: true, skip_revision: true)
-    rescue => err
-      Discourse.warn_exception(
-        err,
-        message:
-          "Failed to remap category hashtag #{old_ref} to #{new_ref} for category ID #{category.id} in post ID #{post.id}",
+      Jobs::RemapHashtag.new.execute(
+        remaps: [
+          { type: CategoryHashtagDataSource.type, id: args[:category_id], old_ref: args[:old_ref] },
+        ],
       )
-    end
-
-    def raw_hashtag_pattern(ref)
-      "(?<![:\\w])##{Regexp.escape(ref)}(?![\\w:-])"
-    end
-
-    def raw_hashtag_regex(ref)
-      /(?<![:\w])##{Regexp.escape(ref)}(?![\w:-])/i
     end
   end
 end

--- a/app/jobs/regular/remap_hashtag.rb
+++ b/app/jobs/regular/remap_hashtag.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RemapHashtag < ::Jobs::Base
+    sidekiq_options queue: "low"
+    cluster_concurrency 1
+
+    def execute(args)
+      rewritten = Set.new
+
+      Array(args[:remaps]).each do |remap|
+        remap = remap.symbolize_keys
+
+        counts =
+          HashtagRemapper.remap!(
+            type: remap[:type],
+            id: remap[:id],
+            old_ref: remap[:old_ref],
+            rewritten:,
+          )
+        next if counts.blank?
+
+        Rails.logger.warn("Remapped #{remap[:type]} hashtag ##{remap[:old_ref]}: #{counts.to_json}")
+      rescue => error
+        Discourse.warn_exception(
+          error,
+          message: "Failed to remap #{remap[:type]} hashtag ##{remap[:old_ref]}",
+        )
+      end
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1307,28 +1307,26 @@ class Category < ActiveRecord::Base
         parent_category_id
       end
 
-    enqueue_category_hashtag_remap_job(
-      category_id: id,
-      old_ref:
-        Category.hashtag_ref_from(slug: old_slug, parent_category_id: old_parent_category_id),
-      new_ref: slug_ref,
-    )
+    type = CategoryHashtagDataSource.type
+    remaps = [
+      {
+        type:,
+        id:,
+        old_ref:
+          Category.hashtag_ref_from(slug: old_slug, parent_category_id: old_parent_category_id),
+      },
+    ]
 
     if saved_change_to_slug?
-      subcategories.find_each do |subcategory|
-        enqueue_category_hashtag_remap_job(
-          category_id: subcategory.id,
-          old_ref: [old_slug, subcategory.slug].join(Category::SLUG_REF_SEPARATOR),
-          new_ref: [slug, subcategory.slug].join(Category::SLUG_REF_SEPARATOR),
-        )
-      end
+      remaps +=
+        subcategories
+          .pluck(:id, :slug)
+          .map do |sub_id, sub_slug|
+            { type:, id: sub_id, old_ref: [old_slug, sub_slug].join(Category::SLUG_REF_SEPARATOR) }
+          end
     end
-  end
 
-  def enqueue_category_hashtag_remap_job(category_id:, old_ref:, new_ref:)
-    return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
-
-    DB.after_commit { Jobs.enqueue(:remap_category_hashtag, category_id:, old_ref:, new_ref:) }
+    HashtagRemapper.enqueue(remaps)
   end
 
   def cannot_delete_reason

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -323,11 +323,7 @@ class Post < ActiveRecord::Base
     !add_nofollow?
   end
 
-  def cook(raw, opts = {})
-    # For some posts, for example those imported via RSS, we support raw HTML. In that
-    # case we can skip the rendering pipeline.
-    return raw if cook_method == Post.cook_methods[:raw_html]
-
+  def markdown_options(opts = {})
     options = opts.dup
     options[:cook_method] = cook_method
 
@@ -340,6 +336,15 @@ class Post < ActiveRecord::Base
     options[:user_id] = last_editor_id
     options[:omit_nofollow] = true if omit_nofollow?
     options[:post_id] = id
+    options
+  end
+
+  def cook(raw, opts = {})
+    # For some posts, for example those imported via RSS, we support raw HTML. In that
+    # case we can skip the rendering pipeline.
+    return raw if cook_method == Post.cook_methods[:raw_html]
+
+    options = markdown_options(opts)
 
     if should_secure_uploads?
       each_upload_url do |url|

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -71,6 +71,7 @@ class Tag < ActiveRecord::Base
 
   before_save :cook_description
 
+  after_update :enqueue_tag_hashtag_remap, if: :saved_change_to_name?
   after_save :index_search
   after_save :update_synonym_associations
 
@@ -342,6 +343,13 @@ class Tag < ActiveRecord::Base
 
   def name_validator
     errors.add(:name, :invalid) if name.present? && RESERVED_TAGS.include?(name.strip.downcase)
+  end
+
+  def enqueue_tag_hashtag_remap
+    old_ref = name_before_last_save
+    return if old_ref.blank? || old_ref.casecmp?(name)
+
+    HashtagRemapper.enqueue([{ type: TagHashtagDataSource.type, id:, old_ref: }])
   end
 end
 

--- a/app/services/category_hashtag_data_source.rb
+++ b/app/services/category_hashtag_data_source.rb
@@ -16,6 +16,10 @@ class CategoryHashtagDataSource
     "category"
   end
 
+  def self.ref_for(category_id)
+    Category.find_by(id: category_id)&.slug_ref
+  end
+
   def self.category_to_hashtag_item(category)
     HashtagAutocompleteService::HashtagItem.new.tap do |item|
       item.text =

--- a/app/services/hashtag_autocomplete_service.rb
+++ b/app/services/hashtag_autocomplete_service.rb
@@ -48,6 +48,10 @@ class HashtagAutocompleteService
     enabled_data_sources.find { |ds| ds.type == type }
   end
 
+  def self.ref_for(type, record_id)
+    data_sources.find { |ds| ds.type == type }.try(:ref_for, record_id).presence
+  end
+
   def self.find_priorities_for_context(context)
     contextual_type_priorities.select { |ctp| ctp[:context] == context }
   end

--- a/app/services/hashtag_remapper.rb
+++ b/app/services/hashtag_remapper.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  DEFAULT_CONTEXT = "topic-composer"
+
+  def self.stores
+    [
+      PostStore,
+      PostLocalizationStore,
+      UserProfileStore,
+      GroupStore,
+      TagDescriptionStore,
+      TagLocalizationStore,
+      SiteSettingLocalizationStore,
+      CategoryLocalizationStore,
+    ]
+  end
+
+  def self.enqueue(remaps)
+    usable =
+      remaps.reject do |remap|
+        current = HashtagAutocompleteService.ref_for(remap[:type], remap[:id])
+        current.present? && remap[:old_ref].casecmp?(current)
+      end
+    return if usable.blank?
+
+    DB.after_commit { Jobs.enqueue(:remap_hashtag, remaps: usable) }
+  end
+
+  def self.remap!(type:, id:, old_ref:, rewritten: Set.new)
+    return if type.blank? || id.blank? || !HashtagRewriter.usable_ref?(old_ref)
+
+    new_ref = HashtagAutocompleteService.ref_for(type, id)
+    return if new_ref.blank? || old_ref.casecmp?(new_ref)
+    return if !HashtagRewriter.usable_ref?(new_ref)
+
+    new(type:, record_id: id, old_ref:, new_ref:, rewritten:).remap!
+  end
+
+  def initialize(type:, record_id:, old_ref:, new_ref:, rewritten: Set.new)
+    @type = type
+    @record_id = record_id.to_s
+    @old_ref = old_ref
+    @new_ref = new_ref
+    @old_suffixed = "#{old_ref}::#{type}"
+    @new_suffixed = "#{new_ref}::#{type}"
+    @rewritten = rewritten
+    @bare_new_refs = {}
+  end
+
+  def remap!
+    self
+      .class
+      .stores
+      .to_h { |store| [store.key, remap_store(store)] }
+      .reject { |_, counts| counts.empty? }
+  end
+
+  private
+
+  attr_reader :type, :record_id, :old_ref, :new_ref, :old_suffixed, :new_suffixed, :rewritten
+
+  def remap_store(store)
+    counts = Hash.new(0)
+
+    store
+      .candidates(old_ref)
+      .find_each do |record|
+        counts[:scanned] += 1
+        counts[:rewritten] += 1 if rewrite_record(store, record)
+      rescue => error
+        counts[:failed] += 1
+        Discourse.warn_exception(
+          error,
+          message:
+            "Failed to remap #{type} hashtag ##{old_ref} to ##{new_ref} in #{store.key} #{record.id}",
+        )
+      end
+
+    counts
+  end
+
+  def rewrite_record(store, record)
+    raw = store.raw(record)
+    return false if raw.blank?
+
+    rewrite_bare = bare_ref_belongs_to_record?(store, record)
+
+    new_raw =
+      HashtagRewriter
+        .new(raw, store.cook_options(record))
+        .rewrite do |ref|
+          next new_suffixed if ref.casecmp?(old_suffixed)
+          next bare_new_ref(store) if rewrite_bare && ref.casecmp?(old_ref)
+        end
+
+    return false if new_raw == raw
+
+    store.write!(record, new_raw)
+    rewritten << [store, record.id]
+    true
+  end
+
+  def bare_ref_belongs_to_record?(store, record)
+    claims =
+      PrettyText
+        .extract_hashtags(store.cooked(record))
+        .select { |anchor| anchor[:ref]&.casecmp?(old_ref) }
+
+    return rewritten.include?([store, record.id]) if claims.empty?
+
+    claims.all? { |anchor| points_at_record?(anchor) }
+  end
+
+  def bare_new_ref(store)
+    context = store.hashtag_context || DEFAULT_CONTEXT
+
+    @bare_new_refs[context] ||= begin
+      found =
+        PrettyText::Helpers.hashtag_lookup(
+          new_ref,
+          Discourse.system_user.id,
+          HashtagAutocompleteService.ordered_types_for_context(context),
+        )
+
+      found && points_at_record?(found) ? new_ref : new_suffixed
+    end
+  end
+
+  def points_at_record?(anchor)
+    anchor[:type] == type && anchor[:id].to_s == record_id
+  end
+end

--- a/app/services/hashtag_remapper/category_localization_store.rb
+++ b/app/services/hashtag_remapper/category_localization_store.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class CategoryLocalizationStore < Store
+    def self.key = "category_localization"
+    def self.relation = CategoryLocalization.all
+    def self.raw_column = :description
+  end
+end

--- a/app/services/hashtag_remapper/group_store.rb
+++ b/app/services/hashtag_remapper/group_store.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class GroupStore < Store
+    def self.key = "group"
+    def self.relation = Group.all
+    def self.raw_column = :bio_raw
+    def self.cooked(group) = group.bio_cooked
+  end
+end

--- a/app/services/hashtag_remapper/post_localization_store.rb
+++ b/app/services/hashtag_remapper/post_localization_store.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class PostLocalizationStore < Store
+    def self.key = "post_localization"
+    def self.relation = PostLocalization.all
+    def self.raw_column = :raw
+    def self.cooked(localization) = localization.cooked
+
+    def self.write!(localization, raw)
+      localization.raw = raw
+      localization.cooked = PrettyText.cook(raw)
+      localization.save!(validate: false)
+      Jobs.enqueue(:process_localized_cooked, post_localization_id: localization.id)
+    end
+  end
+end

--- a/app/services/hashtag_remapper/post_store.rb
+++ b/app/services/hashtag_remapper/post_store.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class PostStore < Store
+    def self.key = "post"
+    def self.raw_column = :raw
+    def self.cooked(post) = post.cooked
+    def self.cook_options(post) = post.markdown_options
+
+    def self.relation
+      Post
+        .where.not(cook_method: Post.cook_methods[:raw_html])
+        .joins(:topic)
+        .where(topics: { deleted_at: nil })
+    end
+
+    def self.write!(post, raw)
+      super
+      post.sync_first_post_caches
+      post.trigger_post_process(
+        bypass_bump: true,
+        priority: :ultra_low,
+        skip_pull_hotlinked_images: true,
+      )
+    end
+  end
+end

--- a/app/services/hashtag_remapper/site_setting_localization_store.rb
+++ b/app/services/hashtag_remapper/site_setting_localization_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class SiteSettingLocalizationStore < Store
+    def self.key = "site_setting_localization"
+    def self.relation = SiteSettingLocalization.where.not(cooked: nil)
+    def self.raw_column = :value
+    def self.cooked(localization) = localization.cooked
+
+    def self.write!(localization, raw)
+      localization.value = raw
+      localization.save!
+    end
+  end
+end

--- a/app/services/hashtag_remapper/store.rb
+++ b/app/services/hashtag_remapper/store.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class Store
+    def self.key = raise(NotImplementedError)
+    def self.relation = raise(NotImplementedError)
+    def self.raw_column = raise(NotImplementedError)
+    def self.cooked(record) = nil
+    def self.cook_options(record) = {}
+    def self.hashtag_context = nil
+    def self.raw(record) = record.public_send(raw_column)
+
+    def self.write!(record, raw)
+      record.public_send(:"#{raw_column}=", raw)
+      record.save!(validate: false)
+    end
+
+    def self.candidates(old_ref)
+      column = "#{relation.table_name}.#{raw_column}"
+
+      relation.where(
+        "#{column} ILIKE ?",
+        "%##{ActiveRecord::Base.sanitize_sql_like(old_ref)}%",
+      ).where("#{column} ~* ?", HashtagRewriter.sql_pattern(old_ref))
+    end
+  end
+end

--- a/app/services/hashtag_remapper/tag_description_store.rb
+++ b/app/services/hashtag_remapper/tag_description_store.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class TagDescriptionStore < Store
+    def self.key = "tag_description"
+    def self.relation = Tag.all
+    def self.raw_column = :description
+    def self.cooked(tag) = tag.description_cooked
+    def self.cook_options(tag) = HasCookedTagDescription::COOK_OPTIONS
+  end
+end

--- a/app/services/hashtag_remapper/tag_localization_store.rb
+++ b/app/services/hashtag_remapper/tag_localization_store.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class TagLocalizationStore < Store
+    def self.key = "tag_localization"
+    def self.relation = TagLocalization.all
+    def self.raw_column = :description
+    def self.cooked(localization) = localization.description_cooked
+    def self.cook_options(localization) = HasCookedTagDescription::COOK_OPTIONS
+  end
+end

--- a/app/services/hashtag_remapper/user_profile_store.rb
+++ b/app/services/hashtag_remapper/user_profile_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class UserProfileStore < Store
+    def self.key = "user_profile"
+    def self.relation = UserProfile.all
+    def self.raw_column = :bio_raw
+    def self.cooked(profile) = profile.bio_cooked
+
+    def self.write!(profile, raw)
+      profile.skip_pull_hotlinked_image = true
+      super
+    end
+  end
+end

--- a/app/services/tag_hashtag_data_source.rb
+++ b/app/services/tag_hashtag_data_source.rb
@@ -20,6 +20,10 @@ class TagHashtagDataSource
     "icon"
   end
 
+  def self.ref_for(tag_id)
+    Tag.where(id: tag_id).pick(:name)
+  end
+
   def self.tag_to_hashtag_item(tag, guardian)
     topic_count_column = Tag.topic_count_column(guardian)
 

--- a/lib/hashtag_rewriter.rb
+++ b/lib/hashtag_rewriter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class HashtagRewriter
+  LEADING_BOUNDARY = "(?<![^[:space:][:punct:]])(?<!/)"
+  TRAILING_BOUNDARY = "(?![^[:space:][:punct:]])"
+  REF = "[À-῿Ⰰ-퟿\\w:-](?:[À-῿Ⰰ-퟿\\w:.-]{0,99}[À-῿Ⰰ-퟿\\w:-])?"
+  HASHTAG = Regexp.new("#{LEADING_BOUNDARY}#(#{REF})#{TRAILING_BOUNDARY}")
+
+  def self.sql_pattern(ref)
+    "#{LEADING_BOUNDARY}##{Regexp.escape(ref)}#{TRAILING_BOUNDARY}"
+  end
+
+  def self.usable_ref?(ref)
+    return false if ref.blank?
+
+    match = HASHTAG.match(" ##{ref} ")
+    match.present? && match[1] == ref
+  end
+
+  def initialize(raw, cook_options = {})
+    @raw = raw.to_s
+    @cook_options = cook_options
+  end
+
+  def rewrite(&block)
+    wanted = {}
+
+    probed =
+      each_hashtag do |index, ref|
+        replacement = block.call(ref)
+        next "##{unresolvable_prefix}" if replacement.blank?
+
+        wanted[index] = replacement
+        "##{unresolvable_ref(index)}"
+      end
+
+    return @raw if wanted.empty?
+
+    live = cooked_as_hashtag(probed, wanted)
+    return @raw if live.empty?
+
+    each_hashtag { |index, _| "##{live[index]}" if live.key?(index) }
+  end
+
+  private
+
+  def each_hashtag
+    index = -1
+
+    @raw.gsub(HASHTAG) { |match| yield(index += 1, Regexp.last_match(1)) || match }
+  end
+
+  def cooked_as_hashtag(probed, wanted)
+    cooked = PrettyText.markdown(probed, @cook_options.dup)
+
+    wanted.select do |index, _|
+      cooked.include?(%{<span class="hashtag-raw">##{unresolvable_ref(index)}</span>})
+    end
+  end
+
+  def unresolvable_ref(index)
+    "#{unresolvable_prefix}#{index}z"
+  end
+
+  def unresolvable_prefix
+    @unresolvable_prefix ||=
+      loop do
+        prefix = "z#{SecureRandom.hex(6)}z"
+        break prefix if @raw.exclude?(prefix)
+      end
+  end
+end

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -462,6 +462,21 @@ module PrettyText
       end
   end
 
+  def self.extract_hashtags(html)
+    return [] if html.blank?
+
+    Nokogiri::HTML5
+      .fragment(html)
+      .css("a.hashtag-cooked")
+      .map do |anchor|
+        {
+          type: anchor["data-type"],
+          id: anchor["data-id"],
+          ref: anchor["data-ref"] || anchor["data-slug"],
+        }
+      end
+  end
+
   def self.extract_mentions(cooked)
     mentions =
       cooked

--- a/lib/tasks/hashtags.rake
+++ b/lib/tasks/hashtags.rake
@@ -13,3 +13,16 @@ task "hashtags:mark_old_format_for_rebake" => :environment do
   posts_to_rebake.update_all(baked_version: 0)
   puts "Done, rebakes will happen when periodical updates job runs."
 end
+
+desc "Rewrite #old_ref to a record's current hashtag reference everywhere it was cooked"
+task "hashtags:remap", %i[type id old_ref] => :environment do |_task, args|
+  type, id, old_ref = args[:type], args[:id], args[:old_ref]
+
+  abort "Usage: rake 'hashtags:remap[tag,123,old-name]'" if [type, id, old_ref].any?(&:blank?)
+
+  counts = HashtagRemapper.remap!(type:, id:, old_ref:)
+
+  abort "Nothing to remap for #{type} #{id}" if counts.blank?
+
+  counts.each { |store, count| puts "  #{store}: #{count.inspect}" }
+end

--- a/spec/jobs/remap_category_hashtag_spec.rb
+++ b/spec/jobs/remap_category_hashtag_spec.rb
@@ -1,70 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::RemapCategoryHashtag do
-  it "rewrites category hashtag refs and rebakes posts" do
-    parent_category = Fabricate(:category, slug: "support")
-    category = Fabricate(:category, slug: "bucks", parent_category: parent_category)
-    post = create_post(raw: "See #support:bucks for details.")
+  it "remaps inline so in-flight jobs still work after a deploy" do
+    category = Fabricate(:category, slug: "support")
+    post = create_post(raw: "See #support for details.")
 
-    parent_category.update!(slug: "help")
+    category.update!(slug: "help")
+    described_class.new.execute(category_id: category.id, old_ref: "support", new_ref: "help")
 
-    described_class.new.execute(
-      category_id: category.id,
-      old_ref: "support:bucks",
-      new_ref: "help:bucks",
-    )
-
-    post.reload
-    category.reload
-
-    expect(post.raw).to eq("See #help:bucks for details.")
-    expect(post.cooked).to include(category.url)
+    expect(post.reload.raw).to eq("See #help for details.")
   end
 
-  it "rewrites only standalone matching hashtag refs" do
-    category = Fabricate(:category, slug: "bug")
-    post = create_post(raw: "#bug #bug-more #bug:suffix #bug::tag #other:bug #bug.")
+  it "does nothing when the category is gone" do
+    post = create_post(raw: "See #support for details.")
 
-    category.update!(slug: "issue")
+    described_class.new.execute(category_id: -1, old_ref: "support", new_ref: "help")
 
-    described_class.new.execute(category_id: category.id, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("#issue #bug-more #bug:suffix #bug::tag #other:bug #issue.")
-  end
-
-  it "skips raw matches that were cooked for a different category" do
-    category = Fabricate(:category, slug: "bug")
-    other_category = Fabricate(:category, slug: "other")
-    post = create_post(raw: "See #bug")
-
-    category.update!(slug: "issue")
-
-    described_class.new.execute(category_id: other_category.id, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("See #bug")
-  end
-
-  it "skips raw matches when the category no longer exists" do
-    category = Fabricate(:category, slug: "bug")
-    post = create_post(raw: "See #bug")
-    category_id = category.id
-
-    category.destroy!
-
-    described_class.new.execute(category_id:, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("See #bug")
-  end
-
-  it "uses the current category ref as the replacement target" do
-    category = Fabricate(:category, slug: "bug")
-    post = create_post(raw: "See #bug")
-
-    category.update!(slug: "issue")
-    category.update!(slug: "defect")
-
-    described_class.new.execute(category_id: category.id, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("See #defect")
+    expect(post.reload.raw).to eq("See #support for details.")
   end
 end

--- a/spec/jobs/remap_hashtag_spec.rb
+++ b/spec/jobs/remap_hashtag_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::RemapHashtag do
+  def run(remaps)
+    described_class.new.execute(remaps:)
+  end
+
+  def tag_remap(tag, old_ref)
+    { "type" => "tag", "id" => tag.id, "old_ref" => old_ref }
+  end
+
+  it "remaps a renamed tag" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+
+    tag.update!(name: "help")
+    run([tag_remap(tag, "support")])
+
+    expect(post.reload.raw).to eq("See #help for details.")
+  end
+
+  it "remaps a renamed category, including its subcategories" do
+    parent = Fabricate(:category, slug: "support")
+    child = Fabricate(:category, slug: "bucks", parent_category: parent)
+    post = create_post(raw: "See #support and #support:bucks.")
+
+    parent.update!(slug: "help")
+    run(
+      [
+        { "type" => "category", "id" => parent.id, "old_ref" => "support" },
+        { "type" => "category", "id" => child.id, "old_ref" => "support:bucks" },
+      ],
+    )
+
+    expect(post.reload.raw).to eq("See #help and #help:bucks.")
+  end
+
+  it "uses the record's current reference, not the one it was enqueued with" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+
+    tag.update!(name: "help")
+    tag.update!(name: "assistance")
+    run([tag_remap(tag, "support")])
+
+    expect(post.reload.raw).to eq("See #assistance for details.")
+  end
+
+  it "does nothing when the record no longer exists" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+    remap = tag_remap(tag, "support")
+
+    tag.destroy!
+    run([remap])
+
+    expect(post.reload.raw).to eq("See #support for details.")
+  end
+
+  it "does nothing when only the casing changed" do
+    SiteSetting.force_lowercase_tags = false
+    tag = Fabricate(:tag, name: "Support")
+    post = create_post(raw: "See #Support for details.")
+
+    tag.update!(name: "support")
+    run([tag_remap(tag, "Support")])
+
+    expect(post.reload.raw).to eq("See #Support for details.")
+  end
+
+  it "refuses to write a reference the matcher cannot read back" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+
+    tag.update_columns(name: "not a ref")
+    run([tag_remap(tag, "support")])
+
+    expect(post.reload.raw).to eq("See #support for details.")
+  end
+
+  it "ignores malformed entries" do
+    expect { run([{ "type" => "tag" }, { "id" => 1 }, {}]) }.not_to raise_error
+  end
+end

--- a/spec/lib/hashtag_rewriter_spec.rb
+++ b/spec/lib/hashtag_rewriter_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+RSpec.describe HashtagRewriter do
+  def rewrite(raw, from: "alpha", to: "beta", cook_options: {})
+    described_class.new(raw, cook_options).rewrite { |ref| to if ref.casecmp?(from) }
+  end
+
+  it "rewrites a plain reference" do
+    expect(rewrite("See #alpha here.")).to eq("See #beta here.")
+  end
+
+  it "leaves references the markdown pipeline would not cook" do
+    protected_raws = {
+      "fenced code" => "Live #alpha\n\n```\nfenced #alpha\n```",
+      "fenced code with a language" => "Live #alpha\n\n```ruby\nfenced #alpha\n```",
+      "tilde fence" => "Live #alpha\n\n~~~\nfenced #alpha\n~~~",
+      "unclosed fence" => "Live #alpha\n\n```\nfenced #alpha",
+      "inline code" => "Live #alpha and `inline #alpha`",
+      "double backtick span" => "Live #alpha and ``inline #alpha``",
+      "indented code" => "Live #alpha\n\n    indented #alpha",
+      "code bbcode" => "Live #alpha and [code]bbcode #alpha[/code]",
+      "link text" => "Live #alpha and [#alpha](https://example.com/)",
+      "link destination" => "Live #alpha and [x](https://example.com/#alpha)",
+      "autolink" => "Live #alpha and <https://example.com/#alpha>",
+      "linkified url fragment" => "Live #alpha and https://example.com/?tab=#alpha",
+      "image alt" => "Live #alpha and ![#alpha](https://example.com/a.png)",
+      "html attribute" => %{Live #alpha and <div data-x="#alpha">x</div>},
+    }
+
+    protected_raws.each do |name, raw|
+      expect(rewrite(raw)).to eq(raw.sub("Live #alpha", "Live #beta")),
+      "expected #{name} to be left alone"
+    end
+  end
+
+  it "rewrites references the markdown pipeline does cook" do
+    live_raws = {
+      "blockquote" => "> quoted #alpha",
+      "quote bbcode" => "[quote]quoted #alpha[/quote]",
+      "heading" => "## heading #alpha",
+      "list item" => "- item #alpha",
+      "table cell" => "| a |\n| --- |\n| #alpha |",
+      "bold" => "**bold #alpha**",
+      "details" => "[details=x]inner #alpha[/details]",
+      "unclosed backtick" => "unclosed `#alpha",
+    }
+
+    live_raws.each do |name, raw|
+      expect(rewrite(raw)).to eq(raw.sub("#alpha", "#beta")), "expected #{name} to be rewritten"
+    end
+  end
+
+  it "matches whole references, so a longer reference is untouched" do
+    expect(rewrite("I use #alpha.js daily and #alpha rarely.")).to eq(
+      "I use #alpha.js daily and #beta rarely.",
+    )
+  end
+
+  it "does not read a non-ascii neighbour as part of an ascii reference" do
+    expect(rewrite("One #alpha and two #alphaé here.", from: "alpha")).to eq(
+      "One #beta and two #alphaé here.",
+    )
+  end
+
+  it "matches case-insensitively when the caller asks it to" do
+    expect(rewrite("See #ALPHA here.")).to eq("See #beta here.")
+  end
+
+  it "handles a raw with every context at once" do
+    raw = <<~MD
+      Live #alpha here.
+
+      ```
+      fence #alpha
+      ```
+
+      Inline `#alpha` span.
+
+      [#alpha](https://example.com/) and https://example.com/?tab=#alpha
+
+          indented #alpha
+
+      <div data-x="#alpha">html</div>
+
+      > quoted #alpha is live
+    MD
+
+    result = rewrite(raw)
+
+    expect(result.scan("#beta").size).to eq(2)
+    expect(result).to include("Live #beta here.", "> quoted #beta is live")
+    expect(result).to include("fence #alpha", "`#alpha`", "?tab=#alpha", "    indented #alpha")
+  end
+
+  it "respects the cook options it is given" do
+    raw = "and `inline #alpha` here"
+
+    expect(rewrite(raw)).to eq(raw)
+    expect(rewrite(raw, cook_options: { markdown_it_rules: %w[table] })).to eq(
+      "and `inline #beta` here",
+    )
+  end
+
+  it "leaves everything alone when the block never asks for a replacement" do
+    raw = "See #alpha and #gamma here."
+
+    expect(described_class.new(raw).rewrite { nil }).to eq(raw)
+  end
+
+  describe "parity with the markdown pipeline" do
+    it "ports the matcher the cooker uses" do
+      js = File.read("frontend/discourse-markdown-it/src/features/hashtag-autocomplete.js")
+      matcher = js[%r{matcher:\s*(/.+/),?\n}, 1]
+
+      expect(matcher).to be_present
+
+      ported =
+        matcher[1..-2]
+          .gsub(/\\u([0-9A-Fa-f]{4})/) { [Regexp.last_match(1).hex].pack("U") }
+          .gsub("\\/", "/")
+
+      expect(described_class::REF).to eq(ported[/#\((.+)\)\z/, 1])
+    end
+
+    it "agrees with the cooker about which references become hashtags" do
+      Fabricate(:tag, name: "alpha")
+
+      corpus = [
+        "plain #alpha",
+        "#alpha.js and #alpha",
+        "a#alpha and #alpha",
+        "/#alpha and #alpha",
+        "x:#alpha",
+        "##alpha",
+        "(#alpha)",
+        "#alpha, #alpha and #alpha",
+      ]
+
+      corpus.each do |raw|
+        cooked = PrettyText.cook(raw)
+        anchors = cooked.scan(/class="hashtag-cooked"/).size
+        matched = raw.scan(described_class::HASHTAG).flatten.count { |ref| ref == "alpha" }
+
+        expect(matched).to eq(anchors), "mismatch for #{raw.inspect}"
+      end
+    end
+  end
+
+  describe ".usable_ref?" do
+    it "accepts references the matcher can read back" do
+      expect(described_class.usable_ref?("node.js")).to eq(true)
+      expect(described_class.usable_ref?("café")).to eq(true)
+      expect(described_class.usable_ref?("support:bucks")).to eq(true)
+    end
+
+    it "rejects references that would not survive a round trip" do
+      expect(described_class.usable_ref?("")).to eq(false)
+      expect(described_class.usable_ref?(nil)).to eq(false)
+      expect(described_class.usable_ref?("has space")).to eq(false)
+      expect(described_class.usable_ref?("trailing.")).to eq(false)
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1725,11 +1725,9 @@ RSpec.describe Category do
       category = Fabricate(:category, slug: "support")
 
       expect_enqueued_with(
-        job: :remap_category_hashtag,
+        job: :remap_hashtag,
         args: {
-          category_id: category.id,
-          old_ref: "support",
-          new_ref: "help",
+          remaps: [{ type: "category", id: category.id, old_ref: "support" }],
         },
       ) { category.update!(slug: "help") }
     end
@@ -1739,25 +1737,24 @@ RSpec.describe Category do
       parent_category = Fabricate(:category, slug: "support")
 
       expect_enqueued_with(
-        job: :remap_category_hashtag,
+        job: :remap_hashtag,
         args: {
-          category_id: category.id,
-          old_ref: "bucks",
-          new_ref: "support:bucks",
+          remaps: [{ type: "category", id: category.id, old_ref: "bucks" }],
         },
       ) { category.update!(parent_category: parent_category) }
     end
 
-    it "enqueues child remap jobs when the slug changes" do
+    it "enqueues subcategories in the same job when the slug changes" do
       parent_category = Fabricate(:category, slug: "support")
       category = Fabricate(:category, slug: "bucks", parent_category: parent_category)
 
       expect_enqueued_with(
-        job: :remap_category_hashtag,
+        job: :remap_hashtag,
         args: {
-          category_id: category.id,
-          old_ref: "support:bucks",
-          new_ref: "help:bucks",
+          remaps: [
+            { type: "category", id: parent_category.id, old_ref: "support" },
+            { type: "category", id: category.id, old_ref: "support:bucks" },
+          ],
         },
       ) { parent_category.update!(slug: "help") }
     end
@@ -1765,7 +1762,7 @@ RSpec.describe Category do
     it "does not enqueue a remap job for unrelated changes" do
       category = Fabricate(:category, slug: "support")
 
-      expect_not_enqueued_with(job: :remap_category_hashtag) { category.update!(color: "ABCDEF") }
+      expect_not_enqueued_with(job: :remap_hashtag) { category.update!(color: "ABCDEF") }
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -775,4 +775,30 @@ RSpec.describe Tag do
       end
     end
   end
+
+  describe "tag hashtag remapping" do
+    it "enqueues a remap job when the name changes" do
+      tag = Fabricate(:tag, name: "support")
+
+      expect_enqueued_with(
+        job: :remap_hashtag,
+        args: {
+          remaps: [{ type: "tag", id: tag.id, old_ref: "support" }],
+        },
+      ) { tag.update!(name: "help") }
+    end
+
+    it "does not enqueue a remap job when only the casing changes" do
+      SiteSetting.force_lowercase_tags = false
+      tag = Fabricate(:tag, name: "Support")
+
+      expect_not_enqueued_with(job: :remap_hashtag) { tag.update!(name: "support") }
+    end
+
+    it "does not enqueue a remap job for unrelated changes" do
+      tag = Fabricate(:tag, name: "support")
+
+      expect_not_enqueued_with(job: :remap_hashtag) { tag.update!(description: "a description") }
+    end
+  end
 end

--- a/spec/services/hashtag_remapper_spec.rb
+++ b/spec/services/hashtag_remapper_spec.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+RSpec.describe HashtagRemapper do
+  def remap(type:, record:, old_ref:, new_ref:, rewritten: Set.new)
+    described_class.new(type:, record_id: record.id, old_ref:, new_ref:, rewritten:).remap!
+  end
+
+  def remap_tag(tag, old_ref, rewritten: Set.new)
+    remap(type: "tag", record: tag, old_ref:, new_ref: tag.name, rewritten:)
+  end
+
+  describe "posts" do
+    it "rewrites a bare reference and re-cooks" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("See #help for details.")
+      expect(post.cooked).to include(%{data-type="tag"}, %{data-id="#{tag.id}"})
+    end
+
+    it "rewrites the type-suffixed form and keeps the suffix" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support::tag for details.")
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("See #help::tag for details.")
+    end
+
+    it "leaves a longer reference belonging to another tag" do
+      Fabricate(:tag, name: "node.js")
+      tag = Fabricate(:tag, name: "node")
+      post = create_post(raw: "I use #node.js daily and #node rarely.")
+
+      tag.update!(name: "nodejs")
+      remap_tag(tag, "node")
+
+      expect(post.reload.raw).to eq("I use #node.js daily and #nodejs rarely.")
+    end
+
+    it "leaves a non-ascii neighbour alone" do
+      Fabricate(:tag, name: "café")
+      tag = Fabricate(:tag, name: "caf")
+      post = create_post(raw: "One #caf and two #café here.")
+
+      tag.update!(name: "coffee")
+      remap_tag(tag, "caf")
+
+      expect(post.reload.raw).to eq("One #coffee and two #café here.")
+    end
+
+    it "leaves references the markdown pipeline does not cook" do
+      tag = Fabricate(:tag, name: "support")
+      raw = <<~MD
+        Live #support here.
+
+        ```
+        fence #support
+        ```
+
+        Inline `#support` and https://example.com/?tab=#support
+      MD
+      post = create_post(raw:)
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq(raw.sub("Live #support", "Live #help").rstrip)
+    end
+
+    it "only rewrites the suffixed form when a category owns the bare reference" do
+      Fabricate(:category, slug: "clash")
+      tag = Fabricate(:tag, name: "clash")
+      post = create_post(raw: "Bare #clash and explicit #clash::tag.")
+
+      expect(post.cooked).to include(%{data-type="category"})
+
+      tag.update!(name: "clash-tag")
+      remap_tag(tag, "clash")
+
+      expect(post.reload.raw).to eq("Bare #clash and explicit #clash-tag::tag.")
+    end
+
+    it "rewrites the bare reference when this post cooked it as the tag" do
+      category = Fabricate(:category, slug: "secret")
+      category.update!(read_restricted: true)
+      tag = Fabricate(:tag, name: "secret")
+      post = create_post(raw: "Bare #secret here.")
+
+      expect(post.cooked).to include(%{data-type="tag"})
+
+      tag.update!(name: "secret-tag")
+      remap_tag(tag, "secret")
+
+      expect(post.reload.raw).to eq("Bare #secret-tag here.")
+    end
+
+    it "uses the suffixed form when the new reference would resolve elsewhere" do
+      Fabricate(:category, slug: "help", name: "Help")
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support here.")
+
+      expect(post.cooked).to include(%{data-type="tag"})
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      post.reload
+      expect(post.raw).to eq("See #help::tag here.")
+      expect(post.cooked).to include(%{data-type="tag"}, %{data-id="#{tag.id}"})
+    end
+
+    it "remaps a synonym by its own name" do
+      target = Fabricate(:tag, name: "main")
+      synonym = Fabricate(:tag, name: "syn", target_tag: target)
+      post = create_post(raw: "See #syn and #main.")
+
+      synonym.update!(name: "synonym")
+      remap_tag(synonym, "syn")
+
+      expect(post.reload.raw).to eq("See #synonym and #main.")
+    end
+
+    it "does not revise, bump or reattribute the post" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+      editor = post.last_editor_id
+      bumped = post.topic.bumped_at
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      post.reload
+      expect(post.raw).to eq("See #help for details.")
+      expect(post.version).to eq(1)
+      expect(post.last_editor_id).to eq(editor)
+      expect(PostRevision.where(post_id: post.id).count).to eq(0)
+      expect(post.topic.reload.bumped_at).to eq_time(bumped)
+    end
+
+    it "rewrites a post that no longer passes validation" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+
+      tag.update!(name: "help")
+      SiteSetting.max_post_length = 5
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("See #help for details.")
+    end
+
+    it "re-runs post processing so the cooked keeps its lightboxes and oneboxes" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+
+      tag.update!(name: "help")
+
+      expect_enqueued_with(job: :process_post, args: { post_id: post.id }) do
+        remap_tag(tag, "support")
+      end
+    end
+
+    it "keeps going when one record fails" do
+      tag = Fabricate(:tag, name: "support")
+      first = create_post(raw: "First #support here.")
+      second = create_post(raw: "Second #support here.")
+
+      tag.update!(name: "help")
+      Post.any_instance.stubs(:save!).raises(StandardError.new("boom")).then.returns(true)
+      Discourse.expects(:warn_exception).once
+
+      counts = remap_tag(tag, "support")
+
+      expect(counts["post"][:scanned]).to eq(2)
+      expect(counts["post"][:failed]).to eq(1)
+    end
+  end
+
+  describe "references that never belonged to this record" do
+    it "leaves prose alone even after the content is rebaked" do
+      post = nil
+      freeze_time(2.days.ago) { post = create_post(raw: "Ticket #support was closed.") }
+
+      expect(post.cooked).not_to include("hashtag-cooked")
+
+      tag = Fabricate(:tag, name: "support")
+      tag.update!(name: "help")
+      post.rebake!
+
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("Ticket #support was closed.")
+    end
+
+    it "leaves content authored after the rename alone" do
+      tag = Fabricate(:tag, name: "support")
+      tag.update!(name: "help")
+
+      post = create_post(raw: "Ticket #support was closed.")
+
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("Ticket #support was closed.")
+    end
+
+    it "still rewrites a reference this run orphaned itself" do
+      parent = Fabricate(:category, slug: "support")
+      child = Fabricate(:category, slug: "bucks", parent_category: parent)
+      post = create_post(raw: "See #support and #support:bucks.")
+
+      parent.update!(slug: "help")
+      rewritten = Set.new
+
+      remap(type: "category", record: parent, old_ref: "support", new_ref: "help", rewritten:)
+      remap(
+        type: "category",
+        record: child,
+        old_ref: "support:bucks",
+        new_ref: "help:bucks",
+        rewritten:,
+      )
+
+      expect(post.reload.raw).to eq("See #help and #help:bucks.")
+    end
+  end
+
+  describe "the other content stores" do
+    fab!(:tag) { Fabricate(:tag, name: "support") }
+
+    def rename_and_remap
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+    end
+
+    it "rewrites a user bio" do
+      profile = Fabricate(:user).user_profile
+      profile.update!(bio_raw: "I follow #support closely.")
+
+      rename_and_remap
+
+      profile.reload
+      expect(profile.bio_raw).to eq("I follow #help closely.")
+      expect(profile.bio_cooked).to include(%{data-id="#{tag.id}"})
+    end
+
+    it "rewrites a group bio" do
+      group = Fabricate(:group, bio_raw: "We own #support.")
+
+      rename_and_remap
+
+      expect(group.reload.bio_raw).to eq("We own #help.")
+    end
+
+    it "rewrites a tag description" do
+      other = Fabricate(:tag, name: "other", description: "See also #support.")
+
+      rename_and_remap
+
+      other.reload
+      expect(other.description).to eq("See also #help.")
+      expect(other.description_cooked).to include(%{data-id="#{tag.id}"})
+    end
+
+    it "rewrites a post localization" do
+      post = create_post(raw: "See #support.")
+      localization =
+        Fabricate(
+          :post_localization,
+          post:,
+          locale: "fr",
+          raw: "Voir #support.",
+          cooked: PrettyText.cook("Voir #support."),
+        )
+
+      expect_enqueued_with(
+        job: :process_localized_cooked,
+        args: {
+          post_localization_id: localization.id,
+        },
+      ) { rename_and_remap }
+
+      localization.reload
+      expect(localization.raw).to eq("Voir #help.")
+      expect(localization.cooked).to include(%{data-id="#{tag.id}"})
+    end
+
+    it "rewrites a tag localization description" do
+      other = Fabricate(:tag, name: "other")
+      localization =
+        Fabricate(:tag_localization, tag: other, locale: "fr", description: "Voir #support.")
+
+      rename_and_remap
+
+      expect(localization.reload.description).to eq("Voir #help.")
+    end
+
+    it "rewrites only the suffixed form in a store that does not keep cooked" do
+      category = Fabricate(:category)
+      localization =
+        Fabricate(
+          :category_localization,
+          category:,
+          locale: "fr",
+          description: "Voir #support et #support::tag.",
+        )
+
+      rename_and_remap
+
+      expect(localization.reload.description).to eq("Voir #support et #help::tag.")
+    end
+  end
+end


### PR DESCRIPTION
Renaming a tag left every `#old_name` in post bodies pointing at nothing, and the category equivalent had four defects. This rebuilds both on one mechanism.

The breakage is delayed, which is why it is easy to miss: the stored cooked keeps working because its `href` carries the record id, so nothing looks wrong until the content is rebaked, and then the reference degrades to plain text.

### Only rewrite what is actually a hashtag

A `#ref` inside a code fence, a code span, link text, an image, raw HTML or a linkified URL is not a hashtag. Rather than reimplement markdown-it's grammar in Ruby, `HashtagRewriter` asks the engine: splice a reference that cannot resolve over each candidate, cook once, and keep the positions that came back as a hashtag. Verified exact against a corpus.

There is deliberately no "does this raw look like it contains code" shortcut — `example.com/?tab=#ref` is protected and contains no code delimiter, so nothing short of cooking can tell.

Capturing the whole reference is also what keeps `#node.js` from being read as `#node`, and `#café` from being read as `#caf`. Both were live corruption paths in the old category job, since Ruby's `\w` is ASCII-only while Postgres' is not, so its SELECT and its gsub disagreed.

### Only rewrite references that belong to this record

References collide across types and resolve with the author's permissions. A category outranks a tag with the same reference, and the same raw cooks to a private category for a member and to a public tag for an outsider. So "a record with this reference exists" is not a sound test — the content's own cooked output is. The `#ref::type` form is unambiguous and always rewritten.

The reverse case matters too: renaming tag `support` to `help` when a category `help` exists would silently retarget the post to the category, so the job writes `#help::tag` when the bare form would no longer resolve to the renamed record.

### Defects closed in `Jobs::RemapCategoryHashtag`

- the rescue in `update_post` interpolated a local variable not in scope there, so it raised `NameError` while building its own log message and one bad post aborted the whole run
- the `\w` mismatch above
- `#ref::category` was never remapped
- the two `cooked LIKE` tests could be satisfied by two different anchors, and category ids collide with tag ids, so a post could be rewritten for a record it never referenced

It is kept as a delegator so jobs already in Sidekiq at deploy time keep working.

### Scope

Posts, post localizations, user and group bios, tag descriptions, tag and category localizations, cooked site setting localizations. Writes bypass `PostRevisor` — a rename is not an edit, so no revision, no bump, no reattribution, and no notification. This also fixes a silent skip: `post.revise` returns `false` when a post no longer validates, stranding it on a dead reference with nothing logged.

Chat channels are the third hashtag type and are handled in the PR stacked on this one.

### Notes for review

- `spec/lib/hashtag_rewriter_spec.rb` parses the matcher out of `hashtag-autocomplete.js` and asserts the Ruby port still matches, so the two cannot drift silently.
- Downstream post processing runs at `ultra_low` and skips the hotlinked image refetch — a hashtag rewrite cannot change an image.
- `rake 'hashtags:remap[tag,123,old-name]'` re-runs a remap by hand.