### PR TITLE
DEV: Add a hashtag content store registry and a shared remap job

### DIFF
--- a/app/jobs/regular/remap_hashtag.rb
+++ b/app/jobs/regular/remap_hashtag.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RemapHashtag < ::Jobs::Base
+    sidekiq_options queue: "low"
+    cluster_concurrency 1
+
+    def execute(args)
+      rewritten = Set.new
+
+      Array(args[:remaps]).each do |remap|
+        remap = remap.symbolize_keys
+
+        counts =
+          HashtagRemapper.remap!(
+            type: remap[:type],
+            id: remap[:id],
+            old_ref: remap[:old_ref],
+            rewritten:,
+          )
+        next if counts.blank?
+
+        Rails.logger.warn("Remapped #{remap[:type]} hashtag ##{remap[:old_ref]}: #{counts.to_json}")
+      rescue => error
+        Discourse.warn_exception(
+          error,
+          message: "Failed to remap #{remap[:type]} hashtag ##{remap[:old_ref]}",
+        )
+      end
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -323,11 +323,7 @@ class Post < ActiveRecord::Base
     !add_nofollow?
   end
 
-  def cook(raw, opts = {})
-    # For some posts, for example those imported via RSS, we support raw HTML. In that
-    # case we can skip the rendering pipeline.
-    return raw if cook_method == Post.cook_methods[:raw_html]
-
+  def markdown_options(opts = {})
     options = opts.dup
     options[:cook_method] = cook_method
 
@@ -340,6 +336,15 @@ class Post < ActiveRecord::Base
     options[:user_id] = last_editor_id
     options[:omit_nofollow] = true if omit_nofollow?
     options[:post_id] = id
+    options
+  end
+
+  def cook(raw, opts = {})
+    # For some posts, for example those imported via RSS, we support raw HTML. In that
+    # case we can skip the rendering pipeline.
+    return raw if cook_method == Post.cook_methods[:raw_html]
+
+    options = markdown_options(opts)
 
     if should_secure_uploads?
       each_upload_url do |url|

--- a/app/services/category_hashtag_data_source.rb
+++ b/app/services/category_hashtag_data_source.rb
@@ -16,6 +16,10 @@ class CategoryHashtagDataSource
     "category"
   end
 
+  def self.ref_for(category_id)
+    Category.find_by(id: category_id)&.slug_ref
+  end
+
   def self.category_to_hashtag_item(category)
     HashtagAutocompleteService::HashtagItem.new.tap do |item|
       item.text =

--- a/app/services/hashtag_autocomplete_service.rb
+++ b/app/services/hashtag_autocomplete_service.rb
@@ -48,6 +48,10 @@ class HashtagAutocompleteService
     enabled_data_sources.find { |ds| ds.type == type }
   end
 
+  def self.ref_for(type, record_id)
+    data_sources.find { |ds| ds.type == type }.try(:ref_for, record_id).presence
+  end
+
   def self.find_priorities_for_context(context)
     contextual_type_priorities.select { |ctp| ctp[:context] == context }
   end

--- a/app/services/hashtag_remapper.rb
+++ b/app/services/hashtag_remapper.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  DEFAULT_CONTEXT = "topic-composer"
+
+  def self.stores
+    [
+      PostStore,
+      PostLocalizationStore,
+      UserProfileStore,
+      GroupStore,
+      TagDescriptionStore,
+      TagLocalizationStore,
+      SiteSettingLocalizationStore,
+      CategoryLocalizationStore,
+    ]
+  end
+
+  def self.enqueue(remaps)
+    usable =
+      remaps.reject do |remap|
+        current = HashtagAutocompleteService.ref_for(remap[:type], remap[:id])
+        current.present? && remap[:old_ref].casecmp?(current)
+      end
+    return if usable.blank?
+
+    DB.after_commit { Jobs.enqueue(:remap_hashtag, remaps: usable) }
+  end
+
+  def self.remap!(type:, id:, old_ref:, rewritten: Set.new)
+    return if type.blank? || id.blank? || !HashtagRewriter.usable_ref?(old_ref)
+
+    new_ref = HashtagAutocompleteService.ref_for(type, id)
+    return if new_ref.blank? || old_ref.casecmp?(new_ref)
+    return if !HashtagRewriter.usable_ref?(new_ref)
+
+    new(type:, record_id: id, old_ref:, new_ref:, rewritten:).remap!
+  end
+
+  def initialize(type:, record_id:, old_ref:, new_ref:, rewritten: Set.new)
+    @type = type
+    @record_id = record_id.to_s
+    @old_ref = old_ref
+    @new_ref = new_ref
+    @old_suffixed = "#{old_ref}::#{type}"
+    @new_suffixed = "#{new_ref}::#{type}"
+    @rewritten = rewritten
+    @bare_new_refs = {}
+  end
+
+  def remap!
+    self
+      .class
+      .stores
+      .to_h { |store| [store.key, remap_store(store)] }
+      .reject { |_, counts| counts.empty? }
+  end
+
+  private
+
+  attr_reader :type, :record_id, :old_ref, :new_ref, :old_suffixed, :new_suffixed, :rewritten
+
+  def remap_store(store)
+    counts = Hash.new(0)
+
+    store
+      .candidates(old_ref)
+      .find_each do |record|
+        counts[:scanned] += 1
+        counts[:rewritten] += 1 if rewrite_record(store, record)
+      rescue => error
+        counts[:failed] += 1
+        Discourse.warn_exception(
+          error,
+          message:
+            "Failed to remap #{type} hashtag ##{old_ref} to ##{new_ref} in #{store.key} #{record.id}",
+        )
+      end
+
+    counts
+  end
+
+  def rewrite_record(store, record)
+    raw = store.raw(record)
+    return false if raw.blank?
+
+    rewrite_bare = bare_ref_belongs_to_record?(store, record)
+
+    new_raw =
+      HashtagRewriter
+        .new(raw, store.cook_options(record))
+        .rewrite do |ref|
+          next new_suffixed if ref.casecmp?(old_suffixed)
+          next bare_new_ref(store) if rewrite_bare && ref.casecmp?(old_ref)
+        end
+
+    return false if new_raw == raw
+    return false if store.raw(record.reload) != raw
+
+    store.write!(record, new_raw)
+    rewritten << [store, record.id]
+    true
+  end
+
+  def bare_ref_belongs_to_record?(store, record)
+    claims =
+      PrettyText
+        .extract_hashtags(store.cooked(record))
+        .select { |anchor| anchor[:ref]&.casecmp?(old_ref) }
+
+    return rewritten.include?([store, record.id]) if claims.empty?
+
+    claims.all? { |anchor| points_at_record?(anchor) }
+  end
+
+  def bare_new_ref(store)
+    context = store.hashtag_context || DEFAULT_CONTEXT
+
+    @bare_new_refs[context] ||= begin
+      found =
+        PrettyText::Helpers.hashtag_lookup(
+          new_ref,
+          Discourse.system_user.id,
+          HashtagAutocompleteService.ordered_types_for_context(context),
+        )
+
+      found && points_at_record?(found) ? new_ref : new_suffixed
+    end
+  end
+
+  def points_at_record?(anchor)
+    anchor[:type] == type && anchor[:id].to_s == record_id
+  end
+end

--- a/app/services/hashtag_remapper/category_localization_store.rb
+++ b/app/services/hashtag_remapper/category_localization_store.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class CategoryLocalizationStore < Store
+    def self.key = "category_localization"
+    def self.relation = CategoryLocalization.all
+    def self.raw_column = :description
+  end
+end

--- a/app/services/hashtag_remapper/group_store.rb
+++ b/app/services/hashtag_remapper/group_store.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class GroupStore < Store
+    def self.key = "group"
+    def self.relation = Group.all
+    def self.raw_column = :bio_raw
+    def self.cooked(group) = group.bio_cooked
+  end
+end

--- a/app/services/hashtag_remapper/post_localization_store.rb
+++ b/app/services/hashtag_remapper/post_localization_store.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class PostLocalizationStore < Store
+    def self.key = "post_localization"
+    def self.relation = PostLocalization.all
+    def self.raw_column = :raw
+    def self.cooked(localization) = localization.cooked
+
+    def self.write!(localization, raw)
+      localization.raw = raw
+      localization.cooked = PrettyText.cook(raw)
+      localization.save!(validate: false)
+      Jobs.enqueue(:process_localized_cooked, post_localization_id: localization.id)
+    end
+  end
+end

--- a/app/services/hashtag_remapper/post_store.rb
+++ b/app/services/hashtag_remapper/post_store.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class PostStore < Store
+    def self.key = "post"
+    def self.raw_column = :raw
+    def self.cooked(post) = post.cooked
+    def self.cook_options(post) = post.markdown_options
+
+    def self.relation
+      Post
+        .where.not(cook_method: Post.cook_methods[:raw_html])
+        .joins(:topic)
+        .where(topics: { deleted_at: nil })
+    end
+
+    def self.write!(post, raw)
+      super
+      post.sync_first_post_caches
+      post.trigger_post_process(
+        bypass_bump: true,
+        priority: :ultra_low,
+        skip_pull_hotlinked_images: true,
+      )
+    end
+  end
+end

--- a/app/services/hashtag_remapper/site_setting_localization_store.rb
+++ b/app/services/hashtag_remapper/site_setting_localization_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class SiteSettingLocalizationStore < Store
+    def self.key = "site_setting_localization"
+    def self.relation = SiteSettingLocalization.where.not(cooked: nil)
+    def self.raw_column = :value
+    def self.cooked(localization) = localization.cooked
+
+    def self.write!(localization, raw)
+      localization.value = raw
+      localization.save!
+    end
+  end
+end

--- a/app/services/hashtag_remapper/store.rb
+++ b/app/services/hashtag_remapper/store.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class Store
+    def self.key = raise(NotImplementedError)
+    def self.relation = raise(NotImplementedError)
+    def self.raw_column = raise(NotImplementedError)
+    def self.cooked(record) = nil
+    def self.cook_options(record) = {}
+    def self.hashtag_context = nil
+    def self.raw(record) = record.public_send(raw_column)
+
+    def self.write!(record, raw)
+      record.public_send(:"#{raw_column}=", raw)
+      record.save!(validate: false)
+    end
+
+    def self.candidates(old_ref)
+      column = "#{relation.table_name}.#{raw_column}"
+
+      relation.where("#{column} ILIKE ?", HashtagRewriter.sql_like_pattern(old_ref))
+    end
+  end
+end

--- a/app/services/hashtag_remapper/tag_description_store.rb
+++ b/app/services/hashtag_remapper/tag_description_store.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class TagDescriptionStore < Store
+    def self.key = "tag_description"
+    def self.relation = Tag.all
+    def self.raw_column = :description
+    def self.cooked(tag) = tag.description_cooked
+    def self.cook_options(tag) = HasCookedTagDescription::COOK_OPTIONS
+  end
+end

--- a/app/services/hashtag_remapper/tag_localization_store.rb
+++ b/app/services/hashtag_remapper/tag_localization_store.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class TagLocalizationStore < Store
+    def self.key = "tag_localization"
+    def self.relation = TagLocalization.all
+    def self.raw_column = :description
+    def self.cooked(localization) = localization.description_cooked
+    def self.cook_options(localization) = HasCookedTagDescription::COOK_OPTIONS
+  end
+end

--- a/app/services/hashtag_remapper/user_profile_store.rb
+++ b/app/services/hashtag_remapper/user_profile_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class HashtagRemapper
+  class UserProfileStore < Store
+    def self.key = "user_profile"
+    def self.relation = UserProfile.all
+    def self.raw_column = :bio_raw
+    def self.cooked(profile) = profile.bio_cooked
+
+    def self.write!(profile, raw)
+      profile.skip_pull_hotlinked_image = true
+      super
+    end
+  end
+end

--- a/app/services/tag_hashtag_data_source.rb
+++ b/app/services/tag_hashtag_data_source.rb
@@ -20,6 +20,10 @@ class TagHashtagDataSource
     "icon"
   end
 
+  def self.ref_for(tag_id)
+    Tag.where(id: tag_id).pick(:name)
+  end
+
   def self.tag_to_hashtag_item(tag, guardian)
     topic_count_column = Tag.topic_count_column(guardian)
 

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -470,6 +470,21 @@ module PrettyText
       end
   end
 
+  def self.extract_hashtags(html)
+    return [] if html.blank?
+
+    Nokogiri::HTML5
+      .fragment(html)
+      .css("a.hashtag-cooked")
+      .map do |anchor|
+        {
+          type: anchor["data-type"],
+          id: anchor["data-id"],
+          ref: anchor["data-ref"] || anchor["data-slug"],
+        }
+      end
+  end
+
   def self.extract_mentions(cooked)
     mentions =
       cooked

--- a/lib/tasks/hashtags.rake
+++ b/lib/tasks/hashtags.rake
@@ -13,3 +13,16 @@ task "hashtags:mark_old_format_for_rebake" => :environment do
   posts_to_rebake.update_all(baked_version: 0)
   puts "Done, rebakes will happen when periodical updates job runs."
 end
+
+desc "Rewrite #old_ref to a record's current hashtag reference everywhere it was cooked"
+task "hashtags:remap", %i[type id old_ref] => :environment do |_task, args|
+  type, id, old_ref = args[:type], args[:id], args[:old_ref]
+
+  abort "Usage: rake 'hashtags:remap[tag,123,old-name]'" if [type, id, old_ref].any?(&:blank?)
+
+  counts = HashtagRemapper.remap!(type:, id:, old_ref:)
+
+  abort "Nothing to remap for #{type} #{id}" if counts.blank?
+
+  counts.each { |store, count| puts "  #{store}: #{count.inspect}" }
+end

--- a/spec/jobs/remap_hashtag_spec.rb
+++ b/spec/jobs/remap_hashtag_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::RemapHashtag do
+  def run(remaps)
+    described_class.new.execute(remaps:)
+  end
+
+  def tag_remap(tag, old_ref)
+    { "type" => "tag", "id" => tag.id, "old_ref" => old_ref }
+  end
+
+  it "remaps a renamed tag" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+
+    tag.update!(name: "help")
+    run([tag_remap(tag, "support")])
+
+    expect(post.reload.raw).to eq("See #help for details.")
+  end
+
+  it "remaps a renamed category, including its subcategories" do
+    parent = Fabricate(:category, slug: "support")
+    child = Fabricate(:category, slug: "bucks", parent_category: parent)
+    post = create_post(raw: "See #support and #support:bucks.")
+
+    parent.update!(slug: "help")
+    run(
+      [
+        { "type" => "category", "id" => parent.id, "old_ref" => "support" },
+        { "type" => "category", "id" => child.id, "old_ref" => "support:bucks" },
+      ],
+    )
+
+    expect(post.reload.raw).to eq("See #help and #help:bucks.")
+  end
+
+  it "uses the record's current reference, not the one it was enqueued with" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+
+    tag.update!(name: "help")
+    tag.update!(name: "assistance")
+    run([tag_remap(tag, "support")])
+
+    expect(post.reload.raw).to eq("See #assistance for details.")
+  end
+
+  it "does nothing when the record no longer exists" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+    remap = tag_remap(tag, "support")
+
+    tag.destroy!
+    run([remap])
+
+    expect(post.reload.raw).to eq("See #support for details.")
+  end
+
+  it "does nothing when only the casing changed" do
+    SiteSetting.force_lowercase_tags = false
+    tag = Fabricate(:tag, name: "Support")
+    post = create_post(raw: "See #Support for details.")
+
+    tag.update!(name: "support")
+    run([tag_remap(tag, "Support")])
+
+    expect(post.reload.raw).to eq("See #Support for details.")
+  end
+
+  it "refuses to write a reference the matcher cannot read back" do
+    tag = Fabricate(:tag, name: "support")
+    post = create_post(raw: "See #support for details.")
+
+    tag.update_columns(name: "not a ref")
+    run([tag_remap(tag, "support")])
+
+    expect(post.reload.raw).to eq("See #support for details.")
+  end
+
+  it "ignores malformed entries" do
+    expect { run([{ "type" => "tag" }, { "id" => 1 }, {}]) }.not_to raise_error
+  end
+end

--- a/spec/services/hashtag_remapper_spec.rb
+++ b/spec/services/hashtag_remapper_spec.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+RSpec.describe HashtagRemapper do
+  def remap(type:, record:, old_ref:, new_ref:, rewritten: Set.new)
+    described_class.new(type:, record_id: record.id, old_ref:, new_ref:, rewritten:).remap!
+  end
+
+  def remap_tag(tag, old_ref, rewritten: Set.new)
+    remap(type: "tag", record: tag, old_ref:, new_ref: tag.name, rewritten:)
+  end
+
+  describe "posts" do
+    it "rewrites a bare reference and re-cooks" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("See #help for details.")
+      expect(post.cooked).to include(%{data-type="tag"}, %{data-id="#{tag.id}"})
+    end
+
+    it "rewrites the type-suffixed form and keeps the suffix" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support::tag for details.")
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("See #help::tag for details.")
+    end
+
+    it "leaves a longer reference belonging to another tag" do
+      Fabricate(:tag, name: "node.js")
+      tag = Fabricate(:tag, name: "node")
+      post = create_post(raw: "I use #node.js daily and #node rarely.")
+
+      tag.update!(name: "nodejs")
+      remap_tag(tag, "node")
+
+      expect(post.reload.raw).to eq("I use #node.js daily and #nodejs rarely.")
+    end
+
+    it "leaves a non-ascii neighbour alone" do
+      Fabricate(:tag, name: "café")
+      tag = Fabricate(:tag, name: "caf")
+      post = create_post(raw: "One #caf and two #café here.")
+
+      tag.update!(name: "coffee")
+      remap_tag(tag, "caf")
+
+      expect(post.reload.raw).to eq("One #coffee and two #café here.")
+    end
+
+    it "leaves references the markdown pipeline does not cook" do
+      tag = Fabricate(:tag, name: "support")
+      raw = <<~MD
+        Live #support here.
+
+        ```
+        fence #support
+        ```
+
+        Inline `#support` and https://example.com/?tab=#support
+      MD
+      post = create_post(raw:)
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq(raw.sub("Live #support", "Live #help").rstrip)
+    end
+
+    it "only rewrites the suffixed form when a category owns the bare reference" do
+      Fabricate(:category, slug: "clash")
+      tag = Fabricate(:tag, name: "clash")
+      post = create_post(raw: "Bare #clash and explicit #clash::tag.")
+
+      expect(post.cooked).to include(%{data-type="category"})
+
+      tag.update!(name: "clash-tag")
+      remap_tag(tag, "clash")
+
+      expect(post.reload.raw).to eq("Bare #clash and explicit #clash-tag::tag.")
+    end
+
+    it "rewrites the bare reference when this post cooked it as the tag" do
+      category = Fabricate(:category, slug: "secret")
+      category.update!(read_restricted: true)
+      tag = Fabricate(:tag, name: "secret")
+      post = create_post(raw: "Bare #secret here.")
+
+      expect(post.cooked).to include(%{data-type="tag"})
+
+      tag.update!(name: "secret-tag")
+      remap_tag(tag, "secret")
+
+      expect(post.reload.raw).to eq("Bare #secret-tag here.")
+    end
+
+    it "uses the suffixed form when the new reference would resolve elsewhere" do
+      Fabricate(:category, slug: "help", name: "Help")
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support here.")
+
+      expect(post.cooked).to include(%{data-type="tag"})
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      post.reload
+      expect(post.raw).to eq("See #help::tag here.")
+      expect(post.cooked).to include(%{data-type="tag"}, %{data-id="#{tag.id}"})
+    end
+
+    it "remaps a synonym by its own name" do
+      target = Fabricate(:tag, name: "main")
+      synonym = Fabricate(:tag, name: "syn", target_tag: target)
+      post = create_post(raw: "See #syn and #main.")
+
+      synonym.update!(name: "synonym")
+      remap_tag(synonym, "syn")
+
+      expect(post.reload.raw).to eq("See #synonym and #main.")
+    end
+
+    it "does not revise, bump or reattribute the post" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+      editor = post.last_editor_id
+      bumped = post.topic.bumped_at
+
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+
+      post.reload
+      expect(post.raw).to eq("See #help for details.")
+      expect(post.version).to eq(1)
+      expect(post.last_editor_id).to eq(editor)
+      expect(PostRevision.where(post_id: post.id).count).to eq(0)
+      expect(post.topic.reload.bumped_at).to eq_time(bumped)
+    end
+
+    it "rewrites a post that no longer passes validation" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+
+      tag.update!(name: "help")
+      SiteSetting.max_post_length = 5
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("See #help for details.")
+    end
+
+    it "re-runs post processing so the cooked keeps its lightboxes and oneboxes" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+
+      tag.update!(name: "help")
+
+      expect_enqueued_with(job: :process_post, args: { post_id: post.id }) do
+        remap_tag(tag, "support")
+      end
+    end
+
+    it "leaves an edit that landed while the job was running" do
+      tag = Fabricate(:tag, name: "support")
+      post = create_post(raw: "See #support for details.")
+      edited = "Edited to say #support differently."
+
+      tag.update!(name: "help")
+      HashtagRemapper::PostStore
+        .stubs(:cook_options)
+        .with { Post.where(id: post.id).update_all(raw: edited) }
+        .returns({})
+
+      counts = remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq(edited)
+      expect(counts["post"][:rewritten]).to eq(0)
+    end
+
+    it "keeps going when one record fails" do
+      tag = Fabricate(:tag, name: "support")
+      first = create_post(raw: "First #support here.")
+      second = create_post(raw: "Second #support here.")
+
+      tag.update!(name: "help")
+      Post.any_instance.stubs(:save!).raises(StandardError.new("boom")).then.returns(true)
+      Discourse.expects(:warn_exception).once
+
+      counts = remap_tag(tag, "support")
+
+      expect(counts["post"][:scanned]).to eq(2)
+      expect(counts["post"][:failed]).to eq(1)
+    end
+  end
+
+  describe "references that never belonged to this record" do
+    it "leaves prose alone even after the content is rebaked" do
+      post = nil
+      freeze_time(2.days.ago) { post = create_post(raw: "Ticket #support was closed.") }
+
+      expect(post.cooked).not_to include("hashtag-cooked")
+
+      tag = Fabricate(:tag, name: "support")
+      tag.update!(name: "help")
+      post.rebake!
+
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("Ticket #support was closed.")
+    end
+
+    it "leaves content authored after the rename alone" do
+      tag = Fabricate(:tag, name: "support")
+      tag.update!(name: "help")
+
+      post = create_post(raw: "Ticket #support was closed.")
+
+      remap_tag(tag, "support")
+
+      expect(post.reload.raw).to eq("Ticket #support was closed.")
+    end
+
+    it "still rewrites a reference this run orphaned itself" do
+      parent = Fabricate(:category, slug: "support")
+      child = Fabricate(:category, slug: "bucks", parent_category: parent)
+      post = create_post(raw: "See #support and #support:bucks.")
+
+      parent.update!(slug: "help")
+      rewritten = Set.new
+
+      remap(type: "category", record: parent, old_ref: "support", new_ref: "help", rewritten:)
+      remap(
+        type: "category",
+        record: child,
+        old_ref: "support:bucks",
+        new_ref: "help:bucks",
+        rewritten:,
+      )
+
+      expect(post.reload.raw).to eq("See #help and #help:bucks.")
+    end
+  end
+
+  describe "the other content stores" do
+    fab!(:tag) { Fabricate(:tag, name: "support") }
+
+    def rename_and_remap
+      tag.update!(name: "help")
+      remap_tag(tag, "support")
+    end
+
+    it "rewrites a user bio" do
+      profile = Fabricate(:user).user_profile
+      profile.update!(bio_raw: "I follow #support closely.")
+
+      rename_and_remap
+
+      profile.reload
+      expect(profile.bio_raw).to eq("I follow #help closely.")
+      expect(profile.bio_cooked).to include(%{data-id="#{tag.id}"})
+    end
+
+    it "rewrites a group bio" do
+      group = Fabricate(:group, bio_raw: "We own #support.")
+
+      rename_and_remap
+
+      expect(group.reload.bio_raw).to eq("We own #help.")
+    end
+
+    it "rewrites a tag description" do
+      other = Fabricate(:tag, name: "other", description: "See also #support.")
+
+      rename_and_remap
+
+      other.reload
+      expect(other.description).to eq("See also #help.")
+      expect(other.description_cooked).to include(%{data-id="#{tag.id}"})
+    end
+
+    it "rewrites a post localization" do
+      post = create_post(raw: "See #support.")
+      localization =
+        Fabricate(
+          :post_localization,
+          post:,
+          locale: "fr",
+          raw: "Voir #support.",
+          cooked: PrettyText.cook("Voir #support."),
+        )
+
+      expect_enqueued_with(
+        job: :process_localized_cooked,
+        args: {
+          post_localization_id: localization.id,
+        },
+      ) { rename_and_remap }
+
+      localization.reload
+      expect(localization.raw).to eq("Voir #help.")
+      expect(localization.cooked).to include(%{data-id="#{tag.id}"})
+    end
+
+    it "rewrites a tag localization description" do
+      other = Fabricate(:tag, name: "other")
+      localization =
+        Fabricate(:tag_localization, tag: other, locale: "fr", description: "Voir #support.")
+
+      rename_and_remap
+
+      expect(localization.reload.description).to eq("Voir #help.")
+    end
+
+    it "rewrites only the suffixed form in a store that does not keep cooked" do
+      category = Fabricate(:category)
+      localization =
+        Fabricate(
+          :category_localization,
+          category:,
+          locale: "fr",
+          description: "Voir #support et #support::tag.",
+        )
+
+      rename_and_remap
+
+      expect(localization.reload.description).to eq("Voir #support et #help::tag.")
+    end
+  end
+end


### PR DESCRIPTION
Stacked on #42913. Still inert — no model calls this yet, so nothing changes behaviour in this PR either.

`HashtagRemapper` rewrites `#old_ref` to a record's current hashtag reference everywhere that reference was cooked. A `Store` subclass per table says where the raw lives, how to write it back, and which markdown options that content cooks with. The core set covers posts, post localizations, user and group bios, tag descriptions, tag and category localizations, and cooked site setting localizations.

### Only rewrite references that belong to this record

References collide across types and resolve with the author's permissions. A category outranks a tag with the same reference, and the same raw cooks to a private category for a member and to a public tag for an outsider. So "a record with this reference exists" is not a sound test — the content's own cooked output is. The `#ref::type` form is unambiguous and always rewritten.

The reverse case matters too: renaming tag `support` to `help` when a category `help` already exists would silently retarget the post to the category, so the job writes `#help::tag` when the bare form would no longer resolve to the renamed record.

### Job

`Jobs::RemapHashtag` re-reads the record's current reference at execute time, so retried and out-of-order jobs converge on the same result. `queue: "low"`, `cluster_concurrency 1`, per-remap rescue so one bad entry in a batch does not strand the rest.

Writes bypass `PostRevisor` — a rename is not an edit, so no revision, no bump, no reattribution, no notification. That also fixes a silent skip: `post.revise` returns `false` when a post no longer validates, stranding it on a dead reference with nothing raised and nothing logged.

Downstream post processing runs at `ultra_low` and skips the hotlinked image refetch, since a hashtag rewrite cannot change an image.

### Also adds

- `PrettyText.extract_hashtags`, next to `extract_mentions`
- `HashtagAutocompleteService.ref_for` and an optional `ref_for` on hashtag data sources
- `Post#markdown_options`, extracted from `Post#cook` so the rewriter's probe and the real cook cannot disagree about `cook_method` or `omit_nofollow`
- `rake 'hashtags:remap[tag,123,old-name]'` to re-run a remap by hand

---

Stack: #42913 → **this** → #42915 → #42916 → #42917