### PR TITLE
FIX: Remap category hashtags correctly when a slug or parent changes

### DIFF
--- a/app/jobs/regular/remap_category_hashtag.rb
+++ b/app/jobs/regular/remap_category_hashtag.rb
@@ -6,64 +6,11 @@ module Jobs
     cluster_concurrency 1
 
     def execute(args)
-      return if args[:category_id].blank?
-      category = category_from(args)
-      return if category.blank?
-
-      old_ref = args[:old_ref].presence
-      new_ref = category&.slug_ref.presence || args[:new_ref].presence
-      return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
-
-      posts_matching(old_ref, category.id).find_each { |post| update_post(post, old_ref, new_ref) }
-    end
-
-    private
-
-    def category_from(args)
-      Category.find_by(id: args[:category_id])
-    end
-
-    def posts_matching(old_ref, category_id)
-      posts =
-        Post
-          .joins(:topic)
-          .where("topics.deleted_at IS NULL")
-          .where("posts.raw ~* ?", "(?n)#{raw_hashtag_pattern(old_ref)}")
-
-      # More accurate way to find matching hashtags than looking
-      # at raw since we can have tags/chat channels with the same
-      # hashtag ref
-      if category_id.present?
-        posts =
-          posts.where(
-            "posts.cooked LIKE ? AND posts.cooked LIKE ?",
-            '%data-type="category"%',
-            "%data-id=\"#{category_id}\"%",
-          )
-      end
-
-      posts
-    end
-
-    def update_post(post, old_ref, new_ref)
-      new_raw = post.raw.gsub(raw_hashtag_regex(old_ref), "##{new_ref}")
-      return if new_raw == post.raw
-
-      post.revise(Discourse.system_user, { raw: new_raw }, bypass_bump: true, skip_revision: true)
-    rescue => err
-      Discourse.warn_exception(
-        err,
-        message:
-          "Failed to remap category hashtag #{old_ref} to #{new_ref} for category ID #{category.id} in post ID #{post.id}",
+      Jobs::RemapHashtag.new.execute(
+        remaps: [
+          { type: CategoryHashtagDataSource.type, id: args[:category_id], old_ref: args[:old_ref] },
+        ],
       )
-    end
-
-    def raw_hashtag_pattern(ref)
-      "(?<![:\\w])##{Regexp.escape(ref)}(?![\\w:-])"
-    end
-
-    def raw_hashtag_regex(ref)
-      /(?<![:\w])##{Regexp.escape(ref)}(?![\w:-])/i
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1307,28 +1307,26 @@ class Category < ActiveRecord::Base
         parent_category_id
       end
 
-    enqueue_category_hashtag_remap_job(
-      category_id: id,
-      old_ref:
-        Category.hashtag_ref_from(slug: old_slug, parent_category_id: old_parent_category_id),
-      new_ref: slug_ref,
-    )
+    type = CategoryHashtagDataSource.type
+    remaps = [
+      {
+        type:,
+        id:,
+        old_ref:
+          Category.hashtag_ref_from(slug: old_slug, parent_category_id: old_parent_category_id),
+      },
+    ]
 
     if saved_change_to_slug?
-      subcategories.find_each do |subcategory|
-        enqueue_category_hashtag_remap_job(
-          category_id: subcategory.id,
-          old_ref: [old_slug, subcategory.slug].join(Category::SLUG_REF_SEPARATOR),
-          new_ref: [slug, subcategory.slug].join(Category::SLUG_REF_SEPARATOR),
-        )
-      end
+      remaps +=
+        subcategories
+          .pluck(:id, :slug)
+          .map do |sub_id, sub_slug|
+            { type:, id: sub_id, old_ref: [old_slug, sub_slug].join(Category::SLUG_REF_SEPARATOR) }
+          end
     end
-  end
 
-  def enqueue_category_hashtag_remap_job(category_id:, old_ref:, new_ref:)
-    return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
-
-    DB.after_commit { Jobs.enqueue(:remap_category_hashtag, category_id:, old_ref:, new_ref:) }
+    HashtagRemapper.enqueue(remaps)
   end
 
   def cannot_delete_reason

--- a/spec/jobs/remap_category_hashtag_spec.rb
+++ b/spec/jobs/remap_category_hashtag_spec.rb
@@ -1,70 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::RemapCategoryHashtag do
-  it "rewrites category hashtag refs and rebakes posts" do
-    parent_category = Fabricate(:category, slug: "support")
-    category = Fabricate(:category, slug: "bucks", parent_category: parent_category)
-    post = create_post(raw: "See #support:bucks for details.")
+  it "remaps inline so in-flight jobs still work after a deploy" do
+    category = Fabricate(:category, slug: "support")
+    post = create_post(raw: "See #support for details.")
 
-    parent_category.update!(slug: "help")
+    category.update!(slug: "help")
+    described_class.new.execute(category_id: category.id, old_ref: "support", new_ref: "help")
 
-    described_class.new.execute(
-      category_id: category.id,
-      old_ref: "support:bucks",
-      new_ref: "help:bucks",
-    )
-
-    post.reload
-    category.reload
-
-    expect(post.raw).to eq("See #help:bucks for details.")
-    expect(post.cooked).to include(category.url)
+    expect(post.reload.raw).to eq("See #help for details.")
   end
 
-  it "rewrites only standalone matching hashtag refs" do
-    category = Fabricate(:category, slug: "bug")
-    post = create_post(raw: "#bug #bug-more #bug:suffix #bug::tag #other:bug #bug.")
+  it "does nothing when the category is gone" do
+    post = create_post(raw: "See #support for details.")
 
-    category.update!(slug: "issue")
+    described_class.new.execute(category_id: -1, old_ref: "support", new_ref: "help")
 
-    described_class.new.execute(category_id: category.id, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("#issue #bug-more #bug:suffix #bug::tag #other:bug #issue.")
-  end
-
-  it "skips raw matches that were cooked for a different category" do
-    category = Fabricate(:category, slug: "bug")
-    other_category = Fabricate(:category, slug: "other")
-    post = create_post(raw: "See #bug")
-
-    category.update!(slug: "issue")
-
-    described_class.new.execute(category_id: other_category.id, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("See #bug")
-  end
-
-  it "skips raw matches when the category no longer exists" do
-    category = Fabricate(:category, slug: "bug")
-    post = create_post(raw: "See #bug")
-    category_id = category.id
-
-    category.destroy!
-
-    described_class.new.execute(category_id:, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("See #bug")
-  end
-
-  it "uses the current category ref as the replacement target" do
-    category = Fabricate(:category, slug: "bug")
-    post = create_post(raw: "See #bug")
-
-    category.update!(slug: "issue")
-    category.update!(slug: "defect")
-
-    described_class.new.execute(category_id: category.id, old_ref: "bug", new_ref: "issue")
-
-    expect(post.reload.raw).to eq("See #defect")
+    expect(post.reload.raw).to eq("See #support for details.")
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1728,11 +1728,9 @@ RSpec.describe Category do
       category = Fabricate(:category, slug: "support")
 
       expect_enqueued_with(
-        job: :remap_category_hashtag,
+        job: :remap_hashtag,
         args: {
-          category_id: category.id,
-          old_ref: "support",
-          new_ref: "help",
+          remaps: [{ type: "category", id: category.id, old_ref: "support" }],
         },
       ) { category.update!(slug: "help") }
     end
@@ -1742,25 +1740,24 @@ RSpec.describe Category do
       parent_category = Fabricate(:category, slug: "support")
 
       expect_enqueued_with(
-        job: :remap_category_hashtag,
+        job: :remap_hashtag,
         args: {
-          category_id: category.id,
-          old_ref: "bucks",
-          new_ref: "support:bucks",
+          remaps: [{ type: "category", id: category.id, old_ref: "bucks" }],
         },
       ) { category.update!(parent_category: parent_category) }
     end
 
-    it "enqueues child remap jobs when the slug changes" do
+    it "enqueues subcategories in the same job when the slug changes" do
       parent_category = Fabricate(:category, slug: "support")
       category = Fabricate(:category, slug: "bucks", parent_category: parent_category)
 
       expect_enqueued_with(
-        job: :remap_category_hashtag,
+        job: :remap_hashtag,
         args: {
-          category_id: category.id,
-          old_ref: "support:bucks",
-          new_ref: "help:bucks",
+          remaps: [
+            { type: "category", id: parent_category.id, old_ref: "support" },
+            { type: "category", id: category.id, old_ref: "support:bucks" },
+          ],
         },
       ) { parent_category.update!(slug: "help") }
     end
@@ -1768,7 +1765,7 @@ RSpec.describe Category do
     it "does not enqueue a remap job for unrelated changes" do
       category = Fabricate(:category, slug: "support")
 
-      expect_not_enqueued_with(job: :remap_category_hashtag) { category.update!(color: "ABCDEF") }
+      expect_not_enqueued_with(job: :remap_hashtag) { category.update!(color: "ABCDEF") }
     end
   end
 


### PR DESCRIPTION
Stacked on #42914. First PR in the stack that changes behaviour.

Points `Category` at `HashtagRemapper` with a batched self-and-subcategories payload, and reduces `Jobs::RemapCategoryHashtag` to a delegator so jobs already sitting in Sidekiq at deploy time keep working. It can be deleted a release later.

### Defects closed in the job it replaces

**The rescue could not run.** `update_post`'s rescue interpolated `category.id`, but `category` is a local of `execute` and not in scope there. It raised `NameError` while building its own log message, so one bad post aborted the entire `find_each` and every remaining post was silently skipped — the opposite of the per-post isolation it looked like it had.

**Ruby and Postgres disagreed on word boundaries.** Ruby's `\w` is ASCII-only, Postgres' is not. The `SELECT` used one and the `gsub` the other, so a post selected for a legitimate match could have unrelated neighbouring text rewritten. Renaming slug `caf` turned `one #caf and two #café here` into `one #tea and two #teaé here`.

**`#ref::category` was never remapped.** The lookahead deliberately excluded it, so explicitly disambiguated references stayed broken after a rename.

**The cooked filter could match the wrong record.** `cooked LIKE '%data-type="category"%' AND cooked LIKE '%data-id="N"%'` are two independent substring tests that can be satisfied by two different anchors, and category ids collide with tag ids freely. A post could be rewritten for a record it never referenced.

### Also

Picks up the code and link protection from #42913, and no longer loses a post whose raw stopped validating.

Note that the callback still fires on `saved_change_to_hashtag_ref?` (slug or parent), not on name — a category's hashtag reference is its slug.

---

Stack: #42913 → #42914 → **this** → #42916 → #42917