### PR TITLE
FIX: Remap tag hashtags when a tag is renamed

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -72,6 +72,7 @@ class Tag < ActiveRecord::Base
 
   before_save :cook_description
 
+  after_update :enqueue_tag_hashtag_remap, if: :saved_change_to_name?
   after_save :index_search
   after_save :update_synonym_associations
 
@@ -348,6 +349,13 @@ class Tag < ActiveRecord::Base
 
   def name_validator
     errors.add(:name, :invalid) if name.present? && RESERVED_TAGS.include?(name.strip.downcase)
+  end
+
+  def enqueue_tag_hashtag_remap
+    old_ref = name_before_last_save
+    return if old_ref.blank? || old_ref.casecmp?(name)
+
+    HashtagRemapper.enqueue([{ type: TagHashtagDataSource.type, id:, old_ref: }])
   end
 end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -787,4 +787,30 @@ RSpec.describe Tag do
       end
     end
   end
+
+  describe "tag hashtag remapping" do
+    it "enqueues a remap job when the name changes" do
+      tag = Fabricate(:tag, name: "support")
+
+      expect_enqueued_with(
+        job: :remap_hashtag,
+        args: {
+          remaps: [{ type: "tag", id: tag.id, old_ref: "support" }],
+        },
+      ) { tag.update!(name: "help") }
+    end
+
+    it "does not enqueue a remap job when only the casing changes" do
+      SiteSetting.force_lowercase_tags = false
+      tag = Fabricate(:tag, name: "Support")
+
+      expect_not_enqueued_with(job: :remap_hashtag) { tag.update!(name: "support") }
+    end
+
+    it "does not enqueue a remap job for unrelated changes" do
+      tag = Fabricate(:tag, name: "support")
+
+      expect_not_enqueued_with(job: :remap_hashtag) { tag.update!(description: "a description") }
+    end
+  end
 end


### PR DESCRIPTION
Stacked on the category fix.

Renaming a tag left every `#old_name` in post bodies pointing at nothing. Categories had a remap; tags never did — no job, no callback, nothing.

The breakage is delayed, which is why it is easy to miss. The stored cooked keeps working because its `href` carries the record id, so nothing looks wrong until the content is rebaked, and then the reference degrades to plain text:

```
<p>Hashtag reference: <span class="hashtag-raw">#strategic_access</span></p>
```

Tag renames now go through `HashtagRemapper`. Because the mechanism already exists at this point in the stack, the change is a callback and a guard.

Two tag-specific notes:

- Tag hashtag lookup is case-insensitive (`Tag.where_name` lowercases both sides), so a rename that only changes casing breaks nothing and is skipped rather than rewriting every referencing post for no gain.
- Renaming a **synonym** remaps references to the synonym's own name, because the data source keys on the synonym's own id and name rather than its target's.

The callback lives on the model rather than in `TagsController`, since there are two rename paths today — `TagsController#update` and `TagSettingsUpdater` — plus the console and importers.

---

Stack: #42913 → #42914 → #42915 → **this** → #42917