### PR TITLE
FEATURE: Remap channel hashtags when a chat channel slug changes

### DIFF
--- a/app/services/hashtag_remapper.rb
+++ b/app/services/hashtag_remapper.rb
@@ -13,7 +13,7 @@ class HashtagRemapper
       TagLocalizationStore,
       SiteSettingLocalizationStore,
       CategoryLocalizationStore,
-    ]
+    ] | DiscoursePluginRegistry.hashtag_content_stores.to_a
   end
 
   def self.enqueue(remaps)

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -119,6 +119,7 @@ class DiscoursePluginRegistry
   define_filtered_register :user_destroyer_on_content_deletion_callbacks
 
   define_filtered_register :hashtag_autocomplete_data_sources
+  define_filtered_register :hashtag_content_stores
   define_filtered_register :hashtag_autocomplete_contextual_type_priorities
 
   define_filtered_register :search_groups_set_query_callbacks

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1448,6 +1448,14 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_hashtag_autocomplete_data_source(klass, self)
   end
 
+  def register_hashtag_content_store(klass)
+    if !(klass < HashtagRemapper::Store)
+      raise ArgumentError.new("Hashtag content stores must inherit from HashtagRemapper::Store")
+    end
+
+    DiscoursePluginRegistry.register_hashtag_content_store(klass, self)
+  end
+
   ##
   # Used to set up the priority ordering of hashtag autocomplete results by
   # type using HashtagAutocompleteService.

--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -46,6 +46,7 @@ module Chat
     validates :emoji, length: { maximum: 100 }
     validate :ensure_slug_ok, if: :slug_changed?
     before_validation :generate_auto_slug
+    after_update :enqueue_channel_hashtag_remap, if: :saved_change_to_slug?
 
     scope :with_categories,
           -> do
@@ -110,6 +111,13 @@ module Chat
     ].each { |name| define_method(name) { false } }
 
     %i[allowed_user_ids allowed_group_ids chatable_url].each { |name| define_method(name) { nil } }
+
+    def enqueue_channel_hashtag_remap
+      old_ref = slug_before_last_save
+      return if old_ref.blank? || old_ref.casecmp?(slug.to_s)
+
+      HashtagRemapper.enqueue([{ type: Chat::ChannelHashtagDataSource.type, id:, old_ref: }])
+    end
 
     def ensure_slug_ok
       if self.slug.present?

--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -282,10 +282,8 @@ module Chat
       entity
     ]
 
-    def self.cook(message, opts = {})
+    def self.markdown_options(opts = {})
       bot = opts[:user_id] && opts[:user_id].negative?
-      slash_command = match_slash_command(message, opts[:author_username])
-      message_to_cook = slash_command ? slash_command[:content] : message
 
       features = MARKDOWN_FEATURES.dup
       features << "image-grid" if bot
@@ -300,15 +298,20 @@ module Chat
       # this when cooking #hashtags to determine whether we should render
       # the found hashtag based on whether the user can access the channel it
       # is referencing.
-      cooked =
-        PrettyText.cook(
-          message_to_cook,
-          features_override: features + DiscoursePluginRegistry.chat_markdown_features.to_a,
-          markdown_it_rules: rules,
-          force_quote_link: true,
-          user_id: opts[:user_id],
-          hashtag_context: "chat-composer",
-        )
+      {
+        features_override: features + DiscoursePluginRegistry.chat_markdown_features.to_a,
+        markdown_it_rules: rules,
+        force_quote_link: true,
+        user_id: opts[:user_id],
+        hashtag_context: "chat-composer",
+      }
+    end
+
+    def self.cook(message, opts = {})
+      slash_command = match_slash_command(message, opts[:author_username])
+      message_to_cook = slash_command ? slash_command[:content] : message
+
+      cooked = PrettyText.cook(message_to_cook, markdown_options(opts))
       cooked = format_slash_command(cooked, slash_command, opts[:author_username]) if slash_command
 
       result =

--- a/plugins/chat/lib/chat/channel_hashtag_data_source.rb
+++ b/plugins/chat/lib/chat/channel_hashtag_data_source.rb
@@ -14,6 +14,10 @@ module Chat
       "channel"
     end
 
+    def self.ref_for(channel_id)
+      Chat::Channel.where(id: channel_id, deleted_at: nil).pick(:slug)
+    end
+
     def self.channel_to_hashtag_item(guardian, channel)
       HashtagAutocompleteService::HashtagItem.new.tap do |item|
         item.text = channel.title

--- a/plugins/chat/lib/chat/message_hashtag_store.rb
+++ b/plugins/chat/lib/chat/message_hashtag_store.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Chat
+  class MessageHashtagStore < HashtagRemapper::Store
+    def self.key = "chat_message"
+    def self.relation = Chat::Message.where(deleted_at: nil)
+    def self.raw_column = :message
+    def self.cooked(message) = message.cooked
+    def self.hashtag_context = "chat-composer"
+    def self.cook_options(message) = Chat::Message.markdown_options(user_id: message.last_editor_id)
+
+    def self.write!(message, raw)
+      message.message = raw
+      message.cook
+      message.excerpt = message.build_excerpt
+      message.save!(validate: false)
+      message.rebake!(skip_notifications: true, priority: :ultra_low)
+      SearchIndexer.index(message)
+    end
+  end
+end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -613,6 +613,7 @@ after_initialize do
 
   # Make sure to update spec/system/hashtag_autocomplete_spec.rb when changing this.
   register_hashtag_data_source(Chat::ChannelHashtagDataSource)
+  register_hashtag_content_store(Chat::MessageHashtagStore)
   register_hashtag_type_priority_for_context("channel", "chat-composer", 200)
   register_hashtag_type_priority_for_context("category", "chat-composer", 100)
   register_hashtag_type_priority_for_context("tag", "chat-composer", 50)

--- a/plugins/chat/spec/lib/chat/message_hashtag_store_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_hashtag_store_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::MessageHashtagStore do
+  fab!(:channel) { Fabricate(:category_channel, slug: "support") }
+
+  before do
+    SiteSetting.chat_enabled = true
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+  end
+
+  def remap_channel(old_ref)
+    HashtagRemapper.new(
+      type: "channel",
+      record_id: channel.id,
+      old_ref:,
+      new_ref: channel.reload.slug,
+    ).remap!
+  end
+
+  describe "Chat::ChannelHashtagDataSource.ref_for" do
+    it "returns the channel slug" do
+      expect(Chat::ChannelHashtagDataSource.ref_for(channel.id)).to eq("support")
+    end
+
+    it "returns nothing for a trashed channel" do
+      channel.trash!
+
+      expect(Chat::ChannelHashtagDataSource.ref_for(channel.id)).to be_nil
+    end
+  end
+
+  describe "the rename callback" do
+    it "enqueues a remap when the slug changes" do
+      expect_enqueued_with(
+        job: :remap_hashtag,
+        args: {
+          remaps: [{ type: "channel", id: channel.id, old_ref: "support" }],
+        },
+      ) { channel.update!(slug: "help") }
+    end
+
+    it "does not enqueue a remap for unrelated changes" do
+      expect_not_enqueued_with(job: :remap_hashtag) { channel.update!(description: "hello") }
+    end
+
+    it "does not rewrite anything to the tombstone slug when a channel is trashed" do
+      post = create_post(raw: "See #support for details.")
+
+      Chat::TrashChannel.call(
+        params: {
+          channel_id: channel.id,
+        },
+        guardian: Discourse.system_user.guardian,
+      )
+
+      Jobs::RemapHashtag.new.execute(
+        remaps: [{ "type" => "channel", "id" => channel.id, "old_ref" => "support" }],
+      )
+
+      expect(post.reload.raw).to eq("See #support for details.")
+    end
+  end
+
+  describe "the chat message store" do
+    it "rewrites a channel reference in a chat message" do
+      message = Fabricate(:chat_message, chat_channel: channel, message: "See #support here.")
+
+      expect(message.cooked).to include(%{data-type="channel"}, %{data-id="#{channel.id}"})
+
+      channel.update!(slug: "help")
+      remap_channel("support")
+
+      message.reload
+      expect(message.message).to eq("See #help here.")
+      expect(message.cooked).to include(%{data-id="#{channel.id}"})
+      expect(message.excerpt).to be_present
+    end
+
+    it "leaves a reference inside a code fence alone" do
+      fenced =
+        Fabricate(
+          :chat_message,
+          chat_channel: channel,
+          message: "Live #support\n\n```\nfence #support\n```",
+        )
+
+      channel.update!(slug: "help")
+      remap_channel("support")
+
+      expect(fenced.reload.message).to eq("Live #help\n\n```\nfence #support\n```")
+    end
+  end
+
+  describe "across stores" do
+    it "rewrites a channel reference in a post" do
+      post = create_post(raw: "See #support for details.")
+
+      expect(post.cooked).to include(%{data-type="channel"})
+
+      channel.update!(slug: "help")
+      remap_channel("support")
+
+      expect(post.reload.raw).to eq("See #help for details.")
+    end
+  end
+end


### PR DESCRIPTION
Last of the stack, on top of #42916.

Of the three registered hashtag types, chat channels were the only one with no remap at all, so renaming a channel silently broke every `#old-slug` referring to it.

### A plugin API for cooked content

`register_hashtag_content_store` lets a plugin declare a table whose cooked content should be remapped, using the same `HashtagRemapper::Store` contract core uses. It validates the class at registration, so a bad store fails at boot rather than with a `NoMethodError` inside a Sidekiq loop over posts.

Chat registers its messages through it, which means chat messages become a remap target for **category and tag** renames too, not just channel ones.

### Trashed channels

`Chat::TrashChannel` renames the slug to a timestamped tombstone before soft deleting, in the same transaction, and the `after_update` callback fires on that rename. Without a guard, every `#support` on the site would be rewritten to `#20260825-2027-support-deleted`. `Chat::ChannelHashtagDataSource.ref_for` skips trashed channels, with a spec pinning it.

### `Chat::Message.markdown_options`

Pure extraction from `Chat::Message.cook`, guarded by the existing chat cook specs. Chat cooks with a restricted feature and rule set, and which constructs suppress a hashtag differs as a result — the store needs the same options the cooker uses, and duplicating them would drift silently.

### Known gap

`chat_messages` has `cooked_version` but no bake timestamp, so a message rebaked between the rename and the job keeps a dead reference. `rake 'hashtags:remap[channel,123,old-slug]'` repairs it.

---

Stack: #42913 → #42914 → #42915 → #42916 → **this**