### PR TITLE
FIX: Use topic filters for ordered topic IDs

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -132,15 +132,13 @@ class ListController < ApplicationController
   def filter
     topic_query_opts = { no_definitions: !SiteSetting.show_category_definitions_in_topic_lists }
 
-    %i[page q topic_ids].each do |key|
+    %i[page q].each do |key|
       if params.key?(key.to_s)
         value = params[key]
         raise Discourse::InvalidParameters.new(key) if !TopicQuery.validate?(key, value)
         topic_query_opts[key] = value
       end
     end
-
-    topic_query_opts[:topic_ids] = param_to_integer_list(:topic_ids) if params.key?(:topic_ids)
 
     user = current_user
     list = TopicQuery.new(user, topic_query_opts).list_filter

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3184,6 +3184,8 @@ en:
       order: "Sort topics by a specific field"
       category: "Show topics in a specific category"
       category_any: "Show topics in any of the specified categories (comma-separated)"
+      topic: "Show specific topics by ID"
+      topic_any: "Show topics in the specified order (comma-separated IDs)"
       exclude_category: "Exclude topics from a specific category"
       category_without_subcategories: "Show topics only in the parent category, excluding subcategories"
       exclude_category_without_subcategories: "Exclude topics only from the parent category, not subcategories"

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -318,18 +318,14 @@ class TopicQuery
       results = remove_muted_topics(results, @user)
     end
 
-    if (topic_ids = @options[:topic_ids].presence)
-      results =
-        results.reorder(
-          DB.sql_fragment("array_position(ARRAY[?]::integer[], topics.id)", topic_ids.uniq),
-        )
-    elsif results.order_values.empty?
-      results = apply_ordering(results)
-    end
+    results = apply_ordering(results) if results.order_values.empty?
 
     create_list(
       :filter,
-      { include_filter_option_info: @options[:include_filter_option_info].to_s != "false" },
+      {
+        include_filter_option_info: @options[:include_filter_option_info].to_s != "false",
+        unordered: topics_filter.topic_ids.present?,
+      },
       results,
     )
   end

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TopicsFilter
-  attr_reader :topic_notification_levels
+  attr_reader :topic_ids, :topic_notification_levels
 
   def initialize(guardian:, scope: Topic.all, loaded_topic_users_reference: false)
     @loaded_topic_users_reference = loaded_topic_users_reference
@@ -104,6 +104,8 @@ class TopicsFilter
         filter_tag_groups(values: key_prefixes.zip(filter_values))
       when "tag"
         filter_tags(values: key_prefixes.zip(filter_values))
+      when "topic"
+        filter_topics(values: filter_values)
       when "locale"
         filter_locale(values: key_prefixes.zip(filter_values))
       when "views-min"
@@ -198,6 +200,12 @@ class TopicsFilter
             description: I18n.t("filter.description.exclude_category_without_subcategories"),
           },
         ],
+      },
+      {
+        name: "topic:",
+        description: I18n.t("filter.description.topic"),
+        type: "text",
+        delimiters: [{ name: ",", description: I18n.t("filter.description.topic_any") }],
       },
       {
         name: "activity-before:",
@@ -400,6 +408,17 @@ class TopicsFilter
   end
 
   private
+
+  def filter_topics(values:)
+    @topic_ids =
+      values
+        .flat_map { |value| value.split(",") }
+        .filter_map { |value| Integer(value, 10, exception: false) }
+        .select(&:positive?)
+        .uniq
+
+    @scope = @scope.in_order_of(:id, @topic_ids)
+  end
 
   YYYY_MM_DD_REGEXP =
     /\A(?<year>[12][0-9]{3})-(?<month>0?[1-9]|1[0-2])-(?<day>0?[1-9]|[12]\d|3[01])\z/

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1842,12 +1842,13 @@ RSpec.describe ListController do
       end
     end
 
-    it "returns topic_ids in the order when specified" do
-      topic_1 = Fabricate(:topic, bumped_at: 3.days.ago)
+    it "returns topics in the order specified by the topic filter" do
+      topic_1 =
+        Fabricate(:topic, bumped_at: 3.days.ago, pinned_at: 1.day.ago, pinned_globally: true)
       topic_2 = Fabricate(:topic, bumped_at: 2.days.ago)
       topic_3 = Fabricate(:topic, bumped_at: 1.day.ago)
 
-      get "/filter.json", params: { topic_ids: [topic_3.id, topic_1.id, topic_2.id].join(",") }
+      get "/filter.json", params: { q: "topic:#{topic_3.id},#{topic_1.id},#{topic_2.id}" }
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] }).to eq(


### PR DESCRIPTION
We should use the `?q` queries, instead of a direct `?topic_id`. This prevents more new paradigms from forming.

<img width="351" height="202" alt="Screenshot 2026-08-26 at 6 10 36 PM" src="https://github.com/user-attachments/assets/2dc821a7-0f1e-402e-98cf-f4c8dd3c98df" />
