### PR TITLE
DEV: Exclude thinking in the final output for locale detection

### DIFF
--- a/plugins/discourse-ai/lib/translation/language_detector.rb
+++ b/plugins/discourse-ai/lib/translation/language_detector.rb
@@ -48,8 +48,9 @@ module DiscourseAi
           )
 
         result = +""
-        bot.reply(context) do |partial|
-          next if partial.strip.blank?
+        bot.reply(context) do |partial, _, type|
+          next if type == :thinking || partial.strip.blank?
+
           result << partial
         end
 

--- a/plugins/discourse-ai/spec/lib/translation/language_detector_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/language_detector_spec.rb
@@ -70,6 +70,15 @@ describe DiscourseAi::Translation::LanguageDetector do
       expect(locale_detector.detect).to eq("nl")
     end
 
+    it "returns the language when the streamed response includes thinking" do
+      thinking =
+        DiscourseAi::Completions::Thinking.new(message: "Determining Dutch context", partial: false)
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([[thinking, "nl"]]) do
+        expect(locale_detector.detect).to eq("nl")
+      end
+    end
+
     it "returns the language when the streamed response has surrounding whitespace" do
       bot = instance_double(DiscourseAi::Agents::Bot)
       allow(DiscourseAi::Agents::Bot).to receive(:as).and_return(bot)


### PR DESCRIPTION
When the locale detector uses a reasoning model, `Bot#reply` can stream a thinking summary before the final language code. Both were appended to the result, causing it to fail language tag validation and leaving the content locale unset.

This PR ignores `:thinking` chunks when building the locale detector response, while continuing to use the model's final text output.