### PR TITLE
DEV: move Events admin route label to discourse_events.title

### DIFF
--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -1,7 +1,6 @@
 en:
   admin_js:
     admin:
-      calendar: "Events"
       site_settings:
         categories:
           discourse_post_event: "Discourse Event"
@@ -27,6 +26,7 @@ en:
             topic_id:
               label: Topic ID
     discourse_events:
+      title: "Events"
       livestream:
         zoom:
           join: "Join Zoom"

--- a/plugins/discourse-events/plugin.rb
+++ b/plugins/discourse-events/plugin.rb
@@ -274,7 +274,7 @@ after_initialize do
 
   # DISCOURSE CALENDAR HOLIDAYS
 
-  add_admin_route "admin.calendar", "discourse-events", use_new_show_route: true
+  add_admin_route "discourse_events.title", "discourse-events", use_new_show_route: true
 
   # DISCOURSE POST EVENT
 

--- a/plugins/discourse-events/test/javascripts/acceptance/admin-holidays-test.js
+++ b/plugins/discourse-events/test/javascripts/acceptance/admin-holidays-test.js
@@ -20,7 +20,7 @@ acceptance("Admin - Events - Holidays", function (needs) {
         humanized_name: "Events",
         is_discourse_owned: true,
         admin_route: {
-          label: "admin.calendar",
+          label: "discourse_events.title",
           location: "discourse-events",
           use_new_show_route: true,
         },


### PR DESCRIPTION
Previously, the Events plugin registered its admin route label under `admin_js.admin.calendar`, a leftover from the Discourse Calendar naming that sat in the shared `admin` namespace rather than the plugin's own.

This change moves the label to `js.discourse_events.title`, matching the convention other core plugins follow.