### PR TITLE
FEATURE: Paginate AI semantic search with `page` and `per_page`

### DIFF
--- a/lib/search/grouped_search_results.rb
+++ b/lib/search/grouped_search_results.rb
@@ -41,7 +41,8 @@ class Search
       blurb_term: nil,
       is_header_search: false,
       use_pg_headlines_for_excerpt: SiteSetting.use_pg_headlines_for_excerpt,
-      can_lazy_load_categories: false
+      can_lazy_load_categories: false,
+      per_page: nil
     )
       @type_filter = type_filter
       @term = term
@@ -58,6 +59,12 @@ class Search
       @is_header_search = is_header_search
       @use_pg_headlines_for_excerpt = use_pg_headlines_for_excerpt
       @can_lazy_load_categories = can_lazy_load_categories
+      @per_page = per_page
+    end
+
+    # callers may request a smaller page than the site setting, never a larger one
+    def per_page
+      [@per_page || Search.per_filter, Search.per_filter].min
     end
 
     def error=(error)
@@ -109,7 +116,7 @@ class Search
 
     def add(object)
       type = object.class.to_s.downcase.pluralize
-      if !@is_header_search && public_send(type).length == Search.per_filter
+      if !@is_header_search && public_send(type).length == per_page
         @more_full_page_results = true
       elsif @is_header_search && public_send(type).length == Search.per_facet
         instance_variable_set(:"@more_#{type}", true)

--- a/plugins/discourse-ai/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
@@ -33,7 +33,8 @@ module DiscourseAi
 
         page = positive_integer_param(:page) || 1
         raise Discourse::InvalidParameters.new(:page) if page > MAX_PAGE
-        per_page = positive_integer_param(:per_page)
+        per_page =
+          DiscourseAi::Embeddings::SemanticSearch.page_size(positive_integer_param(:per_page))
 
         grouped_results =
           Search::GroupedSearchResults.new(

--- a/plugins/discourse-ai/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
@@ -16,6 +16,8 @@ module DiscourseAi
       # in addition to per-IP limits.
       MAX_ANON_SEARCHES_PER_MINUTE = 60
 
+      MAX_PAGE = 10
+
       def search
         query = params[:q].to_s
         use_hyde = SiteSetting.ai_embeddings_semantic_search_use_hyde
@@ -29,6 +31,10 @@ module DiscourseAi
           raise Discourse::InvalidParameters.new(:q)
         end
 
+        page = positive_integer_param(:page) || 1
+        raise Discourse::InvalidParameters.new(:page) if page > MAX_PAGE
+        per_page = positive_integer_param(:per_page)
+
         grouped_results =
           Search::GroupedSearchResults.new(
             type_filter: SEMANTIC_SEARCH_TYPE,
@@ -36,6 +42,7 @@ module DiscourseAi
             search_context: guardian,
             use_pg_headlines_for_excerpt: false,
             can_lazy_load_categories: guardian.can_lazy_load_categories?,
+            per_page: per_page,
           )
 
         semantic_search = DiscourseAi::Embeddings::SemanticSearch.new(guardian)
@@ -67,7 +74,7 @@ module DiscourseAi
         hijack do
           begin
             semantic_search
-              .search_for_topics(query, _page = 1, hyde: use_hyde)
+              .search_for_topics(query, page, hyde: use_hyde, per_page: per_page)
               .each { |topic_post| grouped_results.add(topic_post) }
           rescue Discourse::InvalidAccess
             return render_json_error(I18n.t("invalid_access"), status: 403)
@@ -119,6 +126,17 @@ module DiscourseAi
       end
 
       private
+
+      def positive_integer_param(name)
+        value = params[name]
+        return if value.blank?
+
+        if !value.is_a?(String) || value.to_i.to_s != value || value.to_i < 1
+          raise Discourse::InvalidParameters.new(name)
+        end
+
+        value.to_i
+      end
 
       # Applies both per-IP and global anonymous rate limits, following the same
       # pattern as SearchController#rate_limit_search. The per-IP limit prevents

--- a/plugins/discourse-ai/lib/embeddings/semantic_search.rb
+++ b/plugins/discourse-ai/lib/embeddings/semantic_search.rb
@@ -65,9 +65,15 @@ module DiscourseAi
 
       MAX_RESULTS_PER_PAGE = 100
 
+      # callers share this so that the page size used to query and the page size used to
+      # collect results cannot drift apart
+      def self.page_size(per_page = nil)
+        max = [Search.per_filter, MAX_RESULTS_PER_PAGE].min
+        per_page ? per_page.clamp(1, max) : max
+      end
+
       def search_for_topics(query, page = 1, hyde: true, per_page: nil)
-        page_size = [Search.per_filter, MAX_RESULTS_PER_PAGE].min
-        page_size = per_page.clamp(1, page_size) if per_page
+        page_size = self.class.page_size(per_page)
         limit = page_size + 1
         offset = (page - 1) * page_size
         search = Search.new(query, { guardian: guardian })

--- a/plugins/discourse-ai/lib/embeddings/semantic_search.rb
+++ b/plugins/discourse-ai/lib/embeddings/semantic_search.rb
@@ -63,10 +63,13 @@ module DiscourseAi
       # if the user filtered the results or index is a bit out of date
       OVER_SELECTION_FACTOR = 4
 
-      def search_for_topics(query, page = 1, hyde: true)
-        max_results_per_page = 100
-        limit = [Search.per_filter, max_results_per_page].min + 1
-        offset = (page - 1) * limit
+      MAX_RESULTS_PER_PAGE = 100
+
+      def search_for_topics(query, page = 1, hyde: true, per_page: nil)
+        page_size = [Search.per_filter, MAX_RESULTS_PER_PAGE].min
+        page_size = per_page.clamp(1, page_size) if per_page
+        limit = page_size + 1
+        offset = (page - 1) * page_size
         search = Search.new(query, { guardian: guardian })
         search_term = search.term
 
@@ -85,11 +88,13 @@ module DiscourseAi
 
         schema = DiscourseAi::Embeddings::Schema.for(Topic)
 
+        # paginate the filtered rows rather than the candidate list, so that rows
+        # dropped by the filters below cannot be skipped or repeated across pages
         candidate_topic_ids =
           schema.asymmetric_similarity_search(
             search_embedding,
-            limit: over_selection_limit,
-            offset: offset,
+            limit: over_selection_limit + offset,
+            offset: 0,
           ).map(&:topic_id)
 
         semantic_results =
@@ -99,6 +104,7 @@ module DiscourseAi
             .where("topics.visible")
             .where(topic_id: candidate_topic_ids, post_number: 1)
             .order("array_position(ARRAY#{candidate_topic_ids}, posts.topic_id)")
+            .offset(offset)
             .limit(limit)
 
         query_filter_results = search.apply_filters(semantic_results)

--- a/plugins/discourse-ai/spec/requests/embeddings/embeddings_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/embeddings/embeddings_controller_spec.rb
@@ -273,6 +273,71 @@ describe DiscourseAi::Embeddings::EmbeddingsController do
         end
       end
     end
+
+    context "when paginating results" do
+      def index_with(target, embedding)
+        stub_request(:post, "https://api.openai.com/v1/embeddings").to_return(
+          status: 200,
+          body: JSON.dump({ data: [{ embedding: embedding }] }),
+        )
+
+        DiscourseAi::Embeddings::Vector.instance.generate_representation_from(target)
+      end
+
+      # distinct embeddings keep the relevance order, and so the page boundaries, deterministic
+      before do
+        index_with(topic, [0.049382] * 1536)
+        index_with(topic_in_subcategory, ([0.1] * 768) + ([-0.1] * 768))
+        stub_embedding("test")
+      end
+
+      it "returns the next set of results when `page` is given" do
+        SiteSetting.search_page_size = 1
+
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topics"].map { |result| result["id"] }).to eq([topic.id])
+        expect(response.parsed_body["grouped_search_result"]["more_full_page_results"]).to eq(true)
+
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false&page=2"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topics"].map { |result| result["id"] }).to eq(
+          [topic_in_subcategory.id],
+        )
+        expect(response.parsed_body["grouped_search_result"]["more_full_page_results"]).to eq(nil)
+      end
+
+      it "narrows a page to `per_page` without changing the site page size" do
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false&per_page=1"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topics"].map { |result| result["id"] }).to eq([topic.id])
+        expect(response.parsed_body["grouped_search_result"]["more_full_page_results"]).to eq(true)
+      end
+
+      it "ignores a `per_page` above the site page size" do
+        SiteSetting.search_page_size = 1
+
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false&per_page=50"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topics"].map { |result| result["id"] }).to eq([topic.id])
+      end
+
+      it "returns 400 for a malformed or out of range `page` or `per_page`" do
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false&page=0"
+        expect(response.status).to eq(400)
+
+        out_of_range = described_class::MAX_PAGE + 1
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false&page=#{out_of_range}"
+        expect(response.status).to eq(400)
+
+        get "/discourse-ai/embeddings/semantic-search.json?q=test&hyde=false&per_page=abc"
+        expect(response.status).to eq(400)
+      end
+    end
   end
 
   context "when embedding API fails" do

--- a/spec/lib/search/grouped_search_results_spec.rb
+++ b/spec/lib/search/grouped_search_results_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe Search::GroupedSearchResults do
+  fab!(:posts) { Fabricate.times(3, :post) }
+
+  def build_results(per_page: nil)
+    described_class.new(
+      type_filter: "topic",
+      term: "hello",
+      search_context: nil,
+      per_page: per_page,
+    )
+  end
+
+  describe "#add" do
+    it "falls back to the site page size when `per_page` is omitted" do
+      SiteSetting.search_page_size = 2
+      results = build_results
+      posts.each { |post| results.add(post) }
+
+      expect(results.posts).to eq(posts.first(2))
+      expect(results.more_full_page_results).to eq(true)
+    end
+
+    it "collects up to `per_page` posts and flags that more results exist" do
+      results = build_results(per_page: 2)
+      posts.each { |post| results.add(post) }
+
+      expect(results.posts).to eq(posts.first(2))
+      expect(results.more_full_page_results).to eq(true)
+    end
+
+    it "ignores a `per_page` above the site page size" do
+      SiteSetting.search_page_size = 1
+      results = build_results(per_page: 10)
+      posts.each { |post| results.add(post) }
+
+      expect(results.posts).to eq(posts.first(1))
+      expect(results.more_full_page_results).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Previously, the AI semantic search endpoint always returned the first page. `SemanticSearch#search_for_topics` accepted a `page` argument, but the controller passed a hardcoded `1`. Callers couldn't reach anything past the first `search_page_size` topics.

This change accepts `page` and `per_page` on the endpoint. It also applies the offset to the filtered rows, so a page can't skip or repeat a topic.

```
GET /discourse-ai/embeddings/semantic-search.json?q=TERM&page=2&per_page=10
```

`page` defaults to 1 and is capped at `MAX_PAGE` (10), matching `SearchController#show`. `per_page` can only narrow `search_page_size`, never widen it. Both return a 400 when malformed. Paginate until `grouped_search_result.more_full_page_results` is false.

`Search::GroupedSearchResults` gains an optional `per_page` to support this. It defaults to `Search.per_filter`, so existing callers keep their current behaviour.

The response shape is unchanged, and `quick_search` is unchanged.
