### PR TITLE
SECURITY: Fix Topic#visible_tags to enforce category-based tag restrictions in topic JSON

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2270,7 +2270,10 @@ class Topic < ActiveRecord::Base
   end
 
   def visible_tags(guardian)
-    tags.reject { |tag| guardian.hidden_tag_names.include?(tag[:name]) }
+    guardian ||= Guardian.new
+    return tags if guardian.is_admin?
+
+    tags.select { |tag| guardian.visible_tag_ids.include?(tag.id) }
   end
 
   def self.editable_custom_fields(guardian)

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -757,7 +757,8 @@ module DiscourseTagging
   end
 
   def self.filter_visible_in_accessible_categories(query, guardian = nil)
-    return query if guardian.nil? || guardian.is_admin?
+    guardian ||= Guardian.new
+    return query if guardian.is_admin?
 
     query.where(<<~SQL, ids: guardian.allowed_category_ids)
       tags.id NOT IN (

--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -39,6 +39,10 @@ module TagGuardian
     is_staff? && SiteSetting.tagging_enabled
   end
 
+  def visible_tag_ids
+    @visible_tag_ids ||= DiscourseTagging.visible_tags(self).pluck(:id).to_set
+  end
+
   def hidden_tag_names
     @hidden_tag_names ||=
       if SiteSetting.tagging_enabled && !is_admin?

--- a/plugins/discourse-templates/spec/helpers/topics_helper.rb
+++ b/plugins/discourse-templates/spec/helpers/topics_helper.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 module DiscourseTemplates::TopicsHelper
-  def serialize_topics(topics)
+  def serialize_topics(topics, user = nil)
+    guardian = user ? user.guardian : Guardian.new
     JSON.parse(
       ActiveModel::ArraySerializer.new(
         topics,
         each_serializer: DiscourseTemplates::TemplatesSerializer,
+        scope: guardian,
       ).to_json,
     )
   end

--- a/plugins/discourse-templates/spec/requests/templates_controller_spec.rb
+++ b/plugins/discourse-templates/spec/requests/templates_controller_spec.rb
@@ -92,7 +92,8 @@ describe DiscourseTemplates::TemplatesController do
         expect(response.status).to eq(200)
 
         parsed = response.parsed_body
-        expected_response = serialize_topics([template_item6, template_item7].sort_by(&:title))
+        expected_response =
+          serialize_topics([template_item6, template_item7].sort_by(&:title), user)
 
         expect(parsed["templates"]).to eq(expected_response)
       end
@@ -128,6 +129,7 @@ describe DiscourseTemplates::TemplatesController do
         expected_response =
           serialize_topics(
             [template_item6, template_item7, template_item_from_other_parent].sort_by(&:title),
+            user,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -149,6 +151,7 @@ describe DiscourseTemplates::TemplatesController do
               template_item6,
               template_item7,
             ].sort_by(&:title),
+            user,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -199,6 +202,7 @@ describe DiscourseTemplates::TemplatesController do
               template_item7,
               template_item_from_other_parent,
             ].sort_by(&:title),
+            moderator,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -229,6 +233,7 @@ describe DiscourseTemplates::TemplatesController do
               template_item7,
               template_item_from_other_parent,
             ].sort_by(&:title),
+            user_in_group1,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -250,6 +255,7 @@ describe DiscourseTemplates::TemplatesController do
               template_item7,
               template_item_from_other_parent,
             ].sort_by(&:title),
+            user_in_group2,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -285,6 +291,7 @@ describe DiscourseTemplates::TemplatesController do
               template_item7,
               template_item_from_other_parent,
             ].sort_by(&:title),
+            admin,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -315,6 +322,7 @@ describe DiscourseTemplates::TemplatesController do
               template_item7,
               template_item_from_other_parent,
             ].sort_by(&:title),
+            admin,
           )
 
         expect(parsed["templates"]).to eq(expected_response)
@@ -387,7 +395,7 @@ describe DiscourseTemplates::TemplatesController do
         expect(response.status).to eq(200)
 
         parsed = response.parsed_body
-        expected_response = serialize_topics([template_item3])
+        expected_response = serialize_topics([template_item3], moderator)
 
         expect(parsed["templates"]).to eq(expected_response)
         expect(parsed["templates"][0]["usages"]).to eq(0)
@@ -401,7 +409,7 @@ describe DiscourseTemplates::TemplatesController do
         parsed = response.parsed_body
 
         template_item3.reload
-        expected_response = serialize_topics([template_item3])
+        expected_response = serialize_topics([template_item3], moderator)
 
         expect(parsed["templates"]).to eq(expected_response)
         expect(parsed["templates"][0]["usages"]).to eq(1)

--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -118,6 +118,22 @@ RSpec.describe DiscourseTagging do
     end
   end
 
+  describe ".filter_visible_in_accessible_categories" do
+    it "treats a nil guardian as anonymous" do
+      public_tag = Fabricate(:tag)
+      restricted_tag = Fabricate(:tag)
+      private_category = Fabricate(:private_category, group: Group[:staff])
+      private_category.tags = [restricted_tag]
+
+      visible_tags =
+        DiscourseTagging.filter_visible_in_accessible_categories(
+          Tag.where(id: [public_tag.id, restricted_tag.id]),
+        )
+
+      expect(visible_tags).to contain_exactly(public_tag)
+    end
+  end
+
   describe "#validate_one_tag_from_group_per_topic" do
     fab!(:tag_group) { Fabricate(:tag_group, tags: [tag1, tag2, tag3], one_per_topic: true) }
     fab!(:topic)

--- a/spec/lib/guardian/tag_guardian_spec.rb
+++ b/spec/lib/guardian/tag_guardian_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe TagGuardian do
     end
   end
 
+  describe "#visible_tag_ids" do
+    it "memoizes category-aware tag visibility" do
+      visible_tag = Fabricate(:tag)
+      restricted_tag = Fabricate(:tag)
+      private_category = Fabricate(:private_category, group: Group[:staff])
+      private_category.tags = [restricted_tag]
+      guardian = Guardian.new(user)
+
+      queries = track_sql_queries { 2.times { guardian.visible_tag_ids } }
+
+      expect(guardian.visible_tag_ids).to include(visible_tag.id)
+      expect(guardian.visible_tag_ids).not_to include(restricted_tag.id)
+      expect(queries.count { |query| query.include?("FROM \"tags\"") }).to eq(1)
+    end
+  end
+
   describe "#can_create_tag?" do
     it "returns false when tagging is disabled" do
       SiteSetting.tagging_enabled = false

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3312,6 +3312,39 @@ RSpec.describe TopicsController do
       expect(response.parsed_body).not_to have_key("tags_descriptions")
     end
 
+    it "does not expose tags restricted to inaccessible categories" do
+      SiteSetting.tagging_enabled = true
+      public_tag = Fabricate(:tag, name: "public-tag", description: "public tag description")
+      restricted_tag =
+        Fabricate(:tag, name: "restricted-tag", description: "restricted tag description")
+      topic.tags = [public_tag, restricted_tag]
+      private_category = Fabricate(:private_category, group: Group[:staff])
+      private_category.tags = [restricted_tag]
+
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["tags"].map { |tag| tag["name"] }).to contain_exactly(
+        public_tag.name,
+      )
+      expect(response.parsed_body["tags_descriptions"]).to eq(
+        { public_tag.name => public_tag.description },
+      )
+
+      sign_in(admin)
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["tags"].map { |tag| tag["name"] }).to contain_exactly(
+        public_tag.name,
+        restricted_tag.name,
+      )
+      expect(response.parsed_body["tags_descriptions"]).to eq(
+        public_tag.name => public_tag.description,
+        restricted_tag.name => restricted_tag.description,
+      )
+    end
+
     it "does not expose links from hidden posts in topic details to non-staff viewers" do
       test_topic = Fabricate(:topic, user: post_author1)
       visible_post = Fabricate(:post, topic: test_topic, user: post_author1)


### PR DESCRIPTION
## Summary

Prevent anonymous topic JSON from exposing names and descriptions of tags restricted to inaccessible categories. Topic#visible_tags now routes through DiscourseTagging.filter_visible, applying the shared category-aware visibility scope used elsewhere, with guardian-visible tag IDs memoized per request to avoid per-topic queries. Tags limited to categories the requester cannot access are omitted from every topic-tag serializer caller.

Also fixes broken specs in template_controller_spec.rb where the helper was always returning serialized topics for an anonymous user rather than the current user, and expecting tags to which the anonymous user did not have access to be visible.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/2463

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>