### PR TITLE
FEATURE: Allow admins to re-run the design wizard after onboarding

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -90,6 +90,17 @@
     }
   }
 
+  // a section whose action is how its feature is reached, rather than a control
+  // for a section you are already using, cannot wait for a hover to be found
+  &.sidebar-section--persistent-actions {
+    .sidebar-section-header-wrapper {
+      .btn.sidebar-section-header-dropdown,
+      .sidebar-section-header-button {
+        opacity: 1;
+      }
+    }
+  }
+
   .sidebar-section-header {
     flex: 1 1 auto;
     align-items: center;

--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -90,8 +90,8 @@
     }
   }
 
-  // a section whose action is how its feature is reached, rather than a control
-  // for a section you are already using, cannot wait for a hover to be found
+  // opt out of the hover reveal above, for actions that have to be found rather
+  // than reached for
   &.sidebar-section--persistent-actions {
     .sidebar-section-header-wrapper {
       .btn.sidebar-section-header-dropdown,

--- a/app/assets/stylesheets/common/components/design-wizard.scss
+++ b/app/assets/stylesheets/common/components/design-wizard.scss
@@ -873,3 +873,15 @@ $dw-button-default-border: #d3d3d3;
     transform: translate(0, 0);
   }
 }
+
+.admin-config-area-themes__design-wizard {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  margin-top: var(--space-4);
+}
+
+.admin-config-area-themes__design-wizard-description {
+  font-size: var(--font-down-1);
+  color: var(--primary-medium);
+}

--- a/app/assets/stylesheets/common/components/design-wizard.scss
+++ b/app/assets/stylesheets/common/components/design-wizard.scss
@@ -878,7 +878,9 @@ $dw-button-default-border: #d3d3d3;
   display: flex;
   gap: var(--space-3);
   align-items: center;
+  padding-block: var(--space-4);
   margin-top: var(--space-4);
+  border-block: 1px solid var(--content-border-color);
 }
 
 .admin-config-area-themes__design-wizard-description {

--- a/app/assets/stylesheets/common/components/design-wizard.scss
+++ b/app/assets/stylesheets/common/components/design-wizard.scss
@@ -189,6 +189,31 @@ $dw-button-default-border: #d3d3d3;
     color: var(--primary-medium);
   }
 
+  &__intro {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: var(--space-4);
+    align-items: flex-start;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  &__intro-description,
+  &__intro-note {
+    margin: 0;
+  }
+
+  &__intro-note {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-2);
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
+    background: var(--primary-100);
+    border-radius: var(--d-border-radius);
+  }
+
   &__sections {
     display: flex;
     flex: 1 1 auto;

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -87,7 +87,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :is_impersonating,
              :impersonation_expires_at,
              :can_change_post_owner,
-             :show_site_owner_onboarding
+             :show_site_owner_onboarding,
+             :can_run_design_wizard
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -173,6 +174,18 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def can_send_private_messages
     scope.can_send_private_messages?
+  end
+
+  # The wizard only offers the core themes and rewrites the site's design in one
+  # pass, so it stops being useful once a site has been customized past what it
+  # covers.
+  def include_can_run_design_wizard?
+    object.admin? && Theme::CORE_THEMES.value?(SiteSetting.default_theme_id) &&
+      !Theme.where.not(id: Theme::CORE_THEMES.values).exists?
+  end
+
+  def can_run_design_wizard
+    true
   end
 
   def include_show_site_owner_onboarding?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -614,12 +614,11 @@ en:
       save: "Save and finish"
       back: "Back"
       next: "Next"
-      launch: "Customize site wizard"
+      launch: "Design wizard"
+      launch_description: "Walk through your site's theme, colors, fonts, and layout again."
       intro:
         description: "This wizard walks you through your site's theme, colors, fonts, homepage layout, welcome banner, and search style."
-        autosave: "Each step is saved as you go, so members see the changes right away."
-        revert_available: "You can put everything back when you close."
-        revert_unavailable: "Your site's current theme is not one this wizard offers, so it cannot be restored afterwards."
+        autosave: "Each step is saved as you go, so members see the changes right away. You can put everything back when you close."
         start: "Get started"
       close:
         message: "You have already saved some changes to your site's design. Do you want to keep them?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -614,6 +614,19 @@ en:
       save: "Save and finish"
       back: "Back"
       next: "Next"
+      launch: "Customize site wizard"
+      intro:
+        description: "This wizard walks you through your site's theme, colors, fonts, homepage layout, welcome banner, and search style."
+        autosave: "Each step is saved as you go, so members see the changes right away."
+        revert_available: "You can put everything back when you close."
+        revert_unavailable: "Your site's current theme is not one this wizard offers, so it cannot be restored afterwards."
+        start: "Get started"
+      close:
+        message: "You have already saved some changes to your site's design. Do you want to keep them?"
+        message_without_revert: "You have already saved some changes to your site's design. They cannot be undone from here."
+        keep: "Keep changes"
+        revert: "Revert changes"
+        continue_editing: "Continue editing"
       sections:
         theme: "Theme"
         colors: "Default color"

--- a/frontend/discourse/admin/components/admin-config-areas/themes.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/themes.gjs
@@ -14,6 +14,8 @@ import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import { i18n } from "discourse-i18n";
 
 export default class AdminConfigAreasThemes extends Component {
+  @service currentUser;
+  @service designWizard;
   @service modal;
   @service router;
   @service toasts;
@@ -74,6 +76,11 @@ export default class AdminConfigAreasThemes extends Component {
   }
 
   @action
+  launchDesignWizard() {
+    this.designWizard.launch({ returnUrl: this.router.currentURL });
+  }
+
+  @action
   clearParams() {
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: { repoUrl: null, repoName: null },
@@ -102,6 +109,13 @@ export default class AdminConfigAreasThemes extends Component {
             @action={{this.installModal}}
           />
         </PluginOutlet>
+        {{#if this.currentUser.admin}}
+          <actions.Default
+            @label="design_wizard.launch"
+            @icon="wand-magic"
+            @action={{this.launchDesignWizard}}
+          />
+        {{/if}}
       </:actions>
     </DPageSubheader>
     <ThemesGrid @themes={{@themes}} @openInstallModal={{this.installModal}} />

--- a/frontend/discourse/admin/components/admin-config-areas/themes.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/themes.gjs
@@ -10,6 +10,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import getURL from "discourse/lib/get-url";
 import DiscourseURL from "discourse/lib/url";
+import DButton from "discourse/ui-kit/d-button";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import { i18n } from "discourse-i18n";
 
@@ -109,15 +110,22 @@ export default class AdminConfigAreasThemes extends Component {
             @action={{this.installModal}}
           />
         </PluginOutlet>
-        {{#if this.currentUser.admin}}
-          <actions.Default
-            @label="design_wizard.launch"
-            @icon="wand-magic"
-            @action={{this.launchDesignWizard}}
-          />
-        {{/if}}
       </:actions>
     </DPageSubheader>
     <ThemesGrid @themes={{@themes}} @openInstallModal={{this.installModal}} />
+
+    {{#if this.currentUser.can_run_design_wizard}}
+      <div class="admin-config-area-themes__design-wizard">
+        <DButton
+          @label="design_wizard.launch"
+          @icon="wand-magic"
+          @action={{this.launchDesignWizard}}
+          class="btn-default admin-config-area-themes__design-wizard-button"
+        />
+        <span class="admin-config-area-themes__design-wizard-description">
+          {{i18n "design_wizard.launch_description"}}
+        </span>
+      </div>
+    {{/if}}
   </template>
 }

--- a/frontend/discourse/app/components/design-wizard-panel.gjs
+++ b/frontend/discourse/app/components/design-wizard-panel.gjs
@@ -6,9 +6,11 @@ import DesignWizardControls from "discourse/components/design-wizard/controls";
 import { isTesting } from "discourse/lib/environment";
 import { prefersReducedMotion } from "discourse/lib/utilities";
 import DButton from "discourse/ui-kit/d-button";
+import { i18n } from "discourse-i18n";
 
 export default class DesignWizardPanel extends Component {
   @service designWizard;
+  @service dialog;
 
   element;
 
@@ -19,6 +21,47 @@ export default class DesignWizardPanel extends Component {
 
   @action
   async close() {
+    // steps are saved as they are completed, so closing a run that changed the
+    // live site is a decision rather than a dismissal
+    if (this.designWizard.needsCloseConfirmation) {
+      const canRevert = this.designWizard.canRevert;
+
+      this.dialog.alert({
+        message: i18n(
+          canRevert
+            ? "design_wizard.close.message"
+            : "design_wizard.close.message_without_revert"
+        ),
+        buttons: [
+          {
+            label: i18n("design_wizard.close.keep"),
+            class: "btn-primary",
+            action: () => this.dismiss(),
+          },
+          {
+            label: i18n("design_wizard.close.continue_editing"),
+            class: "btn-flat",
+          },
+          // last, so the destructive choice is not the one landed on by accident
+          ...(canRevert
+            ? [
+                {
+                  label: i18n("design_wizard.close.revert"),
+                  class: "btn-danger",
+                  action: () => this.designWizard.revert(),
+                },
+              ]
+            : []),
+        ],
+      });
+      return;
+    }
+
+    await this.dismiss();
+  }
+
+  @action
+  async dismiss() {
     if (this.element && !isTesting() && !prefersReducedMotion()) {
       const slideOut =
         getComputedStyle(this.element)

--- a/frontend/discourse/app/components/design-wizard/controls.gjs
+++ b/frontend/discourse/app/components/design-wizard/controls.gjs
@@ -167,10 +167,7 @@ export default class DesignWizardControls extends Component {
       </header>
 
       {{#if this.designWizard.showIntro}}
-        <IntroSection
-          @revertable={{this.designWizard.revertable}}
-          @onStart={{this.startFlow}}
-        />
+        <IntroSection @onStart={{this.startFlow}} />
       {{else}}
         <div class="design-wizard__sections">
           {{#if (eq this.currentStep "theme")}}

--- a/frontend/discourse/app/components/design-wizard/controls.gjs
+++ b/frontend/discourse/app/components/design-wizard/controls.gjs
@@ -6,6 +6,7 @@ import { service } from "@ember/service";
 import ColorsSection from "discourse/components/design-wizard/colors-section";
 import FontsSection from "discourse/components/design-wizard/fonts-section";
 import HomepageSection from "discourse/components/design-wizard/homepage-section";
+import IntroSection from "discourse/components/design-wizard/intro-section";
 import SearchSection from "discourse/components/design-wizard/search-section";
 import Section from "discourse/components/design-wizard/section";
 import ThemeSection from "discourse/components/design-wizard/theme-section";
@@ -145,6 +146,11 @@ export default class DesignWizardControls extends Component {
   }
 
   @action
+  startFlow() {
+    this.designWizard.dismissIntro();
+  }
+
+  @action
   save() {
     this.designWizard.save();
   }
@@ -160,107 +166,114 @@ export default class DesignWizardControls extends Component {
         </span>
       </header>
 
-      <div class="design-wizard__sections">
-        {{#if (eq this.currentStep "theme")}}
-          <Section @title={{i18n "design_wizard.sections.theme"}}>
-            <ThemeSection
-              @themes={{this.designWizard.data.themes}}
-              @currentTheme={{this.designWizard.data.current_theme}}
-              @selectedThemeId={{this.designWizard.themeId}}
-              @applying={{this.busy}}
-              @onSelect={{this.selectTheme}}
-            />
-          </Section>
-        {{else if (eq this.currentStep "colors")}}
-          <Section @title={{i18n "design_wizard.sections.colors"}}>
-            <ColorsSection
-              @pairs={{this.designWizard.pairs}}
-              @selectedPairKey={{this.designWizard.selectedPair.key}}
-              @selectedPairName={{this.designWizard.selectedPair.name}}
-              @colorMode={{this.designWizard.effectiveColorMode}}
-              @darkOnly={{this.designWizard.selectedPair.dark_only}}
-              @userSelectable={{this.designWizard.palettesUserSelectable}}
-              @onSelectPair={{this.selectPair}}
-              @onSelectMode={{this.selectColorMode}}
-              @onToggleUserSelectable={{this.toggleUserSelectable}}
-            />
-          </Section>
-
-          <Section @title={{i18n "design_wizard.sections.fonts"}}>
-            <FontsSection
-              @bodyFont={{this.designWizard.bodyFont}}
-              @headingFont={{this.designWizard.headingFont}}
-              @onSelectBodyFont={{this.selectBodyFont}}
-              @onSelectHeadingFont={{this.selectHeadingFont}}
-            />
-          </Section>
-        {{else}}
-          <Section @title={{i18n "design_wizard.sections.homepage"}}>
-            <HomepageSection
-              @themeId={{this.designWizard.themeId}}
-              @homepage={{this.designWizard.homepage}}
-              @categoryPageStyle={{this.designWizard.categoryPageStyle}}
-              @onSelectHomepage={{this.selectHomepage}}
-              @onSelectCategoryPageStyle={{this.selectCategoryPageStyle}}
-            />
-          </Section>
-
-          <Section @title={{i18n "design_wizard.sections.welcome_banner"}}>
-            <WelcomeBannerSection
-              @enabled={{this.designWizard.welcomeBanner}}
-              @location={{this.designWizard.welcomeBannerLocation}}
-              @onToggle={{this.toggleWelcomeBanner}}
-              @onSelectLocation={{this.selectWelcomeBannerLocation}}
-            />
-          </Section>
-
-          <Section @title={{i18n "design_wizard.sections.search"}}>
-            <SearchSection
-              @searchExperience={{this.designWizard.searchExperience}}
-              @onSelect={{this.selectSearchExperience}}
-            />
-          </Section>
-        {{/if}}
-      </div>
-
-      <footer class="design-wizard__actions">
-        <div class="design-wizard__step-dots">
-          {{#each STEPS as |step index|}}
-            <button
-              type="button"
-              class="design-wizard__step-dot
-                {{if (eq step this.currentStep) '--active'}}"
-              aria-label={{this.goToStepLabel index}}
-              aria-current={{if (eq step this.currentStep) "true"}}
-              disabled={{this.busy}}
-              {{on "click" (fn this.goToStep index)}}
-            ></button>
-          {{/each}}
-        </div>
-        <DButton
-          @action={{this.back}}
-          @label="design_wizard.back"
-          @disabled={{if this.busy true this.isFirstStep}}
-          class="btn-flat design-wizard__back"
+      {{#if this.designWizard.showIntro}}
+        <IntroSection
+          @revertable={{this.designWizard.revertable}}
+          @onStart={{this.startFlow}}
         />
-        {{#if this.isLastStep}}
+      {{else}}
+        <div class="design-wizard__sections">
+          {{#if (eq this.currentStep "theme")}}
+            <Section @title={{i18n "design_wizard.sections.theme"}}>
+              <ThemeSection
+                @themes={{this.designWizard.data.themes}}
+                @currentTheme={{this.designWizard.data.current_theme}}
+                @selectedThemeId={{this.designWizard.themeId}}
+                @applying={{this.busy}}
+                @onSelect={{this.selectTheme}}
+              />
+            </Section>
+          {{else if (eq this.currentStep "colors")}}
+            <Section @title={{i18n "design_wizard.sections.colors"}}>
+              <ColorsSection
+                @pairs={{this.designWizard.pairs}}
+                @selectedPairKey={{this.designWizard.selectedPair.key}}
+                @selectedPairName={{this.designWizard.selectedPair.name}}
+                @colorMode={{this.designWizard.effectiveColorMode}}
+                @darkOnly={{this.designWizard.selectedPair.dark_only}}
+                @userSelectable={{this.designWizard.palettesUserSelectable}}
+                @onSelectPair={{this.selectPair}}
+                @onSelectMode={{this.selectColorMode}}
+                @onToggleUserSelectable={{this.toggleUserSelectable}}
+              />
+            </Section>
+
+            <Section @title={{i18n "design_wizard.sections.fonts"}}>
+              <FontsSection
+                @bodyFont={{this.designWizard.bodyFont}}
+                @headingFont={{this.designWizard.headingFont}}
+                @onSelectBodyFont={{this.selectBodyFont}}
+                @onSelectHeadingFont={{this.selectHeadingFont}}
+              />
+            </Section>
+          {{else}}
+            <Section @title={{i18n "design_wizard.sections.homepage"}}>
+              <HomepageSection
+                @themeId={{this.designWizard.themeId}}
+                @homepage={{this.designWizard.homepage}}
+                @categoryPageStyle={{this.designWizard.categoryPageStyle}}
+                @onSelectHomepage={{this.selectHomepage}}
+                @onSelectCategoryPageStyle={{this.selectCategoryPageStyle}}
+              />
+            </Section>
+
+            <Section @title={{i18n "design_wizard.sections.welcome_banner"}}>
+              <WelcomeBannerSection
+                @enabled={{this.designWizard.welcomeBanner}}
+                @location={{this.designWizard.welcomeBannerLocation}}
+                @onToggle={{this.toggleWelcomeBanner}}
+                @onSelectLocation={{this.selectWelcomeBannerLocation}}
+              />
+            </Section>
+
+            <Section @title={{i18n "design_wizard.sections.search"}}>
+              <SearchSection
+                @searchExperience={{this.designWizard.searchExperience}}
+                @onSelect={{this.selectSearchExperience}}
+              />
+            </Section>
+          {{/if}}
+        </div>
+
+        <footer class="design-wizard__actions">
+          <div class="design-wizard__step-dots">
+            {{#each STEPS as |step index|}}
+              <button
+                type="button"
+                class="design-wizard__step-dot
+                  {{if (eq step this.currentStep) '--active'}}"
+                aria-label={{this.goToStepLabel index}}
+                aria-current={{if (eq step this.currentStep) "true"}}
+                disabled={{this.busy}}
+                {{on "click" (fn this.goToStep index)}}
+              ></button>
+            {{/each}}
+          </div>
           <DButton
-            @action={{this.save}}
-            @label="design_wizard.save"
-            @isLoading={{this.designWizard.saving}}
-            @disabled={{this.busy}}
-            class="btn-primary design-wizard__save"
+            @action={{this.back}}
+            @label="design_wizard.back"
+            @disabled={{if this.busy true this.isFirstStep}}
+            class="btn-flat design-wizard__back"
           />
-        {{else}}
-          <DButton
-            @action={{this.next}}
-            @label="design_wizard.next"
-            @isLoading={{this.designWizard.saving}}
-            @disabled={{if this.busy true this.needsThemeChoice}}
-            class="btn-primary design-wizard__next"
-          />
-        {{/if}}
-      </footer>
+          {{#if this.isLastStep}}
+            <DButton
+              @action={{this.save}}
+              @label="design_wizard.save"
+              @isLoading={{this.designWizard.saving}}
+              @disabled={{this.busy}}
+              class="btn-primary design-wizard__save"
+            />
+          {{else}}
+            <DButton
+              @action={{this.next}}
+              @label="design_wizard.next"
+              @isLoading={{this.designWizard.saving}}
+              @disabled={{if this.busy true this.needsThemeChoice}}
+              class="btn-primary design-wizard__next"
+            />
+          {{/if}}
+        </footer>
+      {{/if}}
     </div>
   </template>
 }

--- a/frontend/discourse/app/components/design-wizard/intro-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/intro-section.gjs
@@ -1,0 +1,29 @@
+import DButton from "discourse/ui-kit/d-button";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+const DesignWizardIntroSection = <template>
+  <div class="design-wizard__intro">
+    <p class="design-wizard__intro-description">
+      {{i18n "design_wizard.intro.description"}}
+    </p>
+    <p class="design-wizard__intro-note">
+      {{dIcon "circle-info" class="design-wizard__intro-note-icon"}}
+      <span>
+        {{i18n "design_wizard.intro.autosave"}}
+        {{if
+          @revertable
+          (i18n "design_wizard.intro.revert_available")
+          (i18n "design_wizard.intro.revert_unavailable")
+        }}
+      </span>
+    </p>
+    <DButton
+      @action={{@onStart}}
+      @label="design_wizard.intro.start"
+      class="btn-primary design-wizard__intro-start"
+    />
+  </div>
+</template>;
+
+export default DesignWizardIntroSection;

--- a/frontend/discourse/app/components/design-wizard/intro-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/intro-section.gjs
@@ -9,14 +9,7 @@ const DesignWizardIntroSection = <template>
     </p>
     <p class="design-wizard__intro-note">
       {{dIcon "circle-info" class="design-wizard__intro-note-icon"}}
-      <span>
-        {{i18n "design_wizard.intro.autosave"}}
-        {{if
-          @revertable
-          (i18n "design_wizard.intro.revert_available")
-          (i18n "design_wizard.intro.revert_unavailable")
-        }}
-      </span>
+      <span>{{i18n "design_wizard.intro.autosave"}}</span>
     </p>
     <DButton
       @action={{@onStart}}

--- a/frontend/discourse/app/components/sidebar/api-section.gjs
+++ b/frontend/discourse/app/components/sidebar/api-section.gjs
@@ -24,6 +24,7 @@ export default class SidebarApiSection extends Component {
         @headerLinkTitle={{@section.title}}
         @headerActionsIcon={{@section.actionsIcon}}
         @headerActions={{@section.actions}}
+        @persistentActions={{@section.persistentActions}}
         @willDestroy={{@section.willDestroy}}
         @collapsable={{@collapsable}}
         @displaySection={{@section.displaySection}}

--- a/frontend/discourse/app/components/sidebar/section.gjs
+++ b/frontend/discourse/app/components/sidebar/section.gjs
@@ -351,6 +351,7 @@ export default class SidebarSection extends Component {
             "sidebar-section--expanded"
             "sidebar-section--collapsed"
           )
+          (if @persistentActions "sidebar-section--persistent-actions")
         }}
         ...attributes
       >
@@ -394,6 +395,7 @@ export default class SidebarSection extends Component {
                   {{on "click" headerAction.action}}
                   type="button"
                   title={{headerAction.title}}
+                  aria-label={{headerAction.title}}
                   class="sidebar-section-header-button btn-icon btn-flat"
                 >
                   {{dIcon @headerActionsIcon}}

--- a/frontend/discourse/app/instance-initializers/design-wizard.js
+++ b/frontend/discourse/app/instance-initializers/design-wizard.js
@@ -18,6 +18,10 @@ export default {
     const params = new URLSearchParams(window.location.search);
 
     if (params.get(DESIGN_WIZARD_PARAM)) {
+      if (!currentUser.can_run_design_wizard) {
+        return;
+      }
+
       // the sheet previews the page behind it, so the link is meant for a forum
       // page; the parameter is dropped so a refresh does not reopen the wizard.
       // The history API rather than the router, which has not booted yet

--- a/frontend/discourse/app/instance-initializers/design-wizard.js
+++ b/frontend/discourse/app/instance-initializers/design-wizard.js
@@ -1,0 +1,38 @@
+import {
+  DESIGN_WIZARD_PARAM,
+  SOURCE_ADMIN,
+} from "discourse/services/design-wizard";
+
+// The wizard sheet outlives the page it was opened from: picking a theme is a
+// different asset build, so previewing one reloads the whole page. Resuming has
+// to happen at boot rather than from whichever component opened the sheet, or
+// only the onboarding banner could ever survive that reload.
+export default {
+  initialize(owner) {
+    const currentUser = owner.lookup("service:current-user");
+    if (!currentUser?.admin) {
+      return;
+    }
+
+    const designWizard = owner.lookup("service:design-wizard");
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get(DESIGN_WIZARD_PARAM)) {
+      // the sheet previews the page behind it, so the link is meant for a forum
+      // page; the parameter is dropped so a refresh does not reopen the wizard.
+      // The history API rather than the router, which has not booted yet
+      params.delete(DESIGN_WIZARD_PARAM);
+      const search = params.toString();
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${search ? `?${search}` : ""}`
+      );
+
+      designWizard.start({ source: SOURCE_ADMIN });
+      return;
+    }
+
+    designWizard.resumeAfterThemePreview();
+  },
+};

--- a/frontend/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/frontend/discourse/app/lib/sidebar/admin-nav-map.js
@@ -251,6 +251,13 @@ export const ADMIN_NAV_MAP = [
   {
     name: "appearance",
     label: "admin.config_sections.appearance.title",
+    headerActions: [
+      {
+        id: "design_wizard",
+        icon: "wand-magic",
+        label: "design_wizard.launch",
+      },
+    ],
     links: [
       {
         name: "admin_logo",

--- a/frontend/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/frontend/discourse/app/lib/sidebar/admin-sidebar.js
@@ -19,6 +19,13 @@ import I18n, { i18n } from "discourse-i18n";
 
 let additionalAdminSidebarSectionLinks = {};
 
+// Section headers can only render links, so anything that is an action rather
+// than a destination is resolved here by the id the nav map declares.
+const SECTION_HEADER_ACTIONS = {
+  design_wizard: ({ designWizard, router }) =>
+    designWizard.launch({ returnUrl: router.currentURL }),
+};
+
 // For testing.
 export function clearAdditionalAdminSidebarSectionLinks() {
   additionalAdminSidebarSectionLinks = {};
@@ -153,7 +160,8 @@ function defineAdminSection(
   adminNavSectionData,
   adminSidebarStateManager,
   router,
-  currentUser
+  currentUser,
+  headerActionContext
 ) {
   const AdminNavSection = class extends BaseCustomSidebarSection {
     constructor() {
@@ -199,6 +207,34 @@ function defineAdminSection(
 
     get collapsedByDefault() {
       return this.adminNavSectionData.name !== "root";
+    }
+
+    get actionsIcon() {
+      return this.#headerActions.length > 1
+        ? "ellipsis-vertical"
+        : this.#headerActions[0]?.icon;
+    }
+
+    @cached
+    get actions() {
+      return this.#headerActions.map((headerAction) => ({
+        id: headerAction.id,
+        title: i18n(headerAction.label),
+        action: () =>
+          SECTION_HEADER_ACTIONS[headerAction.id](headerActionContext),
+      }));
+    }
+
+    // a header action is how its section's own feature is reached, so unlike
+    // the personal sidebar's editing controls it cannot wait for a hover
+    get persistentActions() {
+      return this.#headerActions.length > 0;
+    }
+
+    get #headerActions() {
+      return (this.adminNavSectionData.headerActions ?? []).filter(
+        (headerAction) => SECTION_HEADER_ACTIONS[headerAction.id]
+      );
     }
   };
 
@@ -350,6 +386,9 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     const store = getOwnerWithFallback(this).lookup("service:store");
     const router = getOwnerWithFallback(this).lookup("service:router");
     const session = getOwnerWithFallback(this).lookup("service:session");
+    const designWizard = getOwnerWithFallback(this).lookup(
+      "service:design-wizard"
+    );
 
     this.adminSidebarStateManager = getOwnerWithFallback(this).lookup(
       "service:admin-sidebar-state-manager"
@@ -463,7 +502,8 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         section,
         this.adminSidebarStateManager,
         router,
-        currentUser
+        currentUser,
+        { designWizard, router }
       );
     });
   }

--- a/frontend/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/frontend/discourse/app/lib/sidebar/admin-sidebar.js
@@ -22,8 +22,11 @@ let additionalAdminSidebarSectionLinks = {};
 // Section headers can only render links, so anything that is an action rather
 // than a destination is resolved here by the id the nav map declares.
 const SECTION_HEADER_ACTIONS = {
-  design_wizard: ({ designWizard, router }) =>
-    designWizard.launch({ returnUrl: router.currentURL }),
+  design_wizard: {
+    available: ({ currentUser }) => currentUser?.can_run_design_wizard,
+    action: ({ designWizard, router }) =>
+      designWizard.launch({ returnUrl: router.currentURL }),
+  },
 };
 
 // For testing.
@@ -221,7 +224,7 @@ function defineAdminSection(
         id: headerAction.id,
         title: i18n(headerAction.label),
         action: () =>
-          SECTION_HEADER_ACTIONS[headerAction.id](headerActionContext),
+          SECTION_HEADER_ACTIONS[headerAction.id].action(headerActionContext),
       }));
     }
 
@@ -233,7 +236,10 @@ function defineAdminSection(
 
     get #headerActions() {
       return (this.adminNavSectionData.headerActions ?? []).filter(
-        (headerAction) => SECTION_HEADER_ACTIONS[headerAction.id]
+        (headerAction) =>
+          SECTION_HEADER_ACTIONS[headerAction.id]?.available(
+            headerActionContext
+          )
       );
     }
   };
@@ -503,7 +509,7 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         this.adminSidebarStateManager,
         router,
         currentUser,
-        { designWizard, router }
+        { currentUser, designWizard, router }
       );
     });
   }

--- a/frontend/discourse/app/services/design-wizard.js
+++ b/frontend/discourse/app/services/design-wizard.js
@@ -236,12 +236,10 @@ export default class DesignWizardService extends Service {
 
   // the endpoint only accepts core themes, so a site whose default theme the
   // wizard cannot express is not offered a way back to it
-  get revertable() {
-    return this.source === SOURCE_ADMIN && !!this.#snapshot;
-  }
-
   get canRevert() {
-    return this.revertable && this.progressSaved;
+    return (
+      this.source === SOURCE_ADMIN && this.progressSaved && !!this.#snapshot
+    );
   }
 
   // closing a run that changed the live site is a decision, even when the
@@ -378,8 +376,8 @@ export default class DesignWizardService extends Service {
     this.#reset();
 
     // a saved step or a previewed theme means the page is rendering something
-    // other than what the site is now, so leaving needs a full load
-    if (previewingTheme || progressSaved) {
+    // other than what the site is now, so returning to admin needs a full load
+    if (previewingTheme || (returnsToAdmin && progressSaved)) {
       DiscourseURL.redirectTo(returnsToAdmin ? returnUrl : "/");
     } else if (returnsToAdmin) {
       this.router.transitionTo(returnUrl);

--- a/frontend/discourse/app/services/design-wizard.js
+++ b/frontend/discourse/app/services/design-wizard.js
@@ -15,9 +15,10 @@ import {
   clearPreview,
 } from "discourse/lib/design-wizard-preview";
 import { isTesting } from "discourse/lib/environment";
-import getURL from "discourse/lib/get-url";
 import discourseLater from "discourse/lib/later";
 import { HORIZON_THEME_ID, setLocalTheme } from "discourse/lib/theme-selector";
+import DiscourseURL from "discourse/lib/url";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 const STATE_KEY = "design_wizard_panel_state";
 // site settings the wizard mutates locally to preview a selection, and which
@@ -29,6 +30,13 @@ const PREVIEWED_SITE_SETTINGS = [
   "search_experience",
 ];
 const SELECT_THEME_STEP = "select_theme";
+const SUPPORTED_HOMEPAGES = ["latest", "new", "hot", "categories"];
+// the wizard as the first stop of admin onboarding, versus an admin running it
+// again later from the admin interface
+export const SOURCE_ONBOARDING = "onboarding";
+export const SOURCE_ADMIN = "admin";
+// launches the wizard on load, so it can be reached by URL from anywhere
+export const DESIGN_WIZARD_PARAM = "design_wizard";
 // mirrors the onboarding step's own completion key so a wizard finished
 // after its caller was torn down still marks the step complete
 const STEP_COMPLETED_KEY = `onboarding_step_${SELECT_THEME_STEP}`;
@@ -63,8 +71,16 @@ export default class DesignWizardService extends Service {
   // resuming an in-progress wizard (e.g. after a theme-preview reload)
   // should not replay the sheet's entrance animation
   @tracked animateEntrance = true;
+  @tracked source = SOURCE_ONBOARDING;
+  @tracked returnUrl;
+  // whether a step has been saved, i.e. whether the live site has changed yet
+  @tracked progressSaved = false;
+  @tracked showIntro = false;
 
   #onComplete;
+  #snapshot;
+  #starting = false;
+  #startFailed = false;
   #originalSiteSettings;
   #originalColorSchemeLinks;
   #prefetched = false;
@@ -94,8 +110,15 @@ export default class DesignWizardService extends Service {
     }
   }
 
-  async start({ onComplete } = {}) {
+  async start({
+    onComplete,
+    source = SOURCE_ONBOARDING,
+    returnUrl,
+    resuming = false,
+  } = {}) {
     this.#onComplete = onComplete;
+    this.#starting = true;
+    this.#startFailed = false;
     this.#originalSiteSettings ??= Object.fromEntries(
       PREVIEWED_SITE_SETTINGS.map((name) => [name, this.siteSettings[name]])
     );
@@ -105,23 +128,50 @@ export default class DesignWizardService extends Service {
     try {
       this.data = await ajax("/admin/config/design-wizard.json");
     } catch (error) {
+      this.#starting = false;
+      this.#startFailed = true;
       popupAjaxError(error);
       return;
     }
 
-    const stored = this.#storedState;
+    // stored state describes the run the theme preview interrupted; a run
+    // started from anywhere else is a new one and must not inherit it
+    const stored = resuming ? this.#storedState : null;
     if (stored) {
       this.#restore(stored);
     } else {
+      this.keyValueStore.remove(STATE_KEY);
+      this.source = source;
+      this.returnUrl = returnUrl;
+      this.progressSaved = false;
+      // onboarding introduces the wizard itself; a re-run has to say what it is
+      // about to change before it changes anything
+      this.showIntro = source !== SOURCE_ONBOARDING;
       this.#initFromData();
+      this.#snapshot = this.#buildSnapshot();
+      // the source, the page to return to and the snapshot all have to outlive
+      // the reload a theme preview performs
+      this.#persistState();
     }
 
     this.animateEntrance = !stored;
     this.active = true;
+    this.#starting = false;
     this.#originalColorSchemeLinks = captureColorSchemeLinks();
 
     this.#previewSiteSettings();
     await this.#previewSelections();
+  }
+
+  // entry point for an admin re-running the wizard: the page behind the sheet
+  // is the preview, so the flow has to move to the forum before it opens
+  async launch({ returnUrl } = {}) {
+    if (this.active || this.#starting) {
+      return;
+    }
+
+    await this.router.transitionTo(`discovery.${defaultHomepage()}`);
+    await this.start({ source: SOURCE_ADMIN, returnUrl });
   }
 
   // lets `save` fall back to the store instead of reaching into a caller that
@@ -134,21 +184,27 @@ export default class DesignWizardService extends Service {
 
   resumeAfterThemePreview({ onComplete } = {}) {
     // the caller can remount while the sheet is open (the onboarding banner
-    // renders per-route); an active wizard has nothing to resume, only the
-    // completion callback needs to point at the fresh caller
-    if (this.active) {
+    // renders per-route); an active or opening wizard has nothing to resume,
+    // only the completion callback needs to point at the fresh caller
+    if (this.active || this.#starting) {
       this.#onComplete = onComplete;
+      return;
+    }
+
+    if (this.#startFailed) {
       return;
     }
 
     const previewThemeId = new URLSearchParams(window.location.search).get(
       "preview_theme_id"
     );
-    if (!this.#storedState || previewThemeId === null) {
+    const stored = this.#storedState;
+    // a preview of some other theme is somebody else's link, not this run
+    if (!stored || String(stored.themeId) !== previewThemeId) {
       return;
     }
 
-    this.start({ onComplete });
+    this.start({ onComplete, resuming: true });
   }
 
   get selectedTheme() {
@@ -176,6 +232,26 @@ export default class DesignWizardService extends Service {
     return this.effectiveColorMode === "dark"
       ? (pair.dark ?? pair.light)
       : (pair.light ?? pair.dark);
+  }
+
+  // the endpoint only accepts core themes, so a site whose default theme the
+  // wizard cannot express is not offered a way back to it
+  get revertable() {
+    return this.source === SOURCE_ADMIN && !!this.#snapshot;
+  }
+
+  get canRevert() {
+    return this.revertable && this.progressSaved;
+  }
+
+  // closing a run that changed the live site is a decision, even when the
+  // change cannot be undone from here
+  get needsCloseConfirmation() {
+    return this.source === SOURCE_ADMIN && this.progressSaved;
+  }
+
+  dismissIntro() {
+    this.showIntro = false;
   }
 
   selectTheme(themeId) {
@@ -283,6 +359,10 @@ export default class DesignWizardService extends Service {
   }
 
   stop() {
+    const { returnUrl, progressSaved } = this;
+    const previewingTheme = this.#currentPreviewThemeId !== null;
+    const returnsToAdmin = this.source === SOURCE_ADMIN && !!returnUrl;
+
     this.active = false;
     this.#onComplete = undefined;
     this.keyValueStore.remove(STATE_KEY);
@@ -295,9 +375,14 @@ export default class DesignWizardService extends Service {
       this.#refreshCategoriesPage();
     }
     restoreColorSchemeLinks(this.#originalColorSchemeLinks);
+    this.#reset();
 
-    if (this.#currentPreviewThemeId !== null) {
-      window.location.assign(getURL("/"));
+    // a saved step or a previewed theme means the page is rendering something
+    // other than what the site is now, so leaving needs a full load
+    if (previewingTheme || progressSaved) {
+      DiscourseURL.redirectTo(returnsToAdmin ? returnUrl : "/");
+    } else if (returnsToAdmin) {
+      this.router.transitionTo(returnUrl);
     }
   }
 
@@ -313,13 +398,40 @@ export default class DesignWizardService extends Service {
       this.keyValueStore.remove(STATE_KEY);
       setLocalTheme([], 0);
 
-      if (this.#onComplete) {
-        await this.#onComplete();
-      } else {
-        await this.#completeStepWithoutCaller();
+      // a re-run is not part of onboarding and must not report progress on it
+      if (this.source === SOURCE_ONBOARDING) {
+        if (this.#onComplete) {
+          await this.#onComplete();
+        } else {
+          await this.#completeStepWithoutCaller();
+        }
       }
 
-      window.location.assign(getURL("/"));
+      this.#leave();
+    } catch (error) {
+      this.saving = false;
+      popupAjaxError(error);
+    }
+  }
+
+  // puts the site back the way it was when this run started, for an admin who
+  // explored the wizard on a live site and decided against the result
+  async revert() {
+    if (!this.canRevert) {
+      return;
+    }
+
+    this.saving = true;
+
+    try {
+      await ajax("/admin/config/design-wizard.json", {
+        type: "PUT",
+        data: this.#snapshot,
+      });
+
+      this.keyValueStore.remove(STATE_KEY);
+      setLocalTheme([], 0);
+      this.#leave();
     } catch (error) {
       this.saving = false;
       popupAjaxError(error);
@@ -336,6 +448,9 @@ export default class DesignWizardService extends Service {
         type: "PUT",
         data: this.#selectionsPayload,
       });
+
+      this.progressSaved = true;
+      this.#persistState();
 
       // saving recompiles stylesheets and the live reloader swaps them in,
       // which can momentarily replace the previewed palette with the saved
@@ -367,6 +482,50 @@ export default class DesignWizardService extends Service {
     if (!alreadyCompleted) {
       await logOnboardingEvent("step_completed", SELECT_THEME_STEP);
     }
+  }
+
+  // a full load, so what renders afterwards is the saved site rather than the
+  // preview the sheet was showing
+  #leave() {
+    DiscourseURL.redirectTo(this.returnUrl || "/");
+  }
+
+  #reset() {
+    this.source = SOURCE_ONBOARDING;
+    this.returnUrl = undefined;
+    this.progressSaved = false;
+    this.showIntro = false;
+    this.#snapshot = undefined;
+    this.#originalSiteSettings = undefined;
+  }
+
+  // captured before anything is previewed or saved, from the values the server
+  // reported, so a revert restores the site rather than the preview
+  #buildSnapshot() {
+    const currentTheme = this.data.themes.find((theme) => theme.default);
+    if (!currentTheme) {
+      return;
+    }
+
+    const settings = this.#originalSiteSettings ?? this.siteSettings;
+
+    return {
+      theme_id: currentTheme.id,
+      light_palette_id: currentTheme.color_scheme_id,
+      dark_palette_id: currentTheme.dark_color_scheme_id,
+      palettes_user_selectable: this.data.palettes_user_selectable,
+      base_font: this.data.base_font,
+      heading_font: this.data.heading_font,
+      // a homepage the wizard cannot express is left alone rather than replaced
+      // with the one it fell back to
+      homepage: SUPPORTED_HOMEPAGES.includes(this.data.homepage)
+        ? this.data.homepage
+        : null,
+      category_page_style: settings.desktop_category_page_style,
+      enable_welcome_banner: settings.enable_welcome_banner,
+      welcome_banner_location: settings.welcome_banner_location,
+      search_experience: settings.search_experience,
+    };
   }
 
   get #selectionsPayload() {
@@ -428,6 +587,12 @@ export default class DesignWizardService extends Service {
   }
 
   #restore(stored) {
+    this.source = stored.source ?? SOURCE_ONBOARDING;
+    this.returnUrl = stored.returnUrl;
+    this.progressSaved = stored.progressSaved ?? false;
+    this.#snapshot = stored.snapshot;
+    // the intro is only ever shown once, before the first selection
+    this.showIntro = false;
     this.themeId = stored.themeId;
     this.selectedPairKeys = new Map(stored.selectedPairKeys);
     this.colorMode = stored.colorMode ?? renderedColorMode();
@@ -464,6 +629,10 @@ export default class DesignWizardService extends Service {
         welcomeBanner: this.welcomeBanner,
         welcomeBannerLocation: this.welcomeBannerLocation,
         searchExperience: this.searchExperience,
+        source: this.source,
+        returnUrl: this.returnUrl,
+        progressSaved: this.progressSaved,
+        snapshot: this.#snapshot,
       }),
     });
   }
@@ -486,15 +655,13 @@ export default class DesignWizardService extends Service {
   }
 
   #navigateToThemePreview(themeId) {
-    window.location.assign(
-      getURL(`/?preview_theme_id=${encodeURIComponent(themeId)}`)
+    DiscourseURL.redirectTo(
+      `/?preview_theme_id=${encodeURIComponent(themeId)}`
     );
   }
 
   #supportedHomepage(homepage) {
-    return ["latest", "new", "hot", "categories"].includes(homepage)
-      ? homepage
-      : "latest";
+    return SUPPORTED_HOMEPAGES.includes(homepage) ? homepage : "latest";
   }
 
   #currentPairKey(theme) {

--- a/frontend/discourse/tests/acceptance/design-wizard-test.gjs
+++ b/frontend/discourse/tests/acceptance/design-wizard-test.gjs
@@ -53,7 +53,11 @@ const designWizardData = () => ({
 acceptance("Design wizard - admin launch", function (needs) {
   let savedPayloads = [];
 
-  needs.user({ admin: true, groups: [AUTO_GROUPS.admins] });
+  needs.user({
+    admin: true,
+    groups: [AUTO_GROUPS.admins],
+    can_run_design_wizard: true,
+  });
 
   needs.hooks.beforeEach(function () {
     savedPayloads = [];
@@ -209,5 +213,32 @@ acceptance("Design wizard - moderators", function (needs) {
     assert
       .dom(APPEARANCE_LAUNCH_BUTTON)
       .doesNotExist("so the launcher cannot be reached");
+  });
+});
+
+acceptance("Design wizard - customized site", function (needs) {
+  // a site that has installed a theme or moved off the core themes has grown
+  // past what the wizard can express
+  needs.user({
+    admin: true,
+    groups: [AUTO_GROUPS.admins],
+    can_run_design_wizard: false,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/admin/config/site_settings.json", () =>
+      helper.response(200, { site_settings: [] })
+    );
+  });
+
+  test("the launcher is not offered", async function (assert) {
+    await visit("/admin");
+
+    assert
+      .dom(".sidebar-section[data-section-name='admin-appearance']")
+      .exists("the appearance section is still there");
+    assert
+      .dom(APPEARANCE_LAUNCH_BUTTON)
+      .doesNotExist("but the wizard is not offered any more");
   });
 });

--- a/frontend/discourse/tests/acceptance/design-wizard-test.gjs
+++ b/frontend/discourse/tests/acceptance/design-wizard-test.gjs
@@ -1,0 +1,213 @@
+import {
+  click,
+  currentURL,
+  visit,
+  waitFor,
+  waitUntil,
+} from "@ember/test-helpers";
+import { test } from "qunit";
+import sinon from "sinon";
+import { AUTO_GROUPS } from "discourse/lib/constants";
+import DiscourseURL from "discourse/lib/url";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+const APPEARANCE_LAUNCH_BUTTON =
+  ".sidebar-section[data-section-name='admin-appearance'] .sidebar-section-header-button";
+
+const designWizardData = () => ({
+  themes: [
+    {
+      id: -1,
+      name: "Foundation",
+      default: true,
+      color_scheme_id: null,
+      dark_color_scheme_id: null,
+      screenshot_light_url: null,
+      screenshot_dark_url: null,
+      palette_pairs: [
+        {
+          key: "default",
+          name: "Default",
+          dark_only: false,
+          light: {
+            id: -1,
+            name: "Light",
+            colors: { primary: "222222", secondary: "ffffff" },
+          },
+          dark: {
+            id: -2,
+            name: "Dark",
+            colors: { primary: "dddddd", secondary: "222222" },
+          },
+        },
+      ],
+    },
+  ],
+  current_theme: null,
+  base_font: "inter",
+  heading_font: "inter",
+  homepage: "latest",
+  palettes_user_selectable: false,
+});
+
+acceptance("Design wizard - admin launch", function (needs) {
+  let savedPayloads = [];
+
+  needs.user({ admin: true, groups: [AUTO_GROUPS.admins] });
+
+  needs.hooks.beforeEach(function () {
+    savedPayloads = [];
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/admin/config/design-wizard.json", () =>
+      helper.response(200, designWizardData())
+    );
+
+    server.put("/admin/config/design-wizard.json", (request) => {
+      savedPayloads.push(helper.parsePostData(request.requestBody));
+      return helper.response(200, { success: "OK" });
+    });
+
+    server.get("/color-scheme-stylesheet/:id", () =>
+      helper.response(200, {
+        color_scheme_id: -1,
+        new_href: "/stylesheets/color_definitions_preview.css",
+      })
+    );
+
+    server.get("/color-scheme-stylesheet/:id/:themeId", () =>
+      helper.response(200, {
+        color_scheme_id: -1,
+        new_href: "/stylesheets/color_definitions_preview.css",
+      })
+    );
+
+    server.get("/admin/config/site_settings.json", () =>
+      helper.response(200, { site_settings: [] })
+    );
+  });
+
+  test("the appearance section launches the wizard on the forum", async function (assert) {
+    await visit("/admin");
+
+    assert
+      .dom(APPEARANCE_LAUNCH_BUTTON)
+      .exists("the appearance section offers a launcher");
+
+    await click(APPEARANCE_LAUNCH_BUTTON);
+    await waitFor(".design-wizard");
+
+    assert.dom(".design-wizard").exists("the sheet slides in");
+    assert.strictEqual(
+      currentURL(),
+      "/latest",
+      "leaves the admin interface, so the page behind the sheet is the preview"
+    );
+    assert
+      .dom(".design-wizard__intro")
+      .exists("a re-run says what it is about to change before changing it");
+    assert
+      .dom(".design-wizard__theme-card")
+      .doesNotExist("the steps wait until the intro is acknowledged");
+    assert.strictEqual(savedPayloads.length, 0, "nothing is saved yet");
+  });
+
+  test("closing a run that already saved a step offers to revert", async function (assert) {
+    // leaving is a full page load, which is a no-op under test
+    const redirect = sinon.stub(DiscourseURL, "redirectTo");
+
+    await visit("/admin");
+    await click(APPEARANCE_LAUNCH_BUTTON);
+    await waitFor(".design-wizard__intro-start");
+
+    await click(".design-wizard__intro-start");
+    assert.dom(".design-wizard__theme-card").exists("the first step is shown");
+
+    await click(".design-wizard__next");
+    await waitUntil(() => savedPayloads.length === 1);
+    assert.strictEqual(
+      savedPayloads.length,
+      1,
+      "completing a step saves it to the live site"
+    );
+
+    await click(".design-wizard__close");
+    assert
+      .dom(".dialog-footer .btn-danger")
+      .exists("closing offers to put the site back");
+
+    await click(".dialog-footer .btn-danger");
+    await waitUntil(() => savedPayloads.length === 2);
+
+    assert.strictEqual(
+      savedPayloads[1].theme_id,
+      "-1",
+      "reverts to the theme the site started on"
+    );
+    assert.strictEqual(
+      savedPayloads[1].base_font,
+      "inter",
+      "reverts the fonts the site started with"
+    );
+    assert.true(
+      redirect.calledWith("/admin"),
+      "returns to the admin page the wizard was launched from"
+    );
+  });
+
+  test("a fresh launch ignores an abandoned run", async function (assert) {
+    // a run whose tab was closed rather than dismissed, so its state was left
+    // behind in the key value store
+    window.localStorage.setItem(
+      "discourse_design_wizard_panel_state",
+      JSON.stringify({
+        themeId: -1,
+        selectedPairKeys: [],
+        source: "onboarding",
+        returnUrl: "/somewhere-else",
+        progressSaved: true,
+      })
+    );
+
+    await visit("/admin");
+    await click(APPEARANCE_LAUNCH_BUTTON);
+    await waitFor(".design-wizard");
+
+    assert
+      .dom(".design-wizard__intro")
+      .exists("the abandoned run does not skip this one's intro");
+
+    await click(".design-wizard__close");
+    assert
+      .dom(".dialog-footer")
+      .doesNotExist("the abandoned run's saved steps are not this run's");
+    assert.dom(".design-wizard").doesNotExist("the sheet closes");
+  });
+
+  test("a run that saved nothing closes without asking", async function (assert) {
+    await visit("/admin");
+    await click(APPEARANCE_LAUNCH_BUTTON);
+    await waitFor(".design-wizard__close");
+
+    await click(".design-wizard__close");
+
+    assert.dom(".dialog-footer").doesNotExist("nothing to decide about");
+    assert.dom(".design-wizard").doesNotExist("the sheet closes");
+  });
+});
+
+acceptance("Design wizard - moderators", function (needs) {
+  needs.user({ moderator: true, admin: false });
+
+  test("moderators are not offered the wizard", async function (assert) {
+    await visit("/admin");
+
+    assert
+      .dom(".sidebar-section[data-section-name='admin-appearance']")
+      .doesNotExist("the appearance section is admin-only to begin with");
+    assert
+      .dom(APPEARANCE_LAUNCH_BUTTON)
+      .doesNotExist("so the launcher cannot be reached");
+  });
+});

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -510,6 +510,36 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  describe "#can_run_design_wizard" do
+    fab!(:admin)
+
+    let(:admin_serializer) { described_class.new(admin, scope: Guardian.new(admin), root: false) }
+
+    it "is not included for non-admin users" do
+      expect(serializer.as_json).not_to have_key(:can_run_design_wizard)
+    end
+
+    it "is true for an admin on a site that still uses a core theme" do
+      expect(admin_serializer.as_json[:can_run_design_wizard]).to eq(true)
+    end
+
+    it "is not included once a theme is installed" do
+      Fabricate(:theme)
+      expect(admin_serializer.as_json).not_to have_key(:can_run_design_wizard)
+    end
+
+    it "is not included once a component is installed" do
+      Fabricate(:theme, component: true)
+      expect(admin_serializer.as_json).not_to have_key(:can_run_design_wizard)
+    end
+
+    it "is not included when the default theme is not a core theme" do
+      custom_theme = Fabricate(:theme)
+      custom_theme.set_default!
+      expect(admin_serializer.as_json).not_to have_key(:can_run_design_wizard)
+    end
+  end
+
   describe "#has_new_upcoming_changes" do
     def serialize_for(user)
       described_class.new(user, scope: user.guardian, root: false).as_json


### PR DESCRIPTION
**Previously**, the design wizard could only be reached from the site owner onboarding banner, so an admin who dismissed or outgrew onboarding had no way back into it.

**In this update**, the wizard can be launched from the admin Appearance sidebar section or below the themes list, opening on an intro that says what it will change and offering to revert once it has saved a step. It is only offered while a site still uses a core theme and has no other theme or component installed.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/raw/refs/heads/gh-attach-assets/deca119e-f9e2-4f73-b07c-581281c9b30d/wizard-before.png) | ![after](https://github.com/discourse/discourse/raw/refs/heads/gh-attach-assets/ab8eab68-3c13-4106-89e9-0aff0674575f/wizard-after.png) |