### PR TITLE
FEATURE: Allow setting group access when creating a Data Explorer query

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -1,11 +1,10 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import AceEditor from "discourse/components/ace-editor";
 import BackButton from "discourse/components/back-button";
 import DSegmentedControl from "discourse/components/d-segmented-control";
-import MultiSelect from "discourse/select-kit/components/multi-select";
+import GroupChooser from "discourse/select-kit/components/group-chooser";
 import { and, eq, notEq, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
@@ -103,10 +102,9 @@ export default class QueriesEdit extends Component {
             <div class="groups">
               <span class="label">{{i18n "explorer.allow_groups"}}</span>
               <span>
-                <MultiSelect
+                <GroupChooser
                   @value={{@controller.model.group_ids}}
                   @content={{@controller.groupOptions}}
-                  @options={{hash allowAny=false}}
                   @onChange={{@controller.updateGroupIds}}
                 />
               </span>

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/new.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/new.gjs
@@ -3,6 +3,7 @@ import AceEditor from "discourse/components/ace-editor";
 import BackButton from "discourse/components/back-button";
 import DSegmentedControl from "discourse/components/d-segmented-control";
 import Form from "discourse/components/form";
+import GroupChooser from "discourse/select-kit/components/group-chooser";
 import { and, eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
@@ -149,6 +150,16 @@ export default <template>
               {{on "input" @controller.updateDescription}}
               class="query-new__description-input"
             />
+
+            <label class="query-new__field-label">
+              {{i18n "explorer.allow_groups"}}
+            </label>
+            <GroupChooser
+              @value={{@controller.aiGroupIds}}
+              @content={{@controller.groupOptions}}
+              @onChange={{@controller.updateAiGroupIds}}
+              class="query-group-select"
+            />
           </div>
 
           <div class="query-new__actions">
@@ -192,6 +203,22 @@ export default <template>
             as |field|
           >
             <field.Control />
+          </form.Field>
+          <form.Field
+            @name="groupIds"
+            @title={{i18n "explorer.allow_groups"}}
+            @format="full"
+            @type="custom"
+            as |field|
+          >
+            <field.Control>
+              <GroupChooser
+                @value={{field.value}}
+                @content={{@controller.groupOptions}}
+                @onChange={{field.set}}
+                class="query-group-select"
+              />
+            </field.Control>
           </form.Field>
           <label class="query-new__sql-label">
             {{i18n "explorer.ai.sql_label"}}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { AUTO_GROUPS } from "discourse/lib/constants";
 import I18n, { i18n } from "discourse-i18n";
 import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
 import { dataExplorerAiQueriesEnabled } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-query-availability";
@@ -32,6 +33,8 @@ export default class AdminPluginsExplorerNew extends Controller {
   @tracked generatedDescription = "";
   @tracked mode = rememberedMode() ?? "ai";
   @tracked schema = null;
+  @tracked groups = null;
+  @tracked aiGroupIds = [];
   @tracked hideSchema = dataExplorerStore.get(HIDE_SCHEMA_KEY) === "true";
   @tracked manualSql = "SELECT 1";
   @tracked previewLoading = false;
@@ -39,13 +42,17 @@ export default class AdminPluginsExplorerNew extends Controller {
   @tracked showPreview = false;
   @tracked view = "sql";
 
-  manualFormData = { name: "", description: "" };
+  manualFormData = { name: "", description: "", groupIds: [] };
   _teardownAiGeneration = null;
 
   get previewDisabled() {
     return (
       this.aiGenerating || this.previewLoading || !this.generatedSql.trim()
     );
+  }
+
+  get groupOptions() {
+    return (this.groups ?? []).filter((g) => g.id !== AUTO_GROUPS.everyone.id);
   }
 
   get viewItems() {
@@ -115,7 +122,12 @@ export default class AdminPluginsExplorerNew extends Controller {
   }
 
   @action
-  async create({ name, description }) {
+  updateAiGroupIds(value) {
+    this.aiGroupIds = value;
+  }
+
+  @action
+  async create({ name, description, groupIds }) {
     try {
       this.loading = true;
       const result = await this.store
@@ -123,6 +135,7 @@ export default class AdminPluginsExplorerNew extends Controller {
           name: name.trim(),
           description: description?.trim(),
           sql: this.manualSql,
+          group_ids: groupIds,
         })
         .save();
       this.toasts.success({
@@ -242,6 +255,7 @@ export default class AdminPluginsExplorerNew extends Controller {
           name: this.generatedName,
           description: this.generatedDescription,
           sql: this.generatedSql,
+          group_ids: this.aiGroupIds,
         })
         .save();
       this.toasts.success({
@@ -293,10 +307,12 @@ export default class AdminPluginsExplorerNew extends Controller {
     this.generatedDescription = "";
     this.mode = rememberedMode() ?? "ai";
     this.schema = null;
+    this.groups = null;
+    this.aiGroupIds = [];
     this.hideSchema = dataExplorerStore.get(HIDE_SCHEMA_KEY) === "true";
     this.manualSql = "SELECT 1";
     this.loading = false;
-    this.manualFormData = { name: "", description: "" };
+    this.manualFormData = { name: "", description: "", groupIds: [] };
     this.previewLoading = false;
     this.previewResults = null;
     this.showPreview = false;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/models/query.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/models/query.js
@@ -74,9 +74,8 @@ export default class Query extends RestModel {
 
   createProperties() {
     if (this.sql) {
-      // Importing or saving with SQL
       return this.updateProperties();
     }
-    return this.getProperties("name", "description");
+    return this.getProperties("name", "description", "group_ids");
   }
 }

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/new.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/new.js
@@ -2,15 +2,20 @@ import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AdminPluginsExplorerNew extends DiscourseRoute {
-  model() {
-    return ajax("/admin/plugins/discourse-data-explorer/schema.json", {
-      cache: true,
-    }).then((schema) => ({ schema }));
+  async model() {
+    const [schema, groups] = await Promise.all([
+      ajax("/admin/plugins/discourse-data-explorer/schema.json", {
+        cache: true,
+      }),
+      ajax("/admin/plugins/discourse-data-explorer/groups.json"),
+    ]);
+
+    return { schema, groups };
   }
 
   setupController(controller, model) {
     controller.resetState();
-    controller.setProperties({ schema: model.schema });
+    controller.setProperties({ schema: model.schema, groups: model.groups });
   }
 
   resetController(controller) {

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -729,6 +729,10 @@ table.group-reports {
     min-height: 60px;
   }
 
+  .query-group-select {
+    width: 100%;
+  }
+
   .query-new__actions {
     display: flex;
     gap: 0.5em;

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -119,6 +119,38 @@ describe DiscourseDataExplorer::QueryController do
       end
     end
 
+    describe "#create" do
+      fab!(:group)
+
+      it "grants the given groups access to the new query" do
+        post "/admin/plugins/discourse-data-explorer/queries.json",
+             params: {
+               query: {
+                 name: "My query",
+                 description: "A description",
+                 sql: "SELECT 1",
+                 group_ids: [group.id],
+               },
+             }
+
+        expect(response.status).to eq(200)
+        expect(response_json["query"]["group_ids"]).to eq([group.id])
+      end
+
+      it "creates a query without groups when none are given" do
+        post "/admin/plugins/discourse-data-explorer/queries.json",
+             params: {
+               query: {
+                 name: "My query",
+                 sql: "SELECT 1",
+               },
+             }
+
+        expect(response.status).to eq(200)
+        expect(response_json["query"]["group_ids"]).to eq([])
+      end
+    end
+
     describe "#update" do
       fab!(:user2, :user)
       fab!(:group2) { Fabricate(:group, users: [user2]) }

--- a/plugins/discourse-data-explorer/spec/system/new_query_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/new_query_spec.rb
@@ -17,13 +17,16 @@ describe "Data explorer new query" do
     expect(page).to have_current_path("/admin/plugins/discourse-data-explorer/queries/new")
   end
 
-  it "creates a query with name, description, and SQL" do
+  it "creates a query with name, description, SQL, and group access" do
+    Fabricate(:group, name: "support")
+
     query_runner.visit_new_query
     expect(page).to have_css(".query-new__manual-form .right-panel .schema", text: "topics")
 
     query_runner
       .fill_new_query_name("Test Query")
       .fill_new_query_description("A test description")
+      .select_new_query_groups("support")
       .fill_new_query_sql("SELECT 1")
       .submit_new_query
 
@@ -35,6 +38,11 @@ describe "Data explorer new query" do
     expect(page).to have_current_path("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
     expect(query_runner).to have_query_name("Test Query")
     expect(query_runner).to have_query_description("A test description")
+    expect(query_runner).to have_query_groups("support")
+
+    page.refresh
+
+    expect(query_runner).to have_query_groups("support")
   end
 
   it "creates a query with name only" do

--- a/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_query_runner.rb
+++ b/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_query_runner.rb
@@ -107,6 +107,19 @@ module PageObjects
         self
       end
 
+      def select_new_query_groups(*group_names)
+        select_kit = PageObjects::Components::SelectKit.new(".query-new .query-group-select")
+        select_kit.expand
+        group_names.each { |name| select_kit.select_row_by_name(name) }
+        self
+      end
+
+      def has_query_groups?(*group_names)
+        PageObjects::Components::SelectKit.new(
+          ".query-edit .groups .select-kit",
+        ).has_selected_names?(*group_names)
+      end
+
       def submit_new_query
         page.find(".query-new .btn-primary").click
         self

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/new-query-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/new-query-test.js
@@ -5,6 +5,7 @@ import {
   acceptance,
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("New Query", function (needs) {
   needs.user();
@@ -14,6 +15,11 @@ acceptance("New Query", function (needs) {
   });
 
   const dataExplorerStore = new KeyValueStore("discourse_data_explorer_");
+  let createParams;
+
+  needs.hooks.beforeEach(() => {
+    createParams = null;
+  });
 
   needs.hooks.afterEach(() => {
     dataExplorerStore.remove("hide_schema");
@@ -37,7 +43,10 @@ acceptance("New Query", function (needs) {
     });
 
     server.get("/admin/plugins/discourse-data-explorer/groups.json", () => {
-      return helper.response([]);
+      return helper.response([
+        { id: 0, name: "everyone" },
+        { id: 41, name: "support" },
+      ]);
     });
 
     server.get("/admin/plugins/discourse-data-explorer/schema.json", () => {
@@ -58,7 +67,8 @@ acceptance("New Query", function (needs) {
       });
     });
 
-    server.post("/admin/plugins/discourse-data-explorer/queries", () => {
+    server.post("/admin/plugins/discourse-data-explorer/queries", (request) => {
+      createParams = new URLSearchParams(request.requestBody);
       return helper.response({
         query: {
           id: -15,
@@ -68,7 +78,7 @@ acceptance("New Query", function (needs) {
           param_info: [],
           created_at: "2021-02-05T16:42:45.572Z",
           username: "system",
-          group_ids: [],
+          group_ids: [41],
           last_run_at: "2021-02-08T15:37:49.188Z",
           hidden: false,
           user_id: -1,
@@ -134,6 +144,53 @@ acceptance("New Query", function (needs) {
       .exists("schema hidden state persists across Data Explorer pages");
   });
 
+  test("group access can be granted while creating the query", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/new");
+
+    const groups = selectKit(
+      ".query-new__manual-form [data-name='groupIds'] .query-group-select"
+    );
+    await groups.expand();
+
+    assert.deepEqual(
+      groups.displayedContent().map((row) => row.name),
+      ["support"],
+      "the everyone group is not offered"
+    );
+
+    await groups.selectRowByValue(41);
+    await fillIn(".query-new__manual-form [data-name='name'] input", "foo");
+    await click(".query-new__manual-form .btn-primary");
+
+    assert.deepEqual(
+      createParams.getAll("query[group_ids][]"),
+      ["41"],
+      "the selected groups are sent with the new query"
+    );
+  });
+
+  test("group access survives creating a query with no SQL", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/new");
+
+    document
+      .querySelector(".query-new__manual-form .editor-panel .ace_editor")
+      .env.editor.setValue("", 1);
+
+    const groups = selectKit(
+      ".query-new__manual-form [data-name='groupIds'] .query-group-select"
+    );
+    await groups.expand();
+    await groups.selectRowByValue(41);
+    await fillIn(".query-new__manual-form [data-name='name'] input", "foo");
+    await click(".query-new__manual-form .btn-primary");
+
+    assert.deepEqual(
+      createParams.getAll("query[group_ids][]"),
+      ["41"],
+      "the selected groups are sent even when there is no SQL to save"
+    );
+  });
+
   test("starts with the schema hidden when the preference is stored", async function (assert) {
     dataExplorerStore.set({ key: "hide_schema", value: "true" });
 
@@ -160,6 +217,11 @@ acceptance("New Query - AI", function (needs) {
   });
 
   const GENERATION_ID = "test-generation";
+  let createParams;
+
+  needs.hooks.beforeEach(() => {
+    createParams = null;
+  });
 
   needs.pretender((server, helper) => {
     server.get("/admin/plugins/discourse-data-explorer.json", () => {
@@ -179,7 +241,10 @@ acceptance("New Query - AI", function (needs) {
     });
 
     server.get("/admin/plugins/discourse-data-explorer/groups.json", () =>
-      helper.response([])
+      helper.response([
+        { id: 0, name: "everyone" },
+        { id: 41, name: "support" },
+      ])
     );
     server.get("/admin/plugins/discourse-data-explorer/schema.json", () =>
       helper.response({ topics: [] })
@@ -209,8 +274,9 @@ acceptance("New Query - AI", function (needs) {
         })
     );
 
-    server.post("/admin/plugins/discourse-data-explorer/queries", () =>
-      helper.response({
+    server.post("/admin/plugins/discourse-data-explorer/queries", (request) => {
+      createParams = new URLSearchParams(request.requestBody);
+      return helper.response({
         query: {
           id: -15,
           sql: "SELECT 23 AS my_value",
@@ -221,8 +287,8 @@ acceptance("New Query - AI", function (needs) {
           hidden: false,
           user_id: -1,
         },
-      })
-    );
+      });
+    });
 
     server.get("/admin/plugins/discourse-data-explorer/queries/-15", () =>
       helper.response({
@@ -313,6 +379,21 @@ acceptance("New Query - AI", function (needs) {
     assert
       .dom(".query-new__sql-editor .ace-wrapper")
       .exists("the SQL is available behind its own tab");
+  });
+
+  test("group access can be granted before saving a generated query", async function (assert) {
+    await generate("show me a value");
+
+    const groups = selectKit(".query-new__fields .query-group-select");
+    await groups.expand();
+    await groups.selectRowByValue(41);
+    await click(".query-new__save-btn");
+
+    assert.deepEqual(
+      createParams.getAll("query[group_ids][]"),
+      ["41"],
+      "the selected groups are sent with the new query"
+    );
   });
 
   test("saving transitions to the edit page without running the query", async function (assert) {


### PR DESCRIPTION
Admins had to save a Data Explorer query before choosing which groups could access it, so every new query needed a second trip through the edit page.

This change adds the group picker to both the Write SQL and Generate with AI creation modes. It also fixes group_ids being silently dropped when a query is created without SQL, and moves both the new and edit pages to GroupChooser, which offers a filter rather than listing every group on sites with more than 100.