### PR TITLE
SECURITY: Reject array-valued email/user parameter in PM invite to prevent email-account disclosure

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -917,6 +917,10 @@ class TopicsController < ApplicationController
     guardian.ensure_can_invite_to!(topic)
 
     username_or_email = params[:user] ? fetch_username : fetch_email
+    unless String === username_or_email
+      return render(json: failed_json, status: :unprocessable_entity)
+    end
+
     group_ids =
       Group.lookup_groups(group_ids: params[:group_ids], group_names: params[:group_names]).pluck(
         :id,

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7297,6 +7297,17 @@ RSpec.describe TopicsController do
         expect(pm.reload.topic_allowed_users.pluck(:user_id)).not_to include(user_2.id)
       end
 
+      it "does not disclose an existing user from a form-encoded array email invite" do
+        pm = Fabricate(:private_message_topic, user: user)
+
+        post "/t/#{pm.id}/invite.json", params: { email: [user_2.email, "@"] }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["failed"]).to eq("FAILED")
+        expect(response.body).not_to include(user_2.username)
+        expect(pm.reload.topic_allowed_users.pluck(:user_id)).not_to include(user_2.id)
+      end
+
       it "returns generic success without side effects when an authorized email invite matches an existing user" do
         sign_in(admin)
         pm = Fabricate(:private_message_topic, user: admin)


### PR DESCRIPTION
## Summary

Fix a private-message email-invite bypass where a non-scalar (array) `email` or `user` parameter could slip past the scalar-only email validation and authorization check, allowing an authenticated PM participant without email-invite permission to resolve and disclose a registered account's basic profile and add it to their PM. The controller now rejects any non-String invitee identifier before authorization-sensitive lookups, returning a generic 422 response.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1518

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>