### PR TITLE
DEV: Disallow `everyone` from ai_bot_allowed_groups

### DIFF
--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -411,6 +411,7 @@ discourse_ai:
     list_type: compact
     default: "3|14" # 3: @staff, 14: @trust_level_4
     area: "ai-features/bot"
+    disallowed_groups: "0" # everyone
   ai_bot_public_sharing_allowed_groups:
     client: false
     type: group_list

--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -895,7 +895,7 @@ module DiscourseAi
       def can_attach?(post)
         return false if bot.bot_user.nil?
         return false if post.topic.private_message? && post.post_type != Post.types[:regular]
-        return false if (SiteSetting.ai_bot_allowed_groups_map & post.user.group_ids).blank?
+        return false if !post.user.in_any_groups?(SiteSetting.ai_bot_allowed_groups_map)
         return false if post.custom_fields[BYPASS_AI_REPLY_CUSTOM_FIELD].present?
 
         true


### PR DESCRIPTION
Also fix one call site where user.in_any_groups? was not used
