### PR TITLE
SECURITY: Invalidate topic AI summaries when a post is destroyed

### DIFF
--- a/plugins/discourse-ai/lib/summarization/entry_point.rb
+++ b/plugins/discourse-ai/lib/summarization/entry_point.rb
@@ -99,6 +99,10 @@ module DiscourseAi
           end
         end
 
+        plugin.on(:post_destroyed) do |post|
+          AiSummary.where(target_type: "Topic", target_id: post.topic_id).delete_all
+        end
+
         plugin.on(:posts_moved) do |args|
           if SiteSetting.discourse_ai_enabled && SiteSetting.ai_summarization_enabled &&
                !SiteSetting.ai_summary_backfill_maximum_topics_per_hour.zero?

--- a/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
@@ -156,7 +156,6 @@ RSpec.describe DiscourseAi::Summarization::SummaryController do
         get "/discourse-ai/summarization/t/#{topic.id}.json"
 
         expect(response.status).to eq(404)
-        expect(response.body).not_to include(summary.summarized_text)
       end
 
       it "returns a summary" do

--- a/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
@@ -145,6 +145,20 @@ RSpec.describe DiscourseAi::Summarization::SummaryController do
         expect(response.status).to eq(403)
       end
 
+      it "does not expose a cached summary after a post is soft-deleted" do
+        sensitive_content = "Content removed by staff"
+        post_2.update!(raw: sensitive_content)
+        summary = create_cached_summary(topic)
+        summary.update!(summarized_text: sensitive_content)
+
+        PostDestroyer.new(Fabricate(:admin), post_2).destroy
+
+        get "/discourse-ai/summarization/t/#{topic.id}.json"
+
+        expect(response.status).to eq(404)
+        expect(response.body).not_to include(summary.summarized_text)
+      end
+
       it "returns a summary" do
         summary_text = "This is a summary"
 


### PR DESCRIPTION
## Summary

Prevent disclosure of removed post content by deleting all cached topic summaries (complete summaries, locale variants, and gists) when any post in the topic is destroyed. This ensures cached summary responses can no longer serialize text from a post staff has removed.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1860

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>