### PR TITLE
SECURITY: Preserve topic secure audience for reaction MessageBus broadcasts

### DIFF
--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -377,11 +377,11 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
     message = { post_id: post.id, reactions: [reaction, previous_reaction].compact.uniq }
 
-    opts = {}
-    secure_audience = topic.secure_audience_publish_messages
-    opts = secure_audience if secure_audience[:user_ids] != [] && secure_audience[:group_ids] != []
+    opts = topic.secure_audience_publish_messages
 
-    MessageBus.publish("/topic/#{topic.id}/reactions", message, opts)
+    if opts[:user_ids] != [] && opts[:group_ids] != []
+      MessageBus.publish("/topic/#{topic.id}/reactions", message, opts)
+    end
   end
 
   def secure_reaction_users!(reaction_users)

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -136,7 +136,7 @@ describe DiscourseReactions::CustomReactionsController do
       expect(messages[1].data[:reactions]).to contain_exactly("cry", "angry")
     end
 
-    it "publishes MessageBus messages securely" do
+    it "publishes MessageBus messages to private-message users" do
       sign_in(user_1)
       messages =
         MessageBus.track_publish("/topic/#{private_post.topic.id}/reactions") do
@@ -146,9 +146,30 @@ describe DiscourseReactions::CustomReactionsController do
                 "HTTP_API_USERNAME" => api_key.user.username,
               }
         end
-      user_1_messages = messages.find { |m| m.user_ids.include?(user_1.id) }
+
       expect(messages.count).to eq(1)
-      expect(user_1_messages).to eq(nil)
+      expect(messages.first.user_ids).to include(user_2.id, admin.id)
+      expect(messages.first.group_ids).to be_nil
+      expect(messages.first.user_ids).not_to include(user_1.id)
+    end
+
+    it "does not publish reactions to an empty secure audience" do
+      category = Fabricate(:category, read_restricted: true)
+      topic = Fabricate(:topic, category: category)
+      post = Fabricate(:post, topic: topic)
+
+      messages =
+        MessageBus.track_publish("/topic/#{topic.id}/reactions") do
+          put "/discourse-reactions/posts/#{post.id}/custom-reactions/hugs/toggle.json",
+              headers: {
+                "HTTP_API_KEY" => api_key.key,
+                "HTTP_API_USERNAME" => api_key.user.username,
+              }
+        end
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["reactions"]).to eq(payload_with_user)
+      expect(messages).to be_empty
     end
 
     it "does not publish MessageBus messages when the post topic is unavailable" do


### PR DESCRIPTION
## Summary

Discourse-reactions controller now publishes reaction-change MessageBus events with the topic's secure audience instead of falling back to an unrestricted publish, preventing disclosure of post IDs and reaction activity for read-restricted topics with no permitted groups. The fix matches core fail-closed behavior and skips broadcasts only when no authorized recipients exist.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1323

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>