### PR TITLE
UX: Link AI configuration usage details

### DIFF
--- a/frontend/discourse/app/components/card-contents-base.js
+++ b/frontend/discourse/app/components/card-contents-base.js
@@ -182,6 +182,8 @@ export default class CardContentsBase extends Component {
         event.preventDefault();
         event.stopPropagation();
       }
+
+      return true;
     }
 
     return false;

--- a/frontend/discourse/app/components/group-card-contents.gjs
+++ b/frontend/discourse/app/components/group-card-contents.gjs
@@ -28,6 +28,8 @@ export default class GroupCardContents extends CardContentsBase {
   @service composer;
 
   elementId = "group-card";
+  avatarSelector = "[data-group-card]";
+  avatarDataAttrKey = "groupCard";
   mentionSelector = "a.mention-group";
 
   group = null;

--- a/frontend/discourse/tests/acceptance/group-card-test.js
+++ b/frontend/discourse/tests/acceptance/group-card-test.js
@@ -1,0 +1,74 @@
+import { click, find, settled, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Group Card", function (needs) {
+  needs.user();
+  needs.pretender((server, helper) => {
+    server.get("/groups/support/members.json", () =>
+      helper.response({
+        members: [],
+        owners: [],
+        meta: { total: 0, limit: 10, offset: 0 },
+      })
+    );
+  });
+
+  test("opens for group links and cooked group mentions", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    find("#main-outlet").insertAdjacentHTML(
+      "beforeend",
+      '<a class="user-group trigger-group-card" data-group-card="discourse" href="/g/discourse">Discourse</a>' +
+        '<a class="mention-group" href="/g/discourse">@discourse</a>' +
+        '<a class="mention-group" data-group-card="support" href="/g/support">@support</a>'
+    );
+
+    await click('a[data-group-card="discourse"]');
+
+    assert
+      .dom(".group-card.show .group-page-link")
+      .exists({ count: 1 }, "opens one group card")
+      .hasText("discourse", "loads the group identified by the data attribute");
+
+    await click("#main-outlet");
+    await click('a.mention-group[href="/g/discourse"]');
+
+    assert
+      .dom(".group-card.show .group-page-link")
+      .exists({ count: 1 }, "opens one card for a cooked mention")
+      .hasText("discourse", "derives the group from the cooked mention text");
+
+    await click("#main-outlet");
+    await click('a.mention-group[data-group-card="support"]');
+
+    assert
+      .dom(".group-card.show .group-page-link")
+      .exists({ count: 1 }, "opens one card when both selectors match")
+      .hasText("support", "prefers the authoritative group data attribute");
+  });
+
+  test("does not intercept modifier-click navigation", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    find("#main-outlet").insertAdjacentHTML(
+      "beforeend",
+      '<a class="user-group trigger-group-card" data-group-card="discourse" href="/g/discourse">Discourse</a>'
+    );
+
+    const link = find('a[data-group-card="discourse"]');
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+    });
+
+    assert.true(
+      link.dispatchEvent(event),
+      "leaves native navigation unprevented"
+    );
+    await settled();
+
+    assert.dom(".group-card.show").doesNotExist("does not open the group card");
+  });
+});

--- a/frontend/discourse/tests/integration/components/group-link-test.gjs
+++ b/frontend/discourse/tests/integration/components/group-link-test.gjs
@@ -1,0 +1,45 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import GroupLink from "discourse/components/group-link";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | GroupLink", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders the group card contract with a supplied href", async function (assert) {
+    await render(
+      <template>
+        <GroupLink @name="team" @href="/custom/team">Team</GroupLink>
+      </template>
+    );
+
+    assert
+      .dom("a.user-group.trigger-group-card")
+      .hasAttribute("href", "/custom/team", "preserves the supplied href")
+      .hasAttribute(
+        "data-group-card",
+        "team",
+        "identifies the group for the card"
+      )
+      .hasText("Team", "renders the link contents");
+  });
+
+  test("uses the group URL and name", async function (assert) {
+    this.group = { name: "developers", url: "/g/developers" };
+
+    await render(
+      <template>
+        <GroupLink @group={{this.group}}>Developers</GroupLink>
+      </template>
+    );
+
+    assert
+      .dom("a.user-group.trigger-group-card")
+      .hasAttribute("href", "/g/developers", "uses the group URL")
+      .hasAttribute(
+        "data-group-card",
+        "developers",
+        "uses the group name for the card"
+      );
+  });
+});

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
+import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import AdminSectionLandingItem from "discourse/admin/components/admin-section-landing-item";
@@ -18,6 +19,73 @@ function isPreseeded(llm) {
   if (llm.id < 0) {
     return true;
   }
+}
+
+const FEATURE_USAGE_TYPES = new Set([
+  "ai_bot",
+  "ai_helper",
+  "ai_image_caption",
+  "ai_summarization",
+  "ai_embeddings_semantic_search",
+]);
+
+const RECORD_USAGE_ROUTES = {
+  ai_agent: { route: "adminPlugins.show.discourse-ai-agents.edit" },
+  automation: {
+    route: "adminPlugins.show.automation.edit",
+    parentModel: "automation",
+  },
+  vision_delegate: { route: "adminPlugins.show.discourse-ai-llms.edit" },
+};
+
+export function usageRoute(usage) {
+  if (!usage?.type) {
+    return null;
+  }
+
+  if (FEATURE_USAGE_TYPES.has(usage.type)) {
+    return usage.id === null || usage.id === undefined
+      ? null
+      : {
+          route: "adminPlugins.show.discourse-ai-features.edit",
+          models: [usage.id],
+        };
+  }
+
+  if (usage.type === "ai_spam") {
+    return { route: "adminPlugins.show.discourse-ai-spam" };
+  }
+
+  const target = RECORD_USAGE_ROUTES[usage.type];
+
+  if (!target || usage.id === null || usage.id === undefined) {
+    return null;
+  }
+
+  return {
+    route: target.route,
+    models: target.parentModel ? [target.parentModel, usage.id] : [usage.id],
+  };
+}
+
+class UsageItem extends Component {
+  get target() {
+    return usageRoute(this.args.usage);
+  }
+
+  <template>
+    {{#if this.target}}
+      {{#if this.target.models}}
+        <LinkTo @route={{this.target.route}} @models={{this.target.models}}>
+          {{@label}}
+        </LinkTo>
+      {{else}}
+        <LinkTo @route={{this.target.route}}>{{@label}}</LinkTo>
+      {{/if}}
+    {{else}}
+      {{@label}}
+    {{/if}}
+  </template>
 }
 
 export default class AiLlmsListEditor extends Component {
@@ -127,9 +195,16 @@ export default class AiLlmsListEditor extends Component {
   }
 
   localizeUsage(usage) {
-    return i18n(`discourse_ai.llms.usage.${usage.type}`, {
-      agent: usage.name,
-    });
+    if (!usage?.type) {
+      return usage?.name || "";
+    }
+
+    const key = `discourse_ai.llms.usage.${usage.type}`;
+    if (I18n.lookup(key, { ignoreMissing: true })) {
+      return i18n(key, { agent: usage.name });
+    }
+
+    return usage.name || usage.type;
   }
 
   <template>
@@ -188,7 +263,12 @@ export default class AiLlmsListEditor extends Component {
                       {{#if llm.used_by}}
                         <ul class="ai-llm-list-editor__usages">
                           {{#each llm.used_by as |usage|}}
-                            <li>{{this.localizeUsage usage}}</li>
+                            <li>
+                              <UsageItem
+                                @usage={{usage}}
+                                @label={{this.localizeUsage usage}}
+                              />
+                            </li>
                           {{/each}}
                         </ul>
                       {{/if}}

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-feature-card.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-feature-card.gjs
@@ -3,6 +3,8 @@ import { tracked } from "@glimmer/tracking";
 import { concat } from "@ember/helper";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
+import GroupLink from "discourse/components/group-link";
+import { groupPath } from "discourse/lib/url";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
@@ -162,7 +164,15 @@ export default class AiFeatureCard extends Component {
               {{#if (this.hasGroups @feature)}}
                 <ul class="ai-feature-card__item-groups">
                   {{#each (this.groupList @feature) as |group|}}
-                    <li>{{group.name}}</li>
+                    <li>
+                      <GroupLink
+                        @name={{group.name}}
+                        @href={{groupPath group.name}}
+                        class="mention-group"
+                      >
+                        {{group.name}}
+                      </GroupLink>
+                    </li>
                   {{/each}}
                 </ul>
               {{else}}

--- a/plugins/discourse-ai/assets/stylesheets/common/ai-features.scss
+++ b/plugins/discourse-ai/assets/stylesheets/common/ai-features.scss
@@ -78,14 +78,6 @@
     flex-flow: row wrap;
     gap: var(--space-1);
     margin: 0;
-
-    li {
-      font-size: var(--font-down-1);
-      border-radius: var(--d-border-radius);
-      background: var(--primary-very-low);
-      border: 1px solid var(--primary-low);
-      padding: 1px 3px;
-    }
   }
 }
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -140,6 +140,12 @@
   display: flex;
   flex-wrap: wrap;
 
+  a,
+  a:hover {
+    color: inherit;
+    text-decoration: none;
+  }
+
   li {
     font-size: var(--font-down-2);
     border-radius: 0.25em;

--- a/plugins/discourse-ai/lib/configuration/llm_enumerator.rb
+++ b/plugins/discourse-ai/lib/configuration/llm_enumerator.rb
@@ -9,7 +9,9 @@ module DiscourseAi
         rval = Hash.new { |h, k| h[k] = [] }
 
         if SiteSetting.ai_bot_enabled
-          LlmModel.enabled_chat_bot_ids.each { |llm_id| rval[llm_id] << { type: :ai_bot } }
+          LlmModel.enabled_chat_bot_ids.each do |llm_id|
+            rval[llm_id] << { type: :ai_bot, id: DiscourseAi::Configuration::Module::BOT_ID }
+          end
         end
 
         # this is unconditional, so it is clear that we always signal configuration
@@ -43,7 +45,11 @@ module DiscourseAi
             next if agent.blank? || agent.default_llm_id.blank?
 
             model_id = agent.default_llm_id || SiteSetting.ai_default_llm_model.to_i
-            rval[model_id] << { type: :ai_helper, name: helper_type }
+            rval[model_id] << {
+              type: :ai_helper,
+              name: helper_type,
+              id: DiscourseAi::Configuration::Module::AI_HELPER_ID,
+            }
           end
         end
 
@@ -53,7 +59,10 @@ module DiscourseAi
           if image_caption_agent.present?
             model_id = image_caption_agent.default_llm_id || SiteSetting.ai_default_llm_model.to_i
 
-            rval[model_id] << { type: :ai_image_caption }
+            rval[model_id] << {
+              type: :ai_image_caption,
+              id: DiscourseAi::Configuration::Module::IMAGE_CAPTION_ID,
+            }
           end
         end
 
@@ -61,22 +70,28 @@ module DiscourseAi
           summarization_agent = AiAgent.find_by(id: SiteSetting.ai_summarization_agent)
           model_id = summarization_agent.default_llm_id || SiteSetting.ai_default_llm_model.to_i
 
-          rval[model_id] << { type: :ai_summarization }
+          rval[model_id] << {
+            type: :ai_summarization,
+            id: DiscourseAi::Configuration::Module::SUMMARIZATION_ID,
+          }
         end
 
         if SiteSetting.ai_embeddings_semantic_search_enabled
           search_agent = AiAgent.find_by(id: SiteSetting.ai_embeddings_semantic_search_hyde_agent)
           model_id = search_agent.default_llm_id || SiteSetting.ai_default_llm_model.to_i
 
-          rval[model_id] << { type: :ai_embeddings_semantic_search }
+          rval[model_id] << {
+            type: :ai_embeddings_semantic_search,
+            id: DiscourseAi::Configuration::Module::EMBEDDINGS_ID,
+          }
         end
 
         if SiteSetting.ai_spam_detection_enabled && AiModerationSetting.spam.present?
           model_id = AiModerationSetting.spam[:llm_model_id]
-          rval[model_id] << { type: :ai_spam }
+          rval[model_id] << { type: :ai_spam, id: DiscourseAi::Configuration::Module::SPAM_ID }
         end
 
-        if defined?(DiscourseAutomation::Automation)
+        if defined?(DiscourseAutomation::Automation) && SiteSetting.discourse_automation_enabled
           DiscourseAutomation::Automation
             .joins(:fields)
             .where(script: %w[llm_report llm_triage])

--- a/plugins/discourse-ai/spec/configuration/llm_enumerator_spec.rb
+++ b/plugins/discourse-ai/spec/configuration/llm_enumerator_spec.rb
@@ -49,20 +49,68 @@ RSpec.describe DiscourseAi::Configuration::LlmEnumerator do
   end
 
   describe "#global_usage" do
-    it "returns a hash of Llm models in use globally" do
+    it "returns destination metadata for every built-in feature usage" do
       assign_fake_provider_to(:ai_default_llm_model)
+      # The image caption setting only accepts vision-capable agents and models.
+      fake_model.update!(vision_enabled: true)
+      ai_agent.update!(vision_enabled: true)
+      SiteSetting.ai_bot_enabled = true
+      SiteSetting.ai_bot_enabled_llms = fake_model.id.to_s
       SiteSetting.ai_helper_proofreader_agent = ai_agent.id
       SiteSetting.ai_helper_enabled = true
-      expect(described_class.global_usage).to eq(
-        fake_model.id => [{ type: :ai_helper }],
-        fake_model.id => [
-          { id: ai_agent.id, name: ai_agent.name, type: :ai_agent },
-          { name: "Proofread text", type: :ai_helper },
-        ],
+      SiteSetting.ai_image_caption_agent = ai_agent.id
+      SiteSetting.ai_post_image_captions_enabled = true
+      SiteSetting.ai_summarization_agent = ai_agent.id
+      SiteSetting.ai_summarization_enabled = true
+      SiteSetting.ai_embeddings_semantic_search_hyde_agent = ai_agent.id
+      SiteSetting.ai_embeddings_semantic_search_enabled = true
+      AiModerationSetting.create!(setting_type: :spam, llm_model: fake_model)
+      SiteSetting.ai_spam_detection_enabled = true
+
+      expect(described_class.global_usage.fetch(fake_model.id)).to contain_exactly(
+        { id: ai_agent.id, name: ai_agent.name, type: :ai_agent },
+        { id: DiscourseAi::Configuration::Module::BOT_ID, type: :ai_bot },
+        {
+          id: DiscourseAi::Configuration::Module::AI_HELPER_ID,
+          name: "Proofread text",
+          type: :ai_helper,
+        },
+        { id: DiscourseAi::Configuration::Module::IMAGE_CAPTION_ID, type: :ai_image_caption },
+        { id: DiscourseAi::Configuration::Module::SUMMARIZATION_ID, type: :ai_summarization },
+        {
+          id: DiscourseAi::Configuration::Module::EMBEDDINGS_ID,
+          type: :ai_embeddings_semantic_search,
+        },
+        { id: DiscourseAi::Configuration::Module::SPAM_ID, type: :ai_spam },
       )
     end
 
-    it "returns information about automation rules" do
+    it "returns destination records for automation and vision delegation" do
+      SiteSetting.discourse_automation_enabled = true
+      automation.fields.create!(
+        component: "text",
+        name: "model",
+        metadata: {
+          value: llm_model.id,
+        },
+        target: "script",
+      )
+      vision_target = Fabricate(:llm_model, vision_enabled: true)
+      delegating_model =
+        Fabricate(:llm_model, display_name: "Delegating model", vision_llm_model: vision_target)
+
+      usage = described_class.global_usage
+
+      expect(usage.fetch(llm_model.id)).to contain_exactly(
+        { id: automation.id, name: automation.name, type: :automation },
+      )
+      expect(usage.fetch(vision_target.id)).to contain_exactly(
+        { id: delegating_model.id, name: delegating_model.display_name, type: :vision_delegate },
+      )
+    end
+
+    it "does not emit automation destinations when their admin routes are unavailable" do
+      SiteSetting.discourse_automation_enabled = false
       automation.fields.create!(
         component: "text",
         name: "model",
@@ -72,12 +120,7 @@ RSpec.describe DiscourseAi::Configuration::LlmEnumerator do
         target: "script",
       )
 
-      usage = described_class.global_usage
-
-      expect(usage).to eq(
-        fake_model.id => [{ id: ai_agent.id, name: ai_agent.name, type: :ai_agent }],
-        llm_model.id => [{ id: automation.id, name: automation.name, type: :automation }],
-      )
+      expect(described_class.global_usage).not_to have_key(llm_model.id)
     end
   end
 end

--- a/plugins/discourse-ai/spec/requests/admin/ai_llms_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_llms_controller_spec.rb
@@ -156,20 +156,32 @@ RSpec.describe DiscourseAi::Admin::AiLlmsController do
       llms = response.parsed_body["ai_llms"]
 
       model_json = llms.find { |m| m["id"] == llm_model.id }
-      expect(model_json["used_by"]).to contain_exactly({ "type" => "ai_bot" })
+      expect(model_json["used_by"]).to contain_exactly(
+        { "type" => "ai_bot", "id" => DiscourseAi::Configuration::Module::BOT_ID },
+      )
 
       model2_json = llms.find { |m| m["id"] == llm_model2.id }
 
       expect(model2_json["used_by"]).to contain_exactly(
         { "type" => "ai_agent", "name" => "Cool agent", "id" => ai_agent.id },
-        { "type" => "ai_helper", "name" => "Proofread text" },
+        {
+          "type" => "ai_helper",
+          "name" => "Proofread text",
+          "id" => DiscourseAi::Configuration::Module::AI_HELPER_ID,
+        },
       )
 
       model3_json = llms.find { |m| m["id"] == fake_model.id }
 
       expect(model3_json["used_by"]).to contain_exactly(
-        { "type" => "ai_summarization" },
-        { "type" => "ai_embeddings_semantic_search" },
+        {
+          "type" => "ai_summarization",
+          "id" => DiscourseAi::Configuration::Module::SUMMARIZATION_ID,
+        },
+        {
+          "type" => "ai_embeddings_semantic_search",
+          "id" => DiscourseAi::Configuration::Module::EMBEDDINGS_ID,
+        },
       )
     end
   end

--- a/plugins/discourse-ai/spec/system/llms/ai_llm_spec.rb
+++ b/plugins/discourse-ai/spec/system/llms/ai_llm_spec.rb
@@ -100,6 +100,35 @@ RSpec.describe "Managing LLM configurations" do
     expect(LlmModel.count).to eq(llm_count + 1)
   end
 
+  it "links usage labels to their configuration pages" do
+    SiteSetting.discourse_automation_enabled = true
+    llm_model = Fabricate(:llm_model)
+    SiteSetting.ai_bot_enabled_llms = llm_model.id.to_s
+    automation = Fabricate(:automation, script: "llm_report", name: "LLM report", enabled: true)
+    automation.fields.create!(
+      component: "text",
+      name: "model",
+      metadata: {
+        value: llm_model.id,
+      },
+      target: "script",
+    )
+
+    visit "/admin/plugins/discourse-ai/ai-llms"
+
+    within("[data-llm-id='#{llm_model.name}'] .ai-llm-list-editor__usages") do
+      expect(page).to have_link(
+        I18n.t("js.discourse_ai.llms.usage.ai_bot"),
+        href:
+          "/admin/plugins/discourse-ai/ai-features/#{DiscourseAi::Configuration::Module::BOT_ID}/edit",
+      )
+      expect(page).to have_link(
+        I18n.t("js.discourse_ai.llms.usage.automation", agent: automation.name),
+        href: "/admin/plugins/automation/automation/#{automation.id}",
+      )
+    end
+  end
+
   context "when changing the provider" do
     it "has the correct provider params when visiting the edit page" do
       llm =

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-feature-card-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-feature-card-test.gjs
@@ -1,0 +1,64 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setPrefix } from "discourse/lib/get-url";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import AiFeatureCard from "discourse/plugins/discourse-ai/discourse/components/ai-feature-card";
+
+module("Integration | Component | AiFeatureCard", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  hooks.afterEach(() => setPrefix(""));
+
+  test("renders deduplicated prefix-aware group card links", async function (assert) {
+    setPrefix("/forum");
+    this.feature = {
+      name: "test_feature",
+      enabled: true,
+      llm_models: [],
+      agents: [
+        {
+          id: 1,
+          name: "First agent",
+          allowed_groups: [
+            { id: 10, name: "team" },
+            { id: 11, name: "staff" },
+          ],
+        },
+        {
+          id: 2,
+          name: "Second agent",
+          allowed_groups: [{ id: 10, name: "team" }],
+        },
+      ],
+    };
+
+    await render(
+      <template>
+        <AiFeatureCard
+          @feature={{this.feature}}
+          @localizedFeatureName="Test feature"
+          @showGroups={{true}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".ai-feature-card__item-groups li")
+      .exists({ count: 2 }, "renders each group once");
+    assert
+      .dom('.ai-feature-card__item-groups a[data-group-card="team"]')
+      .exists({ count: 1 }, "deduplicates repeated groups")
+      .hasClass("user-group", "uses the standard group link class")
+      .hasClass("trigger-group-card", "triggers the standard group card")
+      .hasClass("mention-group", "uses the standard group mention styling")
+      .hasAttribute(
+        "href",
+        "/forum/g/team",
+        "uses the prefix-aware group path"
+      );
+    assert
+      .dom('.ai-feature-card__item-groups a[data-group-card="staff"]')
+      .exists({ count: 1 }, "renders the other group")
+      .hasAttribute("href", "/forum/g/staff", "prefixes every group path");
+  });
+});

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-llms-list-editor-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-llms-list-editor-test.gjs
@@ -1,0 +1,142 @@
+import Service from "@ember/service";
+import { findAll, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import AiLlmsListEditor, {
+  usageRoute,
+} from "discourse/plugins/discourse-ai/discourse/components/ai-llms-list-editor";
+
+class AdminPluginNavManagerStub extends Service {
+  currentPlugin = { name: "discourse-ai" };
+}
+
+module("Integration | Component | AiLlmsListEditor", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  hooks.beforeEach(function () {
+    this.owner.unregister("service:admin-plugin-nav-manager");
+    this.owner.register(
+      "service:admin-plugin-nav-manager",
+      AdminPluginNavManagerStub
+    );
+
+    pretender.get("/admin/plugins/discourse-ai/ai-llms.json", () =>
+      response({ ai_llms: [{ id: 1, display_name: "Test model" }] })
+    );
+    pretender.get("/admin/config/site_settings.json", () =>
+      response({
+        site_settings: [
+          {
+            setting: "ai_default_llm_model",
+            value: "1",
+            default: "",
+            type: "enum",
+          },
+        ],
+      })
+    );
+  });
+
+  test("maps supported usages to their admin routes", function (assert) {
+    const featureRoute = "adminPlugins.show.discourse-ai-features.edit";
+
+    for (const type of [
+      "ai_bot",
+      "ai_helper",
+      "ai_image_caption",
+      "ai_summarization",
+      "ai_embeddings_semantic_search",
+    ]) {
+      assert.deepEqual(
+        usageRoute({ type, id: 7 }),
+        { route: featureRoute, models: [7] },
+        `maps ${type} to the feature editor`
+      );
+    }
+
+    assert.deepEqual(usageRoute({ type: "ai_spam", id: 8 }), {
+      route: "adminPlugins.show.discourse-ai-spam",
+    });
+    assert.deepEqual(usageRoute({ type: "ai_agent", id: 2 }), {
+      route: "adminPlugins.show.discourse-ai-agents.edit",
+      models: [2],
+    });
+    assert.deepEqual(usageRoute({ type: "automation", id: 3 }), {
+      route: "adminPlugins.show.automation.edit",
+      models: ["automation", 3],
+    });
+    assert.deepEqual(usageRoute({ type: "vision_delegate", id: 4 }), {
+      route: "adminPlugins.show.discourse-ai-llms.edit",
+      models: [4],
+    });
+    assert.deepEqual(usageRoute({ type: "ai_spam" }), {
+      route: "adminPlugins.show.discourse-ai-spam",
+    });
+    assert.strictEqual(usageRoute({ type: "ai_bot" }), null);
+    assert.strictEqual(usageRoute({ type: "ai_agent" }), null);
+    assert.strictEqual(usageRoute({ type: "future_usage", id: 5 }), null);
+    assert.strictEqual(usageRoute(null), null);
+  });
+
+  test("links known usages and leaves unknown targets as whole plain text labels", async function (assert) {
+    this.llms = {
+      content: [
+        {
+          id: 1,
+          name: "test-model",
+          display_name: "Test model",
+          provider: "fake",
+          used_by: [
+            { type: "ai_agent", id: 2, name: "Research agent" },
+            { type: "ai_bot", id: 7 },
+            { type: "ai_spam", id: 8 },
+            { type: "future_usage", id: 9, name: "Future integration" },
+            { type: "automation", name: "Missing target" },
+          ],
+        },
+      ],
+      resultSetMeta: { presets: [] },
+    };
+
+    await render(<template><AiLlmsListEditor @llms={{this.llms}} /></template>);
+
+    const usages = findAll(".ai-llm-list-editor__usages li");
+    assert.strictEqual(usages.length, 5, "renders every usage");
+    assert.strictEqual(
+      usages[0].querySelector("a")?.textContent.trim(),
+      "Agent (Research agent)",
+      "keeps the complete agent label inside its link"
+    );
+    assert.strictEqual(
+      usages[1].querySelector("a")?.textContent.trim(),
+      "AI bot",
+      "links a built-in feature"
+    );
+    assert.strictEqual(
+      usages[2].querySelector("a")?.textContent.trim(),
+      "Spam",
+      "links spam to its dedicated destination"
+    );
+    assert.strictEqual(
+      usages[3].querySelector("a"),
+      null,
+      "does not guess a route for an unknown usage"
+    );
+    assert.strictEqual(
+      usages[3].textContent.trim(),
+      "Future integration",
+      "keeps an unknown usage readable"
+    );
+    assert.strictEqual(
+      usages[4].querySelector("a"),
+      null,
+      "does not link a target with a missing ID"
+    );
+    assert.strictEqual(
+      usages[4].textContent.trim(),
+      "Automation (Missing target)",
+      "keeps the malformed target label intact"
+    );
+  });
+});


### PR DESCRIPTION
Make LLM usage labels navigate to their relevant feature, agent, automation, spam, or model configuration pages. Include stable feature IDs in usage metadata and keep unknown or incomplete usages readable without guessing a destination.

Render allowed groups with standard group links so their cards open correctly, including when a link matches both group-card selectors or uses modifier-click navigation.
