### PR TITLE
DEV: Update deleted post summary expectation

### DIFF
--- a/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
@@ -105,7 +105,10 @@ RSpec.describe DiscourseAi::Summarization::SummaryController do
 
         get "/discourse-ai/summarization/t/#{topic.id}.json"
 
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("ai_topic_summary", "summarized_text")).not_to include(
+          sensitive_content,
+        )
       end
 
       it "returns a summary" do


### PR DESCRIPTION
## What changed

Update the deleted-post summary request spec for the release branch, where a missing summary returns HTTP 200, and verify that deleted post content is not exposed.

## Testing

Test-only change.