### PR TITLE
SECURITY: Enforce hide_user_activity_tab in reactions activity endpoint

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -186,7 +186,7 @@ module UserGuardian
     !profile_hidden
   end
 
-  def can_see_user_actions?(user, action_types)
+  def can_see_user_actions?(user, action_types = [])
     return true if !@user.anonymous? && (is_me?(user) || is_admin?)
     return false if SiteSetting.hide_user_activity_tab?
     (action_types & UserAction.private_types).empty?

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -45,6 +45,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           current_user.try(:staff?) || (current_user && SiteSetting.show_inactive_accounts),
       )
     raise Discourse::NotFound unless guardian.can_see_profile?(user)
+    raise Discourse::NotFound unless guardian.can_see_user_actions?(user)
 
     reaction_users =
       DiscourseReactions::ReactionUser

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -197,6 +197,23 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]["reaction"]["id"]).to eq(laughing_reaction.id)
     end
 
+    it "hides another user's reaction activity when user activity is hidden" do
+      SiteSetting.hide_user_activity_tab = true
+      sign_in(user_1)
+
+      get "/discourse-reactions/posts/reactions.json", params: { username: user_2.username }
+
+      aggregate_failures do
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).not_to include(
+          reaction_user_1.id.to_s,
+          user_2.id.to_s,
+          post_2.id.to_s,
+          laughing_reaction.reaction_value,
+        )
+      end
+    end
+
     it "does not expose post author names when names are disabled" do
       SiteSetting.enable_names = false
       sign_in(user_1)

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -439,8 +439,8 @@ RSpec.describe UserGuardian do
   end
 
   describe "#can_see_user_actions?" do
-    it "is true by default" do
-      expect(Guardian.new.can_see_user_actions?(nil, [])).to eq(true)
+    it "defaults to no action types" do
+      expect(Guardian.new.can_see_user_actions?(nil)).to eq(true)
     end
 
     context "with 'hide_user_activity_tab' setting" do


### PR DESCRIPTION
## Summary

Prevent ordinary authenticated users from retrieving another user's reaction activity when hide_user_activity_tab is enabled by applying the shared Guardian#can_see_user_actions? policy to the reaction activity endpoint. The policy call now uses a default empty action-type argument, making the no-type form a supported and explicit API. This raises Discourse::NotFound for non-admin/non-self requesters, matching the core user-activity API behavior while preserving access for the profile owner and administrators.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1795

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>