### PR TITLE
SECURITY: Local onebox handler now applies public visibility policy to shared AI conver...

### DIFF
--- a/plugins/discourse-ai/lib/ai_bot/entry_point.rb
+++ b/plugins/discourse-ai/lib/ai_bot/entry_point.rb
@@ -170,7 +170,7 @@ module DiscourseAi
         ) do |url, route|
           if route[:action] == "show" && share_key = route[:share_key]
             if conversation = SharedAiConversation.find_by(share_key: share_key)
-              conversation.onebox
+              conversation.onebox if conversation.publicly_visible?
             end
           end
         end

--- a/plugins/discourse-ai/spec/requests/ai_bot/shared_ai_conversations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/shared_ai_conversations_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DiscourseAi::AiBot::SharedAiConversationsController do
   fab!(:claude_2) { Fabricate(:llm_model, name: "claude-2") }
 
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:attacker) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:topic)
   fab!(:pm, :private_message_topic)
   fab!(:user_pm) { Fabricate(:private_message_topic, recipient: user) }
@@ -430,6 +431,21 @@ RSpec.describe DiscourseAi::AiBot::SharedAiConversationsController do
         artifact.reload
         expect(artifact.metadata&.dig("public")).not_to eq(true)
       end
+    end
+  end
+
+  describe "GET /onebox" do
+    it "does not expose a trashed conversation through a local onebox preview" do
+      source_post = user_pm_share.posts.last
+      source_post.update!(raw: "private transcript excerpt")
+      conversation = SharedAiConversation.share_conversation(user, user_pm_share)
+      user_pm_share.trash!
+
+      sign_in(attacker)
+      get "/onebox.json", params: { url: conversation.url }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include(source_post.raw)
     end
   end
 


### PR DESCRIPTION
## Summary

The local onebox handler for shared AI conversations could render stored PM transcript excerpts even after the source topic was trashed and the direct share route returned 404. The fix now checks `publicly_visible?` before rendering the onebox, so revoked conversations fall back to a plain link instead of exposing transcript content.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1896

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>