### PR TITLE
DEV: Add PLAYWRIGHT_DEVTOOLS env var to automatically show devtools in chrome

### DIFF
--- a/spec/support/system/driver.rb
+++ b/spec/support/system/driver.rb
@@ -116,6 +116,10 @@ module SystemDrivers
       --disable-smooth-scrolling
     ]
 
+    if ENV["PLAYWRIGHT_DEVTOOLS"].presence == "1" || ENV["SELENIUM_DEVTOOLS"].presence == "1"
+      base_args << "--auto-open-devtools-for-tabs"
+    end
+
     if !ENV["CI"]
       base_args << "--remote-debugging-port=" + CHROME_REMOTE_DEBUGGING_PORT
       base_args << "--remote-debugging-address=" + CHROME_REMOTE_DEBUGGING_ADDRESS


### PR DESCRIPTION
Similar to the old CHROME_DEVTOOLS="POSITION" command,
this automatically opens the devtools to the right,
you can't control the position in playwright.
