### PR TITLE
FIX: Prevent starred chat channels from being dropped by fetch limits

### DIFF
--- a/plugins/chat/lib/chat/channel_fetcher.rb
+++ b/plugins/chat/lib/chat/channel_fetcher.rb
@@ -12,11 +12,27 @@ module Chat
     MATCH_QUALITY_PREFIX = 2
     MATCH_QUALITY_PARTIAL = 3
 
+    DEFAULT_MATCH_QUALITY_SELECT = "chat_channels.*, #{MATCH_QUALITY_PARTIAL} AS match_quality"
+
     def self.structured(guardian, include_threads: false)
       memberships = guardian.user ? Chat::ChannelMembershipManager.all_for_user(guardian.user) : []
+
       public_channels = secured_public_channels(guardian, status: :open, following: true)
-      direct_message_channels =
-        guardian.user ? secured_direct_message_channels(guardian.user.id, guardian) : []
+      direct_message_channels = []
+
+      if guardian.user
+        direct_message_channels = secured_direct_message_channels(guardian.user.id, guardian)
+
+        if public_channels.size == MAX_PUBLIC_CHANNEL_RESULTS
+          public_channels |= secured_starred_public_channels(guardian)
+        end
+
+        if direct_message_channels.size == MAX_DM_CHANNEL_RESULTS
+          direct_message_channels |=
+            secured_starred_direct_message_channels(guardian.user.id, guardian)
+        end
+      end
+
       {
         public_channels:,
         direct_message_channels:,
@@ -157,7 +173,7 @@ module Chat
               filter: filter_sql,
             )
 
-          channels = channels.select("chat_channels.*, #{MATCH_QUALITY_PARTIAL} AS match_quality")
+          channels = channels.select(DEFAULT_MATCH_QUALITY_SELECT)
           channels = channels.order("chat_channels.name ASC, categories.name ASC")
         else
           escaped_exact = Chat::Channel.connection.quote(filter_term)
@@ -195,7 +211,7 @@ module Chat
             channels.order("match_quality ASC, chat_channels.name ASC, categories.name ASC")
         end
       else
-        channels = channels.select("chat_channels.*, #{MATCH_QUALITY_PARTIAL} AS match_quality")
+        channels = channels.select(DEFAULT_MATCH_QUALITY_SELECT)
         channels = channels.order("LOWER(chat_channels.name) ASC")
       end
 
@@ -212,6 +228,10 @@ module Chat
                 following: true,
               },
             )
+
+          if options[:starred]
+            channels = channels.where(user_chat_channel_memberships: { starred: true })
+          end
         else
           channels =
             channels.where(
@@ -228,6 +248,10 @@ module Chat
       options[:offset] = [options[:offset].to_i, 0].max
 
       channels.limit(options[:limit]).offset(options[:offset])
+    end
+
+    def self.secured_starred_public_channels(guardian)
+      secured_public_channels(guardian, status: :open, following: true, starred: true)
     end
 
     def self.secured_public_channels(guardian, options = { following: true })
@@ -254,6 +278,10 @@ module Chat
 
     def self.secured_direct_message_channels(user_id, guardian)
       secured_direct_message_channels_search(user_id, guardian, following: true)
+    end
+
+    def self.secured_starred_direct_message_channels(user_id, guardian)
+      secured_direct_message_channels_search(user_id, guardian, following: true, starred: true)
     end
 
     def self.secured_direct_message_channels_search(user_id, guardian, options = {})
@@ -317,12 +345,13 @@ module Chat
 
         query = query.select(select_sql)
       else
-        query = query.select("chat_channels.*, #{MATCH_QUALITY_PARTIAL} AS match_quality")
+        query = query.select(DEFAULT_MATCH_QUALITY_SELECT)
       end
 
       if options.key?(:following)
         following_params = { user_id: }
         following_params[:following] = options[:following] if options[:following].present?
+        following_params[:starred] = true if options[:starred]
         query =
           query.joins(:user_chat_channel_memberships).where(
             user_chat_channel_memberships: following_params,

--- a/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
@@ -41,6 +41,40 @@ describe Chat::ChannelFetcher do
 
       expect(channels).to contain_exactly(category_channel)
     end
+
+    it "returns starred public channels beyond the public channel limit" do
+      first_channel = Fabricate(:category_channel, name: "aardvark")
+      first_channel.user_chat_channel_memberships.create!(user: user1, following: true)
+
+      starred_channel = Fabricate(:category_channel, name: "zebra")
+      starred_channel.user_chat_channel_memberships.create!(
+        user: user1,
+        following: true,
+        starred: true,
+      )
+
+      stub_const(Chat::ChannelFetcher, "MAX_PUBLIC_CHANNEL_RESULTS", 1) do
+        expect(described_class.structured(guardian)[:public_channels]).to contain_exactly(
+          first_channel,
+          starred_channel,
+        )
+      end
+    end
+
+    it "returns starred direct message channels beyond the direct message limit" do
+      recent_channel = Fabricate(:direct_message_channel, users: [user1, user2])
+      recent_channel.update!(last_message: Fabricate(:chat_message, chat_channel: recent_channel))
+
+      starred_channel = Fabricate(:direct_message_channel, users: [user1, user2])
+      starred_channel.membership_for(user1).update!(starred: true)
+
+      stub_const(Chat::ChannelFetcher, "MAX_DM_CHANNEL_RESULTS", 1) do
+        expect(described_class.structured(guardian)[:direct_message_channels]).to contain_exactly(
+          recent_channel,
+          starred_channel,
+        )
+      end
+    end
   end
 
   describe ".tracking_state" do


### PR DESCRIPTION
Previously, `Chat::ChannelFetcher.structured` capped the sidebar payload at 100 followed public channels (ordered alphabetically) and 75 direct message channels (ordered by activity), so a starred channel past either cutoff never reached the client and vanished from the Starred section.

This change fetches starred channels with a dedicated query and merges them into the result, running it only when the base list actually hit its limit so the extra queries cost nothing for the vast majority of users.

Meta: https://meta.discourse.org/t/starred-chats-disappear-if-user-is-in-more-than-100-chats/411040