### PR TITLE
UX: add data explorer admin link to sidebar reports section

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/initializers/data-explorer-admin-plugin-configuration-nav.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/initializers/data-explorer-admin-plugin-configuration-nav.js
@@ -19,6 +19,13 @@ export default {
           route: "adminPlugins.show.explorer",
         },
       ]);
+      api.addAdminSidebarSectionLink("reports", {
+        name: "data_explorer",
+        route: "adminPlugins.show.explorer",
+        routeModels: [PLUGIN_ID],
+        label: "explorer.title",
+        icon: "chart-line",
+      });
     });
   },
 };


### PR DESCRIPTION
When the Data Explorer plugin is installed, this change adds a new sidebar link under reports for admin users.

How it looks:

<img width="278" height="194" alt="CleanShot 2026-08-27 at 12 28 45" src="https://github.com/user-attachments/assets/ddf3638f-c66a-4391-a3ea-247b083626d5" />
