### PR TITLE
FIX: Clamp date-time range ends through a shared helper

### DIFF
--- a/frontend/discourse/app/lib/time-utils.js
+++ b/frontend/discourse/app/lib/time-utils.js
@@ -93,6 +93,22 @@ export function nextBusinessWeekStart(timezone) {
   return startOfDay(now(timezone).add(7, "days")).day(MOMENT_MONDAY);
 }
 
+export function adjustedRangeEnd(from, to, { dateOnly = false } = {}) {
+  if (!from || !to) {
+    return to;
+  }
+
+  if (dateOnly) {
+    return to.isBefore(from, "day") ? from.clone() : to;
+  }
+
+  if (to.isBefore(from) || to.isSame(from)) {
+    return from.clone().add(1, "hour");
+  }
+
+  return to;
+}
+
 export function parseCustomDatetime(
   date,
   time,

--- a/frontend/discourse/app/ui-kit/d-date-time-input-range.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-time-input-range.gjs
@@ -3,6 +3,7 @@ import Component from "@ember/component";
 import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { tagName } from "@ember-decorators/component";
+import { adjustedRangeEnd } from "discourse/lib/time-utils";
 import DDateTimeInput from "discourse/ui-kit/d-date-time-input";
 import { i18n } from "discourse-i18n";
 
@@ -10,8 +11,6 @@ import { i18n } from "discourse-i18n";
 export default class DDateTimeInputRange extends Component {
   from = null;
   to = null;
-  onChangeTo = null;
-  onChangeFrom = null;
   toTimeFirst = false;
   showToTime = true;
   showFromTime = true;
@@ -19,34 +18,17 @@ export default class DDateTimeInputRange extends Component {
 
   @action
   onChangeRanges(options, value) {
-    if (this.onChange) {
-      const state = {
-        from: this.from,
-        to: this.to,
-      };
-
-      const diff = {};
-
-      if (options.prop === "from") {
-        if (this.to && value?.isAfter(this.to)) {
-          diff[options.prop] = value;
-          diff["to"] = value.clone().add(1, "hour");
-        } else {
-          diff[options.prop] = value;
-        }
-      }
-
-      if (options.prop === "to") {
-        if (value && value.isBefore(this.from)) {
-          diff[options.prop] = this.from.clone().add(1, "hour");
-        } else {
-          diff[options.prop] = value;
-        }
-      }
-
-      const newState = { ...state, ...diff };
-      this.onChange(newState);
+    if (!this.onChange) {
+      return;
     }
+
+    const from = options.prop === "from" ? value : this.from;
+    const to = options.prop === "from" ? this.to : value;
+
+    this.onChange({
+      from,
+      to: adjustedRangeEnd(from, to, { dateOnly: !this.showToTime }),
+    });
   }
 
   <template>

--- a/frontend/discourse/tests/integration/ui-kit/d-date-time-input-range-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-date-time-input-range-test.gjs
@@ -73,6 +73,88 @@ module("Integration | ui-kit | DDateTimeInputRange", function (hooks) {
     assert.dom(rows[5]).hasAttribute("data-name", "4:15 PM");
   });
 
+  test("picking an end equal to start pushes the end an hour later", async function (assert) {
+    this.setProperties({
+      state: { from: DEFAULT_DATE_TIME, to: moment("2019-01-29 16:45") },
+    });
+
+    await render(
+      <template>
+        <DDateTimeInputRange
+          @from={{this.state.from}}
+          @onChange={{fn (mut this.state)}}
+          @to={{this.state.to}}
+        />
+      </template>
+    );
+
+    const toTimeSelectKit = selectKit(".to .d-time-input .select-kit");
+    await toTimeSelectKit.expand();
+    await toTimeSelectKit.selectRowByName("2:45 PM");
+
+    assert.strictEqual(
+      this.state.to.format("YYYY-MM-DD h:mm A"),
+      "2019-01-29 3:45 PM",
+      "a zero-length range is not allowed when times are shown"
+    );
+  });
+
+  test("moving the start onto the end pushes the end an hour later", async function (assert) {
+    this.setProperties({
+      state: { from: DEFAULT_DATE_TIME, to: moment("2019-01-29 15:45") },
+    });
+
+    await render(
+      <template>
+        <DDateTimeInputRange
+          @from={{this.state.from}}
+          @onChange={{fn (mut this.state)}}
+          @to={{this.state.to}}
+        />
+      </template>
+    );
+
+    const fromTimeSelectKit = selectKit(".from .d-time-input .select-kit");
+    await fromTimeSelectKit.expand();
+    await fromTimeSelectKit.selectRowByName("3:45 PM");
+
+    assert.strictEqual(
+      this.state.from.format("YYYY-MM-DD h:mm A"),
+      "2019-01-29 3:45 PM"
+    );
+    assert.strictEqual(
+      this.state.to.format("YYYY-MM-DD h:mm A"),
+      "2019-01-29 4:45 PM",
+      "the end keeps a positive duration when the start catches up to it"
+    );
+  });
+
+  test("a single-day range stays intact when times are hidden", async function (assert) {
+    this.setProperties({
+      state: { from: moment("2019-01-29"), to: null },
+    });
+
+    await render(
+      <template>
+        <DDateTimeInputRange
+          @from={{this.state.from}}
+          @onChange={{fn (mut this.state)}}
+          @showFromTime={{false}}
+          @showToTime={{false}}
+          @to={{this.state.to}}
+        />
+      </template>
+    );
+
+    await fillIn(".to.d-date-time-input .date-picker", "2019-01-29");
+
+    assert.strictEqual(
+      this.state.to.format("YYYY-MM-DD HH:mm"),
+      "2019-01-29 00:00",
+      "equal boundaries are a valid date-only range"
+    );
+  });
+
   test("timezone support", async function (assert) {
     this.setProperties({
       state: {

--- a/frontend/discourse/tests/unit/lib/time-utils-test.js
+++ b/frontend/discourse/tests/unit/lib/time-utils-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import {
+  adjustedRangeEnd,
   laterThisWeek,
   laterToday,
   nextMonth,
@@ -13,6 +14,50 @@ const timezone = "Australia/Brisbane";
 
 module("Unit | lib | timeUtils", function (hooks) {
   setupTest(hooks);
+
+  test("adjustedRangeEnd leaves a missing boundary alone", function (assert) {
+    const from = moment("2026-07-01 10:00");
+
+    assert.strictEqual(adjustedRangeEnd(null, null), null);
+    assert.strictEqual(adjustedRangeEnd(from, null), null);
+  });
+
+  test("adjustedRangeEnd pushes an end at or before the start an hour past it", function (assert) {
+    const from = moment("2026-07-01 10:00");
+
+    assert.strictEqual(
+      adjustedRangeEnd(from, from.clone()).format("HH:mm"),
+      "11:00"
+    );
+    assert.strictEqual(
+      adjustedRangeEnd(from, moment("2026-07-01 08:00")).format("HH:mm"),
+      "11:00"
+    );
+  });
+
+  test("adjustedRangeEnd keeps a valid end", function (assert) {
+    const from = moment("2026-07-01 10:00");
+    const to = moment("2026-07-01 12:00");
+
+    assert.strictEqual(adjustedRangeEnd(from, to), to);
+  });
+
+  test("adjustedRangeEnd allows equal boundaries when dateOnly", function (assert) {
+    const from = moment("2026-07-01");
+    const to = moment("2026-07-01");
+
+    assert.strictEqual(adjustedRangeEnd(from, to, { dateOnly: true }), to);
+  });
+
+  test("adjustedRangeEnd snaps an earlier end to the start day when dateOnly", function (assert) {
+    const from = moment("2026-07-01");
+    const to = moment("2026-06-20");
+
+    assert.strictEqual(
+      adjustedRangeEnd(from, to, { dateOnly: true }).format("YYYY-MM-DD"),
+      "2026-07-01"
+    );
+  });
 
   test("nextMonth gets next month correctly", function (assert) {
     withFrozenTime("2019-12-11T08:00:00", timezone, () => {


### PR DESCRIPTION
DDateTimeInputRange hand-rolled its end clamping and accepted a
zero-length range when the picked end equalled the start. Extract the
rule into adjustedRangeEnd: an end at or before the start is pushed an
hour past it, while date-only ranges accept equal boundaries and snap an
earlier end to the start day.

Also drop the dead onChangeTo/onChangeFrom arguments.