### PR TITLE
FIX: Apply the relativeDate min bound in the native date picker

### DIFF
--- a/frontend/discourse/app/ui-kit/d-date-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-input.gjs
@@ -79,13 +79,8 @@ export default class DDateInput extends Component {
       this._picker.setDate(parsedDate, true);
     }
 
-    if (this._picker && this.relativeDate) {
-      const parsedRelativeDate =
-        this.relativeDate instanceof moment
-          ? this.relativeDate
-          : moment(this.relativeDate);
-
-      this._picker.setMinDate(parsedRelativeDate, true);
+    if (this._picker) {
+      this._picker.setMinDate(this.relativeDate);
     }
 
     if (this._picker && !this.date) {
@@ -122,7 +117,12 @@ export default class DDateInput extends Component {
       defaultOptions.minDate = moment(this.relativeDate).toDate();
     }
 
-    return new Pikaday({ ...defaultOptions, ...this._opts() });
+    const picker = new Pikaday({ ...defaultOptions, ...this._opts() });
+    const pikadaySetMinDate = picker.setMinDate.bind(picker);
+    picker.setMinDate = (date) =>
+      pikadaySetMinDate(date ? moment(date).toDate() : null);
+
+    return picker;
   }
 
   _loadNativePicker(container) {
@@ -139,11 +139,15 @@ export default class DDateInput extends Component {
       picker.value = date ? moment(date).format("YYYY-MM-DD") : null;
     };
     picker.setMinDate = (date) => {
-      picker.min = date;
+      picker.min = date ? moment(date).format("YYYY-MM-DD") : "";
     };
 
     if (this.date) {
       picker.setDate(this.date);
+    }
+
+    if (this.relativeDate) {
+      picker.setMinDate(this.relativeDate);
     }
 
     return Promise.resolve(picker);

--- a/frontend/discourse/tests/integration/ui-kit/d-date-input-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-date-input-test.gjs
@@ -1,4 +1,4 @@
-import { fillIn, render, triggerEvent } from "@ember/test-helpers";
+import { fillIn, render, settled, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DDateInput from "discourse/ui-kit/d-date-input";
@@ -46,6 +46,37 @@ module("Integration | ui-kit | DDateInput", function (hooks) {
     await triggerEvent(".date-picker", "change");
 
     assert.true(this.date.isSame(moment("2019-02-02")));
+  });
+
+  test("bounds the picker to the relative date and follows its changes", async function (assert) {
+    this.setProperties({
+      date: DEFAULT_DATE,
+      relativeDate: moment("2019-01-20"),
+    });
+
+    await render(
+      <template>
+        <DDateInput @date={{this.date}} @relativeDate={{this.relativeDate}} />
+      </template>
+    );
+
+    assert
+      .dom(".date-picker")
+      .hasAttribute("min", "2019-01-20", "the bound is applied on load");
+
+    this.set("relativeDate", moment("2019-01-25"));
+    await settled();
+
+    assert
+      .dom(".date-picker")
+      .hasAttribute("min", "2019-01-25", "the bound tracks the relative date");
+
+    this.set("relativeDate", null);
+    await settled();
+
+    assert
+      .dom(".date-picker")
+      .hasAttribute("min", "", "the bound is dropped with the relative date");
   });
 
   test("always shows date in timezone of input timestamp", async function (assert) {

--- a/frontend/discourse/tests/integration/ui-kit/d-date-time-input-range-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-date-time-input-range-test.gjs
@@ -155,6 +155,30 @@ module("Integration | ui-kit | DDateTimeInputRange", function (hooks) {
     );
   });
 
+  test("the to date picker is bounded by the from date", async function (assert) {
+    this.setProperties({
+      state: { from: DEFAULT_DATE_TIME, to: moment("2019-01-30 16:45") },
+    });
+
+    await render(
+      <template>
+        <DDateTimeInputRange
+          @from={{this.state.from}}
+          @onChange={{fn (mut this.state)}}
+          @to={{this.state.to}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".to.d-date-time-input .date-picker")
+      .hasAttribute(
+        "min",
+        "2019-01-29",
+        "days before the start are not selectable"
+      );
+  });
+
   test("timezone support", async function (assert) {
     this.setProperties({
       state: {


### PR DESCRIPTION
Stacked on #42978.

DDateInput accepts @relativeDate as a lower bound, but the native picker
never applied it on load and later assigned a stringified moment that
browsers discard, so the bound only ever worked with pikaday. Format the
bound as YYYY-MM-DD in the date's own timezone, apply it on load, and
normalize the pikaday adapter so both backends take the same input.
Clearing the bound now drops it instead of leaving the last one behind.

Also fix an isDestroying/isDestroyed typo.