### PR TITLE
UX: Bound and clamp event editor dates consistently

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -10,6 +10,10 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { generateLinkifyFunction } from "discourse/lib/text";
+import {
+  adjustedRangeEnd,
+  parseCustomDatetime,
+} from "discourse/lib/time-utils";
 import DButton from "discourse/ui-kit/d-button";
 import DExpandingTextArea from "discourse/ui-kit/d-expanding-text-area";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
@@ -18,6 +22,8 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import PostEventBuilder from "discourse/plugins/discourse-events/discourse/components/modal/post-event-builder";
 import {
+  allDayTransition,
+  attendanceTransition,
   defaultEventState,
   isLivestreamUrl,
   livestreamSource,
@@ -318,7 +324,8 @@ export default class CompactEventEditor extends Component {
       }
     }
 
-    this.#reconcileReminders(oldConfig, this.#configSnapshot());
+    this.#clampEndAfterStart();
+    this.#reconcileReminders(oldConfig);
     this.#emitChange();
   }
 
@@ -333,30 +340,26 @@ export default class CompactEventEditor extends Component {
     }
     const oldConfig = this.#configSnapshot();
     this.startsAt = newStart;
-    this.#reconcileReminders(oldConfig, this.#configSnapshot());
+    this.#clampEndAfterStart();
+    this.#reconcileReminders(oldConfig);
     this.#emitChange();
   }
 
   @action
   onEndDateChange(event) {
     const oldConfig = this.#configSnapshot();
+
     if (!event.target.value) {
       this.endsAt = null;
-      this.#reconcileReminders(oldConfig, this.#configSnapshot());
-      this.#emitChange();
-      return;
-    }
-    const startDateStr = this.formattedStartDate;
-    const dateStr =
-      startDateStr && event.target.value < startDateStr
-        ? startDateStr
-        : event.target.value;
-    if (this.allDay && dateStr === startDateStr) {
-      this.endsAt = null;
     } else {
-      this.endsAt = this.#combineDateTime(dateStr, this.#endTimeForDate());
+      this.endsAt = this.#combineDateTime(
+        event.target.value,
+        this.#endTimeForDate()
+      );
+      this.#clampEndAfterStart();
     }
-    this.#reconcileReminders(oldConfig, this.#configSnapshot());
+
+    this.#reconcileReminders(oldConfig);
     this.#emitChange();
   }
 
@@ -370,7 +373,8 @@ export default class CompactEventEditor extends Component {
       this.formattedEndDate,
       event.target.value || "00:00"
     );
-    this.#reconcileReminders(oldConfig, this.#configSnapshot());
+    this.#clampEndAfterStart();
+    this.#reconcileReminders(oldConfig);
     this.#emitChange();
   }
 
@@ -379,33 +383,17 @@ export default class CompactEventEditor extends Component {
     const newAllDay = !this.allDay;
     const oldConfig = this.#configSnapshot();
 
-    if (newAllDay) {
-      const startDate = (this.startsAt || moment.tz(this.timezone)).format(
-        "YYYY-MM-DD"
-      );
-      const existingEnd = this.endsAt;
-      this.startsAt = moment.tz(startDate, this.timezone);
-
-      if (existingEnd) {
-        const endDate = existingEnd.format("YYYY-MM-DD");
-        this.endsAt =
-          endDate === startDate ? null : moment.tz(endDate, this.timezone);
-      } else {
-        this.endsAt = null;
-      }
-    } else if (this.startsAt) {
-      const nowTime = moment.tz(this.timezone);
-      const newStart = this.startsAt
-        .clone()
-        .hour(nowTime.hour())
-        .minute(nowTime.minute())
-        .second(0)
-        .millisecond(0);
-      this.startsAt = newStart;
-      this.endsAt = newStart.clone().add(1, "hour");
-    }
+    const { startsAt, endsAt } = allDayTransition({
+      startsAt: this.startsAt,
+      endsAt: this.endsAt,
+      timezone: this.timezone,
+      allDay: newAllDay,
+    });
+    this.startsAt = startsAt;
+    this.endsAt = endsAt;
     this.allDay = newAllDay;
-    this.#reconcileReminders(oldConfig, this.#configSnapshot());
+
+    this.#reconcileReminders(oldConfig);
     this.#emitChange();
   }
 
@@ -470,7 +458,11 @@ export default class CompactEventEditor extends Component {
 
   @action
   focusDateInput(event) {
-    next(() => event.target.showPicker?.());
+    next(() => {
+      try {
+        event.target.showPicker?.();
+      } catch {}
+    });
   }
 
   @action
@@ -478,7 +470,7 @@ export default class CompactEventEditor extends Component {
     if (!this.endsAt && this.startsAt) {
       const oldConfig = this.#configSnapshot();
       this.endsAt = this.startsAt.clone().add(1, "day");
-      this.#reconcileReminders(oldConfig, this.#configSnapshot());
+      this.#reconcileReminders(oldConfig);
       this.#emitChange();
     }
 
@@ -607,11 +599,11 @@ export default class CompactEventEditor extends Component {
     this.args.onChange?.(this.currentState);
   }
 
-  #configSnapshot(overrides = {}) {
+  #configSnapshot() {
     return {
-      startsAt: overrides.startsAt ?? this.startsAt,
-      endsAt: overrides.endsAt ?? this.endsAt,
-      allDay: overrides.allDay ?? this.allDay,
+      startsAt: this.startsAt,
+      endsAt: this.endsAt,
+      allDay: this.allDay,
     };
   }
 
@@ -634,8 +626,7 @@ export default class CompactEventEditor extends Component {
     if (!date) {
       return null;
     }
-    const time = (timeStr || "").trim();
-    return moment.tz(time ? `${date} ${time}` : date, this.timezone);
+    return parseCustomDatetime(date, timeStr, this.timezone);
   }
 
   #startTimeForDate() {
@@ -646,33 +637,39 @@ export default class CompactEventEditor extends Component {
     return this.allDay ? "" : this.formattedEndTime || "00:00";
   }
 
-  #reconcileReminders(oldConfig, newConfig) {
+  #reconcileReminders(oldConfig) {
     this.reminders = reconcileDefaultReminder(
       this.reminders,
       oldConfig,
-      newConfig
+      this.#configSnapshot()
     );
   }
 
+  #clampEndAfterStart() {
+    this.endsAt = adjustedRangeEnd(this.startsAt, this.endsAt, {
+      dateOnly: this.allDay,
+    });
+  }
+
   #applyMaxAttendees(value) {
-    if (value === 0) {
-      if (this.status && this.status !== "standalone") {
-        this.#previousRsvpStatus = this.status;
-      }
-      this.status = "standalone";
+    if (value === null) {
       this.maxAttendees = null;
-      this.reminders = this.reminders.map((r) =>
-        r.type === "notification" ? { ...r, type: "bumpTopic" } : r
-      );
-    } else if (this.status === "standalone" && value > 0) {
-      this.status = this.#previousRsvpStatus || "public";
-      this.maxAttendees = value;
-      this.reminders = this.reminders.map((r) =>
-        r.type === "bumpTopic" ? { ...r, type: "notification" } : r
-      );
-    } else {
-      this.maxAttendees = value;
+      this.#emitChange();
+      return;
     }
+
+    const transition = attendanceTransition({
+      mode: value === 0 ? "none" : "upTo",
+      status: this.status,
+      maxAttendees: this.maxAttendees,
+      reminders: this.reminders,
+      previousRsvpStatus: this.#previousRsvpStatus,
+      value,
+    });
+    this.status = transition.status;
+    this.maxAttendees = transition.maxAttendees;
+    this.reminders = transition.reminders;
+    this.#previousRsvpStatus = transition.previousRsvpStatus;
     this.#emitChange();
   }
 

--- a/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -9,6 +9,7 @@ import GroupSelector from "discourse/components/group-selector";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { extractError } from "discourse/lib/ajax-error";
+import { adjustedRangeEnd } from "discourse/lib/time-utils";
 import Group from "discourse/models/group";
 import TimezoneInput from "discourse/select-kit/components/timezone-input";
 import UserChooser from "discourse/select-kit/components/user-chooser";
@@ -22,6 +23,7 @@ import { i18n } from "discourse-i18n";
 import { MAX_HOSTS } from "../../lib/constants";
 import { recurrenceContext } from "../../lib/event-recurrence";
 import {
+  allDayTransition,
   attendanceTransition,
   buildEventBlock,
   buildParams,
@@ -288,7 +290,7 @@ export default class PostEventBuilder extends Component {
       return;
     }
     if (value > 0) {
-      this.#applyUpToValue(value);
+      this.setAttendanceMode("upTo", value);
       return;
     }
     // just clear the data
@@ -440,39 +442,18 @@ export default class PostEventBuilder extends Component {
     const prev = this.#captureConfig();
     this.allDay = allDay;
     this.event.allDay = allDay;
-    if (allDay) {
-      const tz = this.event.timezone || "UTC";
-      const snapped = (this.startsAt ?? moment.tz(tz)).clone().startOf("day");
-      this.startsAt = snapped;
-      this.event.startsAt = snapped;
 
-      const existingEnd = this.endsAt;
-      let newEnd = null;
-      if (existingEnd) {
-        const startDate = snapped.format("YYYY-MM-DD");
-        const endDate = existingEnd.format("YYYY-MM-DD");
-        if (endDate !== startDate) {
-          newEnd = existingEnd.clone().startOf("day");
-        }
-      }
-      this.endsAt = newEnd;
-      this.event.endsAt = newEnd;
-    } else if (this.startsAt) {
-      const tz = this.event.timezone || "UTC";
-      const nowTime = moment.tz(tz);
-      const newStart = this.startsAt
-        .clone()
-        .hour(nowTime.hour())
-        .minute(nowTime.minute())
-        .second(0)
-        .millisecond(0);
-      this.startsAt = newStart;
-      this.event.startsAt = newStart;
+    const { startsAt, endsAt } = allDayTransition({
+      startsAt: this.startsAt,
+      endsAt: this.endsAt,
+      timezone: this.event.timezone || "UTC",
+      allDay,
+    });
+    this.startsAt = startsAt;
+    this.event.startsAt = startsAt;
+    this.endsAt = endsAt;
+    this.event.endsAt = endsAt;
 
-      const newEnd = newStart.clone().add(1, "hour");
-      this.endsAt = newEnd;
-      this.event.endsAt = newEnd;
-    }
     this.#reconcileReminder(prev);
   }
 
@@ -502,26 +483,22 @@ export default class PostEventBuilder extends Component {
 
   @action
   onChangeStartsAt(set, value) {
-    const to =
-      value && this.endsAt && value.isAfter(this.endsAt)
-        ? value.clone().add(1, "hour")
-        : this.endsAt;
+    const to = adjustedRangeEnd(value, this.endsAt, { dateOnly: this.allDay });
     this.onChangeDates({ from: value, to });
     set(value);
   }
 
   @action
   onChangeEndsAt(set, value) {
-    const to =
-      value && this.startsAt && value.isBefore(this.startsAt)
-        ? this.startsAt.clone().add(1, "hour")
-        : value;
+    const to = adjustedRangeEnd(this.startsAt, value, {
+      dateOnly: this.allDay,
+    });
     this.onChangeDates({ from: this.startsAt, to });
     set(to);
   }
 
   @action
-  setAttendanceMode(mode) {
+  setAttendanceMode(mode, value) {
     this.attendanceMode = mode;
     const next = attendanceTransition({
       mode,
@@ -530,6 +507,7 @@ export default class PostEventBuilder extends Component {
       reminders: this.event.reminders,
       previousRsvpStatus: this.previousRsvpStatus,
       previousMaxAttendees: this.previousMaxAttendees,
+      value,
     });
     this.event.status = next.status;
     this.event.maxAttendees = next.maxAttendees;
@@ -719,24 +697,6 @@ export default class PostEventBuilder extends Component {
       set("livestream", false);
       this.event.livestream = false;
     }
-  }
-
-  #applyUpToValue(value) {
-    if (this.event.status === "standalone") {
-      this.event.status = this.previousRsvpStatus || "public";
-      this.event.reminders = (this.event.reminders || []).map((r) =>
-        r.type === "bumpTopic" ? { ...r, type: "notification" } : r
-      );
-      this.#syncRemindersToForm();
-    }
-    this.attendanceMode = "upTo";
-    this.event.maxAttendees = value;
-    this.previousMaxAttendees = value;
-    this.formApi?.setProperties({
-      attendanceMode: "upTo",
-      maxAttendees: value,
-      eventType: this.event.status,
-    });
   }
 
   #syncRemindersToForm() {

--- a/plugins/discourse-events/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -1,3 +1,4 @@
+import { camelize } from "@ember/string";
 import { buildBBCodeAttrs, parseBBCodeTag } from "discourse/lib/text";
 
 let lastSetting;
@@ -71,6 +72,32 @@ export function livestreamSource(location, url) {
   return location?.trim() ? location : url;
 }
 
+export function allDayTransition({ startsAt, endsAt, timezone, allDay }) {
+  if (allDay) {
+    const startDate = (startsAt ?? moment.tz(timezone)).format("YYYY-MM-DD");
+    const start = moment.tz(startDate, timezone);
+    const sameDay = endsAt?.format("YYYY-MM-DD") === startDate;
+    const end =
+      !endsAt || sameDay
+        ? null
+        : moment.tz(endsAt.format("YYYY-MM-DD"), timezone);
+    return { startsAt: start, endsAt: end };
+  }
+
+  if (!startsAt) {
+    return { startsAt, endsAt };
+  }
+
+  const now = moment.tz(timezone);
+  const start = startsAt
+    .clone()
+    .hour(now.hour())
+    .minute(now.minute())
+    .second(0)
+    .millisecond(0);
+  return { startsAt: start, endsAt: start.clone().add(1, "hour") };
+}
+
 export function defaultReminderFor({ startsAt, endsAt, allDay } = {}) {
   const start = startsAt ? moment(startsAt) : null;
   const end = endsAt ? moment(endsAt) : null;
@@ -84,8 +111,7 @@ export function defaultReminderFor({ startsAt, endsAt, allDay } = {}) {
 }
 
 export function reminderToBBCode(reminder) {
-  const raw = parseInt(reminder.value, 10);
-  const magnitude = Math.abs(Number.isFinite(raw) ? raw : 0);
+  const magnitude = Math.abs(parseInt(reminder.value, 10));
   const value = reminder.period === "after" ? -magnitude : magnitude;
   return `${reminder.type}.${value}.${reminder.unit}`;
 }
@@ -107,6 +133,7 @@ export function attendanceTransition({
   reminders,
   previousRsvpStatus,
   previousMaxAttendees,
+  value,
 }) {
   let nextStatus = status;
   let nextMax = maxAttendees;
@@ -139,7 +166,10 @@ export function attendanceTransition({
       }
       nextMax = null;
     } else if (mode === "upTo") {
-      nextMax = previousMaxAttendees || null;
+      nextMax = value ?? previousMaxAttendees ?? null;
+      if (value != null) {
+        nextPrevMax = value;
+      }
     }
   }
 
@@ -264,22 +294,7 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
   }
 
   if (event.reminders && event.reminders.length) {
-    params.reminders = event.reminders
-      .map((r) => {
-        // we create a new intermediate object to avoid changes in the UI while
-        // we prepare the values for request
-        const reminder = Object.assign({}, r);
-
-        if (reminder.period === "after") {
-          reminder.value = `-${Math.abs(parseInt(reminder.value, 10))}`;
-        }
-        if (reminder.period === "before") {
-          reminder.value = Math.abs(parseInt(`${reminder.value}`, 10));
-        }
-
-        return `${reminder.type}.${reminder.value}.${reminder.unit}`;
-      })
-      .join(",");
+    params.reminders = event.reminders.map(reminderToBBCode).join(",");
   }
 
   if (event.imageUpload?.short_url) {
@@ -303,10 +318,6 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
 
 const EVENT_CLOSE_TAG = "[/event]";
 
-function dashedToCamel(key) {
-  return key.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
-}
-
 export function parseEventBlock(raw) {
   if (!raw) {
     return null;
@@ -326,7 +337,7 @@ export function parseEventBlock(raw) {
       const attrs = {};
       for (const [key, value] of Object.entries(parsed.attrs || {})) {
         if (key !== "_default") {
-          attrs[dashedToCamel(key)] = value;
+          attrs[camelize(key)] = value;
         }
       }
 
@@ -467,16 +478,19 @@ export function parseReminders(reminders) {
   if (Array.isArray(reminders)) {
     return reminders;
   }
-  return reminders.split(",").map((reminderStr) => {
-    const [type, value, unit] = reminderStr.split(".");
-    const numericValue = Math.abs(parseInt(value, 10));
-    return {
-      type: type || "notification",
-      value: numericValue,
-      unit: unit || "hours",
-      period: parseInt(value, 10) < 0 ? "after" : "before",
-    };
-  });
+  return reminders
+    .split(",")
+    .map((reminderStr) => {
+      const [unit, value, type] = reminderStr.trim().split(".").reverse();
+      const numericValue = parseInt(value, 10);
+      return {
+        type: type || "notification",
+        value: Math.abs(numericValue),
+        unit,
+        period: numericValue < 0 ? "after" : "before",
+      };
+    })
+    .filter((reminder) => reminder.unit && Number.isFinite(reminder.value));
 }
 
 export function replaceRaw(params, raw) {

--- a/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
@@ -201,4 +201,58 @@ module("Integration | Component | CompactEventEditor", function (hooks) {
       .dom(findAll(".composer-event__date-input")[1])
       .hasAttribute("min", "2027-08-20");
   });
+
+  test("clamps end an hour after start when the picked end time is not after start", async function (assert) {
+    const initialState = stateWith({
+      endsAt: moment("2026-07-01T12:00:00Z"),
+    });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    await fillIn(findAll(".composer-event__time-input")[1], "10:00");
+
+    assert.strictEqual(
+      lastState.endsAt.toISOString(),
+      "2026-07-01T11:00:00.000Z",
+      "an end time at or before start is pushed an hour past start"
+    );
+  });
+
+  test("the end date picker is bounded by the start date", async function (assert) {
+    const initialState = stateWith({
+      allDay: true,
+      startsAt: moment("2026-07-01"),
+      endsAt: null,
+    });
+    await renderEditor(initialState);
+
+    assert
+      .dom(findAll(".composer-event__date-input")[1])
+      .hasAttribute(
+        "min",
+        "2026-07-01",
+        "days before the start are greyed out"
+      );
+  });
+
+  test("picking the start day as the end day keeps a one-day all-day event", async function (assert) {
+    const initialState = stateWith({
+      allDay: true,
+      startsAt: moment("2026-07-01"),
+      endsAt: null,
+    });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    await fillIn(findAll(".composer-event__date-input")[1], "2026-07-01");
+
+    assert.strictEqual(
+      lastState.endsAt.format("YYYY-MM-DD"),
+      "2026-07-01",
+      "an equal boundary is a valid one-day range"
+    );
+    assert
+      .dom(findAll(".composer-event__date-input")[1])
+      .hasValue("2026-07-01", "the picked day stays in the field");
+  });
 });

--- a/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/post-event-builder-test.gjs
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { click, fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 import PostEventBuilder from "../../discourse/components/modal/post-event-builder";
 import DiscoursePostEventEvent from "../../discourse/models/discourse-post-event-event";
 
@@ -19,12 +20,13 @@ function eventWith(attrs = {}) {
   });
 }
 
-async function renderAdvanced(event) {
+async function renderAdvanced(event, modelOverrides = {}) {
   const model = {
     event,
     initialScreen: "advanced",
     onUpdate: () => {},
     toolbarEvent: {},
+    ...modelOverrides,
   };
   const closeModal = () => {};
 
@@ -118,37 +120,14 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
   test("typed custom field keeps its value when the location is edited", async function (assert) {
     this.siteSettings.discourse_post_event_allowed_custom_fields = "test1";
 
-    const event = DiscoursePostEventEvent.create({
-      name: "My event",
-      starts_at: "2022-07-01T10:00:00Z",
-      ends_at: "2022-07-01T11:00:00Z",
-      timezone: "UTC",
-      status: "public",
-      reminders: [],
-      raw_invitees: [],
-      custom_fields: {},
-    });
+    const event = eventWith();
 
     let updatedEvent = null;
-    const model = {
-      event,
-      initialScreen: "advanced",
+    await renderAdvanced(event, {
       onUpdate: (startsAt, endsAt, savedEvent) => {
         updatedEvent = savedEvent;
       },
-      toolbarEvent: {},
-    };
-    const closeModal = () => {};
-
-    await render(
-      <template>
-        <PostEventBuilder
-          @closeModal={{closeModal}}
-          @inline={{true}}
-          @model={{model}}
-        />
-      </template>
-    );
+    });
 
     await fillIn(`[data-name="customFields.test1"] input`, "hello");
     await fillIn(`[data-name="location"] input`, "Sydney");
@@ -168,37 +147,15 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
   test("typed custom field survives a compact-screen edit in between", async function (assert) {
     this.siteSettings.discourse_post_event_allowed_custom_fields = "test1";
 
-    const event = DiscoursePostEventEvent.create({
-      name: "My event",
-      starts_at: "2022-07-01T10:00:00Z",
-      ends_at: "2022-07-01T11:00:00Z",
-      timezone: "UTC",
-      status: "public",
-      reminders: [],
-      raw_invitees: [],
-      custom_fields: { test1: "seeded" },
-    });
+    const event = eventWith({ custom_fields: { test1: "seeded" } });
 
     let updatedEvent = null;
-    const model = {
-      event,
+    await renderAdvanced(event, {
       initialScreen: "compact",
       onUpdate: (startsAt, endsAt, savedEvent) => {
         updatedEvent = savedEvent;
       },
-      toolbarEvent: {},
-    };
-    const closeModal = () => {};
-
-    await render(
-      <template>
-        <PostEventBuilder
-          @closeModal={{closeModal}}
-          @inline={{true}}
-          @model={{model}}
-        />
-      </template>
-    );
+    });
 
     await click(".advanced-mode-btn");
     await fillIn(`[data-name="customFields.test1"] input`, "typed");
@@ -336,5 +293,20 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
         "or URL",
         "the label narrows once url has its own field"
       );
+  });
+
+  test("coerces end an hour after start when the picked end time is not after start", async function (assert) {
+    const event = eventWith({ ends_at: "2022-07-01T12:00:00Z" });
+    await renderAdvanced(event);
+
+    const toTime = selectKit(".to .d-time-input .select-kit");
+    await toTime.expand();
+    await toTime.selectRowByName("10:00 AM");
+
+    assert.strictEqual(
+      moment(event.endsAt).toISOString(),
+      "2022-07-01T11:00:00.000Z",
+      "an end time at or before start is pushed an hour past start"
+    );
   });
 });

--- a/plugins/discourse-events/test/javascripts/lib/raw-event-helper-test.js
+++ b/plugins/discourse-events/test/javascripts/lib/raw-event-helper-test.js
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import {
+  allDayTransition,
   attendanceTransition,
   buildEventBlock,
   buildParams,
@@ -225,6 +226,30 @@ module("Unit | Lib | raw-event-helper", function (hooks) {
     );
   });
 
+  test("parseReminders defaults the type for legacy reminders without one", function (assert) {
+    assert.deepEqual(parseReminders("15.minutes"), [
+      { type: "notification", value: 15, unit: "minutes", period: "before" },
+    ]);
+  });
+
+  test("parseReminders tolerates spaces after commas", function (assert) {
+    assert.deepEqual(
+      parseReminders("notification.15.minutes, bumpTopic.1.days"),
+      [
+        { type: "notification", value: 15, unit: "minutes", period: "before" },
+        { type: "bumpTopic", value: 1, unit: "days", period: "before" },
+      ]
+    );
+  });
+
+  test("parseReminders drops entries without a numeric value and a unit", function (assert) {
+    assert.deepEqual(parseReminders("notification.15"), []);
+    assert.deepEqual(parseReminders("15"), []);
+    assert.deepEqual(parseReminders("notification.abc.minutes,10.minutes"), [
+      { type: "notification", value: 10, unit: "minutes", period: "before" },
+    ]);
+  });
+
   test("defaultReminderFor", function (assert) {
     assert.deepEqual(
       defaultReminderFor({
@@ -348,6 +373,17 @@ module("Unit | Lib | raw-event-helper", function (hooks) {
       "bumpTopic.-30.minutes",
       "serializes an after reminder with negative value"
     );
+
+    assert.strictEqual(
+      reminderToBBCode({
+        type: "notification",
+        value: null,
+        unit: "minutes",
+        period: "before",
+      }),
+      "notification.NaN.minutes",
+      "keeps a cleared value unparseable rather than serializing it as zero"
+    );
   });
 
   test("attendanceTransition: none captures status + max and flips notifications to bumpTopic", function (assert) {
@@ -426,6 +462,63 @@ module("Unit | Lib | raw-event-helper", function (hooks) {
 
     assert.strictEqual(result.maxAttendees, null);
     assert.strictEqual(result.previousMaxAttendees, 25);
+  });
+
+  test("attendanceTransition: upTo with an explicit value applies and remembers it", function (assert) {
+    const result = attendanceTransition({
+      mode: "upTo",
+      status: "public",
+      maxAttendees: 10,
+      reminders: [],
+      previousRsvpStatus: "public",
+      previousMaxAttendees: 10,
+      value: 25,
+    });
+
+    assert.strictEqual(result.maxAttendees, 25);
+    assert.strictEqual(result.previousMaxAttendees, 25);
+  });
+
+  test("allDayTransition: on snaps to day boundaries and drops a same-day end", function (assert) {
+    const result = allDayTransition({
+      startsAt: moment.tz("2024-06-15 10:00", "UTC"),
+      endsAt: moment.tz("2024-06-15 11:00", "UTC"),
+      timezone: "UTC",
+      allDay: true,
+    });
+
+    assert.strictEqual(
+      result.startsAt.format("YYYY-MM-DD HH:mm"),
+      "2024-06-15 00:00"
+    );
+    assert.strictEqual(result.endsAt, null);
+  });
+
+  test("allDayTransition: on keeps a multi-day end as a day", function (assert) {
+    const result = allDayTransition({
+      startsAt: moment.tz("2024-06-15 10:00", "UTC"),
+      endsAt: moment.tz("2024-06-17 11:00", "UTC"),
+      timezone: "UTC",
+      allDay: true,
+    });
+
+    assert.strictEqual(
+      result.endsAt.format("YYYY-MM-DD HH:mm"),
+      "2024-06-17 00:00"
+    );
+  });
+
+  test("allDayTransition: off restores the current wall clock and a one-hour span", function (assert) {
+    const result = allDayTransition({
+      startsAt: moment.tz("2024-06-15", "UTC"),
+      endsAt: null,
+      timezone: "UTC",
+      allDay: false,
+    });
+
+    assert.strictEqual(result.startsAt.format("YYYY-MM-DD"), "2024-06-15");
+    assert.strictEqual(result.startsAt.seconds(), 0);
+    assert.strictEqual(result.endsAt.diff(result.startsAt, "hours"), 1);
   });
 
   test("attendanceTransition: does not mutate the input reminders array", function (assert) {


### PR DESCRIPTION
Stacked on #42980.

Every way of entering event dates now behaves the same: the end-date
pickers in the compact editor and the builder carry a min bound at the
start date, an end picked at or before the start is clamped through the
shared adjustedRangeEnd, and picking the start day as the end keeps a
one-day all-day event instead of clearing the field - the workaround for
the render bug fixed by the previous commit.

The all-day and attendance transitions move into raw-event-helper and
back both editors, reminder serialization reuses reminderToBBCode, which
no longer coerces a cleared value to a zero offset, parseReminders
tolerates legacy spacing and drops unparseable entries, and showPicker()
is guarded against gesture-less focus.