### PR TITLE
PERF: Skip event extraction and batch lookups on hot paths

### DIFF
--- a/plugins/discourse-events/app/serializers/discourse_events/events/event_serializer.rb
+++ b/plugins/discourse-events/app/serializers/discourse_events/events/event_serializer.rb
@@ -197,8 +197,8 @@ module DiscourseEvents
       end
 
       def should_display_invitees
-        (object.public? && object.invitees.count > 0) ||
-          (object.private? && can_display_invitee_details? && Array(object.raw_invitees).count > 0)
+        (object.public? && object.invitees.exists?) ||
+          (object.private? && can_display_invitee_details? && Array(object.raw_invitees).any?)
       end
 
       def include_url?

--- a/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
+++ b/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
@@ -6,11 +6,14 @@ module Jobs
       every 1.minute
 
       def execute(args)
-        DiscourseEvents::Events::EventDate.pending.find_each do |event_date|
-          send_reminder(event_date)
-          trigger_events(event_date)
-          finish(event_date)
-        end
+        DiscourseEvents::Events::EventDate
+          .pending
+          .includes(:event)
+          .find_each do |event_date|
+            send_reminder(event_date)
+            trigger_events(event_date)
+            finish(event_date)
+          end
       end
 
       def send_reminder(event_date)

--- a/plugins/discourse-events/lib/discourse_events/events/parser.rb
+++ b/plugins/discourse-events/lib/discourse_events/events/parser.rb
@@ -29,8 +29,13 @@ module DiscourseEvents
       LEGACY_ESCAPED_ATTRS = %w[data-location]
       SCHEME_PREFIX = /\A[a-z][a-z0-9+.\-]*:/i
 
+      EVENT_MARKER = /\[event|discourse-post-event/i
+
       def self.extract_events(post)
-        cooked = PrettyText.cook(post.raw, topic_id: post.topic_id, user_id: post.user_id)
+        raw = post.raw.to_s
+        return [] if !raw.match?(EVENT_MARKER)
+
+        cooked = PrettyText.cook(raw, topic_id: post.topic_id, user_id: post.user_id)
         valid_options = valid_option_attributes
 
         valid_custom_fields =

--- a/plugins/discourse-events/plugin.rb
+++ b/plugins/discourse-events/plugin.rb
@@ -365,7 +365,7 @@ after_initialize do
     if SiteSetting.discourse_post_event_enabled
       topic_view.instance_variable_set(
         :@posts,
-        topic_view.posts.includes(event: [:image_upload, { event_hosts: :user }]),
+        topic_view.posts.includes(event: [:image_upload, :event_dates, { event_hosts: :user }]),
       )
     end
   end

--- a/plugins/discourse-events/spec/lib/discourse_events/events/parser_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_events/events/parser_spec.rb
@@ -19,6 +19,11 @@ describe DiscourseEvents::Events::Parser do
     expect(events.length).to eq(1)
   end
 
+  it "finds an event whose tag is not lowercase" do
+    events = parser.extract_events(build_post(user, '[EVENT start="2020"]\n[/EVENT]'))
+    expect(events.length).to eq(1)
+  end
+
   it "finds multiple events" do
     post_event = build_post user, <<~TXT
       [event start="2020"]


### PR DESCRIPTION
Stacked on #42981.

Extracting events cooked every post's raw on every save, twice, even
when it could not contain event markup; skip extraction when the raw
lacks an event marker. Preload event_dates in topic views (matching the
events controller), preload events in the every-minute date monitor, and
replace COUNT with EXISTS in the invitee serializer check.