### PR TITLE
FIX: right-align numeric columns in the member drill-down table

### DIFF
--- a/app/assets/stylesheets/admin/admin_report_table.scss
+++ b/app/assets/stylesheets/admin/admin_report_table.scss
@@ -175,12 +175,6 @@
         text-align: left;
       }
     }
-
-    .total-row {
-      td {
-        text-align: right;
-      }
-    }
   }
 
   .admin-report-table-cell {

--- a/app/assets/stylesheets/admin/posters_by_member_type_report.scss
+++ b/app/assets/stylesheets/admin/posters_by_member_type_report.scss
@@ -22,6 +22,13 @@
 
   &__members {
     margin-top: var(--space-4);
+
+    .admin-report-table-header.number,
+    .admin-report-table-header.share_formatted,
+    .admin-report-table-cell.number,
+    .admin-report-table-cell.share_formatted {
+      text-align: right;
+    }
   }
 
   &__members-header {
@@ -44,5 +51,20 @@
     margin: 0;
     color: var(--primary-medium);
     font-size: var(--font-down-1);
+  }
+}
+
+.rtl .posters-by-member-type-report {
+  &__numeric {
+    text-align: left;
+  }
+
+  &__members {
+    .admin-report-table-header.number,
+    .admin-report-table-header.share_formatted,
+    .admin-report-table-cell.number,
+    .admin-report-table-cell.share_formatted {
+      text-align: left;
+    }
   }
 }

--- a/app/assets/stylesheets/admin/posters_by_member_type_report.scss
+++ b/app/assets/stylesheets/admin/posters_by_member_type_report.scss
@@ -53,18 +53,3 @@
     font-size: var(--font-down-1);
   }
 }
-
-.rtl .posters-by-member-type-report {
-  &__numeric {
-    text-align: left;
-  }
-
-  &__members {
-    .admin-report-table-header.number,
-    .admin-report-table-header.share_formatted,
-    .admin-report-table-cell.number,
-    .admin-report-table-cell.share_formatted {
-      text-align: left;
-    }
-  }
-}


### PR DESCRIPTION
The per-user table shown after selecting a member type had its Posts and Share numbers unaligned with the table above it, making both harder to scan together. They're now aligned the same way in both LTR and RTL locales.

Before:

<img width=600 src="https://github.com/user-attachments/assets/a8281f5c-b6d6-49f6-8508-884574c3da6a" />

After:

<img width=600 src="https://github.com/user-attachments/assets/a7b94e9a-9abd-46c7-9ee2-3f3624bfbf45" />

Follow up to https://github.com/discourse/discourse/pull/42809