### PR TITLE
UX: Fix spacing in installation wizard

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -157,7 +157,7 @@ body.wizard {
   box-shadow: 0 10px 30px light-dark(rgb(123, 95, 226, 0.15), transparent);
   box-sizing: border-box;
   border-radius: 16px;
-  padding: var(--space-8);
+  padding: var(--space-8, 2rem);
 
   @include viewport.until(md) {
     padding: 2em 1.5em;
@@ -180,7 +180,7 @@ body.wizard {
   }
 
   &__field {
-    margin-bottom: var(--space-4);
+    margin-bottom: var(--space-4, 1rem);
   }
 
   &__field.invalid input {
@@ -209,7 +209,7 @@ body.wizard {
 
   &__step-header {
     text-align: center;
-    margin-bottom: var(--space-8);
+    margin-bottom: var(--space-8, 2rem);
   }
 
   &__step-title {

--- a/spec/system/finish_installation_spec.rb
+++ b/spec/system/finish_installation_spec.rb
@@ -173,6 +173,12 @@ RSpec.describe "Finish Installation" do
         expect(finish_installation_page).to have_no_error_message
       end
 
+      it "gives the registration form consistent spacing" do
+        finish_installation_page.visit_register
+
+        expect(finish_installation_page.container_padding).to eq("32px")
+      end
+
       it "shows validation error when username is blank" do
         finish_installation_page.visit_register.fill_password("supersecurepassword").submit
         expect(finish_installation_page).to have_username_error

--- a/spec/system/page_objects/pages/finish_installation.rb
+++ b/spec/system/page_objects/pages/finish_installation.rb
@@ -100,8 +100,21 @@ module PageObjects
         has_no_css?(".wizard-container__field.invalid")
       end
 
+      def container_padding
+        computed_style(".wizard-container", "padding-top")
+      end
+
       def redirected_to_confirm_email?
         has_current_path?("/finish-installation/confirm-email")
+      end
+
+      private
+
+      def computed_style(selector, property)
+        page.evaluate_script(<<~JS)
+          getComputedStyle(document.querySelector(#{selector.to_json}))
+            .getPropertyValue(#{property.to_json})
+        JS
       end
     end
   end


### PR DESCRIPTION
The regression comes from commit 1cc33b29a84 (“UX: Better use of space in wizard”, August 20). It replaced fixed spacing with --space-* tokens. But --space tokens aren't available in this context.

This commit adds fallbacks to the --space tokens. And a regression spec.