### PR TITLE
FIX: Show advisory on signup page when no login methods are configured

### DIFF
--- a/frontend/discourse/app/components/no-login-methods.gjs
+++ b/frontend/discourse/app/components/no-login-methods.gjs
@@ -1,0 +1,26 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { trustHTML } from "@ember/template";
+import getURL from "discourse/lib/get-url";
+import { i18n } from "discourse-i18n";
+
+export default class NoLoginMethods extends Component {
+  get adminLoginPath() {
+    return getURL("/u/admin-login");
+  }
+
+  <template>
+    <div class="login-welcome-header no-login-methods-configured">
+      <h1 class="login-title">{{i18n "login.no_login_methods.title"}}</h1>
+      <img />
+      <p class="login-subheader">
+        {{trustHTML
+          (i18n
+            "login.no_login_methods.description"
+            (hash adminLoginPath=this.adminLoginPath)
+          )
+        }}
+      </p>
+    </div>
+  </template>
+}

--- a/frontend/discourse/app/controllers/login.js
+++ b/frontend/discourse/app/controllers/login.js
@@ -130,10 +130,6 @@ export default class LoginPageController extends Controller {
     return this.application.canSignUp && !this.showSecondFactor;
   }
 
-  get adminLoginPath() {
-    return getURL("/u/admin-login");
-  }
-
   @action
   async passkeyLogin(mediation = "optional") {
     try {

--- a/frontend/discourse/app/controllers/signup.js
+++ b/frontend/discourse/app/controllers/signup.js
@@ -419,6 +419,15 @@ export default class SignupPageController extends Controller {
     return findAll().length > 0;
   }
 
+  @computed("hasAtLeastOneLoginButton", "canCreateLocal", "hasAuthOptions")
+  get hasNoLoginOptions() {
+    return (
+      !this.hasAtLeastOneLoginButton &&
+      !this.canCreateLocal &&
+      !this.hasAuthOptions
+    );
+  }
+
   @computed(
     "authOptions",
     "hasAtLeastOneLoginButton",

--- a/frontend/discourse/app/templates/login.gjs
+++ b/frontend/discourse/app/templates/login.gjs
@@ -1,9 +1,8 @@
-import { hash } from "@ember/helper";
-import { trustHTML } from "@ember/template";
 import CodeLoginForm from "discourse/components/code-login-form";
 import LocalLoginForm from "discourse/components/local-login-form";
 import LoginButtons from "discourse/components/login-buttons";
 import LoginPageCta from "discourse/components/login-page-cta";
+import NoLoginMethods from "discourse/components/no-login-methods";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import WelcomeHeader from "discourse/components/welcome-header";
 import bodyClass from "discourse/helpers/body-class";
@@ -38,18 +37,7 @@ export default <template>
 
       {{#if @controller.hasNoLoginOptions}}
         <div class={{if @controller.site.desktopView "login-left-side"}}>
-          <div class="login-welcome-header no-login-methods-configured">
-            <h1 class="login-title">{{i18n "login.no_login_methods.title"}}</h1>
-            <img />
-            <p class="login-subheader">
-              {{trustHTML
-                (i18n
-                  "login.no_login_methods.description"
-                  (hash adminLoginPath=@controller.adminLoginPath)
-                )
-              }}
-            </p>
-          </div>
+          <NoLoginMethods />
         </div>
       {{else}}
         {{#if @controller.site.mobileView}}

--- a/frontend/discourse/app/templates/signup.gjs
+++ b/frontend/discourse/app/templates/signup.gjs
@@ -5,6 +5,7 @@ import CodeLoginForm from "discourse/components/code-login-form";
 import FullnameInput from "discourse/components/fullname-input";
 import HoneypotInput from "discourse/components/honeypot-input";
 import LoginButtons from "discourse/components/login-buttons";
+import NoLoginMethods from "discourse/components/no-login-methods";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import SignupPageCta from "discourse/components/signup-page-cta";
 import SignupProgressBar from "discourse/components/signup-progress-bar";
@@ -49,7 +50,9 @@ export default <template>
           @controller.authOptions.auth_provider
         }}
       >
-        {{#unless @controller.skipConfirmation}}
+        {{#if @controller.hasNoLoginOptions}}
+          <NoLoginMethods />
+        {{else if (not @controller.skipConfirmation)}}
           {{! Code signup renders its own heading inside CodeLoginForm. }}
           {{#unless @controller.showCodeSignupForm}}
             <SignupProgressBar @step={{@controller.progressBarStep}} />
@@ -72,7 +75,7 @@ export default <template>
               </WelcomeHeader>
             </PluginOutlet>
           {{/unless}}
-        {{/unless}}
+        {{/if}}
         {{#if @controller.showCodeSignupForm}}
           <CodeLoginForm
             @context="signup"

--- a/frontend/discourse/tests/acceptance/no-login-methods-test.js
+++ b/frontend/discourse/tests/acceptance/no-login-methods-test.js
@@ -1,0 +1,25 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("No login methods configured", function (needs) {
+  needs.settings({
+    enable_local_logins: false,
+    enable_local_logins_via_code: false,
+  });
+
+  test("the login page explains that no login methods are configured", async function (assert) {
+    await visit("/login");
+
+    assert.dom(".login-fullpage .no-login-methods-configured").exists();
+    assert.dom("#login-form").doesNotExist();
+  });
+
+  test("the signup page explains that no login methods are configured", async function (assert) {
+    await visit("/signup");
+
+    assert.dom(".signup-fullpage .no-login-methods-configured").exists();
+    assert.dom("#login-form").doesNotExist();
+    assert.dom(".signup-progress-bar").doesNotExist();
+  });
+});

--- a/frontend/discourse/tests/acceptance/no-login-methods-test.js
+++ b/frontend/discourse/tests/acceptance/no-login-methods-test.js
@@ -7,6 +7,7 @@ acceptance("No login methods configured", function (needs) {
     enable_local_logins: false,
     enable_local_logins_via_code: false,
   });
+  needs.site({ auth_providers: [] });
 
   test("the login page explains that no login methods are configured", async function (assert) {
     await visit("/login");


### PR DESCRIPTION
**Previously**, a site with no login methods configured showed a helpful advisory on the login page, but the signup page silently rendered an empty progress bar and welcome header with no form and no explanation.

**In this update**, the signup page shows the same "No login methods" advisory, now extracted into a shared `NoLoginMethods` component used by both pages.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/raw/refs/heads/gh-attach-assets/26031827-6fbf-43ad-81b1-080441d1761e/before.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-9nv52w.png) |