### PR TITLE
UX: Lay the toolbar menu shortcut out beside its label

### DIFF
--- a/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
@@ -75,7 +75,12 @@
       &.--active {
         .d-button-label__active-icon {
           visibility: visible;
-          margin-left: auto;
+        }
+
+        // The check owns the trailing slot at rest, even for a shortcut that
+        // is otherwise always shown.
+        &:not(:hover, :focus, :focus-visible) .shortcut {
+          visibility: hidden;
         }
       }
 
@@ -83,7 +88,7 @@
       &:focus,
       &:focus-visible {
         .shortcut {
-          display: block;
+          visibility: visible;
         }
 
         .d-button-label__active-icon {
@@ -92,32 +97,29 @@
       }
     }
 
+    // The shortcut and the active check share one trailing cell: both are
+    // laid out so the row reserves their width, and only one is shown.
     .d-button-label {
-      position: relative;
       flex: 1;
-      display: flex;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
-      gap: var(--space-4);
-      min-width: 0; // shrink if needed
+      column-gap: var(--space-4);
+      min-width: 0;
 
-      &__active-icon {
+      &__text {
+        text-align: start;
+      }
+
+      &__active-icon,
+      .shortcut {
+        grid-area: 1 / 2;
+        justify-self: end;
         visibility: hidden;
       }
 
-      &__text {
-        padding-right: var(--space-8); // extra spacing for the shortcut
-      }
-
-      .shortcut {
-        position: absolute;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        display: none;
-
-        &.--always-visible {
-          display: block;
-        }
+      .shortcut.--always-visible {
+        visibility: visible;
       }
     }
   }

--- a/plugins/discourse-local-dates/spec/system/toolbar_shortcut_spec.rb
+++ b/plugins/discourse-local-dates/spec/system/toolbar_shortcut_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe "Local dates toolbar shortcut" do
+  include ThemeScreenshotMarker
+
   fab!(:current_user, :admin)
 
   let(:composer) { PageObjects::Components::Composer.new }
@@ -18,5 +20,23 @@ RSpec.describe "Local dates toolbar shortcut" do
       ".toolbar-menu__options-content [data-name='local-dates'] .d-shortcut",
       visible: :visible,
     )
+  end
+
+  it "lays the shortcut out beside the label instead of over it" do
+    visit "/"
+    find("#create-topic").click
+    expect(composer).to be_opened
+
+    find(".toolbar-menu__options-trigger").click
+    row = find(".toolbar-menu__options-content [data-name='local-dates']")
+    text = row.find(".d-button-label__text")
+    chip = row.find(".d-shortcut")
+
+    text_right = page.evaluate_script("arguments[0].getBoundingClientRect().right", text)
+    chip_left = page.evaluate_script("arguments[0].getBoundingClientRect().left", chip)
+
+    expect(chip_left).to be >= text_right
+
+    screenshot_marker(label: "shortcut-options-menu-at-rest", only: :desktop)
   end
 end


### PR DESCRIPTION
Follow-up to #42938. The shortcut chip in the composer toolbar menus was positioned absolutely over the row, with a fixed 2rem gutter on the label text. Nothing tied that gutter to the chip's real width. On the row with the widest label the chip painted over the text, and the `alwaysShowShortcut` option made that visible at rest on the "Insert date / time" row.

The label is now a two-column grid. The first column holds the text. The trailing cell is shared by the shortcut chip and the active check, both laid out there with only one shown at a time. The row reserves the chip's width, so the menu grows to fit on every platform, including the wider word-form chips on non-Apple systems. The absolute positioning and the reserved padding are gone.

A system example on the local-dates row checks that the chip's left edge stays at or beyond the label's right edge.
