### PR TITLE
FIX: Error when group has no full name in group user chooser

### DIFF
--- a/frontend/discourse/select-kit/components/email-group-user-chooser-row.gjs
+++ b/frontend/discourse/select-kit/components/email-group-user-chooser-row.gjs
@@ -32,7 +32,7 @@ export default class EmailGroupUserChooserRow extends SelectKitRowComponent {
   get shouldExcludeGroupName() {
     return (
       this.selectKit.options.excludeGroupNameWhenMatchingFullName &&
-      this.item.full_name.toLowerCase() ===
+      (this.item.full_name || "").toLowerCase() ===
         this.item.id.toLowerCase().replaceAll("_", " ").replaceAll("-", " ")
     );
   }
@@ -86,11 +86,17 @@ export default class EmailGroupUserChooserRow extends SelectKitRowComponent {
             <span class="identifier">{{this.item.id}}</span>
           {{/unless}}
           <span class="name">{{this.item.full_name}}</span>
-        {{else}}
-          <span class="name">{{this.item.full_name}}</span>
-          {{#unless this.shouldExcludeGroupName}}
-            <span class="identifier">{{this.item.id}}</span>
-          {{/unless}}
+        {{else if (eq this.groupNameOrdering "groupFullNameFirst")}}
+          {{#if this.item.full_name}}
+            <span class="name">{{this.item.full_name}}</span>
+            {{#unless this.shouldExcludeGroupName}}
+              <span class="identifier">{{this.item.id}}</span>
+            {{/unless}}
+          {{else}}
+            {{#unless this.shouldExcludeGroupName}}
+              <span class="name">{{this.item.id}}</span>
+            {{/unless}}
+          {{/if}}
         {{/if}}
       </div>
     {{else}}

--- a/frontend/discourse/tests/integration/components/select-kit/email-group-user-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/email-group-user-chooser-test.gjs
@@ -98,6 +98,11 @@ module(
           full_name: "Team A",
           isGroup: true,
         },
+        {
+          name: "team_b",
+          full_name: null,
+          isGroup: true,
+        },
       ]);
 
       await render(
@@ -116,11 +121,23 @@ module(
       await this.subject.expand();
 
       assert
-        .dom(".email-group-user-chooser__group .identifier")
+        .dom(
+          ".email-group-user-chooser-row[data-index='0'] .email-group-user-chooser__group .identifier"
+        )
         .doesNotExist("hides the equivalent group name");
       assert
-        .dom(".email-group-user-chooser__group .name")
+        .dom(
+          ".email-group-user-chooser-row[data-index='0'] .email-group-user-chooser__group .name"
+        )
         .hasText("Team A", "keeps the full group name visible");
+      assert
+        .dom(
+          ".email-group-user-chooser-row[data-index='1'] .email-group-user-chooser__group .identifier"
+        )
+        .hasText(
+          "team_b",
+          "renders the second group identifier as expected since they have no name"
+        );
     });
 
     test("prioritizeUserNameOrdering can render the name before username", async function (assert) {


### PR DESCRIPTION
Handles an error in the group finder for the ACL editor
when a group has no full name, and fixes the display of
groups with no full name in the dropdown results.

<img width="1920" height="730" alt="image" src="https://github.com/user-attachments/assets/920da06b-39ee-4ac5-89bd-d25c0a1a623d" />
