### PR TITLE
DEV: Move core's reorder surfaces onto `DReorderableList`

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1264,3 +1264,37 @@ a.inline-editable-field {
 @import "admin/discourse_id";
 @import "admin/admin_new_category_setup";
 @import "admin/admin_emoji";
+
+/* The reordering surface behind `enable_new_reordering_controls`. These class
+   names exist only in the new markup, so the rules are inert while the legacy
+   value lists render and the legacy rules above stay untouched.
+
+   TODO (ui-kit-reorderable-list-cleanup) fold back into the `.value-list` block
+   above once the change ships. */
+
+.value-list .value {
+  .d-reorderable-list__remove {
+    margin-left: 0.25em;
+    flex: 0 0 auto;
+
+    @include value-btn;
+  }
+
+  /* A closed set is reordered and removed, never typed into. It keeps the
+     field's footprint so rows line up with the free-text variant, but reads as
+     filled rather than editable. */
+
+  .value-input.--readonly {
+    display: flex;
+    align-items: center;
+    min-height: 2em;
+    padding: 0 0.5em;
+    background: var(--primary-very-low);
+    border: 1px solid var(--primary-low);
+    color: var(--primary);
+    cursor: default;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -626,3 +626,54 @@ $db-bar-height: var(--space-2);
     }
   }
 }
+
+/* The reordering surface behind `enable_new_reordering_controls`. Keyed on the
+   modifier the new markup carries, so these rules are inert while the legacy
+   rows render and need no flag scoping of their own.
+
+   TODO (ui-kit-reorderable-list-cleanup) fold back into the blocks above and
+   drop the modifier once the change ships. */
+
+.db-configure__list.--reorderable {
+  /* Rows tile edge to edge instead. A gap belongs to the container, so a drag
+     crossing it reaches no drop target and the above/below zones stop meeting. */
+  gap: normal;
+}
+
+.db-configure__row.--reorderable {
+  padding: calc(var(--space-3) / 2 + var(--space-half)) 0;
+
+  /* The grip carries its own cursor; promising the whole row drags would
+     misdescribe a press on the label, which selects. */
+  cursor: auto;
+
+  @include viewport.until(sm) {
+    padding: calc(var(--space-5) / 2 + var(--space-half)) 0;
+  }
+
+  /* One boundary, one line. A row's own top border and its predecessor's bottom
+     border are adjacent bands rather than the same pixels, so drawing each state
+     on its own row would shift the indicator by its own width as the pointer
+     crossed the midpoint. "Above row N" is drawn on row N-1's bottom edge, and
+     the shared primitive's inserted line is dropped rather than overridden so
+     both never show at once. */
+
+  &.--drag-below,
+  &:not(.--dragging):has(+ .db-configure__row.--drag-above) {
+    border-bottom-color: var(--d-drag-indicator-color);
+  }
+
+  /* No predecessor to borrow an edge from. */
+  &.--drag-above:first-child {
+    border-top-color: var(--d-drag-indicator-color);
+  }
+
+  &.--drag-above::before,
+  &.--drag-below::after {
+    content: none;
+  }
+
+  .d-reorderable-list__handle {
+    color: var(--primary-low-mid);
+  }
+}

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -628,19 +628,19 @@ $db-bar-height: var(--space-2);
 }
 
 /* The reordering surface behind `enable_new_reordering_controls`. Keyed on the
-   modifier the new markup carries, so these rules are inert while the legacy
-   rows render and need no flag scoping of their own.
+   classes the shared list puts on its own root and rows, so these rules are
+   inert while the legacy rows render and need no flag scoping.
 
-   TODO (ui-kit-reorderable-list-cleanup) fold back into the blocks above and
-   drop the modifier once the change ships. */
+   TODO (ui-kit-reorderable-list-cleanup) fold back into the blocks above once
+   the change ships. */
 
-.db-configure__list.--reorderable {
+.db-configure__list.d-reorderable-list {
   /* Rows tile edge to edge instead. A gap belongs to the container, so a drag
      crossing it reaches no drop target and the above/below zones stop meeting. */
   gap: normal;
 }
 
-.db-configure__row.--reorderable {
+.db-configure__row.d-reorderable-list__row {
   padding: calc(var(--space-3) / 2 + var(--space-half)) 0;
 
   /* The grip carries its own cursor; promising the whole row drags would

--- a/app/assets/stylesheets/admin/badges.scss
+++ b/app/assets/stylesheets/admin/badges.scss
@@ -257,3 +257,34 @@
     }
   }
 }
+
+/* The reordering surface behind `enable_new_reordering_controls`.
+   TODO (ui-kit-reorderable-list-cleanup) fold back above and drop the modifier
+   once the change ships. */
+
+.badge-groupings-modal {
+  .badge-groupings-list {
+    /* The name takes the slack, so the actions stay against the row's end while
+       the grip stays against its start. */
+
+    .badge-grouping-item.--reorderable {
+      justify-content: normal;
+      gap: 0.5em;
+
+      .badge-grouping {
+        flex: 1 1 auto;
+      }
+
+      .badge-grouping-name-input {
+        margin: 0;
+      }
+
+      /* Keeps the row's buttons on one line rather than stacking them. */
+      .actions {
+        display: flex;
+        align-items: center;
+        gap: 0.25em;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/admin/badges.scss
+++ b/app/assets/stylesheets/admin/badges.scss
@@ -259,15 +259,15 @@
 }
 
 /* The reordering surface behind `enable_new_reordering_controls`.
-   TODO (ui-kit-reorderable-list-cleanup) fold back above and drop the modifier
-   once the change ships. */
+   TODO (ui-kit-reorderable-list-cleanup) fold back above once the change
+   ships. */
 
 .badge-groupings-modal {
   .badge-groupings-list {
     /* The name takes the slack, so the actions stay against the row's end while
        the grip stays against its start. */
 
-    .badge-grouping-item.--reorderable {
+    .badge-grouping-item.d-reorderable-list__row {
       justify-content: normal;
       gap: 0.5em;
 

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -379,12 +379,12 @@
 }
 
 /* The reordering surface behind `enable_new_reordering_controls`.
-   TODO (ui-kit-reorderable-list-cleanup) fold back above and drop the modifier
-   once the change ships. */
+   TODO (ui-kit-reorderable-list-cleanup) fold back above once the change
+   ships. */
 
 .edit-user-directory-columns-modal {
   .edit-directory-columns-container {
-    .edit-directory-column.--reorderable {
+    .edit-directory-column.d-reorderable-list__row {
       justify-content: normal;
       align-items: center;
       gap: var(--space-2);

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -377,3 +377,24 @@
     }
   }
 }
+
+/* The reordering surface behind `enable_new_reordering_controls`.
+   TODO (ui-kit-reorderable-list-cleanup) fold back above and drop the modifier
+   once the change ships. */
+
+.edit-user-directory-columns-modal {
+  .edit-directory-columns-container {
+    .edit-directory-column.--reorderable {
+      justify-content: normal;
+      align-items: center;
+      gap: var(--space-2);
+
+      /* The global nudge on checkboxes aligns them to a text baseline; in a
+         centred flex row it only sits the box below the label and the grip. */
+
+      input[type="checkbox"] {
+        margin-top: 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -665,6 +665,11 @@
      and the picker shows its icon. */
 
   .d-reorderable-list .row-wrapper.header {
+    /* The tracks live on the wrapper, so the header has to reach them the same
+       way a row does or its labels stop sitting over the columns they name. */
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+
     @include viewport.until(sm) {
       display: none;
     }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -616,13 +616,6 @@
       grid-column: 2;
     }
 
-    /* The row is the drag source, so the grip must not become one itself or the
-       browser photographs the grip instead of the row. */
-
-    .draggable {
-      -webkit-user-drag: auto;
-    }
-
     @include viewport.until(sm) {
       row-gap: 0.5em;
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -581,3 +581,100 @@
     height: 0.85em;
   }
 }
+
+/* The section form's links region behind `enable_new_reordering_controls`.
+   Keyed on the modifier the new markup carries, so every rule here outranks the
+   legacy one it replaces without depending on stylesheet order, and none of it
+   applies while the legacy rows render.
+
+   TODO (ui-kit-reorderable-list-cleanup) fold back into the blocks above and
+   drop the modifier once the change ships. */
+
+.sidebar-section-form-modal {
+  /* The tracks live on the wrapper and every row reaches them through subgrid,
+     so the header and the rows resolve one set of columns. */
+
+  .sidebar-section-form__links-wrapper.--reorderable {
+    display: grid;
+    grid-template-columns: 2em 4.5em repeat(2, 1fr) 2em;
+
+    @include viewport.until(sm) {
+      /* grip, icon, name, delete; the url line spans beneath them. */
+      grid-template-columns: auto 4em 1fr min-content;
+    }
+  }
+
+  .row-wrapper.--reorderable {
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+
+    /* One midline for every cell, which otherwise stretch and each settle at
+       their own height. */
+    align-items: center;
+
+    .link-icon {
+      grid-column: 2;
+    }
+
+    /* The row is the drag source, so the grip must not become one itself or the
+       browser photographs the grip instead of the row. */
+
+    .draggable {
+      -webkit-user-drag: auto;
+    }
+
+    @include viewport.until(sm) {
+      row-gap: 0.5em;
+
+      /* A phone-width row cannot fit every column, so the url takes a second
+         line and the controls flank both. */
+
+      .d-reorderable-list__handle {
+        grid-row: 1 / 3;
+      }
+
+      .link-url {
+        grid-row: 2;
+        grid-column: 2 / -1;
+      }
+
+      .delete-link {
+        grid-row: 1;
+        grid-column: 4;
+      }
+    }
+
+    /* Two-line rows have no columns for these to head; each control names
+       itself, and the picker shows its icon. */
+
+    &.header {
+      @include viewport.until(sm) {
+        display: none;
+      }
+    }
+
+    /* Drawn on the row's own reserved border so adjacent rows keep sharing one
+       gutter. The shared primitive's inserted line is dropped rather than
+       overridden, or both would show at once. */
+
+    &.--drag-above {
+      border-top: 2px solid var(--d-drag-indicator-color);
+
+      &::before {
+        content: none;
+      }
+    }
+
+    &.--drag-below {
+      border-bottom: 2px solid var(--d-drag-indicator-color);
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  [data-drag-source].--dragging {
+    opacity: 0.4;
+  }
+}

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -583,18 +583,18 @@
 }
 
 /* The section form's links region behind `enable_new_reordering_controls`.
-   Keyed on the modifier the new markup carries, so every rule here outranks the
-   legacy one it replaces without depending on stylesheet order, and none of it
-   applies while the legacy rows render.
+   Keyed on the classes the shared list puts on its own root and rows, so every
+   rule here outranks the legacy one it replaces without depending on stylesheet
+   order, and none of it applies while the legacy rows render.
 
-   TODO (ui-kit-reorderable-list-cleanup) fold back into the blocks above and
-   drop the modifier once the change ships. */
+   TODO (ui-kit-reorderable-list-cleanup) fold back into the blocks above once
+   the change ships. */
 
 .sidebar-section-form-modal {
   /* The tracks live on the wrapper and every row reaches them through subgrid,
      so the header and the rows resolve one set of columns. */
 
-  .sidebar-section-form__links-wrapper.--reorderable {
+  .sidebar-section-form__links-wrapper.d-reorderable-list {
     display: grid;
     grid-template-columns: 2em 4.5em repeat(2, 1fr) 2em;
 
@@ -604,7 +604,7 @@
     }
   }
 
-  .row-wrapper.--reorderable {
+  .row-wrapper.d-reorderable-list__row {
     grid-column: 1 / -1;
     grid-template-columns: subgrid;
 
@@ -644,15 +644,6 @@
       }
     }
 
-    /* Two-line rows have no columns for these to head; each control names
-       itself, and the picker shows its icon. */
-
-    &.header {
-      @include viewport.until(sm) {
-        display: none;
-      }
-    }
-
     /* Drawn on the row's own reserved border so adjacent rows keep sharing one
        gutter. The shared primitive's inserted line is dropped rather than
        overridden, or both would show at once. */
@@ -671,6 +662,18 @@
       &::after {
         content: none;
       }
+    }
+  }
+
+  /* The header is the list's own block, not one of its rows, so it is reached
+     through the list root rather than the row selector.
+
+     Two-line rows have no columns for these to head; each control names itself,
+     and the picker shows its icon. */
+
+  .d-reorderable-list .row-wrapper.header {
+    @include viewport.until(sm) {
+      display: none;
     }
   }
 

--- a/app/assets/stylesheets/common/components/table-layout.scss
+++ b/app/assets/stylesheets/common/components/table-layout.scss
@@ -206,6 +206,17 @@
   }
 }
 
+/* The drag handle's column, sized to the handle. A table shares its free width
+   out among its columns, so without a width of its own this one takes a share of
+   the table to hold a 24px control. A width below the content's minimum is
+   raised to it, which is what makes `1px` mean "no wider than the handle". */
+
+.d-table__cell.--drag-handle,
+.d-table__header-cell.--drag-handle {
+  width: 1px;
+  white-space: nowrap;
+}
+
 .d-table__cell.--controls {
   text-align: right;
   width: auto;

--- a/app/assets/stylesheets/common/modal/manageable-row-list.scss
+++ b/app/assets/stylesheets/common/modal/manageable-row-list.scss
@@ -144,3 +144,24 @@
     font-size: var(--font-down-1);
   }
 }
+
+/* The reordering surface behind `enable_new_reordering_controls`.
+   TODO (ui-kit-reorderable-list-cleanup) fold back above and drop the modifier
+   once the change ships. */
+
+.manageable-row-list {
+  &__row-content {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: var(--space-3);
+    min-width: 0;
+  }
+
+  /* The grip carries its own cursor; promising the whole row drags would
+     misdescribe a press on the label, which selects. */
+
+  &__row.--reorderable[draggable="true"] {
+    cursor: auto;
+  }
+}

--- a/app/assets/stylesheets/common/modal/manageable-row-list.scss
+++ b/app/assets/stylesheets/common/modal/manageable-row-list.scss
@@ -146,8 +146,8 @@
 }
 
 /* The reordering surface behind `enable_new_reordering_controls`.
-   TODO (ui-kit-reorderable-list-cleanup) fold back above and drop the modifier
-   once the change ships. */
+   TODO (ui-kit-reorderable-list-cleanup) fold back above once the change
+   ships. */
 
 .manageable-row-list {
   &__row-content {
@@ -161,7 +161,7 @@
   /* The grip carries its own cursor; promising the whole row drags would
      misdescribe a press on the label, which selects. */
 
-  &__row.--reorderable[draggable="true"] {
+  &__row.d-reorderable-list__row[draggable="true"] {
     cursor: auto;
   }
 }

--- a/app/assets/stylesheets/common/modal/manageable-row-list.scss
+++ b/app/assets/stylesheets/common/modal/manageable-row-list.scss
@@ -164,4 +164,13 @@
   &__row.d-reorderable-list__row[draggable="true"] {
     cursor: auto;
   }
+
+  /* A row that cannot move renders no grip at all, so its text would start at
+     the row's own edge while a movable neighbour's starts past the grip, and
+     the column reads ragged. Reserve the grip's footprint instead: 24px is the
+     size the shared list gives it, plus the row's own gap. */
+
+  &__row.d-reorderable-list__row:not(:has(.d-reorderable-list__handle)) {
+    padding-inline-start: calc(var(--space-6) + 24px + var(--space-3));
+  }
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2969,6 +2969,7 @@ en:
     enable_new_checkbox_style: "Enable the redesigned checkbox style for FormKit checkboxes."
     enable_new_post_reactions_menu: "Enable the redesigned post likes and reactions menu, with infinite scroll and a native mobile experience."
     enable_composer_redesign: "Enable the redesigned composer."
+    enable_new_reordering_controls: "Use the shared reordering controls on every list that can be reordered, giving each one the same drag handle, move menu and keyboard support."
     prioritize_recently_used_tags: "When adding tags while creating or editing a topic, show the tags the member has recently used on their own topics at the top of the list, before the most popular tags of the forum."
     experimental_impersonation_time_limit_minutes: "How long before an impersonation session is automatically ended."
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4741,6 +4741,16 @@ experimental:
       status: "permanent"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/389820"
+  enable_new_reordering_controls:
+    default: false
+    client: true
+    hidden: true
+    area: "experimental"
+    upcoming_change:
+      # TODO (ui-kit-reorderable-list-cleanup) raise to "experimental" once the
+      # meta topic exists; a non-conceptual status requires learn_more_url.
+      status: "conceptual"
+      impact: "feature,all_members"
   enable_composer_redesign:
     default: false
     client: true

--- a/frontend/discourse/admin/components/admin-badges.gjs
+++ b/frontend/discourse/admin/components/admin-badges.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import EditBadgeGroupingsModal from "discourse/admin/components/modal/edit-badge-groupings";
+import EditBadgeGroupingsModalReorderable from "discourse/admin/components/modal/edit-badge-groupings-reorderable";
 import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
 import DNavItem from "discourse/ui-kit/d-nav-item";
 import DPageHeader from "discourse/ui-kit/d-page-header";
@@ -10,6 +11,7 @@ import { i18n } from "discourse-i18n";
 export default class AdminBadges extends Component {
   @service adminBadges;
   @service modal;
+  @service siteSettings;
 
   get badges() {
     return this.adminBadges.badges;
@@ -17,7 +19,13 @@ export default class AdminBadges extends Component {
 
   @action
   editGroupings() {
-    this.modal.show(EditBadgeGroupingsModal, {
+    // TODO (ui-kit-reorderable-list-cleanup) drop the branch and the legacy
+    // component once the change ships.
+    const Modal = this.siteSettings.enable_new_reordering_controls
+      ? EditBadgeGroupingsModalReorderable
+      : EditBadgeGroupingsModal;
+
+    this.modal.show(Modal, {
       model: {
         badgeGroupings: this.adminBadges.badgeGroupings,
         updateGroupings: (groupings) => {

--- a/frontend/discourse/admin/components/admin-config-areas/flags-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/flags-reorderable.gjs
@@ -1,0 +1,135 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import AdminFlagItemReorderable from "discourse/admin/components/admin-flag-item-reorderable";
+import { SYSTEM_FLAG_IDS } from "discourse/admin/lib/constants";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { removeValueFromArray } from "discourse/lib/array-tools";
+import { autoTrackedArray } from "discourse/lib/tracked-tools";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import { i18n } from "discourse-i18n";
+
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `admin-config-areas/flags.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `admin-config-areas/flags.gjs`
+ * and drop the branch in the flags config template.
+ */
+export default class AdminConfigAreasFlags extends Component {
+  @service site;
+
+  /**
+   * Flags with a request in flight, so their rows can drop the `saved`
+   * marker while a toggle, delete, or reorder is being persisted. Held here
+   * because the list owns the row elements the marker paints.
+   */
+  @tracked pendingIds = new Set();
+  @autoTrackedArray flags = this.site.flagTypes;
+
+  flagLabel = (flag) => flag.name;
+
+  movable = (flag) => flag.id !== SYSTEM_FLAG_IDS.notify_user;
+
+  rowClass = (flag) =>
+    dConcatClass(
+      "d-table__row admin-flag-item --reorderable",
+      flag.name_key,
+      this.pendingIds.has(flag.id) ? null : "saved"
+    );
+
+  @action
+  setPending(flag, pending) {
+    const next = new Set(this.pendingIds);
+    if (pending) {
+      next.add(flag.id);
+    } else {
+      next.delete(flag.id);
+    }
+    this.pendingIds = next;
+  }
+
+  /**
+   * Applies a committed move optimistically and persists it through the
+   * single-step reorder endpoint, rolling back on failure. Arrow moves are
+   * always adjacent steps, which is why the surface stays arrows-only for
+   * now: a pointer drag could jump several rows at once, which this endpoint
+   * cannot express.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
+  @action
+  async handleMove(move) {
+    const fallbackFlags = [...this.flags];
+    this.setPending(move.item, true);
+    this.flags.splice(0, this.flags.length, ...move.proposedToItems);
+
+    const direction = move.toIndex > move.fromIndex ? "down" : "up";
+    try {
+      await ajax(`/admin/config/flags/${move.item.id}/reorder/${direction}`, {
+        type: "PUT",
+      });
+    } catch (error) {
+      this.flags.splice(0, this.flags.length, ...fallbackFlags);
+      return popupAjaxError(error);
+    } finally {
+      this.setPending(move.item, false);
+    }
+  }
+
+  @action
+  async deleteFlagCallback(flag) {
+    try {
+      await ajax(`/admin/config/flags/${flag.id}`, {
+        type: "DELETE",
+      });
+
+      removeValueFromArray(this.flags, flag);
+    } catch (error) {
+      popupAjaxError(error);
+    }
+  }
+
+  <template>
+    <div class="container admin-flags">
+      {{! The reorderable list renders the tbody itself, which the static
+          table-group rule cannot see from here. }}
+      {{! eslint-disable-next-line ember/template-table-groups }}
+      <table class="d-table admin-flags__items">
+        <thead class="d-table__header">
+          <th class="d-table__header-cell --reorder"></th>
+          <th class="d-table__header-cell">{{i18n
+              "admin.config_areas.flags.description"
+            }}</th>
+          <th class="d-table__header-cell">{{i18n
+              "admin.config_areas.flags.enabled"
+            }}</th>
+        </thead>
+        <DReorderableList
+          @items={{this.flags}}
+          @key="id"
+          @label={{this.flagLabel}}
+          @movable={{this.movable}}
+          @onMove={{this.handleMove}}
+          @controls="manual"
+          @tag="tbody"
+          @itemTag="tr"
+          @rowClass={{this.rowClass}}
+          class="d-table__body"
+        >
+          <:row as |flag controls|>
+            <AdminFlagItemReorderable
+              @controls={{controls}}
+              @flag={{flag}}
+              @deleteFlagCallback={{this.deleteFlagCallback}}
+              @setPending={{this.setPending}}
+            />
+          </:row>
+        </DReorderableList>
+      </table>
+    </div>
+  </template>
+}

--- a/frontend/discourse/admin/components/admin-config-areas/flags-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/flags-reorderable.gjs
@@ -36,7 +36,7 @@ export default class AdminConfigAreasFlags extends Component {
 
   rowClass = (flag) =>
     dConcatClass(
-      "d-table__row admin-flag-item --reorderable",
+      "d-table__row admin-flag-item",
       flag.name_key,
       this.pendingIds.has(flag.id) ? null : "saved"
     );

--- a/frontend/discourse/admin/components/admin-config-areas/flags-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/flags-reorderable.gjs
@@ -100,7 +100,7 @@ export default class AdminConfigAreasFlags extends Component {
       {{! eslint-disable-next-line ember/template-table-groups }}
       <table class="d-table admin-flags__items">
         <thead class="d-table__header">
-          <th class="d-table__header-cell --reorder"></th>
+          <th class="d-table__header-cell --drag-handle"></th>
           <th class="d-table__header-cell">{{i18n
               "admin.config_areas.flags.description"
             }}</th>

--- a/frontend/discourse/admin/components/admin-config-areas/flags.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/flags.gjs
@@ -9,6 +9,8 @@ import { bind } from "discourse/lib/decorators";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
 import { i18n } from "discourse-i18n";
 
+// TODO (ui-kit-reorderable-list-cleanup) delete this file once
+// `enable_new_reordering_controls` ships; `flags-reorderable.gjs` replaces it.
 export default class AdminConfigAreasFlags extends Component {
   @service site;
 

--- a/frontend/discourse/admin/components/admin-config-areas/user-fields-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/user-fields-list-reorderable.gjs
@@ -109,7 +109,7 @@ export default class AdminConfigAreasUserFieldsList extends Component {
             @controls="manual"
             @tag="tbody"
             @itemTag="tr"
-            @rowClass="d-table__row admin-user_field-item --reorderable"
+            @rowClass="d-table__row admin-user_field-item"
             class="d-table__body"
           >
             <:row as |field controls|>

--- a/frontend/discourse/admin/components/admin-config-areas/user-fields-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/user-fields-list-reorderable.gjs
@@ -92,7 +92,7 @@ export default class AdminConfigAreasUserFieldsList extends Component {
         <table class="d-table user-fields">
           <thead class="d-table__header">
             <tr class="d-table__row">
-              <th class="d-table__header-cell --reorder"></th>
+              <th class="d-table__header-cell --drag-handle"></th>
               <th class="d-table__header-cell">{{i18n
                   "admin.config_areas.user_fields.field"
                 }}</th>

--- a/frontend/discourse/admin/components/admin-config-areas/user-fields-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/user-fields-list-reorderable.gjs
@@ -2,14 +2,20 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import AdminConfigAreaEmptyList from "discourse/admin/components/admin-config-area-empty-list";
-import AdminUserFieldItem from "discourse/admin/components/admin-user-field-item";
+import AdminUserFieldItemReorderable from "discourse/admin/components/admin-user-field-item-reorderable";
 import UserField from "discourse/admin/models/user-field";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { removeValueFromArray } from "discourse/lib/array-tools";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import { i18n } from "discourse-i18n";
 
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `user-fields-list-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `admin-config-areas/user-fields-list.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `admin-config-areas/user-fields-list.gjs`
+ * and drop the branch in the user-fields template.
+ */
 export default class AdminConfigAreasUserFieldsList extends Component {
   @service dialog;
   @service toasts;
@@ -17,6 +23,8 @@ export default class AdminConfigAreasUserFieldsList extends Component {
 
   /** @type {any} */
   fieldTypes = UserField.fieldTypes();
+
+  fieldLabel = (field) => field.name;
 
   get fields() {
     return this.adminUserFields.userFields;
@@ -26,27 +34,27 @@ export default class AdminConfigAreasUserFieldsList extends Component {
     return this.adminUserFields.sortedUserFields;
   }
 
+  /**
+   * Applies a committed move by renumbering every displaced field from its
+   * new slot — a drag can jump several rows, which the old adjacent-swap
+   * persistence could not express.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
   @action
-  moveUp(field) {
-    const idx = this.sortedFields.indexOf(field);
-    if (idx) {
-      const prev = this.sortedFields[idx - 1];
-      const prevPos = prev.get("position");
-
-      prev.update({ position: field.get("position") });
-      field.update({ position: prevPos });
-    }
-  }
-
-  @action
-  moveDown(field) {
-    const idx = this.sortedFields.indexOf(field);
-    if (idx > -1) {
-      const next = this.sortedFields[idx + 1];
-      const nextPos = next.get("position");
-
-      next.update({ position: field.get("position") });
-      field.update({ position: nextPos });
+  async handleMove(move) {
+    try {
+      await Promise.all(
+        move.proposedToItems.map((field, index) => {
+          const position = index + 1;
+          if (field.get("position") === position) {
+            return null;
+          }
+          return field.update({ position });
+        })
+      );
+    } catch (error) {
+      popupAjaxError(error);
     }
   }
 
@@ -78,9 +86,13 @@ export default class AdminConfigAreasUserFieldsList extends Component {
   <template>
     <div class="container admin-user_fields">
       {{#if this.fields}}
+        {{! The reorderable list renders the tbody itself, which the static
+            table-group rule cannot see from here. }}
+        {{! eslint-disable-next-line ember/template-table-groups }}
         <table class="d-table user-fields">
           <thead class="d-table__header">
             <tr class="d-table__row">
+              <th class="d-table__header-cell --reorder"></th>
               <th class="d-table__header-cell">{{i18n
                   "admin.config_areas.user_fields.field"
                 }}</th>
@@ -89,17 +101,26 @@ export default class AdminConfigAreasUserFieldsList extends Component {
                 }}</th>
             </tr>
           </thead>
-          <tbody class="d-table__body">
-            {{#each this.sortedFields as |field|}}
-              <AdminUserFieldItem
+          <DReorderableList
+            @items={{this.sortedFields}}
+            @key="id"
+            @label={{this.fieldLabel}}
+            @onMove={{this.handleMove}}
+            @controls="manual"
+            @tag="tbody"
+            @itemTag="tr"
+            @rowClass="d-table__row admin-user_field-item --reorderable"
+            class="d-table__body"
+          >
+            <:row as |field controls|>
+              <AdminUserFieldItemReorderable
+                @controls={{controls}}
                 @userField={{field}}
                 @fieldTypes={{this.fieldTypes}}
                 @destroyAction={{this.destroyField}}
-                @moveUpAction={{this.moveUp}}
-                @moveDownAction={{this.moveDown}}
               />
-            {{/each}}
-          </tbody>
+            </:row>
+          </DReorderableList>
         </table>
       {{else}}
         <AdminConfigAreaEmptyList

--- a/frontend/discourse/admin/components/admin-flag-item-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-flag-item-reorderable.gjs
@@ -1,0 +1,186 @@
+/* eslint-disable ember/no-tracked-properties-from-args */
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
+import { trustHTML } from "@ember/template";
+import { SYSTEM_FLAG_IDS } from "discourse/admin/lib/constants";
+import DMenu from "discourse/float-kit/components/d-menu";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { not } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
+import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
+import { i18n } from "discourse-i18n";
+
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `admin-flag-item.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `admin-flag-item.gjs`
+ * and drop the branch in flags-reorderable.gjs.
+ */
+export default class AdminFlagItem extends Component {
+  @service dialog;
+  @service router;
+
+  @tracked enabled = this.args.flag.enabled;
+
+  get canMove() {
+    return this.args.flag.id !== SYSTEM_FLAG_IDS.notify_user;
+  }
+
+  get canEdit() {
+    return !Object.values(SYSTEM_FLAG_IDS).includes(this.args.flag.id);
+  }
+
+  get canDelete() {
+    return this.canEdit && !this.args.flag.is_used;
+  }
+
+  get editTitle() {
+    return this.canEdit
+      ? "admin.config_areas.flags.form.edit_flag"
+      : "admin.config_areas.flags.form.non_editable";
+  }
+
+  get deleteTitle() {
+    return this.canDelete
+      ? "admin.config_areas.flags.form.delete_flag"
+      : "admin.config_areas.flags.form.non_deletable";
+  }
+
+  @action
+  toggleFlagEnabled(flag) {
+    this.enabled = !this.enabled;
+    this.args.setPending(flag, true);
+
+    return ajax(`/admin/config/flags/${flag.id}/toggle`, {
+      type: "PUT",
+    })
+      .then(() => {
+        this.args.flag.enabled = this.enabled;
+      })
+      .catch((error) => {
+        this.enabled = !this.enabled;
+        return popupAjaxError(error);
+      })
+      .finally(() => {
+        this.args.setPending(flag, false);
+      });
+  }
+
+  @action
+  onRegisterApi(api) {
+    this.dMenu = api;
+  }
+
+  @action
+  edit() {
+    this.router.transitionTo("adminConfig.flags.edit", this.args.flag);
+  }
+
+  @action
+  delete() {
+    this.args.setPending(this.args.flag, true);
+    this.dialog.yesNoConfirm({
+      message: i18n("admin.config_areas.flags.delete_confirm", {
+        name: this.args.flag.name,
+      }),
+      didConfirm: async () => {
+        try {
+          await this.args.deleteFlagCallback(this.args.flag);
+          this.args.setPending(this.args.flag, false);
+          this.dMenu.close();
+        } catch (error) {
+          popupAjaxError(error);
+        }
+      },
+      didCancel: () => {
+        this.args.setPending(this.args.flag, false);
+        this.dMenu.close();
+      },
+    });
+  }
+
+  <template>
+    <td class="d-table__cell --reorder">
+      {{#if @controls.handle}}<@controls.handle />{{/if}}
+    </td>
+    <td class="d-table__cell --overview">
+      {{#if this.canEdit}}
+        <LinkTo
+          @route="adminConfig.flags.edit"
+          @model={{@flag}}
+          class="d-table__overview-link"
+        >
+          <div
+            class="d-table__overview-name admin-flag-item__name"
+          >{{@flag.name}}</div>
+          <div class="d-table__overview-about">{{trustHTML
+              @flag.description
+            }}</div>
+        </LinkTo>
+      {{else}}
+        <div
+          class="d-table__overview-name admin-flag-item__name"
+        >{{@flag.name}}</div>
+        <div class="d-table__overview-about">{{trustHTML
+            @flag.description
+          }}</div>
+      {{/if}}
+    </td>
+    <td class="d-table__cell --detail">
+      <div class="d-table__mobile-label">
+        {{i18n "admin.config_areas.flags.enabled"}}
+      </div>
+      <DToggleSwitch
+        @state={{this.enabled}}
+        class="admin-flag-item__toggle {{@flag.name_key}}"
+        {{on "click" (fn this.toggleFlagEnabled @flag)}}
+      />
+    </td>
+    <td class="d-table__cell --controls">
+      <div class="d-table__cell-actions">
+
+        <DButton
+          class="btn-default btn-small admin-flag-item__edit"
+          @action={{this.edit}}
+          @label="admin.config_areas.flags.edit"
+          @disabled={{not this.canEdit}}
+          @title={{this.editTitle}}
+        />
+
+        {{#if this.canMove}}
+          <DMenu
+            @identifier="flag-menu"
+            @title={{i18n "admin.config_areas.flags.more_options.title"}}
+            @icon="ellipsis-vertical"
+            @onRegisterApi={{this.onRegisterApi}}
+            @triggerClass="btn-default"
+          >
+            <:content>
+              <DDropdownMenu as |dropdown|>
+
+                <dropdown.item>
+                  <DButton
+                    @label="admin.config_areas.flags.delete"
+                    @icon="trash-can"
+                    class="btn-transparent --danger admin-flag-item__delete"
+                    @action={{this.delete}}
+                    @disabled={{not this.canDelete}}
+                    @title={{this.deleteTitle}}
+                  />
+                </dropdown.item>
+              </DDropdownMenu>
+            </:content>
+          </DMenu>
+        {{/if}}
+      </div>
+    </td>
+  </template>
+}

--- a/frontend/discourse/admin/components/admin-flag-item-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-flag-item-reorderable.gjs
@@ -108,7 +108,7 @@ export default class AdminFlagItem extends Component {
   }
 
   <template>
-    <td class="d-table__cell --reorder">
+    <td class="d-table__cell --drag-handle">
       {{#if @controls.handle}}<@controls.handle />{{/if}}
     </td>
     <td class="d-table__cell --overview">

--- a/frontend/discourse/admin/components/admin-flag-item.gjs
+++ b/frontend/discourse/admin/components/admin-flag-item.gjs
@@ -18,6 +18,8 @@ import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
+// TODO (ui-kit-reorderable-list-cleanup) delete this file once
+// `enable_new_reordering_controls` ships; `admin-flag-item-reorderable.gjs` replaces it.
 export default class AdminFlagItem extends Component {
   @service dialog;
   @service router;

--- a/frontend/discourse/admin/components/admin-logo-form.gjs
+++ b/frontend/discourse/admin/components/admin-logo-form.gjs
@@ -6,6 +6,7 @@ import { trackedObject } from "@ember/reactive/collections";
 import { service } from "@ember/service";
 import AdminConfigAreaCardSection from "discourse/admin/components/admin-config-area-card-section";
 import SimpleList from "discourse/admin/components/simple-list";
+import SimpleListReorderable from "discourse/admin/components/simple-list-reorderable";
 import Form from "discourse/components/form";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse/lib/decorators";
@@ -307,13 +308,25 @@ export default class AdminLogoForm extends Component {
               as |field|
             >
               <field.Control>
-                <SimpleList
-                  @onChange={{fn this.updateManifestScreenshots field}}
-                  @inputDelimiter="|"
-                  @values={{field.value}}
-                  @allowAny={{true}}
-                  id={{field.id}}
-                />
+                {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+                    legacy component once the change ships. }}
+                {{#if this.siteSettings.enable_new_reordering_controls}}
+                  <SimpleListReorderable
+                    @onChange={{fn this.updateManifestScreenshots field}}
+                    @inputDelimiter="|"
+                    @values={{field.value}}
+                    @allowAny={{true}}
+                    id={{field.id}}
+                  />
+                {{else}}
+                  <SimpleList
+                    @onChange={{fn this.updateManifestScreenshots field}}
+                    @inputDelimiter="|"
+                    @values={{field.value}}
+                    @allowAny={{true}}
+                    id={{field.id}}
+                  />
+                {{/if}}
               </field.Control>
             </form.Field>
             <form.Field

--- a/frontend/discourse/admin/components/admin-user-field-item-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-user-field-item-reorderable.gjs
@@ -51,7 +51,7 @@ export default class AdminUserFieldItem extends Component {
   }
 
   <template>
-    <td class="d-table__cell --reorder">
+    <td class="d-table__cell --drag-handle">
       <@controls.handle />
     </td>
     <td class="d-table__cell --overview">

--- a/frontend/discourse/admin/components/admin-user-field-item-reorderable.gjs
+++ b/frontend/discourse/admin/components/admin-user-field-item-reorderable.gjs
@@ -1,0 +1,106 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
+import { trustHTML } from "@ember/template";
+import { USER_FIELD_FLAGS } from "discourse/admin/lib/constants";
+import UserField from "discourse/admin/models/user-field";
+import DMenu from "discourse/float-kit/components/d-menu";
+import DButton from "discourse/ui-kit/d-button";
+import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import { i18n } from "discourse-i18n";
+
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `admin-user-field-item.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `admin-user-field-item.gjs`
+ * and drop the branch in user-fields-list-reorderable.gjs.
+ */
+export default class AdminUserFieldItem extends Component {
+  @service router;
+
+  get fieldName() {
+    return UserField.fieldTypeById(this.fieldType)?.name;
+  }
+
+  get flags() {
+    return USER_FIELD_FLAGS.map((flag) => {
+      if (this.args.userField[flag]) {
+        return i18n(`admin.user_fields.${flag}.enabled`);
+      }
+    })
+      .filter(Boolean)
+      .join(", ");
+  }
+
+  @action
+  destroy() {
+    this.args.destroyAction(this.args.userField);
+    this.dMenu.close();
+  }
+
+  @action
+  onRegisterApi(api) {
+    this.dMenu = api;
+  }
+
+  @action
+  edit() {
+    this.router.transitionTo("adminUserFields.edit", this.args.userField);
+  }
+
+  <template>
+    <td class="d-table__cell --reorder">
+      <@controls.handle />
+    </td>
+    <td class="d-table__cell --overview">
+      <LinkTo
+        class="d-table__overview-link"
+        @route="adminUserFields.edit"
+        @model={{@userField}}
+      >
+        <div class="d-table__overview-name admin-user_field-item__name">
+          {{@userField.name}}
+        </div>
+        <div class="d-table__overview-about">{{trustHTML
+            @userField.description
+          }}</div>
+      </LinkTo>
+      <div class="d-table__overview-flags">{{this.flags}}</div>
+    </td>
+    <td class="d-table__cell --detail">
+      {{@userField.fieldTypeName}}
+    </td>
+    <td class="d-table__cell --controls">
+      <div class="d-table__cell-actions">
+        <DButton
+          class="btn-default btn-small admin-user_field-item__edit"
+          @action={{this.edit}}
+          @label="admin.user_fields.edit"
+        />
+
+        <DMenu
+          @identifier="user_field-menu"
+          @title={{i18n "admin.config_areas.user_fields.more_options.title"}}
+          @icon="ellipsis-vertical"
+          @onRegisterApi={{this.onRegisterApi}}
+          @triggerClass="btn-default"
+        >
+          <:content>
+            <DDropdownMenu as |dropdown|>
+              <dropdown.item>
+                <DButton
+                  @label="admin.config_areas.user_fields.delete"
+                  @icon="trash-can"
+                  class="btn-transparent --danger admin-user_field-item__delete"
+                  @action={{this.destroy}}
+                />
+              </dropdown.item>
+            </DDropdownMenu>
+          </:content>
+        </DMenu>
+      </div>
+    </td>
+  </template>
+}

--- a/frontend/discourse/admin/components/admin-user-field-item.gjs
+++ b/frontend/discourse/admin/components/admin-user-field-item.gjs
@@ -10,6 +10,8 @@ import DButton from "discourse/ui-kit/d-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import { i18n } from "discourse-i18n";
 
+// TODO (ui-kit-reorderable-list-cleanup) delete this file once
+// `enable_new_reordering_controls` ships; `admin-user-field-item-reorderable.gjs` replaces it.
 export default class AdminUserFieldItem extends Component {
   @service adminUserFields;
   @service router;

--- a/frontend/discourse/admin/components/admin-user-fields-form.gjs
+++ b/frontend/discourse/admin/components/admin-user-fields-form.gjs
@@ -5,6 +5,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import ValueList from "discourse/admin/components/value-list";
+import ValueListReorderable from "discourse/admin/components/value-list-reorderable";
 import UserField from "discourse/admin/models/user-field";
 import Form from "discourse/components/form";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -19,6 +20,7 @@ export default class AdminUserFieldsForm extends Component {
   @service adminUserFields;
   @service adminCustomUserFields;
   @service toasts;
+  @service siteSettings;
 
   @tracked
   editableDisabled = this.args.userField.requirement === "for_all_users";
@@ -195,11 +197,21 @@ export default class AdminUserFieldsForm extends Component {
           as |field|
         >
           <field.Control>
-            <ValueList
-              @values={{transientData.options}}
-              @inputType="array"
-              @onChange={{field.set}}
-            />
+            {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+                legacy component once the change ships. }}
+            {{#if this.siteSettings.enable_new_reordering_controls}}
+              <ValueListReorderable
+                @values={{transientData.options}}
+                @inputType="array"
+                @onChange={{field.set}}
+              />
+            {{else}}
+              <ValueList
+                @values={{transientData.options}}
+                @inputType="array"
+                @onChange={{field.set}}
+              />
+            {{/if}}
           </field.Control>
         </form.Field>
       {{/if}}

--- a/frontend/discourse/admin/components/dashboard/configure-menu-reorderable.gjs
+++ b/frontend/discourse/admin/components/dashboard/configure-menu-reorderable.gjs
@@ -1,0 +1,62 @@
+import Component from "@glimmer/component";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
+import { i18n } from "discourse-i18n";
+
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Renders the
+ * same sections as `configure-menu.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `configure-menu.gjs`
+ * and drop the branch in `redesigned-admin-dashboard.gjs`.
+ */
+export default class ConfigureMenu extends Component {
+  sectionLabel = (section) =>
+    i18n(`admin.dashboard.sections.${section.id}.title`);
+
+  toggleLabel = (section) =>
+    i18n("admin.dashboard.configure.toggle_visibility", {
+      label: this.sectionLabel(section),
+    });
+
+  /**
+   * Forwards a committed move to the controlled owner. The list has already
+   * normalized both input paths, suppressed no-ops, and announced, so what
+   * remains is the owner's own index-based contract.
+   *
+   * @param {Object} move - The normalized move.
+   */
+  @action
+  handleMove(move) {
+    this.args.onReorder(move.fromIndex, move.toIndex);
+  }
+
+  <template>
+    <div class="db-configure">
+      <DReorderableList
+        @items={{@sections}}
+        @key="id"
+        @label={{this.sectionLabel}}
+        @onMove={{this.handleMove}}
+        @rowClass="db-configure__row --reorderable"
+        class="db-configure__list --reorderable"
+        aria-label={{i18n "admin.dashboard.configure.menu_title"}}
+      >
+        <:row as |section|>
+          <span class="db-configure__section-name">
+            {{this.sectionLabel section}}
+          </span>
+
+          <DToggleSwitch
+            @state={{section.visible}}
+            {{on "click" (fn @onToggleVisibility section.id)}}
+            aria-label={{this.toggleLabel section}}
+          />
+        </:row>
+      </DReorderableList>
+    </div>
+  </template>
+}

--- a/frontend/discourse/admin/components/dashboard/configure-menu-reorderable.gjs
+++ b/frontend/discourse/admin/components/dashboard/configure-menu-reorderable.gjs
@@ -41,8 +41,8 @@ export default class ConfigureMenu extends Component {
         @key="id"
         @label={{this.sectionLabel}}
         @onMove={{this.handleMove}}
-        @rowClass="db-configure__row --reorderable"
-        class="db-configure__list --reorderable"
+        @rowClass="db-configure__row"
+        class="db-configure__list"
         aria-label={{i18n "admin.dashboard.configure.menu_title"}}
       >
         <:row as |section|>

--- a/frontend/discourse/admin/components/dashboard/configure-menu.gjs
+++ b/frontend/discourse/admin/components/dashboard/configure-menu.gjs
@@ -12,6 +12,9 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+// TODO (ui-kit-reorderable-list-cleanup) delete this file once
+// `enable_new_reordering_controls` ships; `configure-menu-reorderable.gjs`
+// replaces it.
 class ConfigureRow extends Component {
   @service site;
 

--- a/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
@@ -7,6 +7,7 @@ import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import CompareGroups from "discourse/admin/components/modal/compare-groups";
+import CompareGroupsReorderable from "discourse/admin/components/modal/compare-groups-reorderable";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Category from "discourse/models/category";
@@ -33,6 +34,7 @@ export default class WhosPosting extends Component {
   @service currentUser;
   @service toasts;
   @service modal;
+  @service siteSettings;
 
   @tracked selectedCategories = [];
   @tracked selectedGroups = [];
@@ -131,7 +133,13 @@ export default class WhosPosting extends Component {
 
   @action
   openCompareGroups() {
-    this.modal.show(CompareGroups, {
+    // TODO (ui-kit-reorderable-list-cleanup) drop the branch and the legacy
+    // component once the change ships.
+    const Modal = this.siteSettings.enable_new_reordering_controls
+      ? CompareGroupsReorderable
+      : CompareGroups;
+
+    this.modal.show(Modal, {
       model: {
         currentTokens: this.selectedGroups,
         footerNote: i18n(

--- a/frontend/discourse/admin/components/dashboard/reports.gjs
+++ b/frontend/discourse/admin/components/dashboard/reports.gjs
@@ -9,6 +9,7 @@ import DashboardReportEmptyState from "discourse/admin/components/dashboard/repo
 import DashboardReportErrorState from "discourse/admin/components/dashboard/report-error-state";
 import DashboardSection from "discourse/admin/components/dashboard/section";
 import ManageReports from "discourse/admin/components/modal/manage-reports";
+import ManageReportsReorderable from "discourse/admin/components/modal/manage-reports-reorderable";
 import { lookupAdminDashboardReportRenderer } from "discourse/admin/lib/admin-dashboard-report-renderers";
 import { loadDashboardReports } from "discourse/admin/lib/dashboard-reports-loader";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -25,6 +26,7 @@ const VISIBLE_CAP = 10;
 export default class DashboardReports extends Component {
   @service currentUser;
   @service modal;
+  @service siteSettings;
 
   @tracked cards = [];
   @tracked loading = false;
@@ -109,7 +111,13 @@ export default class DashboardReports extends Component {
 
   @action
   openReportsConfig() {
-    this.modal.show(ManageReports, {
+    // TODO (ui-kit-reorderable-list-cleanup) drop the branch and the legacy
+    // component once the change ships.
+    const Modal = this.siteSettings.enable_new_reordering_controls
+      ? ManageReportsReorderable
+      : ManageReports;
+
+    this.modal.show(Modal, {
       model: { onApplied: this.onLayoutChanged },
     });
   }

--- a/frontend/discourse/admin/components/emoji-value-list.gjs
+++ b/frontend/discourse/admin/components/emoji-value-list.gjs
@@ -176,8 +176,8 @@ export default class EmojiValueList extends Component {
             @onMove={{this.handleMove}}
             @onRemove={{this.removeValue}}
             @removable={{this.isEditable}}
-            @rowClass="value --reorderable"
-            class="values emoji-value-list --reorderable"
+            @rowClass="value"
+            class="values emoji-value-list"
           >
             <:row as |data controls|>
               <div

--- a/frontend/discourse/admin/components/emoji-value-list.gjs
+++ b/frontend/discourse/admin/components/emoji-value-list.gjs
@@ -10,10 +10,16 @@ import { addUniqueValueToArray } from "discourse/lib/array-tools";
 import { emojiUrlFor } from "discourse/lib/text";
 import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import { i18n } from "discourse-i18n";
 
 export default class EmojiValueList extends Component {
   @service menu;
+  @service siteSettings;
+
+  emojiLabel = (data) => data.value;
+
+  isEditable = (item) => item.isEditable;
 
   @cached
   get collection() {
@@ -59,6 +65,7 @@ export default class EmojiValueList extends Component {
     this.#saveValues(newCollection);
   }
 
+  // TODO (ui-kit-reorderable-list-cleanup) delete with the legacy arm below.
   get showUpDownButtons() {
     return this.collection.length > 1;
   }
@@ -94,6 +101,18 @@ export default class EmojiValueList extends Component {
     this.#saveValues(newCollection);
   }
 
+  /**
+   * Applies a committed move and persists the new order. Wrapping and
+   * announcements are the list's own.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
+  @action
+  handleMove(move) {
+    this.#saveValues([...move.proposedToItems]);
+  }
+
+  // TODO (ui-kit-reorderable-list-cleanup) delete with the legacy arm below.
   @action
   shift(operation, index) {
     const updateCollection = [...this.collection];
@@ -146,22 +165,27 @@ export default class EmojiValueList extends Component {
   <template>
     <div class="value-list emoji-list">
       {{#if this.collection}}
-        <ul class="values emoji-value-list">
-          {{#each this.collection key="value" as |data index|}}
-            <li class="value" data-index={{index}}>
-              <DButton
-                @action={{fn this.removeValue data}}
-                @icon="xmark"
-                @disabled={{not data.isEditable}}
-                class="btn-default remove-value-btn btn-small"
-              />
-
+        {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+            legacy arm once the change ships. This component keeps one class
+            because a plugin patches it by resolver key. }}
+        {{#if this.siteSettings.enable_new_reordering_controls}}
+          <DReorderableList
+            @items={{this.collection}}
+            @key="value"
+            @label={{this.emojiLabel}}
+            @onMove={{this.handleMove}}
+            @onRemove={{this.removeValue}}
+            @removable={{this.isEditable}}
+            @rowClass="value --reorderable"
+            class="values emoji-value-list --reorderable"
+          >
+            <:row as |data controls|>
               <div
                 class="value-input emoji-details
                   {{if data.isEditable 'can-edit'}}
                   {{if data.isEditing 'd-editor-textarea-wrapper'}}"
-                {{on "click" (fn this.editValue index)}}
                 role="button"
+                {{on "click" (fn this.editValue controls.index)}}
               >
                 <img
                   height="15px"
@@ -171,22 +195,51 @@ export default class EmojiValueList extends Component {
                 />
                 <span class="emoji-name">{{data.value}}</span>
               </div>
+            </:row>
+          </DReorderableList>
+        {{else}}
+          <ul class="values emoji-value-list">
+            {{#each this.collection key="value" as |data index|}}
+              <li class="value" data-index={{index}}>
+                <DButton
+                  @action={{fn this.removeValue data}}
+                  @icon="xmark"
+                  @disabled={{not data.isEditable}}
+                  class="btn-default remove-value-btn btn-small"
+                />
 
-              {{#if this.showUpDownButtons}}
-                <DButton
-                  @action={{fn this.shift -1 index}}
-                  @icon="arrow-up"
-                  class="btn-default shift-up-value-btn btn-small"
-                />
-                <DButton
-                  @action={{fn this.shift 1 index}}
-                  @icon="arrow-down"
-                  class="btn-default shift-down-value-btn btn-small"
-                />
-              {{/if}}
-            </li>
-          {{/each}}
-        </ul>
+                <div
+                  class="value-input emoji-details
+                    {{if data.isEditable 'can-edit'}}
+                    {{if data.isEditing 'd-editor-textarea-wrapper'}}"
+                  {{on "click" (fn this.editValue index)}}
+                  role="button"
+                >
+                  <img
+                    height="15px"
+                    width="15px"
+                    src={{data.emojiUrl}}
+                    class="emoji-list-emoji"
+                  />
+                  <span class="emoji-name">{{data.value}}</span>
+                </div>
+
+                {{#if this.showUpDownButtons}}
+                  <DButton
+                    @action={{fn this.shift -1 index}}
+                    @icon="arrow-up"
+                    class="btn-default shift-up-value-btn btn-small"
+                  />
+                  <DButton
+                    @action={{fn this.shift 1 index}}
+                    @icon="arrow-down"
+                    class="btn-default shift-down-value-btn btn-small"
+                  />
+                {{/if}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/if}}
       {{/if}}
 
       <div class="value">

--- a/frontend/discourse/admin/components/manageable-row-list-item-reorderable.gjs
+++ b/frontend/discourse/admin/components/manageable-row-list-item-reorderable.gjs
@@ -1,0 +1,48 @@
+import { concat, fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
+import { i18n } from "discourse-i18n";
+
+/**
+ * One row of a toggleable, ordered admin list: its text and its enable
+ * switch.
+ *
+ * Reordering is not drawn here. The surrounding reorderable list owns the
+ * handle, the drag, the move menu and the announcements, so a row only has to
+ * describe itself.
+ */
+// TODO (ui-kit-reorderable-list-cleanup) rename this over
+// `manageable-row-list-item.gjs` once the change ships.
+const ManageableRowListItem = <template>
+  <div class="manageable-row-list__row-content">
+    <div class="manageable-row-list__row-text">
+      <div class="manageable-row-list__row-heading">
+        <span class="manageable-row-list__title">{{@row.title}}</span>
+        {{#if @row.label}}
+          <span class="db-report__label">
+            {{@row.label}}
+          </span>
+        {{/if}}
+      </div>
+      {{#if @row.description}}
+        <p class="manageable-row-list__description">{{@row.description}}</p>
+      {{/if}}
+    </div>
+
+    <DToggleSwitch
+      @state={{@row.enabled}}
+      disabled={{@toggleDisabled}}
+      aria-label={{i18n
+        (if
+          @row.enabled
+          (concat @ariaLabelPrefix ".disable")
+          (concat @ariaLabelPrefix ".enable")
+        )
+        title=@row.title
+      }}
+      {{on "click" (fn @onToggle @row)}}
+    />
+  </div>
+</template>;
+
+export default ManageableRowListItem;

--- a/frontend/discourse/admin/components/manageable-row-list-item.gjs
+++ b/frontend/discourse/admin/components/manageable-row-list-item.gjs
@@ -11,6 +11,8 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+// TODO (ui-kit-reorderable-list-cleanup) delete this file once
+// `enable_new_reordering_controls` ships; `manageable-row-list-item-reorderable.gjs` replaces it.
 export default class ManageableRowListItem extends Component {
   @service site;
 

--- a/frontend/discourse/admin/components/modal/compare-groups-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/compare-groups-reorderable.gjs
@@ -3,12 +3,13 @@ import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import ManageableRowListItem from "discourse/admin/components/manageable-row-list-item";
+import ManageableRowListItemReorderable from "discourse/admin/components/manageable-row-list-item-reorderable";
 import ToggleableOrderedList from "discourse/admin/lib/toggleable-ordered-list";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
 import DModal from "discourse/ui-kit/d-modal";
-import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import { i18n } from "discourse-i18n";
 
 export const VISIBLE_CAP = 10;
@@ -22,8 +23,13 @@ export function groupToken(groupId) {
   return `group:${groupId}`;
 }
 
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `compare-groups-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `modal/compare-groups.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `modal/compare-groups.gjs`
+ * and drop the branch in whos-posting.gjs and report-filters/groups.gjs.
+ */
 export default class CompareGroups extends Component {
   @service site;
 
@@ -34,6 +40,18 @@ export default class CompareGroups extends Component {
   rowsByKey = new Map();
 
   toggleDisabled = (row) => this.list.toggleDisabled(row.key);
+
+  /** Only an enabled row takes part in the order; the rest keep their slots. */
+  isMovable = (row) => row.enabled;
+
+  /** Keeps the row's own class and its enabled modifier on the row element. */
+  rowClass = (row) =>
+    row.enabled
+      ? "manageable-row-list__row --reorderable --enabled"
+      : "manageable-row-list__row --reorderable";
+
+  /** Names a row wherever the list speaks about it: the handle, the menu, the announcement. */
+  rowLabel = (row) => row.title;
 
   constructor() {
     super(...arguments);
@@ -107,28 +125,10 @@ export default class CompareGroups extends Component {
   }
 
   @action
-  moveUp(row) {
-    this.list.moveUp(row.key);
-  }
-
-  @action
-  moveDown(row) {
-    this.list.moveDown(row.key);
-  }
-
-  @action
-  onDragStart(key) {
-    this.list.onDragStart(key);
-  }
-
-  @action
-  onDrop(targetKey, dropAbove) {
-    this.list.onDrop(targetKey, dropAbove);
-  }
-
-  @action
-  onDragEnd() {
-    this.list.onDragEnd();
+  handleMove({ proposedToItems }) {
+    this.list.reorderVisible(
+      proposedToItems.filter((row) => row.enabled).map((row) => row.key)
+    );
   }
 
   @action
@@ -172,30 +172,28 @@ export default class CompareGroups extends Component {
       </:belowHeader>
 
       <:body>
-        <ul
-          class={{dConcatClass
-            "manageable-row-list__list"
-            (if this.list.draggedId "--dragging")
-            (if this.list.reorderable "--reorderable")
+        <DReorderableList
+          class="manageable-row-list__list --reorderable"
+          @disabled={{not this.list.reorderable}}
+          @items={{this.visibleRows}}
+          @key="key"
+          @label={{this.rowLabel}}
+          @listLabel={{i18n
+            "admin.dashboard.sections.engagement.whos_posting.modal.title"
           }}
+          @movable={{this.isMovable}}
+          @onMove={{this.handleMove}}
+          @rowClass={{this.rowClass}}
         >
-          {{#each this.visibleRows key="key" as |row index|}}
-            <ManageableRowListItem
+          <:row as |row|>
+            <ManageableRowListItemReorderable
               @ariaLabelPrefix={{ARIA_LABEL_PREFIX}}
               @row={{row}}
-              @index={{index}}
-              @lastEnabledIndex={{this.lastEnabledIndex}}
-              @reorderable={{this.list.reorderable}}
               @toggleDisabled={{this.toggleDisabled row}}
               @onToggle={{this.toggle}}
-              @onMoveUp={{this.moveUp}}
-              @onMoveDown={{this.moveDown}}
-              @onDragStart={{this.onDragStart}}
-              @onDrop={{this.onDrop}}
-              @onDragEnd={{this.onDragEnd}}
             />
-          {{/each}}
-        </ul>
+          </:row>
+        </DReorderableList>
       </:body>
 
       <:footer>

--- a/frontend/discourse/admin/components/modal/compare-groups-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/compare-groups-reorderable.gjs
@@ -47,8 +47,8 @@ export default class CompareGroups extends Component {
   /** Keeps the row's own class and its enabled modifier on the row element. */
   rowClass = (row) =>
     row.enabled
-      ? "manageable-row-list__row --reorderable --enabled"
-      : "manageable-row-list__row --reorderable";
+      ? "manageable-row-list__row --enabled"
+      : "manageable-row-list__row";
 
   /** Names a row wherever the list speaks about it: the handle, the menu, the announcement. */
   rowLabel = (row) => row.title;
@@ -173,7 +173,7 @@ export default class CompareGroups extends Component {
 
       <:body>
         <DReorderableList
-          class="manageable-row-list__list --reorderable"
+          class="manageable-row-list__list"
           @disabled={{not this.list.reorderable}}
           @items={{this.visibleRows}}
           @key="key"

--- a/frontend/discourse/admin/components/modal/edit-badge-groupings-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/edit-badge-groupings-reorderable.gjs
@@ -97,8 +97,8 @@ export default class EditBadgeGroupings extends Component {
             @onRemove={{this.delete}}
             @removable={{this.canDelete}}
             @controls="manual"
-            @rowClass="badge-grouping-item --reorderable"
-            class="badge-groupings-list --reorderable"
+            @rowClass="badge-grouping-item"
+            class="badge-groupings-list"
           >
             <:row as |wc controls|>
               <controls.handle />

--- a/frontend/discourse/admin/components/modal/edit-badge-groupings-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/edit-badge-groupings-reorderable.gjs
@@ -8,10 +8,16 @@ import { removeValueFromArray } from "discourse/lib/array-tools";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import { i18n } from "discourse-i18n";
 
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `edit-badge-groupings-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `modal/edit-badge-groupings.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `modal/edit-badge-groupings.gjs`
+ * and drop the branch in admin-badges.gjs.
+ */
 export default class EditBadgeGroupings extends Component {
   @service dialog;
   @service store;
@@ -20,14 +26,21 @@ export default class EditBadgeGroupings extends Component {
     this.store.createRecord("badge-grouping", o)
   );
 
-  @action
-  up(item) {
-    this.moveItem(item, -1);
-  }
+  groupingLabel = (grouping) => grouping.displayName || grouping.name;
+  canDelete = (grouping) => !grouping.system;
 
+  /**
+   * Applies a committed move onto the staged working copy.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
   @action
-  down(item) {
-    this.moveItem(item, 1);
+  handleMove(move) {
+    this.workingCopy.splice(
+      0,
+      this.workingCopy.length,
+      ...move.proposedToItems
+    );
   }
 
   @action
@@ -69,15 +82,6 @@ export default class EditBadgeGroupings extends Component {
     }
   }
 
-  moveItem(item, delta) {
-    const index = this.workingCopy.indexOf(item);
-    if (index + delta < 0 || index + delta >= this.workingCopy.length) {
-      return;
-    }
-    this.workingCopy.splice(index, 1); // remove the item from the old position
-    this.workingCopy.splice(index + delta, 0, item); // insert it in the new position
-  }
-
   <template>
     <DModal
       @title={{i18n "admin.badges.badge_groupings.modal_title"}}
@@ -86,54 +90,46 @@ export default class EditBadgeGroupings extends Component {
     >
       <:body>
         <div class="badge-groupings">
-          <ul class="badge-groupings-list">
-            {{#each this.workingCopy as |wc|}}
-              <li class="badge-grouping-item">
-                <div class="badge-grouping">
-                  {{#if wc.editing}}
-                    <Input
-                      @value={{wc.name}}
-                      class="badge-grouping-name-input"
-                    />
-                  {{else}}
-                    <span>{{wc.displayName}}</span>
-                  {{/if}}
-                </div>
-                <div class="actions">
-                  {{#if wc.editing}}
-                    <DButton
-                      @action={{fn (mut wc.editing) false}}
-                      @icon="check"
-                      class="btn-default"
-                    />
-                  {{else}}
-                    <DButton
-                      @action={{fn (mut wc.editing) true}}
-                      @disabled={{wc.system}}
-                      @icon="pencil"
-                      class="btn-default"
-                    />
-                  {{/if}}
+          <DReorderableList
+            @items={{this.workingCopy}}
+            @label={{this.groupingLabel}}
+            @onMove={{this.handleMove}}
+            @onRemove={{this.delete}}
+            @removable={{this.canDelete}}
+            @controls="manual"
+            @rowClass="badge-grouping-item --reorderable"
+            class="badge-groupings-list --reorderable"
+          >
+            <:row as |wc controls|>
+              <controls.handle />
+              <div class="badge-grouping">
+                {{#if wc.editing}}
+                  <Input @value={{wc.name}} class="badge-grouping-name-input" />
+                {{else}}
+                  <span>{{wc.displayName}}</span>
+                {{/if}}
+              </div>
+              <div class="actions">
+                {{#if wc.editing}}
                   <DButton
-                    @action={{fn this.up wc}}
-                    @icon="chevron-up"
+                    @action={{fn (mut wc.editing) false}}
+                    @icon="check"
                     class="btn-default"
                   />
+                {{else}}
                   <DButton
-                    @action={{fn this.down wc}}
-                    @icon="chevron-down"
-                    class="btn-default"
-                  />
-                  <DButton
-                    @action={{fn this.delete wc}}
+                    @action={{fn (mut wc.editing) true}}
                     @disabled={{wc.system}}
-                    @icon="xmark"
+                    @icon="pencil"
                     class="btn-default"
                   />
-                </div>
-              </li>
-            {{/each}}
-          </ul>
+                {{/if}}
+                {{#if controls.remove}}
+                  <controls.remove class="btn-default" />
+                {{/if}}
+              </div>
+            </:row>
+          </DReorderableList>
         </div>
         <DButton
           @action={{this.add}}

--- a/frontend/discourse/admin/components/modal/edit-badge-groupings-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/edit-badge-groupings-reorderable.gjs
@@ -114,18 +114,19 @@ export default class EditBadgeGroupings extends Component {
                   <DButton
                     @action={{fn (mut wc.editing) false}}
                     @icon="check"
-                    class="btn-default"
+                    class="btn-flat"
                   />
                 {{else}}
-                  <DButton
-                    @action={{fn (mut wc.editing) true}}
-                    @disabled={{wc.system}}
-                    @icon="pencil"
-                    class="btn-default"
-                  />
+                  {{#unless wc.system}}
+                    <DButton
+                      @action={{fn (mut wc.editing) true}}
+                      @icon="pencil"
+                      class="btn-flat"
+                    />
+                  {{/unless}}
                 {{/if}}
                 {{#if controls.remove}}
-                  <controls.remove class="btn-default" />
+                  <controls.remove />
                 {{/if}}
               </div>
             </:row>

--- a/frontend/discourse/admin/components/modal/manage-reports-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/manage-reports-reorderable.gjs
@@ -49,8 +49,8 @@ export default class ManageReports extends Component {
   /** Keeps the row's own class and its enabled modifier on the row element. */
   rowClass = (row) =>
     row.enabled
-      ? "manageable-row-list__row --reorderable --enabled"
-      : "manageable-row-list__row --reorderable";
+      ? "manageable-row-list__row --enabled"
+      : "manageable-row-list__row";
 
   /** Names a row wherever the list speaks about it: the handle, the menu, the announcement. */
   rowLabel = (row) => row.title;
@@ -249,7 +249,7 @@ export default class ManageReports extends Component {
 
         {{#if this.visibleRows.length}}
           <DReorderableList
-            class="manageable-row-list__list --reorderable"
+            class="manageable-row-list__list"
             @disabled={{not this.list.reorderable}}
             @items={{this.visibleRows}}
             @key="key"

--- a/frontend/discourse/admin/components/modal/manage-reports-reorderable.gjs
+++ b/frontend/discourse/admin/components/modal/manage-reports-reorderable.gjs
@@ -2,26 +2,32 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
-import ManageableRowListItem from "discourse/admin/components/manageable-row-list-item";
+import ManageableRowListItemReorderable from "discourse/admin/components/manageable-row-list-item-reorderable";
 import ToggleableOrderedList from "discourse/admin/lib/toggleable-ordered-list";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DModal from "discourse/ui-kit/d-modal";
-import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import { i18n } from "discourse-i18n";
 
 const VISIBLE_CAP = 10;
 const SEARCH_DEBOUNCE_MS = 200;
 const ARIA_LABEL_PREFIX = "admin.dashboard.reports_section.modal";
 
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `manage-reports-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `modal/manage-reports.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `modal/manage-reports.gjs`
+ * and drop the branch in dashboard/reports.gjs.
+ */
 export default class ManageReports extends Component {
   @tracked allKeys = [];
   @tracked providers = [];
@@ -36,6 +42,18 @@ export default class ManageReports extends Component {
   itemsByKey = new Map();
 
   toggleDisabled = (row) => this.list.toggleDisabled(row.key);
+
+  /** Only an enabled row takes part in the order; the rest keep their slots. */
+  isMovable = (row) => row.enabled;
+
+  /** Keeps the row's own class and its enabled modifier on the row element. */
+  rowClass = (row) =>
+    row.enabled
+      ? "manageable-row-list__row --reorderable --enabled"
+      : "manageable-row-list__row --reorderable";
+
+  /** Names a row wherever the list speaks about it: the handle, the menu, the announcement. */
+  rowLabel = (row) => row.title;
 
   constructor() {
     super(...arguments);
@@ -168,28 +186,10 @@ export default class ManageReports extends Component {
   }
 
   @action
-  moveUp(row) {
-    this.list.moveUp(row.key);
-  }
-
-  @action
-  moveDown(row) {
-    this.list.moveDown(row.key);
-  }
-
-  @action
-  onDragStart(key) {
-    this.list.onDragStart(key);
-  }
-
-  @action
-  onDrop(targetKey, dropAbove) {
-    this.list.onDrop(targetKey, dropAbove);
-  }
-
-  @action
-  onDragEnd() {
-    this.list.onDragEnd();
+  handleMove({ proposedToItems }) {
+    this.list.reorderVisible(
+      proposedToItems.filter((row) => row.enabled).map((row) => row.key)
+    );
   }
 
   @action
@@ -248,30 +248,26 @@ export default class ManageReports extends Component {
       <:body>
 
         {{#if this.visibleRows.length}}
-          <ul
-            class={{dConcatClass
-              "manageable-row-list__list"
-              (if this.list.draggedId "--dragging")
-              (if this.list.reorderable "--reorderable")
-            }}
+          <DReorderableList
+            class="manageable-row-list__list --reorderable"
+            @disabled={{not this.list.reorderable}}
+            @items={{this.visibleRows}}
+            @key="key"
+            @label={{this.rowLabel}}
+            @listLabel={{i18n "admin.dashboard.reports_section.modal.title"}}
+            @movable={{this.isMovable}}
+            @onMove={{this.handleMove}}
+            @rowClass={{this.rowClass}}
           >
-            {{#each this.visibleRows key="key" as |row index|}}
-              <ManageableRowListItem
+            <:row as |row|>
+              <ManageableRowListItemReorderable
                 @ariaLabelPrefix={{ARIA_LABEL_PREFIX}}
                 @row={{row}}
-                @index={{index}}
-                @lastEnabledIndex={{this.lastEnabledIndex}}
-                @reorderable={{this.list.reorderable}}
                 @toggleDisabled={{this.toggleDisabled row}}
                 @onToggle={{this.toggle}}
-                @onMoveUp={{this.moveUp}}
-                @onMoveDown={{this.moveDown}}
-                @onDragStart={{this.onDragStart}}
-                @onDrop={{this.onDrop}}
-                @onDragEnd={{this.onDragEnd}}
               />
-            {{/each}}
-          </ul>
+            </:row>
+          </DReorderableList>
           <DLoadMore
             @action={{this.loadMore}}
             @enabled={{this.hasMore}}

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { service } from "@ember/service";
 import ConfigureMenu from "discourse/admin/components/dashboard/configure-menu";
+import ConfigureMenuReorderable from "discourse/admin/components/dashboard/configure-menu-reorderable";
 import DashboardDateRange from "discourse/admin/components/dashboard/date-range";
 import DashboardEngagement from "discourse/admin/components/dashboard/engagement";
 import DashboardHighlights from "discourse/admin/components/dashboard/highlights";
@@ -24,6 +25,7 @@ const sectionComponentFor = (id) => lookupAdminDashboardSection(id);
 
 export default class RedesignedAdminDashboard extends Component {
   @service currentUser;
+  @service siteSettings;
 
   get configurationSections() {
     return this.args.loadedSections?.configuration?.sections ?? [];
@@ -61,11 +63,21 @@ export default class RedesignedAdminDashboard extends Component {
             @modalForMobile={{true}}
           >
             <:content>
-              <ConfigureMenu
-                @sections={{this.configurationSections}}
-                @onReorder={{@reorderSections}}
-                @onToggleVisibility={{@toggleSection}}
-              />
+              {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+                  legacy component once the change ships. }}
+              {{#if this.siteSettings.enable_new_reordering_controls}}
+                <ConfigureMenuReorderable
+                  @sections={{this.configurationSections}}
+                  @onReorder={{@reorderSections}}
+                  @onToggleVisibility={{@toggleSection}}
+                />
+              {{else}}
+                <ConfigureMenu
+                  @sections={{this.configurationSections}}
+                  @onReorder={{@reorderSections}}
+                  @onToggleVisibility={{@toggleSection}}
+                />
+              {{/if}}
             </:content>
           </DMenu>
         {{/if}}

--- a/frontend/discourse/admin/components/report-filters/groups.gjs
+++ b/frontend/discourse/admin/components/report-filters/groups.gjs
@@ -1,15 +1,23 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import CompareGroups from "discourse/admin/components/modal/compare-groups";
+import CompareGroupsReorderable from "discourse/admin/components/modal/compare-groups-reorderable";
 import FilterComponent from "discourse/admin/components/report-filters/filter";
 import DButton from "discourse/ui-kit/d-button";
 
 export default class Groups extends FilterComponent {
   @service modal;
+  @service siteSettings;
 
   @action
   openCompareGroups() {
-    this.modal.show(CompareGroups, {
+    // TODO (ui-kit-reorderable-list-cleanup) drop the branch and the legacy
+    // component once the change ships.
+    const Modal = this.siteSettings.enable_new_reordering_controls
+      ? CompareGroupsReorderable
+      : CompareGroups;
+
+    this.modal.show(Modal, {
       model: {
         currentTokens: this.filter?.default ?? [],
         onApply: (tokens) => this.applyFilter(this.filter.id, tokens.join(",")),

--- a/frontend/discourse/admin/components/simple-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/simple-list-reorderable.gjs
@@ -6,15 +6,25 @@ import { action } from "@ember/object";
 import { trackedArray } from "@ember/reactive/collections";
 import withEventValue from "discourse/helpers/with-event-value";
 import ComboBox from "discourse/select-kit/components/combo-box";
-import { gt, not } from "discourse/truth-helpers";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import { i18n } from "discourse-i18n";
 
+const INDEX_KEY = "@index";
+
 // args: onChange, inputDelimiter, values, allowAny, choices
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `simple-list-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `simple-list.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `simple-list.gjs`
+ * and drop the branch in the site-settings and logo-form call sites.
+ */
 export default class SimpleList extends Component {
   @tracked newValue = "";
+
+  valueLabel = (value) => value;
 
   @cached
   get collection() {
@@ -58,64 +68,55 @@ export default class SimpleList extends Component {
   }
 
   @action
-  removeItem(index) {
+  removeValue(value, index) {
     this.collection.splice(index, 1);
     this.args.onChange?.(this.collection);
   }
 
+  /**
+   * Applies a committed move onto the delimited collection and reports the
+   * new order. Wrapping and announcements are the list's own.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
   @action
-  shift(index, offset) {
-    let futureIndex = index + offset;
-
-    if (futureIndex > this.collection.length - 1) {
-      futureIndex = 0;
-    } else if (futureIndex < 0) {
-      futureIndex = this.collection.length - 1;
-    }
-
-    const shiftedValue = this.collection[index];
-    this.collection.splice(index, 1);
-    this.collection.splice(futureIndex, 0, shiftedValue);
-
+  handleMove(move) {
+    this.collection.splice(0, this.collection.length, ...move.proposedToItems);
     this.args.onChange?.(this.collection);
   }
 
   <template>
     <div class="simple-list value-list" ...attributes>
-      {{#if this.collection}}
-        <div class="values">
-          {{#each this.collection as |value index|}}
-            <div data-index={{index}} class="value">
-              <DButton
-                @action={{fn this.removeItem index}}
-                @icon="xmark"
-                class="btn-default remove-value-btn btn-small"
-              />
-
-              <input
-                {{on "focusout" (fn this.changeValue index)}}
-                value={{value}}
-                title={{value}}
-                type="text"
-                class="value-input"
-              />
-
-              {{#if (gt this.collection.length 1)}}
-                <DButton
-                  @action={{fn this.shift index -1}}
-                  @icon="arrow-up"
-                  class="btn-default shift-up-value-btn btn-small"
-                />
-                <DButton
-                  @action={{fn this.shift index 1}}
-                  @icon="arrow-down"
-                  class="btn-default shift-down-value-btn btn-small"
-                />
-              {{/if}}
-            </div>
-          {{/each}}
-        </div>
-      {{/if}}
+      <DReorderableList
+        @items={{this.collection}}
+        @key={{INDEX_KEY}}
+        @label={{this.valueLabel}}
+        @onMove={{this.handleMove}}
+        @onRemove={{this.removeValue}}
+        @tag="div"
+        @itemTag="div"
+        @rowClass="value --reorderable"
+        class="values --reorderable"
+      >
+        <:row as |value controls|>
+          {{#if this.isPredefinedList}}
+            {{! A closed set has nothing to type: the value came from the
+              choices and can only be reordered or removed. }}
+            <span
+              class="value-input --readonly"
+              title={{value}}
+            >{{value}}</span>
+          {{else}}
+            <input
+              {{on "focusout" (fn this.changeValue controls.index)}}
+              value={{value}}
+              title={{value}}
+              type="text"
+              class="value-input"
+            />
+          {{/if}}
+        </:row>
+      </DReorderableList>
 
       <div class="simple-list-input">
         {{#if this.isPredefinedList}}
@@ -126,7 +127,14 @@ export default class SimpleList extends Component {
               @onChange={{this.addValue}}
               @valueProperty={{@setting.computedValueProperty}}
               @nameProperty={{@setting.computedNameProperty}}
-              @options={{hash castInteger=true allowAny=false}}
+              {{! Without a `none` label the closed-set picker renders as an
+                empty box under the list. The free-text branch below shows the
+                same string as its placeholder. }}
+              @options={{hash
+                castInteger=true
+                allowAny=false
+                none="admin.site_settings.simple_list.add_item"
+              }}
               class="add-value-input"
             />
           {{/if}}

--- a/frontend/discourse/admin/components/simple-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/simple-list-reorderable.gjs
@@ -95,8 +95,8 @@ export default class SimpleList extends Component {
         @onRemove={{this.removeValue}}
         @tag="div"
         @itemTag="div"
-        @rowClass="value --reorderable"
-        class="values --reorderable"
+        @rowClass="value"
+        class="values"
       >
         <:row as |value controls|>
           {{#if this.isPredefinedList}}
@@ -127,9 +127,9 @@ export default class SimpleList extends Component {
               @onChange={{this.addValue}}
               @valueProperty={{@setting.computedValueProperty}}
               @nameProperty={{@setting.computedNameProperty}}
-              {{! Without a `none` label the closed-set picker renders as an
-                empty box under the list. The free-text branch below shows the
-                same string as its placeholder. }}
+              {{! Without an empty-selection label the closed-set picker renders
+                as an empty box under the list. The free-text branch below shows
+                the same string as its placeholder. }}
               @options={{hash
                 castInteger=true
                 allowAny=false

--- a/frontend/discourse/admin/components/site-settings/list.gjs
+++ b/frontend/discourse/admin/components/site-settings/list.gjs
@@ -1,18 +1,33 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
+import { service } from "@ember/service";
 import { tagName } from "@ember-decorators/component";
 import ValueList from "discourse/admin/components/value-list";
+import ValueListReorderable from "discourse/admin/components/value-list-reorderable";
 
 @tagName("")
 export default class List extends Component {
+  @service siteSettings;
+
   <template>
     <div ...attributes>
-      <ValueList
-        @values={{this.value}}
-        @inputDelimiter="|"
-        @choices={{this.setting.choices}}
-        @disabled={{@disabled}}
-      />
+      {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+          legacy component once the change ships. }}
+      {{#if this.siteSettings.enable_new_reordering_controls}}
+        <ValueListReorderable
+          @values={{this.value}}
+          @inputDelimiter="|"
+          @choices={{this.setting.choices}}
+          @disabled={{@disabled}}
+        />
+      {{else}}
+        <ValueList
+          @values={{this.value}}
+          @inputDelimiter="|"
+          @choices={{this.setting.choices}}
+          @disabled={{@disabled}}
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/frontend/discourse/admin/components/site-settings/simple-list.gjs
+++ b/frontend/discourse/admin/components/site-settings/simple-list.gjs
@@ -1,11 +1,15 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { tagName } from "@ember-decorators/component";
 import SimpleList from "discourse/admin/components/simple-list";
+import SimpleListReorderable from "discourse/admin/components/simple-list-reorderable";
 
 @tagName("")
 export default class SiteSettingSimpleList extends Component {
+  @service siteSettings;
+
   inputDelimiter = "|";
 
   @action
@@ -15,13 +19,25 @@ export default class SiteSettingSimpleList extends Component {
 
   <template>
     <div ...attributes>
-      <SimpleList
-        @values={{this.value}}
-        @inputDelimiter={{this.inputDelimiter}}
-        @onChange={{this.onChange}}
-        @choices={{this.setting.choices}}
-        @allowAny={{this.setting.allow_any}}
-      />
+      {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+          legacy component once the change ships. }}
+      {{#if this.siteSettings.enable_new_reordering_controls}}
+        <SimpleListReorderable
+          @values={{this.value}}
+          @inputDelimiter={{this.inputDelimiter}}
+          @onChange={{this.onChange}}
+          @choices={{this.setting.choices}}
+          @allowAny={{this.setting.allow_any}}
+        />
+      {{else}}
+        <SimpleList
+          @values={{this.value}}
+          @inputDelimiter={{this.inputDelimiter}}
+          @onChange={{this.onChange}}
+          @choices={{this.setting.choices}}
+          @allowAny={{this.setting.allow_any}}
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/frontend/discourse/admin/components/site-settings/url-list.gjs
+++ b/frontend/discourse/admin/components/site-settings/url-list.gjs
@@ -1,17 +1,31 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
+import { service } from "@ember/service";
 import { tagName } from "@ember-decorators/component";
 import ValueList from "discourse/admin/components/value-list";
+import ValueListReorderable from "discourse/admin/components/value-list-reorderable";
 
 @tagName("")
 export default class UrlList extends Component {
+  @service siteSettings;
+
   <template>
     <div ...attributes>
-      <ValueList
-        @disabled={{@disabled}}
-        @values={{this.value}}
-        @addKey="admin.site_settings.add_url"
-      />
+      {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+          legacy component once the change ships. }}
+      {{#if this.siteSettings.enable_new_reordering_controls}}
+        <ValueListReorderable
+          @disabled={{@disabled}}
+          @values={{this.value}}
+          @addKey="admin.site_settings.add_url"
+        />
+      {{else}}
+        <ValueList
+          @disabled={{@disabled}}
+          @values={{this.value}}
+          @addKey="admin.site_settings.add_url"
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/frontend/discourse/admin/components/site-settings/value-list.gjs
+++ b/frontend/discourse/admin/components/site-settings/value-list.gjs
@@ -1,13 +1,23 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
+import { service } from "@ember/service";
 import { tagName } from "@ember-decorators/component";
 import ValueList from "discourse/admin/components/value-list";
+import ValueListReorderable from "discourse/admin/components/value-list-reorderable";
 
 @tagName("")
 export default class SiteSettingValueList extends Component {
+  @service siteSettings;
+
   <template>
     <div ...attributes>
-      <ValueList @disabled={{@disabled}} @values={{this.value}} />
+      {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+          legacy component once the change ships. }}
+      {{#if this.siteSettings.enable_new_reordering_controls}}
+        <ValueListReorderable @disabled={{@disabled}} @values={{this.value}} />
+      {{else}}
+        <ValueList @disabled={{@disabled}} @values={{this.value}} />
+      {{/if}}
     </div>
   </template>
 }

--- a/frontend/discourse/admin/components/value-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/value-list-reorderable.gjs
@@ -181,8 +181,8 @@ export default class ValueList extends Component {
         @onRemove={{this.removeValue}}
         @tag="div"
         @itemTag="div"
-        @rowClass="value --reorderable"
-        class="values --reorderable"
+        @rowClass="value"
+        class="values"
       >
         <:row as |value controls|>
           <Input

--- a/frontend/discourse/admin/components/value-list-reorderable.gjs
+++ b/frontend/discourse/admin/components/value-list-reorderable.gjs
@@ -14,11 +14,18 @@ import {
 import { makeArray } from "discourse/lib/helpers";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
 import ComboBox from "discourse/select-kit/components/combo-box";
-import DButton from "discourse/ui-kit/d-button";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
+
+const INDEX_KEY = "@index";
 
 @classNames("value-list")
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `value-list-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `value-list.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `value-list.gjs`
+ * and drop the branch in the site-settings and user-fields-form call sites.
+ */
 export default class ValueList extends Component {
   @autoTrackedArray collection = null;
 
@@ -28,6 +35,7 @@ export default class ValueList extends Component {
   values = null;
   onChange = null;
 
+  valueLabel = (value) => value;
   @tracked _noneKeyOverride;
 
   @computed("newValue")
@@ -97,20 +105,15 @@ export default class ValueList extends Component {
     this._addValue(choice);
   }
 
+  /**
+   * Applies a committed move onto the collection and persists the new order.
+   * Wrapping and announcements are the list's own.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
   @action
-  shift(operation, index) {
-    let futureIndex = index + operation;
-
-    if (futureIndex > this.collection.length - 1) {
-      futureIndex = 0;
-    } else if (futureIndex < 0) {
-      futureIndex = this.collection.length - 1;
-    }
-
-    const shiftedValue = this.collection[index];
-    this.collection.splice(index, 1);
-    this.collection.splice(futureIndex, 0, shiftedValue);
-
+  handleMove(move) {
+    this.collection.splice(0, this.collection.length, ...move.proposedToItems);
     this._saveValues();
   }
 
@@ -160,11 +163,6 @@ export default class ValueList extends Component {
     this.set("values", this.collection.join(this.inputDelimiter || "\n"));
   }
 
-  @computed("collection")
-  get showUpDownButtons() {
-    return this.collection.length - 1 ? true : false;
-  }
-
   _splitValues(values, delimiter) {
     if (values && values.length) {
       return values.split(delimiter).filter((x) => x);
@@ -175,37 +173,26 @@ export default class ValueList extends Component {
 
   <template>
     {{#if this.collection}}
-      <div class="values">
-        {{#each this.collection as |value index|}}
-          <div data-index={{index}} class="value">
-            <DButton
-              @action={{fn this.removeValue value}}
-              @icon="xmark"
-              class="btn-default remove-value-btn btn-small"
-            />
-
-            <Input
-              title={{value}}
-              @value={{value}}
-              class="value-input"
-              {{on "focusout" (fn this.changeValue index)}}
-            />
-
-            {{#if this.showUpDownButtons}}
-              <DButton
-                @action={{fn this.shift -1 index}}
-                @icon="arrow-up"
-                class="btn-default shift-up-value-btn btn-small"
-              />
-              <DButton
-                @action={{fn this.shift 1 index}}
-                @icon="arrow-down"
-                class="btn-default shift-down-value-btn btn-small"
-              />
-            {{/if}}
-          </div>
-        {{/each}}
-      </div>
+      <DReorderableList
+        @items={{this.collection}}
+        @key={{INDEX_KEY}}
+        @label={{this.valueLabel}}
+        @onMove={{this.handleMove}}
+        @onRemove={{this.removeValue}}
+        @tag="div"
+        @itemTag="div"
+        @rowClass="value --reorderable"
+        class="values --reorderable"
+      >
+        <:row as |value controls|>
+          <Input
+            title={{value}}
+            @value={{value}}
+            class="value-input"
+            {{on "focusout" (fn this.changeValue controls.index)}}
+          />
+        </:row>
+      </DReorderableList>
     {{/if}}
 
     <ComboBox

--- a/frontend/discourse/admin/lib/toggleable-ordered-list.js
+++ b/frontend/discourse/admin/lib/toggleable-ordered-list.js
@@ -44,6 +44,9 @@ export default class ToggleableOrderedList {
     }
   }
 
+  // TODO (ui-kit-reorderable-list-cleanup) the members from here to
+  // `onDragEnd` serve the pre-DReorderableList consumers only. Delete them
+  // with the legacy arms; `reorderVisible` is the replacement.
   moveUp(key) {
     const index = this.enabledOrder.indexOf(key);
     if (index <= 0) {
@@ -96,5 +99,24 @@ export default class ToggleableOrderedList {
 
   onDragEnd() {
     this.draggedId = null;
+  }
+
+  /**
+   * Adopts a new order for the enabled keys that are currently on screen.
+   *
+   * A search filter can hide an enabled row, and a hidden row still holds its
+   * place in the saved order. So the visible keys are written back into the
+   * slots they already occupy and every hidden key keeps its index, rather than
+   * the caller's on-screen sequence replacing the whole order and dropping
+   * whatever it could not see.
+   *
+   * @param {string[]} visibleKeys - Enabled keys in their new on-screen order.
+   */
+  reorderVisible(visibleKeys) {
+    const moving = new Set(visibleKeys);
+    let next = 0;
+    this.enabledOrder = this.enabledOrder.map((key) =>
+      moving.has(key) ? visibleKeys[next++] : key
+    );
   }
 }

--- a/frontend/discourse/admin/templates/admin-config/flags/index.gjs
+++ b/frontend/discourse/admin/templates/admin-config/flags/index.gjs
@@ -1,3 +1,20 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import Flags from "discourse/admin/components/admin-config-areas/flags";
+import FlagsReorderable from "discourse/admin/components/admin-config-areas/flags-reorderable";
 
-export default <template><Flags /></template>
+// TODO (ui-kit-reorderable-list-cleanup) delete this switch and render
+// `Flags` directly once `enable_new_reordering_controls` ships.
+class FlagsSwitch extends Component {
+  @service siteSettings;
+
+  <template>
+    {{#if this.siteSettings.enable_new_reordering_controls}}
+      <FlagsReorderable />
+    {{else}}
+      <Flags />
+    {{/if}}
+  </template>
+}
+
+export default <template><FlagsSwitch /></template>

--- a/frontend/discourse/admin/templates/admin-user-fields/index.gjs
+++ b/frontend/discourse/admin/templates/admin-user-fields/index.gjs
@@ -1,5 +1,22 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import UserFieldsList from "discourse/admin/components/admin-config-areas/user-fields-list";
+import UserFieldsListReorderable from "discourse/admin/components/admin-config-areas/user-fields-list-reorderable";
+
+// TODO (ui-kit-reorderable-list-cleanup) delete this switch and render
+// `UserFieldsList` directly once `enable_new_reordering_controls` ships.
+class UserFieldsSwitch extends Component {
+  @service siteSettings;
+
+  <template>
+    {{#if this.siteSettings.enable_new_reordering_controls}}
+      <UserFieldsListReorderable @userFields={{@userFields}} />
+    {{else}}
+      <UserFieldsList @userFields={{@userFields}} />
+    {{/if}}
+  </template>
+}
 
 export default <template>
-  <UserFieldsList @userFields={{@controller.model}} />
+  <UserFieldsSwitch @userFields={{@controller.model}} />
 </template>

--- a/frontend/discourse/app/components/modal/edit-user-directory-columns-reorderable.gjs
+++ b/frontend/discourse/app/components/modal/edit-user-directory-columns-reorderable.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
-import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import directoryColumnIsAutomatic from "discourse/helpers/directory-column-is-automatic";
 import directoryColumnIsUserField from "discourse/helpers/directory-column-is-user-field";
@@ -11,18 +10,41 @@ import { ajax } from "discourse/lib/ajax";
 import { extractError, popupAjaxError } from "discourse/lib/ajax-error";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
 import dLoadingSpinner from "discourse/ui-kit/helpers/d-loading-spinner";
 import { i18n } from "discourse-i18n";
 
-const UP = "up";
-const DOWN = "down";
-
-// TODO (ui-kit-reorderable-list-cleanup) delete this file once
-// `enable_new_reordering_controls` ships; `edit-user-directory-columns-reorderable.gjs` replaces it.
+/**
+ * The reordering surface behind `enable_new_reordering_controls`. Mirrors
+ * `modal/edit-user-directory-columns.gjs`, over the shared reorderable list.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over `modal/edit-user-directory-columns.gjs`
+ * and drop the branch in app/controllers/users.js.
+ */
 export default class EditUserDirectoryColumns extends Component {
   @tracked loading = true;
   @tracked columns;
   @tracked flash;
+
+  /**
+   * A plain-text name for a column, for the reorder controls and
+   * announcements — the rendered header title can carry icon markup, which an
+   * accessible name cannot.
+   *
+   * @param {Object} column - The column to name.
+   * @returns {string} The translated column name.
+   */
+  columnLabel = (column) => {
+    if (column.type === "automatic") {
+      return i18n(`directory.${column.name}_long`, {
+        defaultValue: i18n(`directory.${column.name}`),
+      });
+    }
+    if (column.user_field) {
+      return column.user_field.name;
+    }
+    return i18n(column.name);
+  };
 
   constructor() {
     super(...arguments);
@@ -85,33 +107,18 @@ export default class EditUserDirectoryColumns extends Component {
     this.columns = resetColumns;
   }
 
+  /**
+   * Applies a committed move and renumbers every column from its new visible
+   * slot — the stored order is exactly the displayed one here.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
   @action
-  moveUp(column) {
-    this._moveColumn(UP, column);
-  }
-
-  @action
-  moveDown(column) {
-    this._moveColumn(DOWN, column);
-  }
-
-  _moveColumn(direction, column) {
-    if (
-      (direction === UP && column.position === 1) ||
-      (direction === DOWN && column.position === this.columns.length)
-    ) {
-      return;
-    }
-
-    const positionOnClick = column.position;
-    const newPosition =
-      direction === UP ? positionOnClick - 1 : positionOnClick + 1;
-    const previousColumn = this.columns.find((c) => c.position === newPosition);
-    column.position = newPosition;
-    previousColumn.position = positionOnClick;
-    this.columns = this.columns.sort((a, b) =>
-      a.position > b.position ? 1 : -1
-    );
+  handleMove(move) {
+    this.columns = move.proposedToItems.map((column, index) => ({
+      ...column,
+      position: index + 1,
+    }));
   }
 
   <template>
@@ -125,45 +132,40 @@ export default class EditUserDirectoryColumns extends Component {
         {{#if this.loading}}
           {{dLoadingSpinner size="large"}}
         {{else}}
-          <div class="edit-directory-columns-container">
-            {{#each this.columns as |column|}}
-              <div class="edit-directory-column">
-                <div class="left-content">
-                  <label class="column-name">
-                    <Input @type="checkbox" @checked={{column.enabled}} />
-                    {{#if (directoryColumnIsAutomatic column=column)}}
-                      {{directoryTableHeaderTitle
-                        field=column.name
-                        icon=column.icon
-                      }}
-                    {{else if (directoryColumnIsUserField column=column)}}
-                      {{directoryTableHeaderTitle
-                        field=column.user_field.name
-                        translated=true
-                      }}
-                    {{else}}
-                      {{directoryTableHeaderTitle
-                        field=(i18n column.name)
-                        translated=true
-                      }}
-                    {{/if}}
-                  </label>
-                </div>
-                <div class="right-content">
-                  <DButton
-                    @icon="arrow-up"
-                    @action={{fn this.moveUp column}}
-                    class="btn-default button-secondary move-column-up"
-                  />
-                  <DButton
-                    @icon="arrow-down"
-                    @action={{fn this.moveDown column}}
-                    class="btn-default button-secondary move-column-down"
-                  />
-                </div>
+          <DReorderableList
+            @items={{this.columns}}
+            @key="id"
+            @label={{this.columnLabel}}
+            @onMove={{this.handleMove}}
+            @tag="div"
+            @itemTag="div"
+            @rowClass="edit-directory-column --reorderable"
+            class="edit-directory-columns-container --reorderable"
+          >
+            <:row as |column|>
+              <div class="left-content">
+                <label class="column-name">
+                  <Input @type="checkbox" @checked={{column.enabled}} />
+                  {{#if (directoryColumnIsAutomatic column=column)}}
+                    {{directoryTableHeaderTitle
+                      field=column.name
+                      icon=column.icon
+                    }}
+                  {{else if (directoryColumnIsUserField column=column)}}
+                    {{directoryTableHeaderTitle
+                      field=column.user_field.name
+                      translated=true
+                    }}
+                  {{else}}
+                    {{directoryTableHeaderTitle
+                      field=(i18n column.name)
+                      translated=true
+                    }}
+                  {{/if}}
+                </label>
               </div>
-            {{/each}}
-          </div>
+            </:row>
+          </DReorderableList>
         {{/if}}
       </:body>
       <:footer>

--- a/frontend/discourse/app/components/modal/edit-user-directory-columns-reorderable.gjs
+++ b/frontend/discourse/app/components/modal/edit-user-directory-columns-reorderable.gjs
@@ -139,8 +139,8 @@ export default class EditUserDirectoryColumns extends Component {
             @onMove={{this.handleMove}}
             @tag="div"
             @itemTag="div"
-            @rowClass="edit-directory-column --reorderable"
-            class="edit-directory-columns-container --reorderable"
+            @rowClass="edit-directory-column"
+            class="edit-directory-columns-container"
           >
             <:row as |column|>
               <div class="left-content">

--- a/frontend/discourse/app/components/modal/sidebar-section-form.gjs
+++ b/frontend/discourse/app/components/modal/sidebar-section-form.gjs
@@ -7,7 +7,8 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { tagName } from "@ember-decorators/component";
-import SectionFormLink from "discourse/components/sidebar/section-form-link";
+import SectionFormLinks from "discourse/components/sidebar/section-form-links";
+import SectionFormLinksReorderable from "discourse/components/sidebar/section-form-links-reorderable";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import withEventValue from "discourse/helpers/with-event-value";
 import { ajax } from "discourse/lib/ajax";
@@ -21,7 +22,7 @@ import { afterRender, bind } from "discourse/lib/decorators";
 import { isSameLocale } from "discourse/lib/locale-normalizer";
 import { sanitize } from "discourse/lib/text";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
-import { eq, has, not } from "discourse/truth-helpers";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
 import DSelect from "discourse/ui-kit/d-select";
@@ -606,14 +607,6 @@ export default class SidebarSectionForm extends Component {
     return duplicates;
   }
 
-  get lastActiveLinkIndex() {
-    return this.activeLinks.length - 1;
-  }
-
-  get lastActiveSecondaryLinkIndex() {
-    return (this.activeSecondaryLinks?.length ?? 0) - 1;
-  }
-
   @cached
   get activeLocalizations() {
     return this.#activeLocalizations(this.transformedModel);
@@ -848,47 +841,11 @@ export default class SidebarSectionForm extends Component {
   @afterRender
   focusNewRowInput(id) {
     document
-      .querySelector(`[data-row-id="${id}"] .d-icon-grid-picker-trigger`)
+      .querySelector(
+        `[data-row-id="${id}"] .d-icon-grid-picker-trigger, ` +
+          `[data-reorderable-key="${id}"] .d-icon-grid-picker-trigger`
+      )
       .focus();
-  }
-
-  @bind
-  setDraggedLink(link) {
-    this.draggedLink = link;
-  }
-
-  @bind
-  reorder(targetLink, above) {
-    if (this.draggedLink === targetLink) {
-      return;
-    }
-
-    const source = this.draggedLink.isPrimary
-      ? this.transformedModel.links
-      : this.transformedModel.secondaryLinks;
-    const destination = targetLink.isPrimary
-      ? this.transformedModel.links
-      : this.transformedModel.secondaryLinks;
-
-    // Nothing to insert next to, so leave both arrays untouched rather than
-    // removing the link and dropping it at an arbitrary offset.
-    if (!destination.includes(targetLink)) {
-      return;
-    }
-
-    removeValueFromArray(source, this.draggedLink);
-
-    // Read after the removal: within one segment the two arrays are the same
-    // one, so a pre-removal index would be off by one when dragging downwards.
-    const toPosition = destination.indexOf(targetLink);
-
-    this.draggedLink.segment = targetLink.isPrimary ? "primary" : "secondary";
-
-    destination.splice(
-      above ? toPosition : toPosition + 1,
-      0,
-      this.draggedLink
-    );
   }
 
   get canDelete() {
@@ -1362,101 +1319,33 @@ export default class SidebarSectionForm extends Component {
               {{i18n "sidebar.sections.custom.links.title"}}
             </div>
 
-            <div
-              role="table"
-              aria-labelledby="section-links-label"
-              aria-rowcount={{this.activeLinks.length}}
-              class="sidebar-section-form__links-wrapper"
-            >
-
-              <div class="row-wrapper header" role="row">
-                <div
-                  class="input-group link-icon"
-                  role="columnheader"
-                  aria-sort="none"
-                >
-                  {{! eslint-disable-next-line ember/template-no-nested-interactive }}
-                  <label>{{i18n
-                      "sidebar.sections.custom.links.icon.label"
-                    }}</label>
-                </div>
-
-                <div
-                  class="input-group link-name"
-                  role="columnheader"
-                  aria-sort="none"
-                >
-                  {{! eslint-disable-next-line ember/template-no-nested-interactive }}
-                  <label>{{i18n
-                      "sidebar.sections.custom.links.name.label"
-                    }}</label>
-                </div>
-
-                <div
-                  class="input-group link-url"
-                  role="columnheader"
-                  aria-sort="none"
-                >
-                  {{! eslint-disable-next-line ember/template-no-nested-interactive }}
-                  <label>{{i18n
-                      "sidebar.sections.custom.links.value.label"
-                    }}</label>
-                </div>
-              </div>
-
-              {{#each this.activeLinks key="objectId" as |link index|}}
-                <SectionFormLink
-                  @link={{link}}
-                  @index={{index}}
-                  @lastIndex={{this.lastActiveLinkIndex}}
-                  @focusNameInput={{eq
-                    link.objectId
-                    this.initialFocusLinkObjectId
-                  }}
-                  @duplicateValue={{has
-                    this.duplicateLinkObjectIds
-                    link.objectId
-                  }}
-                  @deleteLink={{this.deleteLink}}
-                  @reorderCallback={{this.reorder}}
-                  @setDraggedLinkCallback={{this.setDraggedLink}}
-                />
-              {{/each}}
-
-            </div>
-            <DButton
-              @action={{this.addLink}}
-              @title="sidebar.sections.custom.links.add"
-              @icon="plus"
-              @label="sidebar.sections.custom.links.add"
-              @ariaLabel="sidebar.sections.custom.links.add"
-              class="btn-flat btn-text add-link"
-            />
-
-            {{#if this.transformedModel.sectionType}}
-              <hr />
-              <h3>{{i18n "sidebar.sections.custom.more_menu"}}</h3>
-              {{#each this.activeSecondaryLinks key="objectId" as |link index|}}
-                <SectionFormLink
-                  @link={{link}}
-                  @index={{index}}
-                  @lastIndex={{this.lastActiveSecondaryLinkIndex}}
-                  @duplicateValue={{has
-                    this.duplicateLinkObjectIds
-                    link.objectId
-                  }}
-                  @deleteLink={{this.deleteLink}}
-                  @reorderCallback={{this.reorder}}
-                  @setDraggedLinkCallback={{this.setDraggedLink}}
-                />
-              {{/each}}
-              <DButton
-                @action={{this.addSecondaryLink}}
-                @title="sidebar.sections.custom.links.add"
-                @icon="plus"
-                @label="sidebar.sections.custom.links.add"
-                @ariaLabel="sidebar.sections.custom.links.add"
-                class="btn-flat btn-text add-link"
+            {{! TODO (ui-kit-reorderable-list-cleanup) drop the branch and the
+                legacy arm once the change ships. }}
+            {{#if this.siteSettings.enable_new_reordering_controls}}
+              <SectionFormLinksReorderable
+                @activeLinks={{this.activeLinks}}
+                @activeSecondaryLinks={{this.activeSecondaryLinks}}
+                @addLink={{this.addLink}}
+                @addSecondaryLink={{this.addSecondaryLink}}
+                @deleteLink={{this.deleteLink}}
+                @duplicateLinkObjectIds={{this.duplicateLinkObjectIds}}
+                @initialFocusLinkObjectId={{this.initialFocusLinkObjectId}}
+                @links={{this.transformedModel.links}}
+                @secondaryLinks={{this.transformedModel.secondaryLinks}}
+                @sectionType={{this.transformedModel.sectionType}}
+              />
+            {{else}}
+              <SectionFormLinks
+                @activeLinks={{this.activeLinks}}
+                @activeSecondaryLinks={{this.activeSecondaryLinks}}
+                @addLink={{this.addLink}}
+                @addSecondaryLink={{this.addSecondaryLink}}
+                @deleteLink={{this.deleteLink}}
+                @duplicateLinkObjectIds={{this.duplicateLinkObjectIds}}
+                @initialFocusLinkObjectId={{this.initialFocusLinkObjectId}}
+                @links={{this.transformedModel.links}}
+                @secondaryLinks={{this.transformedModel.secondaryLinks}}
+                @sectionType={{this.transformedModel.sectionType}}
               />
             {{/if}}
 

--- a/frontend/discourse/app/components/sidebar/section-form-link-reorderable.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-link-reorderable.gjs
@@ -1,0 +1,99 @@
+import { Input } from "@ember/component";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import withEventValue from "discourse/helpers/with-event-value";
+import DButton from "discourse/ui-kit/d-button";
+import DIconGridPicker from "discourse/ui-kit/d-icon-grid-picker";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dAutoFocus from "discourse/ui-kit/modifiers/d-auto-focus";
+import { i18n } from "discourse-i18n";
+
+/**
+ * One link row's cells inside the section form's reorderable lists. The row
+ * element, its drag wiring, and the reorder announcements are the list's; what
+ * lives here is the link's own fields plus the placement of the pre-wired
+ * controls into the row's grid tracks.
+ */
+// TODO (ui-kit-reorderable-list-cleanup) rename this over
+// `section-form-link.gjs` once the change ships.
+const SectionFormLink = <template>
+  {{! Every viewport, because a touch screen can drag from a grip and had no
+      way to reorder at all while this was desktop-only. The drag starts at the
+      grip rather than anywhere on the row, so a press that was meant to
+      scroll still scrolls, and its menu carries the paths a drag cannot. }}
+  <@controls.handle
+    role="cell"
+    class="draggable"
+    data-link-name={{@link.name}}
+  />
+
+  <div class="input-group link-icon" role="cell">
+    <DIconGridPicker
+      @value={{@link.icon}}
+      @onChange={{fn (mut @link.icon)}}
+      @showCaret={{true}}
+      @btnClass={{dConcatClass "btn-default" @link.iconCssClass}}
+      aria-label={{i18n "sidebar.sections.custom.links.icon.label"}}
+    />
+
+    {{#if @link.invalidIconMessage}}
+      <div class="icon warning" role="alert" aria-live="assertive">
+        {{@link.invalidIconMessage}}
+      </div>
+    {{/if}}
+  </div>
+
+  <div class="input-group link-name" role="cell">
+
+    <Input
+      {{(if @focusNameInput (modifier dAutoFocus selectText=true))}}
+      {{on "input" (withEventValue (fn (mut @link.name)))}}
+      @type="text"
+      @value={{@link.name}}
+      name="link-name"
+      aria-label={{i18n "sidebar.sections.custom.links.name.label"}}
+      class={{@link.nameCssClass}}
+      data-1p-ignore
+    />
+
+    {{#if @link.invalidNameMessage}}
+      <div role="alert" aria-live="assertive" class="name warning">
+        {{@link.invalidNameMessage}}
+      </div>
+    {{/if}}
+  </div>
+
+  <div class="input-group link-url" role="cell">
+
+    <Input
+      {{on "input" (withEventValue (fn (mut @link.value)))}}
+      @type="text"
+      @value={{@link.value}}
+      name="link-url"
+      aria-label={{i18n "sidebar.sections.custom.links.value.label"}}
+      class={{@link.valueCssClass}}
+    />
+
+    {{#if @link.invalidValueMessage}}
+      <div role="alert" aria-live="assertive" class="value warning">
+        {{@link.invalidValueMessage}}
+      </div>
+    {{else if @duplicateValue}}
+      {{! Not announced assertively: nothing is wrong yet, and the row still
+          saves. }}
+      <div class="value warning duplicate-link">
+        {{i18n "sidebar.sections.custom.links.value.duplicate"}}
+      </div>
+    {{/if}}
+  </div>
+
+  <DButton
+    @icon="trash-can"
+    @action={{fn @deleteLink @link}}
+    @title="sidebar.sections.custom.links.delete"
+    role="cell"
+    class="btn-flat delete-link"
+  />
+</template>;
+
+export default SectionFormLink;

--- a/frontend/discourse/app/components/sidebar/section-form-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-link.gjs
@@ -14,6 +14,9 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dAutoFocus from "discourse/ui-kit/modifiers/d-auto-focus";
 import { i18n } from "discourse-i18n";
 
+// TODO (ui-kit-reorderable-list-cleanup) delete this file once
+// `enable_new_reordering_controls` ships; `section-form-link-reorderable.gjs`
+// replaces it.
 export default class SectionFormLink extends Component {
   @service site;
 

--- a/frontend/discourse/app/components/sidebar/section-form-links-reorderable.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-links-reorderable.gjs
@@ -71,17 +71,17 @@ export default class SidebarSectionFormLinksReorderable extends Component {
         @role="table"
         @itemTag="div"
         @itemRole="row"
-        @rowClass="sidebar-section-form-link row-wrapper --reorderable"
+        @rowClass="sidebar-section-form-link row-wrapper"
         aria-labelledby="section-links-label"
         aria-rowcount={{@activeLinks.length}}
-        class="sidebar-section-form__links-wrapper --reorderable"
+        class="sidebar-section-form__links-wrapper"
       >
         <:header>
           {{! The list element around this block carries the table role
                 through its role argument, which the static rule cannot
                 see from here. }}
           {{! eslint-disable-next-line ember/template-require-context-role }}
-          <div class="row-wrapper header --reorderable" role="row">
+          <div class="row-wrapper header" role="row">
             <div
               class="input-group link-icon"
               role="columnheader"
@@ -150,10 +150,10 @@ export default class SidebarSectionFormLinksReorderable extends Component {
           @role="table"
           @itemTag="div"
           @itemRole="row"
-          @rowClass="sidebar-section-form-link row-wrapper --reorderable"
+          @rowClass="sidebar-section-form-link row-wrapper"
           aria-labelledby="section-secondary-links-label"
           aria-rowcount={{@activeSecondaryLinks.length}}
-          class="sidebar-section-form__links-wrapper --secondary --reorderable"
+          class="sidebar-section-form__links-wrapper --secondary"
         >
           <:row as |link controls|>
             <SectionFormLinkReorderable

--- a/frontend/discourse/app/components/sidebar/section-form-links-reorderable.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-links-reorderable.gjs
@@ -1,0 +1,178 @@
+import Component from "@glimmer/component";
+import SectionFormLinkReorderable from "discourse/components/sidebar/section-form-link-reorderable";
+import { removeValueFromArray } from "discourse/lib/array-tools";
+import { bind } from "discourse/lib/decorators";
+import { eq, has } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
+import DReorderableList from "discourse/ui-kit/d-reorderable-list";
+import DReorderableListGroup from "discourse/ui-kit/d-reorderable-list-group";
+import { i18n } from "discourse-i18n";
+
+/**
+ * The section form's links region behind `enable_new_reordering_controls`, over
+ * the shared reorderable list. The two lists are grouped so a link can move
+ * between the primary set and the more menu.
+ *
+ * The arrays arrive by reference and are mutated in place, which is what the
+ * form's own tracking already relies on.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) rename this over
+ * `section-form-links.gjs` and drop the branch in the section form.
+ */
+export default class SidebarSectionFormLinksReorderable extends Component {
+  linkName = (link) => link.name;
+
+  /**
+   * Applies a committed move onto the backing arrays, which hold links awaiting
+   * deletion as well as visible ones.
+   *
+   * @param {Object} move - The normalized move from the list.
+   */
+  @bind
+  handleMove(move) {
+    const arrays = {
+      primary: this.args.links,
+      secondary: this.args.secondaryLinks,
+    };
+    const source = arrays[move.fromList];
+    const destination = arrays[move.toList];
+
+    if (move.fromList !== move.toList) {
+      removeValueFromArray(source, move.item);
+      move.item.segment = move.toList;
+      // Anchored on the visible link that follows the landing slot, so links
+      // awaiting deletion keep their positions in the stored array.
+      const following = move.proposedToItems[move.toIndex + 1];
+      const at = following
+        ? destination.indexOf(following)
+        : destination.length;
+      destination.splice(at, 0, move.item);
+      return;
+    }
+
+    const proposed = [...move.proposedToItems];
+    const next = destination.map((link) =>
+      link._destroy ? link : proposed.shift()
+    );
+    destination.splice(0, destination.length, ...next);
+  }
+
+  <template>
+    <DReorderableListGroup @onMove={{this.handleMove}} as |group|>
+      <DReorderableList
+        @group={{group}}
+        @listId="primary"
+        @listLabel={{i18n "sidebar.sections.custom.links.title"}}
+        @items={{@activeLinks}}
+        @key="objectId"
+        @label={{this.linkName}}
+        @controls="manual"
+        @tag="div"
+        @role="table"
+        @itemTag="div"
+        @itemRole="row"
+        @rowClass="sidebar-section-form-link row-wrapper --reorderable"
+        aria-labelledby="section-links-label"
+        aria-rowcount={{@activeLinks.length}}
+        class="sidebar-section-form__links-wrapper --reorderable"
+      >
+        <:header>
+          {{! The list element around this block carries the table role
+                through its role argument, which the static rule cannot
+                see from here. }}
+          {{! eslint-disable-next-line ember/template-require-context-role }}
+          <div class="row-wrapper header --reorderable" role="row">
+            <div
+              class="input-group link-icon"
+              role="columnheader"
+              aria-sort="none"
+            >
+              {{! eslint-disable-next-line ember/template-no-nested-interactive }}
+              <label>{{i18n "sidebar.sections.custom.links.icon.label"}}</label>
+            </div>
+
+            <div
+              class="input-group link-name"
+              role="columnheader"
+              aria-sort="none"
+            >
+              {{! eslint-disable-next-line ember/template-no-nested-interactive }}
+              <label>{{i18n "sidebar.sections.custom.links.name.label"}}</label>
+            </div>
+
+            <div
+              class="input-group link-url"
+              role="columnheader"
+              aria-sort="none"
+            >
+              {{! eslint-disable-next-line ember/template-no-nested-interactive }}
+              <label>{{i18n
+                  "sidebar.sections.custom.links.value.label"
+                }}</label>
+            </div>
+          </div>
+        </:header>
+        <:row as |link controls|>
+          <SectionFormLinkReorderable
+            @controls={{controls}}
+            @link={{link}}
+            @focusNameInput={{eq link.objectId @initialFocusLinkObjectId}}
+            @duplicateValue={{has @duplicateLinkObjectIds link.objectId}}
+            @deleteLink={{@deleteLink}}
+          />
+        </:row>
+      </DReorderableList>
+      <DButton
+        @action={{@addLink}}
+        @title="sidebar.sections.custom.links.add"
+        @icon="plus"
+        @label="sidebar.sections.custom.links.add"
+        @ariaLabel="sidebar.sections.custom.links.add"
+        class="btn-flat btn-text add-link"
+      />
+
+      {{#if @sectionType}}
+        <hr />
+        <h3 id="section-secondary-links-label">{{i18n
+            "sidebar.sections.custom.more_menu"
+          }}</h3>
+        {{! The rows resolve their columns through the wrapper's grid, so
+          a list rendered without one would collapse. }}
+        <DReorderableList
+          @group={{group}}
+          @listId="secondary"
+          @listLabel={{i18n "sidebar.sections.custom.more_menu"}}
+          @items={{@activeSecondaryLinks}}
+          @key="objectId"
+          @label={{this.linkName}}
+          @controls="manual"
+          @tag="div"
+          @role="table"
+          @itemTag="div"
+          @itemRole="row"
+          @rowClass="sidebar-section-form-link row-wrapper --reorderable"
+          aria-labelledby="section-secondary-links-label"
+          aria-rowcount={{@activeSecondaryLinks.length}}
+          class="sidebar-section-form__links-wrapper --secondary --reorderable"
+        >
+          <:row as |link controls|>
+            <SectionFormLinkReorderable
+              @controls={{controls}}
+              @link={{link}}
+              @duplicateValue={{has @duplicateLinkObjectIds link.objectId}}
+              @deleteLink={{@deleteLink}}
+            />
+          </:row>
+        </DReorderableList>
+        <DButton
+          @action={{@addSecondaryLink}}
+          @title="sidebar.sections.custom.links.add"
+          @icon="plus"
+          @label="sidebar.sections.custom.links.add"
+          @ariaLabel="sidebar.sections.custom.links.add"
+          class="btn-flat btn-text add-link"
+        />
+      {{/if}}
+    </DReorderableListGroup>
+  </template>
+}

--- a/frontend/discourse/app/components/sidebar/section-form-links.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-links.gjs
@@ -1,0 +1,145 @@
+import Component from "@glimmer/component";
+import SectionFormLink from "discourse/components/sidebar/section-form-link";
+import { removeValueFromArray } from "discourse/lib/array-tools";
+import { bind } from "discourse/lib/decorators";
+import { eq, has } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
+import { i18n } from "discourse-i18n";
+
+/**
+ * The section form's links region as it renders without
+ * `enable_new_reordering_controls`: a hand-rolled table whose rows carry their
+ * own drag handlers.
+ *
+ * The arrays arrive by reference and are mutated in place, which is what the
+ * form's own tracking already relies on.
+ *
+ * TODO (ui-kit-reorderable-list-cleanup) delete this file once the change
+ * ships; `sidebar-section-form-links-reorderable.gjs` replaces it.
+ */
+export default class SidebarSectionFormLinks extends Component {
+  // Not a # private: the legacy decorator transform cannot compile a class
+  // that mixes a decorated member with private fields, and it fails the build
+  // rather than the lint.
+  draggedLink;
+
+  get lastActiveLinkIndex() {
+    return this.args.activeLinks.length - 1;
+  }
+
+  get lastActiveSecondaryLinkIndex() {
+    return (this.args.activeSecondaryLinks?.length ?? 0) - 1;
+  }
+
+  @bind
+  setDraggedLink(link) {
+    this.draggedLink = link;
+  }
+
+  @bind
+  reorder(targetLink, above) {
+    if (this.draggedLink === targetLink) {
+      return;
+    }
+
+    const source = this.draggedLink.isPrimary
+      ? this.args.links
+      : this.args.secondaryLinks;
+    const destination = targetLink.isPrimary
+      ? this.args.links
+      : this.args.secondaryLinks;
+
+    // Nothing to insert next to, so leave both arrays untouched rather than
+    // removing the link and dropping it at an arbitrary offset.
+    if (!destination.includes(targetLink)) {
+      return;
+    }
+
+    removeValueFromArray(source, this.draggedLink);
+
+    // Read after the removal: within one segment the two arrays are the same
+    // one, so a pre-removal index would be off by one when dragging downwards.
+    const toPosition = destination.indexOf(targetLink);
+
+    this.draggedLink.segment = targetLink.isPrimary ? "primary" : "secondary";
+
+    destination.splice(
+      above ? toPosition : toPosition + 1,
+      0,
+      this.draggedLink
+    );
+  }
+
+  <template>
+    <div
+      role="table"
+      aria-labelledby="section-links-label"
+      aria-rowcount={{@activeLinks.length}}
+      class="sidebar-section-form__links-wrapper"
+    >
+
+      <div class="row-wrapper header" role="row">
+        <div class="input-group link-icon" role="columnheader" aria-sort="none">
+          {{! eslint-disable-next-line ember/template-no-nested-interactive }}
+          <label>{{i18n "sidebar.sections.custom.links.icon.label"}}</label>
+        </div>
+
+        <div class="input-group link-name" role="columnheader" aria-sort="none">
+          {{! eslint-disable-next-line ember/template-no-nested-interactive }}
+          <label>{{i18n "sidebar.sections.custom.links.name.label"}}</label>
+        </div>
+
+        <div class="input-group link-url" role="columnheader" aria-sort="none">
+          {{! eslint-disable-next-line ember/template-no-nested-interactive }}
+          <label>{{i18n "sidebar.sections.custom.links.value.label"}}</label>
+        </div>
+      </div>
+
+      {{#each @activeLinks key="objectId" as |link index|}}
+        <SectionFormLink
+          @link={{link}}
+          @index={{index}}
+          @lastIndex={{this.lastActiveLinkIndex}}
+          @focusNameInput={{eq link.objectId @initialFocusLinkObjectId}}
+          @duplicateValue={{has @duplicateLinkObjectIds link.objectId}}
+          @deleteLink={{@deleteLink}}
+          @reorderCallback={{this.reorder}}
+          @setDraggedLinkCallback={{this.setDraggedLink}}
+        />
+      {{/each}}
+
+    </div>
+    <DButton
+      @action={{@addLink}}
+      @title="sidebar.sections.custom.links.add"
+      @icon="plus"
+      @label="sidebar.sections.custom.links.add"
+      @ariaLabel="sidebar.sections.custom.links.add"
+      class="btn-flat btn-text add-link"
+    />
+
+    {{#if @sectionType}}
+      <hr />
+      <h3>{{i18n "sidebar.sections.custom.more_menu"}}</h3>
+      {{#each @activeSecondaryLinks key="objectId" as |link index|}}
+        <SectionFormLink
+          @link={{link}}
+          @index={{index}}
+          @lastIndex={{this.lastActiveSecondaryLinkIndex}}
+          @duplicateValue={{has @duplicateLinkObjectIds link.objectId}}
+          @deleteLink={{@deleteLink}}
+          @reorderCallback={{this.reorder}}
+          @setDraggedLinkCallback={{this.setDraggedLink}}
+        />
+      {{/each}}
+      <DButton
+        @action={{@addSecondaryLink}}
+        @title="sidebar.sections.custom.links.add"
+        @icon="plus"
+        @label="sidebar.sections.custom.links.add"
+        @ariaLabel="sidebar.sections.custom.links.add"
+        class="btn-flat btn-text add-link"
+      />
+    {{/if}}
+  </template>
+}

--- a/frontend/discourse/app/controllers/users.js
+++ b/frontend/discourse/app/controllers/users.js
@@ -4,12 +4,14 @@ import { action, computed } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { service } from "@ember/service";
 import EditUserDirectoryColumnsModal from "discourse/components/modal/edit-user-directory-columns";
+import EditUserDirectoryColumnsModalReorderable from "discourse/components/modal/edit-user-directory-columns-reorderable";
 import discourseDebounce from "discourse/lib/debounce";
 import { longDate } from "discourse/lib/formatter";
 import Group from "discourse/models/group";
 
 export default class UsersController extends Controller {
   @service modal;
+  @service siteSettings;
 
   @tracked period = "weekly";
 
@@ -110,7 +112,13 @@ export default class UsersController extends Controller {
 
   @action
   showEditColumnsModal() {
-    this.modal.show(EditUserDirectoryColumnsModal);
+    // TODO (ui-kit-reorderable-list-cleanup) drop the branch and the legacy
+    // component once the change ships.
+    const Modal = this.siteSettings.enable_new_reordering_controls
+      ? EditUserDirectoryColumnsModalReorderable
+      : EditUserDirectoryColumnsModal;
+
+    this.modal.show(Modal);
   }
 
   @action

--- a/frontend/discourse/tests/acceptance/manage-reports-drag-and-drop-test.gjs
+++ b/frontend/discourse/tests/acceptance/manage-reports-drag-and-drop-test.gjs
@@ -1,0 +1,512 @@
+import { getOwner } from "@ember/owner";
+import { fillIn, find, findAll, settled, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import ManageReportsReorderable from "discourse/admin/components/modal/manage-reports-reorderable";
+import {
+  disableClearA11yAnnouncementsInTests,
+  enableClearA11yAnnouncementsInTests,
+} from "discourse/services/a11y";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import {
+  centerOf,
+  dragEvent,
+  simulateDrag,
+} from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+import {
+  moveVia,
+  openMoveMenu,
+} from "discourse/tests/helpers/ui-kit/reorderable-list-helper";
+
+const REORDER_TEST_PREFIX = "Manage reports reordering";
+
+const REPORTS = [
+  {
+    source: "core_report",
+    identifier: "signups",
+    key: "core_report:signups",
+    title: "Matching signups",
+    description: "New account signups",
+  },
+  {
+    source: "core_report",
+    identifier: "topics",
+    key: "core_report:topics",
+    title: "Matching topics",
+    description: "New topics",
+  },
+  {
+    source: "core_report",
+    identifier: "posts",
+    key: "core_report:posts",
+    title: "Other posts",
+    description: "New posts",
+  },
+];
+
+function rowSelector(key) {
+  return `.manageable-row-list__row[data-reorderable-key="${key}"]`;
+}
+
+// A drag starts on the handle rather than anywhere on the row, so a press meant to
+// scroll still scrolls. The row owns the source data, while the shared helper
+// dispatches the browser events on the handle carrying the draggable registration.
+function rowHandleSelector(key) {
+  return `${rowSelector(key)} .d-reorderable-list__handle`;
+}
+
+function enabledKeys() {
+  return findAll(".manageable-row-list__row.--enabled").map(
+    (row) => row.dataset.reorderableKey
+  );
+}
+
+async function openModal(context) {
+  await visit("/");
+  getOwner(context).lookup("service:modal").show(ManageReportsReorderable);
+  await settled();
+}
+
+async function dragReport(sourceKey, targetKey, position) {
+  const source = rowSelector(sourceKey);
+  const target = rowSelector(targetKey);
+
+  const targetRect = find(target).getBoundingClientRect();
+  await simulateDrag(source, target, {
+    dataTransfer: new DataTransfer(),
+    sourceCoordinates: centerOf(rowHandleSelector(sourceKey)),
+    targetCoordinates: {
+      clientY:
+        position === "above" ? targetRect.top + 1 : targetRect.bottom - 1,
+    },
+  });
+}
+
+acceptance("Manage reports drag and drop | reorderable", function (needs) {
+  needs.user({ admin: true });
+  needs.settings({ enable_new_reordering_controls: true });
+  needs.pretender((server, helper) => {
+    server.get("/admin/dashboard/reports/available.json", () =>
+      helper.response({
+        enabled: REPORTS.slice(0, 2),
+        available: REPORTS,
+        providers: [],
+        cursor: null,
+        has_more: false,
+      })
+    );
+  });
+
+  // `settled()` waits out pending timers, and an announcement schedules its own
+  // clear, so a message read after an awaited interaction would always be gone.
+  needs.hooks.beforeEach(disableClearA11yAnnouncementsInTests);
+  needs.hooks.afterEach(enableClearA11yAnnouncementsInTests);
+
+  test(`${REORDER_TEST_PREFIX} adjacent rows leave no dead space between drop zones`, async function (assert) {
+    await openModal(this);
+
+    assert
+      .dom(".d-reorderable-list__handle")
+      .exists("the reorderable arm rendered");
+
+    // Container spacing (a flex `gap`) belongs to the list, not to either row,
+    // so a pointer inside it reaches no drop target and the above/below zones
+    // stop meeting.
+    const rows = findAll(".manageable-row-list__row");
+    for (let i = 1; i < rows.length; i++) {
+      const previous = rows[i - 1].getBoundingClientRect();
+      const current = rows[i].getBoundingClientRect();
+
+      assert.strictEqual(
+        Math.round(current.top),
+        Math.round(previous.bottom),
+        `row ${i} starts exactly where row ${i - 1} ends, so no pointer position between them falls outside both`
+      );
+    }
+  });
+
+  test(`${REORDER_TEST_PREFIX} renders a handle per row and a menu of destinations`, async function (assert) {
+    await openModal(this);
+
+    assert.dom(".d-reorderable-list__handle").exists({ count: 2 });
+    await openMoveMenu("core_report:topics");
+    assert
+      .dom(".d-reorderable-list__move-item")
+      .exists(
+        { count: 2 },
+        "desktop keeps a pointer path to reorder, not only the drag"
+      );
+  });
+
+  test(`${REORDER_TEST_PREFIX} the move menu reorders the enabled list`, async function (assert) {
+    await openModal(this);
+
+    await moveVia("core_report:topics", "up");
+
+    assert.deepEqual(
+      enabledKeys(),
+      ["core_report:topics", "core_report:signups"],
+      "the menu moves the report earlier, with no drag involved"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} the menu path announces through the same call as the drag`, async function (assert) {
+    const a11y = getOwner(this).lookup("service:a11y");
+    await openModal(this);
+
+    await moveVia("core_report:topics", "up");
+
+    assert.strictEqual(
+      a11y.politeMessage,
+      "Moved Matching topics to position 1 of 3",
+      "a menu move announces exactly like the equivalent drag, counting the disabled row the reader can also see"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} announces where a dragged report landed`, async function (assert) {
+    const a11y = getOwner(this).lookup("service:a11y");
+    await openModal(this);
+
+    await dragReport("core_report:topics", "core_report:signups", "above");
+
+    assert.strictEqual(
+      a11y.politeMessage,
+      "Moved Matching topics to position 1 of 3",
+      "a completed drag announces the report and its resulting position"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} announces nothing when a drop changes no order`, async function (assert) {
+    const a11y = getOwner(this).lookup("service:a11y");
+    await openModal(this);
+
+    const before = a11y.politeMessage;
+
+    await dragReport("core_report:signups", "core_report:signups", "above");
+    assert.strictEqual(
+      a11y.politeMessage,
+      before,
+      "dropping a report onto itself is not a reorder, so nothing is announced"
+    );
+
+    // Below the report directly above it resolves to the index it already holds.
+    await dragReport("core_report:topics", "core_report:signups", "below");
+    assert.strictEqual(
+      a11y.politeMessage,
+      before,
+      "a drop that resolves to the report's current index announces nothing"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} reorders by stable key with a search filter applied`, async function (assert) {
+    await openModal(this);
+    await fillIn(
+      ".manageable-row-list__search-wrapper .filter-input",
+      "Matching"
+    );
+
+    await dragReport("core_report:topics", "core_report:signups", "above");
+
+    assert.deepEqual(
+      enabledKeys(),
+      ["core_report:topics", "core_report:signups"],
+      "a filtered reorder resolves fresh visible-row copies through their stable keys"
+    );
+  });
+
+  test(`${REORDER_TEST_PREFIX} conditionally registers rows and puts the grab cursor on the handle`, async function (assert) {
+    await openModal(this);
+
+    const disabledRow = rowSelector("core_report:posts");
+    assert
+      .dom(disabledRow)
+      .doesNotHaveAttribute(
+        "data-drag-source",
+        "a disabled row has no active drag-source registration"
+      )
+      .doesNotHaveAttribute(
+        "draggable",
+        "a disabled row is not stamped as draggable"
+      );
+    // The grip is what a drag begins on, so it is what advertises the grab. The
+    // row must not: its text is selectable, and a `grab` cursor over text would
+    // promise a gesture pressing there does not perform.
+    assert.strictEqual(
+      getComputedStyle(find(rowSelector("core_report:signups"))).cursor,
+      "auto",
+      "an enabled row does not claim the grab cursor across its whole width"
+    );
+    // Paired with the row above, because `auto` is what an unstyled element
+    // reports anyway: on its own that assertion passes even if no rule is
+    // reached at all.
+    assert.strictEqual(
+      getComputedStyle(find(rowHandleSelector("core_report:signups"))).cursor,
+      "grab",
+      "the handle does, so the rule is reached"
+    );
+
+    assert
+      .dom(".manageable-row-list__row.--enabled[data-drop-target]")
+      .exists({ count: 2 }, "every enabled reorderable row is a drop target");
+    assert
+      .dom(".manageable-row-list__row.--enabled[data-drag-source]")
+      .exists(
+        { count: 2 },
+        "every enabled row carries the drag registration, so a drag shows the row"
+      );
+    assert
+      .dom(
+        '.manageable-row-list__row.--enabled .d-reorderable-list__handle[draggable="true"]'
+      )
+      .exists({ count: 2 }, "and its handle is where the drag begins");
+  });
+
+  test(`${REORDER_TEST_PREFIX} uses the shared drag state classes`, async function (assert) {
+    await openModal(this);
+
+    const source = rowSelector("core_report:signups");
+    const target = rowSelector("core_report:topics");
+    const dataTransfer = new DataTransfer();
+    const sourceHandle = rowHandleSelector("core_report:signups");
+    const sourceCoordinates = centerOf(sourceHandle);
+    const targetRect = find(target).getBoundingClientRect();
+    const targetCoordinates = {
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + 1,
+    };
+
+    await dragEvent(sourceHandle, "dragstart", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+    await dragEvent(target, "dragenter", {
+      dataTransfer,
+      ...targetCoordinates,
+    });
+    await dragEvent(target, "dragover", {
+      dataTransfer,
+      offsetY: 1,
+      ...targetCoordinates,
+    });
+
+    assert
+      .dom(source)
+      .hasClass("--dragging", "the source uses the shared dragging class");
+    assert
+      .dom(target)
+      .hasClass("--drag-above", "the target uses the shared above indicator");
+
+    await dragEvent(sourceHandle, "dragend", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+  });
+
+  test(`${REORDER_TEST_PREFIX} leaves no indicator after an abandoned drag`, async function (assert) {
+    await openModal(this);
+
+    const source = rowSelector("core_report:signups");
+    const target = rowSelector("core_report:topics");
+    const dataTransfer = new DataTransfer();
+    const sourceHandle = rowHandleSelector("core_report:signups");
+    const sourceCoordinates = centerOf(sourceHandle);
+    const targetRect = find(target).getBoundingClientRect();
+    const targetCoordinates = {
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + 1,
+    };
+
+    await dragEvent(sourceHandle, "dragstart", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+    await dragEvent(target, "dragenter", {
+      dataTransfer,
+      ...targetCoordinates,
+    });
+    await dragEvent(target, "dragover", {
+      dataTransfer,
+      offsetY: 1,
+      ...targetCoordinates,
+    });
+    await dragEvent(sourceHandle, "dragend", {
+      dataTransfer,
+      ...sourceCoordinates,
+    });
+
+    assert
+      .dom(source)
+      .doesNotHaveClass(
+        "--dragging",
+        "an abandoned drag clears the source indicator"
+      )
+      .doesNotHaveClass(
+        "dragging",
+        "an abandoned drag leaves no legacy source indicator"
+      );
+    assert
+      .dom(target)
+      .doesNotHaveClass(
+        "drag-above",
+        "an abandoned drag leaves no legacy above indicator"
+      )
+      .doesNotHaveClass(
+        "drag-below",
+        "an abandoned drag leaves no legacy below indicator"
+      )
+      .doesNotHaveClass(
+        "--drag-above",
+        "an abandoned drag clears the target's above indicator"
+      )
+      .doesNotHaveClass(
+        "--drag-below",
+        "an abandoned drag clears the target's below indicator"
+      );
+  });
+});
+
+acceptance(
+  "Manage reports menu reorder with a hidden row between matches | reorderable",
+  function (needs) {
+    needs.user({ admin: true });
+    needs.settings({ enable_new_reordering_controls: true });
+    needs.pretender((server, helper) =>
+      server.get("/admin/dashboard/reports/available.json", () =>
+        helper.response({
+          // Order matters: the row the filter hides sits BETWEEN the two it
+          // shows, which is the arrangement that separates moving by displayed
+          // position from moving by stored position.
+          enabled: [REPORTS[0], REPORTS[2], REPORTS[1]],
+          available: REPORTS,
+          providers: [],
+          cursor: null,
+          has_more: false,
+        })
+      )
+    );
+
+    needs.hooks.beforeEach(disableClearA11yAnnouncementsInTests);
+    needs.hooks.afterEach(enableClearA11yAnnouncementsInTests);
+
+    test(`${REORDER_TEST_PREFIX} moves a row past its visible neighbour from the menu`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await openModal(this);
+
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists("the reorderable arm rendered");
+
+      await fillIn(
+        ".manageable-row-list__search-wrapper .filter-input",
+        "Matching"
+      );
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:signups", "core_report:topics"],
+        "the filter shows the two matching rows, with one hidden between them"
+      );
+
+      await moveVia("core_report:signups", "down");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:signups"],
+        "the row moves past its visible neighbour, so the list the user sees actually changes"
+      );
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Matching signups to position 2 of 2",
+        "and the announced position counts the rows on screen, not the stored order"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} drag announces the same displayed position as the menu`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await openModal(this);
+      await fillIn(
+        ".manageable-row-list__search-wrapper .filter-input",
+        "Matching"
+      );
+
+      await dragReport("core_report:signups", "core_report:topics", "below");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:signups"],
+        "the drag reaches the same order the menu did"
+      );
+      // The stored order is three long and the row lands third in it, so an
+      // announcement counted there would say "3 of 3" for a list showing two.
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Matching signups to position 2 of 2",
+        "so it announces the same position, counted on screen rather than in the stored order"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} filtered drag leaves the hidden row in its slot`, async function (assert) {
+      await openModal(this);
+      await fillIn(
+        ".manageable-row-list__search-wrapper .filter-input",
+        "Matching"
+      );
+
+      await dragReport("core_report:signups", "core_report:topics", "below");
+
+      await fillIn(".manageable-row-list__search-wrapper .filter-input", "");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:posts", "core_report:signups"],
+        "the two rows on screen swap the slots they held, and the row between them keeps its own"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} the menu leaves the hidden row in the same slot as drag`, async function (assert) {
+      await openModal(this);
+      await fillIn(
+        ".manageable-row-list__search-wrapper .filter-input",
+        "Matching"
+      );
+
+      await moveVia("core_report:signups", "down");
+
+      await fillIn(".manageable-row-list__search-wrapper .filter-input", "");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:topics", "core_report:posts", "core_report:signups"],
+        "so the two ways of reordering persist the same order rather than disagreeing about the hidden row"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} no-op filtered drag changes nothing`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await openModal(this);
+      await fillIn(
+        ".manageable-row-list__search-wrapper .filter-input",
+        "Matching"
+      );
+
+      const before = a11y.politeMessage;
+
+      // Below the row shown above it, which is the position it already holds.
+      // In the stored order it is a move, because of the row hidden between.
+      await dragReport("core_report:topics", "core_report:signups", "below");
+
+      assert.strictEqual(
+        a11y.politeMessage,
+        before,
+        "a drop onto the position the row already occupies announces nothing"
+      );
+
+      await fillIn(".manageable-row-list__search-wrapper .filter-input", "");
+
+      assert.deepEqual(
+        enabledKeys(),
+        ["core_report:signups", "core_report:posts", "core_report:topics"],
+        "and stores nothing, rather than quietly moving the row the user cannot see"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/dashboard/configure-menu-reorderable-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/configure-menu-reorderable-test.gjs
@@ -1,0 +1,859 @@
+import { tracked } from "@glimmer/tracking";
+import { getOwner } from "@ember/owner";
+import { click, find, findAll, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import ConfigureMenuReorderable from "discourse/admin/components/dashboard/configure-menu-reorderable";
+import DMenus from "discourse/float-kit/components/d-menus";
+import { forceMobile } from "discourse/lib/mobile";
+import {
+  disableClearA11yAnnouncementsInTests,
+  enableClearA11yAnnouncementsInTests,
+} from "discourse/services/a11y";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  centerOf,
+  dragEvent,
+  simulateDrag,
+} from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+import {
+  moveItemSelector,
+  moveVia,
+  moveViaChord,
+  openMoveMenu,
+} from "discourse/tests/helpers/ui-kit/reorderable-list-helper";
+
+const REORDER_TEST_PREFIX = "Dashboard section reordering";
+
+const FOUR_SECTIONS = [
+  { id: "highlights", visible: true },
+  { id: "reports", visible: true },
+  { id: "traffic", visible: false },
+  { id: "engagement", visible: true },
+];
+
+function rowSelector(id) {
+  return `[data-reorderable-key="${id}"]`;
+}
+
+// A drag starts on the grip rather than anywhere on the row, so a press meant to
+// scroll still scrolls and the row's own text stays selectable. The grip is what
+// carries the registration, so that is where the events go.
+function gripSelector(id) {
+  return `${rowSelector(id)} .d-reorderable-list__handle`;
+}
+
+async function dragSection(sourceId, targetId, position) {
+  const source = rowSelector(sourceId);
+  const target = rowSelector(targetId);
+
+  const targetRect = find(target).getBoundingClientRect();
+  await simulateDrag(source, target, {
+    dataTransfer: new DataTransfer(),
+    sourceCoordinates: centerOf(gripSelector(sourceId)),
+    targetCoordinates: {
+      clientY:
+        position === "above" ? targetRect.top + 1 : targetRect.bottom - 1,
+    },
+  });
+}
+
+function isTransparent(color) {
+  return color === "transparent" || /rgba\(0, 0, 0, 0\)/.test(color);
+}
+
+/**
+ * The y-range of whichever row edge is currently painted as the drop indicator.
+ *
+ * Read from the computed border rather than from a class, because the point is
+ * where the line physically lands, not which row was asked to draw it.
+ *
+ * @returns {{top: number, bottom: number}|null} The band, or `null` if none.
+ */
+function indicatorBand() {
+  for (const row of findAll(".db-configure__row")) {
+    const style = getComputedStyle(row);
+    const rect = row.getBoundingClientRect();
+
+    if (!isTransparent(style.borderTopColor)) {
+      return {
+        top: rect.top,
+        bottom: rect.top + parseFloat(style.borderTopWidth),
+      };
+    }
+    if (!isTransparent(style.borderBottomColor)) {
+      return {
+        top: rect.bottom - parseFloat(style.borderBottomWidth),
+        bottom: rect.bottom,
+      };
+    }
+  }
+  return null;
+}
+
+/** Opens a drag and holds it over a target, without dropping. */
+async function hoverOver(sourceId, targetId, position) {
+  const target = rowSelector(targetId);
+  const dataTransfer = new DataTransfer();
+  const targetRect = find(target).getBoundingClientRect();
+  const coordinates = {
+    clientX: targetRect.left + targetRect.width / 2,
+    clientY: position === "above" ? targetRect.top + 1 : targetRect.bottom - 1,
+  };
+
+  // Dispatched on the grip, which is where the registration lives: a row that
+  // scopes its drag to a handle is not itself draggable, so the browser would
+  // never raise `dragstart` on it.
+  await dragEvent(gripSelector(sourceId), "dragstart", {
+    dataTransfer,
+    ...centerOf(gripSelector(sourceId)),
+  });
+  await dragEvent(target, "dragenter", { dataTransfer, ...coordinates });
+  await dragEvent(target, "dragover", { dataTransfer, ...coordinates });
+
+  return () =>
+    dragEvent(gripSelector(sourceId), "dragend", {
+      dataTransfer,
+      ...centerOf(gripSelector(sourceId)),
+    });
+}
+
+module(
+  "Integration | Component | Dashboard | ConfigureMenu | reorderable",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      getOwner(this).lookup(
+        "service:site-settings"
+      ).enable_new_reordering_controls = true;
+    });
+
+    // `settled()` waits out pending timers, and an announcement schedules its own
+    // clear, so a message read after `await click(...)` would always be gone.
+    hooks.beforeEach(disableClearA11yAnnouncementsInTests);
+    hooks.afterEach(enableClearA11yAnnouncementsInTests);
+
+    test(`${REORDER_TEST_PREFIX} renders one row per section`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists("the reorderable arm rendered");
+      assert.dom(".db-configure__row").exists({ count: 4 });
+      assert.dom('[data-reorderable-key="highlights"]').exists();
+      assert.dom('[data-reorderable-key="reports"]').exists();
+      assert.dom('[data-reorderable-key="traffic"]').exists();
+      assert.dom('[data-reorderable-key="engagement"]').exists();
+    });
+
+    test(`${REORDER_TEST_PREFIX} toggle click fires @onToggleVisibility with the section id`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const calls = [];
+      const onToggle = (id) => calls.push(id);
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{onToggle}}
+          />
+        </template>
+      );
+
+      await click(
+        '[data-reorderable-key="highlights"] .d-toggle-switch__checkbox'
+      );
+      assert.deepEqual(calls, ["highlights"]);
+    });
+
+    test(`${REORDER_TEST_PREFIX} reorders in both directions`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const calls = [];
+      const onReorder = (from, to) => calls.push([from, to]);
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{onReorder}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await dragSection("reports", "highlights", "above");
+      await dragSection("highlights", "engagement", "below");
+
+      assert.deepEqual(
+        calls,
+        [
+          [1, 0],
+          [0, 3],
+        ],
+        "drops above and below resolve from source and target rows without dragstart state"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} wires every row as a shared source and target`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{FOUR_SECTIONS}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".db-configure__row[data-drop-target]")
+        .exists(
+          { count: FOUR_SECTIONS.length },
+          "every configure row is a drop target"
+        );
+      assert
+        .dom(".db-configure__row[data-drag-source]")
+        .exists(
+          { count: FOUR_SECTIONS.length },
+          "every configure row carries the drag registration, so a drag shows the row"
+        );
+      assert
+        .dom('.db-configure__row .d-reorderable-list__handle[draggable="true"]')
+        .exists(
+          { count: FOUR_SECTIONS.length },
+          "and its grip is where the drag begins"
+        );
+    });
+
+    test(`${REORDER_TEST_PREFIX} uses the shared drag state classes`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{FOUR_SECTIONS}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      const source = rowSelector("reports");
+      const target = rowSelector("traffic");
+      const dataTransfer = new DataTransfer();
+      const sourceGrip = gripSelector("reports");
+      const sourceCoordinates = centerOf(sourceGrip);
+      const targetRect = find(target).getBoundingClientRect();
+      const targetCoordinates = {
+        clientX: targetRect.left + targetRect.width / 2,
+        clientY: targetRect.top + 1,
+      };
+
+      await dragEvent(sourceGrip, "dragstart", {
+        dataTransfer,
+        ...sourceCoordinates,
+      });
+      await dragEvent(target, "dragenter", {
+        dataTransfer,
+        ...targetCoordinates,
+      });
+      await dragEvent(target, "dragover", {
+        dataTransfer,
+        offsetY: 1,
+        ...targetCoordinates,
+      });
+
+      assert
+        .dom(source)
+        .hasClass("--dragging", "the source uses the shared dragging class");
+      assert
+        .dom(target)
+        .hasClass("--drag-above", "the target uses the shared above indicator");
+
+      await dragEvent(sourceGrip, "dragend", {
+        dataTransfer,
+        ...sourceCoordinates,
+      });
+    });
+
+    test(`${REORDER_TEST_PREFIX} leaves no indicator after an abandoned drag`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{FOUR_SECTIONS}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      const source = rowSelector("reports");
+      const target = rowSelector("traffic");
+      const dataTransfer = new DataTransfer();
+      const sourceGrip = gripSelector("reports");
+      const sourceCoordinates = centerOf(sourceGrip);
+      const targetRect = find(target).getBoundingClientRect();
+      const targetCoordinates = {
+        clientX: targetRect.left + targetRect.width / 2,
+        clientY: targetRect.top + 1,
+      };
+
+      await dragEvent(sourceGrip, "dragstart", {
+        dataTransfer,
+        ...sourceCoordinates,
+      });
+      await dragEvent(target, "dragenter", {
+        dataTransfer,
+        ...targetCoordinates,
+      });
+      await dragEvent(target, "dragover", {
+        dataTransfer,
+        offsetY: 1,
+        ...targetCoordinates,
+      });
+      await dragEvent(sourceGrip, "dragend", {
+        dataTransfer,
+        ...sourceCoordinates,
+      });
+
+      assert
+        .dom(source)
+        .doesNotHaveClass(
+          "--dragging",
+          "an abandoned drag clears the source indicator"
+        )
+        .doesNotHaveClass(
+          "dragging",
+          "an abandoned drag leaves no legacy source indicator"
+        );
+      assert
+        .dom(target)
+        .doesNotHaveClass(
+          "drag-above",
+          "an abandoned drag leaves no legacy above indicator"
+        )
+        .doesNotHaveClass(
+          "drag-below",
+          "an abandoned drag leaves no legacy below indicator"
+        )
+        .doesNotHaveClass(
+          "--drag-above",
+          "an abandoned drag clears the target's above indicator"
+        )
+        .doesNotHaveClass(
+          "--drag-below",
+          "an abandoned drag clears the target's below indicator"
+        );
+    });
+
+    test(`${REORDER_TEST_PREFIX} renders one handle per row on desktop`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert.dom(".d-reorderable-list__handle").exists({ count: 4 });
+
+      await openMoveMenu("reports");
+      assert
+        .dom(".d-reorderable-list__move-item")
+        .exists(
+          { count: 4 },
+          "desktop keeps a pointer path to reorder, not only the drag"
+        );
+    });
+
+    test(`${REORDER_TEST_PREFIX} keeps the moved row's handle focused once it has moved`, async function (assert) {
+      // A live list, unlike the sibling tests: the row has to actually move for
+      // this to say anything about what happens to focus when it does.
+      const state = new (class {
+        @tracked sections = [...FOUR_SECTIONS];
+      })();
+      const onReorder = (from, to) => {
+        const next = [...state.sections];
+        const [moved] = next.splice(from, 1);
+        next.splice(to, 0, moved);
+        state.sections = next;
+      };
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{state.sections}}
+            @onReorder={{onReorder}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await moveVia("highlights", "down");
+
+      assert.deepEqual(
+        state.sections.map((section) => section.id),
+        ["reports", "highlights", "traffic", "engagement"],
+        "the row moved, so focus has something to survive"
+      );
+      // Without this a keyboard user is dropped to the top of the document after
+      // one move and cannot make a second, which defeats the keyboard path.
+      assert.strictEqual(
+        document.activeElement,
+        find(gripSelector("highlights")),
+        "focus follows the row rather than falling back to the body"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} desktop arrow buttons fire @onReorder`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const calls = [];
+      const onReorder = (from, to) => calls.push([from, to]);
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{onReorder}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await moveVia("reports", "up");
+      assert.deepEqual(
+        calls.at(-1),
+        [1, 0],
+        "the up arrow moves the row earlier"
+      );
+
+      await moveVia("highlights", "down");
+      assert.deepEqual(
+        calls.at(-1),
+        [0, 1],
+        "the down arrow moves the row later"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} the Alt chord fires @onReorder`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const calls = [];
+      const onReorder = (from, to) => calls.push([from, to]);
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{onReorder}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await moveViaChord("reports", "up");
+      assert.deepEqual(
+        calls.at(-1),
+        [1, 0],
+        "the accelerator moves the row without opening the menu"
+      );
+
+      await moveViaChord("highlights", "bottom");
+      assert.deepEqual(calls.at(-1), [0, 3], "and sends it to the far end");
+    });
+
+    test(`${REORDER_TEST_PREFIX} adjacent rows leave no dead space between drop zones`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{FOUR_SECTIONS}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      // Each row splits into its own above/below halves at its midpoint, so the
+      // zones only meet end to end if the row boxes themselves touch. Container
+      // spacing (a flex `gap`) is owned by the list, not by either row, so a
+      // pointer inside it reaches no drop target at all.
+      const rows = findAll(".db-configure__row");
+      for (let i = 1; i < rows.length; i++) {
+        const previous = rows[i - 1].getBoundingClientRect();
+        const current = rows[i].getBoundingClientRect();
+
+        // Compared exactly, not rounded: a sub-pixel seam is still a band of
+        // pixels that belongs to no row, and rounding both sides would hide it.
+        assert.strictEqual(
+          current.top,
+          previous.bottom,
+          `row ${i} starts exactly where row ${i - 1} ends, so no pointer position between them falls outside both`
+        );
+      }
+    });
+
+    test(`${REORDER_TEST_PREFIX} both sides of a boundary draw one shared indicator line`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{FOUR_SECTIONS}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      // The same boundary reached from either side. Both resolve to the same
+      // insertion point, so the line has to stay put rather than shifting by its
+      // own width as the pointer crosses the midpoint.
+      const endBelow = await hoverOver("traffic", "highlights", "below");
+      const below = indicatorBand();
+      await endBelow();
+
+      const endAbove = await hoverOver("traffic", "reports", "above");
+      const above = indicatorBand();
+      await endAbove();
+
+      assert.notStrictEqual(
+        below,
+        null,
+        "hovering below the first row paints an indicator"
+      );
+      assert.notStrictEqual(
+        above,
+        null,
+        "hovering above the second row paints an indicator"
+      );
+      assert.deepEqual(
+        above,
+        below,
+        "below row 1 and above row 2 are the same insertion point, so they paint the same pixels"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} the indicator colour follows its own custom property`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <div style="--d-drag-indicator-color: rgb(1, 2, 3)">
+            <ConfigureMenuReorderable
+              @sections={{FOUR_SECTIONS}}
+              @onReorder={{noop}}
+              @onToggleVisibility={{noop}}
+            />
+          </div>
+        </template>
+      );
+
+      const end = await hoverOver("traffic", "highlights", "below");
+      const painted = getComputedStyle(
+        find(rowSelector("highlights"))
+      ).borderBottomColor;
+      await end();
+
+      assert.strictEqual(
+        painted,
+        "rgb(1, 2, 3)",
+        "an ancestor can retune drag feedback without touching any other accent border"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} the arrow path announces where the row landed`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await moveVia("reports", "up");
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Reports to position 1 of 4",
+        "the announcement names the row and its resulting position"
+      );
+
+      await moveVia("highlights", "down");
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Highlights to position 2 of 4",
+        "moving down announces the row's new position, not the direction"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} the drag path announces through the same call as the arrows`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await dragSection("engagement", "highlights", "above");
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Engagement to position 1 of 4",
+        "a completed drag announces exactly like the equivalent arrow press"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} a reorder that moves nothing announces nothing`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      const before = a11y.politeMessage;
+
+      await dragSection("reports", "reports", "above");
+      assert.strictEqual(
+        a11y.politeMessage,
+        before,
+        "dropping a row onto itself is not a reorder, so nothing is announced"
+      );
+
+      // Below the row directly above it resolves to the index it already holds,
+      // so this is a no-op that the self-drop guard alone does not catch.
+      await dragSection("reports", "highlights", "below");
+      assert.strictEqual(
+        a11y.politeMessage,
+        before,
+        "a drop that resolves to the row's current index announces nothing"
+      );
+    });
+
+    test(`${REORDER_TEST_PREFIX} desktop keyboard path reaches every handle and offers only reachable destinations`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists({ count: 4 }, "every section's handle is reachable");
+      assert
+        .dom('.d-reorderable-list__handle[tabindex="-1"]')
+        .doesNotExist("and none is held out of the tab sequence");
+
+      await openMoveMenu("highlights");
+      assert
+        .dom(moveItemSelector("up"))
+        .doesNotExist("the first row cannot move up");
+      await click(moveItemSelector("down"));
+
+      await openMoveMenu("engagement");
+      assert
+        .dom(moveItemSelector("down"))
+        .doesNotExist("the last row cannot move down");
+      await click(moveItemSelector("up"));
+
+      await openMoveMenu("reports");
+      assert.dom(moveItemSelector("up")).exists("a middle row can move up");
+    });
+  }
+);
+
+module(
+  "Integration | Component | Dashboard | ConfigureMenu | Mobile | reorderable",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      getOwner(this).lookup(
+        "service:site-settings"
+      ).enable_new_reordering_controls = true;
+      forceMobile();
+    });
+
+    test(`${REORDER_TEST_PREFIX} renders one handle per row on mobile`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      // Both paths render: a touch screen can drag from the grip and has no
+      // keyboard, so neither is a substitute for the other here.
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists("the reorderable arm rendered");
+      assert.dom(".d-reorderable-list__handle").exists({ count: 4 });
+    });
+
+    test(`${REORDER_TEST_PREFIX} keeps the row draggable from its grip on mobile`, async function (assert) {
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{FOUR_SECTIONS}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists(
+          "the grip renders on mobile, so the drag has a target to press"
+        );
+      assert
+        .dom(".db-configure__row")
+        .hasAttribute(
+          "data-drag-source",
+          "",
+          "a mobile row carries an active drag-source registration"
+        );
+      assert
+        .dom(".db-configure__row .d-reorderable-list__handle")
+        .hasAttribute(
+          "draggable",
+          "true",
+          "and its grip is where a touch press starts the drag"
+        );
+    });
+
+    test(`${REORDER_TEST_PREFIX} mobile menu moves fire @onReorder`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const calls = [];
+      const onReorder = (from, to) => calls.push([from, to]);
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{onReorder}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await moveVia("reports", "up");
+      assert.deepEqual(calls.at(-1), [1, 0]);
+
+      await moveVia("highlights", "down");
+      assert.deepEqual(calls.at(-1), [0, 1]);
+    });
+
+    test(`${REORDER_TEST_PREFIX} omits unavailable mobile destinations`, async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <DMenus />
+          <ConfigureMenuReorderable
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await openMoveMenu("highlights");
+      assert
+        .dom(moveItemSelector("up"))
+        .doesNotExist("the first row cannot move up");
+      await click(moveItemSelector("down"));
+
+      await openMoveMenu("engagement");
+      assert
+        .dom(moveItemSelector("down"))
+        .doesNotExist("the last row cannot move down");
+      await click(moveItemSelector("up"));
+
+      await openMoveMenu("reports");
+      assert.dom(moveItemSelector("up")).exists("a middle row can move up");
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/modal/compare-groups-reorderable-test.gjs
+++ b/frontend/discourse/tests/integration/components/modal/compare-groups-reorderable-test.gjs
@@ -1,0 +1,215 @@
+import { array, hash } from "@ember/helper";
+import { getOwner } from "@ember/owner";
+import { click, fillIn, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import CompareGroupsReorderable from "discourse/admin/components/modal/compare-groups-reorderable";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module(
+  "Integration | Component | Modal | CompareGroups | reorderable",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      getOwner(this).lookup(
+        "service:site-settings"
+      ).enable_new_reordering_controls = true;
+      this.site.groups = [
+        { id: 0, name: "everyone" },
+        { id: 1, name: "admins" },
+        { id: 2, name: "moderators" },
+        { id: 3, name: "staff" },
+        { id: 4, name: "anonymous_users" },
+        { id: 5, name: "logged_in_users" },
+        { id: 10, name: "support", full_name: "Support" },
+        { id: 11, name: "beta_testers", full_name: "Beta testers" },
+      ];
+    });
+
+    const noop = () => {};
+
+    test("pre-selects the given current tokens", async function (assert) {
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash
+              currentTokens=(array "new_members" "returning" "staff")
+            }}
+            @closeModal={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists("the reorderable arm rendered");
+      assert
+        .dom(".manageable-row-list__counter")
+        .hasText("3 of 10 groups selected");
+      assert
+        .dom(
+          "[data-reorderable-key='new_members'].manageable-row-list__row.--enabled"
+        )
+        .exists();
+      assert
+        .dom(
+          "[data-reorderable-key='returning'].manageable-row-list__row.--enabled"
+        )
+        .exists();
+      assert
+        .dom(
+          "[data-reorderable-key='staff'].manageable-row-list__row.--enabled"
+        )
+        .exists();
+    });
+
+    test("excludes the everyone/anonymous/logged-in pseudogroups and the real staff auto-group", async function (assert) {
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash currentTokens=(array "staff")}}
+            @closeModal={{noop}}
+          />
+        </template>
+      );
+
+      assert.dom("[data-reorderable-key='group:0']").doesNotExist();
+      assert.dom("[data-reorderable-key='group:3']").doesNotExist();
+      assert.dom("[data-reorderable-key='group:4']").doesNotExist();
+      assert.dom("[data-reorderable-key='group:5']").doesNotExist();
+      assert.dom("[data-reorderable-key='group:1']").exists();
+      assert.dom("[data-reorderable-key='group:10']").exists();
+    });
+
+    test("search filters the disabled rows by title", async function (assert) {
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash currentTokens=(array "staff")}}
+            @closeModal={{noop}}
+          />
+        </template>
+      );
+
+      await fillIn(".compare-groups input", "support");
+
+      assert.dom("[data-reorderable-key='group:10']").exists();
+      assert.dom("[data-reorderable-key='group:11']").doesNotExist();
+      assert.dom("[data-reorderable-key='staff']").exists();
+    });
+
+    test("toggling a row on adds it to the selection, and off removes it", async function (assert) {
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash currentTokens=(array "staff")}}
+            @closeModal={{noop}}
+          />
+        </template>
+      );
+
+      await click(
+        "[data-reorderable-key='group:10'] .d-toggle-switch__checkbox"
+      );
+      assert
+        .dom(".manageable-row-list__counter")
+        .hasText("2 of 10 groups selected");
+
+      await click("[data-reorderable-key='staff'] .d-toggle-switch__checkbox");
+      assert
+        .dom(".manageable-row-list__counter")
+        .hasText("1 of 10 groups selected");
+    });
+
+    test("prevents disabling the last remaining selected row", async function (assert) {
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash currentTokens=(array "staff")}}
+            @closeModal={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom("[data-reorderable-key='staff'] .d-toggle-switch__checkbox")
+        .isDisabled();
+      assert
+        .dom(".manageable-row-list__counter")
+        .hasText("1 of 10 groups selected");
+      assert
+        .dom(
+          "[data-reorderable-key='staff'].manageable-row-list__row.--enabled"
+        )
+        .exists();
+    });
+
+    test("disables further toggles once the cap of 10 is reached", async function (assert) {
+      this.site.groups = Array.from({ length: 12 }, (_, i) => ({
+        id: 100 + i,
+        name: `group-${i}`,
+      }));
+
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash
+              currentTokens=(array
+                "group:100"
+                "group:101"
+                "group:102"
+                "group:103"
+                "group:104"
+                "group:105"
+                "group:106"
+                "group:107"
+                "group:108"
+                "group:109"
+              )
+            }}
+            @closeModal={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".manageable-row-list__counter")
+        .hasText("10 of 10 groups selected");
+      assert
+        .dom("[data-reorderable-key='group:110'] .d-toggle-switch__checkbox")
+        .isDisabled();
+    });
+
+    test("apply calls onApply with the ordered selection and closes the modal", async function (assert) {
+      let appliedTokens;
+      let closed = false;
+
+      const onApply = (tokens) => (appliedTokens = tokens);
+      const closeModal = () => (closed = true);
+
+      await render(
+        <template>
+          <CompareGroupsReorderable
+            @inline={{true}}
+            @model={{hash currentTokens=(array "staff") onApply=onApply}}
+            @closeModal={{closeModal}}
+          />
+        </template>
+      );
+
+      await click(
+        "[data-reorderable-key='group:10'] .d-toggle-switch__checkbox"
+      );
+      await click(".compare-groups__apply");
+
+      assert.deepEqual(appliedTokens, ["staff", "group:10"]);
+      assert.true(closed);
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/sidebar-section-form-reorderable-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar-section-form-reorderable-test.gjs
@@ -1,0 +1,713 @@
+import { getOwner } from "@ember/owner";
+import {
+  click,
+  find,
+  findAll,
+  render,
+  triggerKeyEvent,
+} from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import SidebarSectionForm from "discourse/components/modal/sidebar-section-form";
+import SectionFormLinksReorderable from "discourse/components/sidebar/section-form-links-reorderable";
+import DMenus from "discourse/float-kit/components/d-menus";
+import {
+  disableClearA11yAnnouncementsInTests,
+  enableClearA11yAnnouncementsInTests,
+} from "discourse/services/a11y";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import {
+  centerOf,
+  dragEvent,
+  simulateDrag,
+} from "discourse/tests/helpers/ui-kit/drag-and-drop-helper";
+
+const REORDER_TEST = "Sidebar link reordering";
+
+function communitySection() {
+  return {
+    id: 42,
+    title: "Community",
+    public: false,
+    section_type: "community",
+    links: [
+      {
+        id: 1,
+        icon: "link",
+        name: "Primary 1",
+        value: "/primary-1",
+        segment: "primary",
+      },
+      {
+        id: 2,
+        icon: "link",
+        name: "Primary 2",
+        value: "/primary-2",
+        segment: "primary",
+      },
+      {
+        id: 3,
+        icon: "link",
+        name: "Secondary 1",
+        value: "/secondary-1",
+        segment: "secondary",
+      },
+      {
+        id: 4,
+        icon: "link",
+        name: "Secondary 2",
+        value: "/secondary-2",
+        segment: "secondary",
+      },
+    ],
+  };
+}
+
+/**
+ * A section whose primary list is long enough that deleting one link still
+ * leaves two visible, so an arrow move has a neighbour to swap with and a
+ * deleted link can sit between them.
+ */
+function sectionWithThreePrimaryLinks() {
+  const section = communitySection();
+
+  section.links.splice(2, 0, {
+    id: 5,
+    icon: "link",
+    name: "Primary 3",
+    value: "/primary-3",
+    segment: "primary",
+  });
+
+  return section;
+}
+
+function linkNames(selector) {
+  return findAll(`${selector} input[name="link-name"]`).map(
+    (input) => input.value
+  );
+}
+
+function renderedLinks() {
+  return {
+    primary: linkNames(
+      ".sidebar-section-form__links-wrapper:not(.--secondary)"
+    ),
+    secondary: linkNames(".sidebar-section-form__links-wrapper.--secondary"),
+  };
+}
+
+function gripSelector(name) {
+  return `.draggable[data-link-name="${name}"]`;
+}
+
+function rowSelector(name) {
+  const row = find(gripSelector(name)).closest(".sidebar-section-form-link");
+  return `[data-reorderable-key="${row.dataset.reorderableKey}"]`;
+}
+
+function moveItemSelector(target) {
+  return `.d-reorderable-list__move-item.--${target}`;
+}
+
+/** Opens one link's move menu, leaving it open for inspection. */
+async function openLinkMenu(name) {
+  await click(`${rowSelector(name)} .d-reorderable-list__handle`);
+}
+
+async function moveLink(name, target) {
+  await openLinkMenu(name);
+  await click(moveItemSelector(target));
+}
+
+async function dragLink(sourceName, targetName, position) {
+  const source = rowSelector(sourceName);
+  const target = rowSelector(targetName);
+
+  const targetRect = find(target).getBoundingClientRect();
+  const targetCoordinates = {
+    clientY: position === "above" ? targetRect.top + 1 : targetRect.bottom - 1,
+  };
+
+  await simulateDrag(source, target, {
+    dataTransfer: new DataTransfer(),
+    sourceCoordinates: centerOf(gripSelector(sourceName)),
+    targetCoordinates,
+  });
+}
+
+async function renderForm(context) {
+  await render(
+    <template>
+      <DMenus />
+      <SidebarSectionForm
+        @closeModal={{context.closeModal}}
+        @inline={{true}}
+        @model={{context.model}}
+      />
+    </template>
+  );
+}
+
+module(
+  "Integration | Component | Modal | SidebarSectionForm | reorderable",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.owner.register(
+        "component:sidebar/section-form-links-reorderable",
+        SectionFormLinksReorderable
+      );
+      getOwner(this).lookup(
+        "service:site-settings"
+      ).enable_new_reordering_controls = true;
+      const section = communitySection();
+
+      this.modalClosed = false;
+      this.closeModal = () => (this.modalClosed = true);
+      this.currentUser.set("sidebar_sections", [section]);
+      this.model = { section };
+    });
+
+    // `settled()` waits out pending timers, and an announcement schedules its own
+    // clear, so a message read after an awaited drag would always be gone.
+    hooks.beforeEach(disableClearA11yAnnouncementsInTests);
+
+    hooks.afterEach(function () {
+      enableClearA11yAnnouncementsInTests();
+      sinon.restore();
+    });
+
+    test(`${REORDER_TEST}: announces a cross-list move at its destination position`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await renderForm(this);
+
+      assert
+        .dom(".d-reorderable-list__handle")
+        .exists("the reorderable arm rendered");
+
+      await dragLink("Primary 1", "Secondary 2", "above");
+
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Primary 1 to More menu, position 2 of 3",
+        "the position is counted within the list the link moved into"
+      );
+    });
+
+    test(`${REORDER_TEST}: announces a within-list reorder`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await renderForm(this);
+
+      await dragLink("Primary 2", "Primary 1", "above");
+
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Primary 2 to position 1 of 2",
+        "a same-list move announces against that list's own length"
+      );
+    });
+
+    test(`${REORDER_TEST}: announces nothing when a drop moves no link`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await renderForm(this);
+
+      const before = a11y.politeMessage;
+
+      await dragLink("Primary 1", "Primary 1", "above");
+
+      assert.strictEqual(
+        a11y.politeMessage,
+        before,
+        "dropping a link onto itself is not a reorder, so nothing is announced"
+      );
+    });
+
+    test(`${REORDER_TEST}: moves a primary link to the chosen position in the secondary list`, async function (assert) {
+      await renderForm(this);
+
+      await dragLink("Primary 1", "Secondary 2", "above");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 2"],
+          secondary: ["Secondary 1", "Primary 1", "Secondary 2"],
+        },
+        "the dragged link is removed from Primary and inserted above its Secondary target"
+      );
+    });
+
+    test(`${REORDER_TEST}: saves a cross-list move at the chosen secondary position`, async function (assert) {
+      let savedLinks;
+
+      pretender.put("/sidebar_sections/42", (request) => {
+        savedLinks = JSON.parse(request.requestBody).links.map(
+          ({ name, segment }) => ({ name, segment })
+        );
+
+        return response({ sidebar_section: communitySection() });
+      });
+
+      await renderForm(this);
+
+      await dragLink("Primary 1", "Secondary 2", "above");
+      await click("#save-section");
+
+      assert.deepEqual(
+        savedLinks,
+        [
+          { name: "Primary 2", segment: "primary" },
+          { name: "Secondary 1", segment: "secondary" },
+          { name: "Primary 1", segment: "secondary" },
+          { name: "Secondary 2", segment: "secondary" },
+        ],
+        "the request preserves the dropped position within the destination list"
+      );
+      assert.true(this.modalClosed, "the successful save closes the modal");
+    });
+
+    test(`${REORDER_TEST}: does not duplicate a cross-list link when the drop is repeated`, async function (assert) {
+      await renderForm(this);
+
+      await dragLink("Primary 1", "Secondary 2", "above");
+      await dragLink("Primary 1", "Secondary 2", "above");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 2"],
+          secondary: ["Secondary 1", "Primary 1", "Secondary 2"],
+        },
+        "the moved link is rendered only once in its destination list"
+      );
+    });
+
+    test(`${REORDER_TEST}: reorders links within the primary list`, async function (assert) {
+      await renderForm(this);
+
+      await dragLink("Primary 2", "Primary 1", "above");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 2", "Primary 1"],
+          secondary: ["Secondary 1", "Secondary 2"],
+        },
+        "the dragged link is inserted above its target without changing lists"
+      );
+    });
+
+    test(`${REORDER_TEST}: moves a primary link below a secondary target`, async function (assert) {
+      await renderForm(this);
+
+      await dragLink("Primary 1", "Secondary 2", "below");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 2"],
+          secondary: ["Secondary 1", "Secondary 2", "Primary 1"],
+        },
+        "the dragged link is removed from Primary and inserted below its Secondary target"
+      );
+    });
+
+    test(`${REORDER_TEST}: moves a secondary link to the chosen position in the primary list`, async function (assert) {
+      await renderForm(this);
+
+      await dragLink("Secondary 2", "Primary 2", "above");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 1", "Secondary 2", "Primary 2"],
+          secondary: ["Secondary 1"],
+        },
+        "the dragged link is removed from Secondary and inserted above its Primary target"
+      );
+    });
+
+    test(`${REORDER_TEST}: wires every desktop row as a handled source and target`, async function (assert) {
+      await renderForm(this);
+
+      assert
+        .dom(".sidebar-section-form-link[data-drop-target]")
+        .exists({ count: 4 }, "every link row is a drop target");
+      assert
+        .dom(".sidebar-section-form-link[data-drag-source]")
+        .exists(
+          { count: 4 },
+          "every link row carries the drag registration, so a drag shows the row"
+        );
+      assert
+        .dom('.sidebar-section-form-link .draggable[draggable="true"]')
+        .exists({ count: 4 }, "and its grip is where the drag begins");
+
+      const source = rowSelector("Primary 1");
+      const target = rowSelector("Primary 2");
+      const dataTransfer = new DataTransfer();
+
+      // The row is not draggable, which is both why a press on its body cannot
+      // begin a drag and why the name and URL inputs beside the grip stay
+      // selectable. Dispatching here anyway proves the row routes nothing.
+      assert.dom(source).doesNotHaveAttribute("draggable");
+      await dragEvent(source, "dragstart", {
+        dataTransfer,
+        ...centerOf(source),
+      });
+      assert
+        .dom(source)
+        .doesNotHaveClass(
+          "--dragging",
+          "pressing the row body does not initiate a drag"
+        );
+      await dragEvent(source, "dragend", {
+        dataTransfer,
+        ...centerOf(source),
+      });
+
+      await dragEvent(gripSelector("Primary 1"), "dragstart", {
+        dataTransfer,
+        ...centerOf(gripSelector("Primary 1")),
+      });
+      assert
+        .dom(source)
+        .hasClass("--dragging", "pressing the grip initiates the row drag");
+      await dragEvent(gripSelector("Primary 1"), "dragend", {
+        dataTransfer,
+        ...centerOf(target),
+      });
+    });
+
+    test(`${REORDER_TEST}: leaves no indicator after an abandoned drag`, async function (assert) {
+      await renderForm(this);
+
+      const source = rowSelector("Primary 1");
+      const target = rowSelector("Primary 2");
+      const dataTransfer = new DataTransfer();
+      const sourceGrip = gripSelector("Primary 1");
+      const sourceCoordinates = centerOf(sourceGrip);
+      const targetRect = find(target).getBoundingClientRect();
+      const targetCoordinates = {
+        clientX: targetRect.left + targetRect.width / 2,
+        clientY: targetRect.top + 1,
+      };
+
+      await dragEvent(sourceGrip, "dragstart", {
+        dataTransfer,
+        ...sourceCoordinates,
+      });
+      assert
+        .dom(source)
+        .hasClass("--dragging", "the source uses the shared dragging class");
+
+      await dragEvent(target, "dragenter", {
+        dataTransfer,
+        ...targetCoordinates,
+      });
+      await dragEvent(target, "dragover", {
+        dataTransfer,
+        ...targetCoordinates,
+      });
+      assert
+        .dom(target)
+        .hasClass("--drag-above", "the target uses the shared above indicator");
+
+      await dragEvent(sourceGrip, "dragend", {
+        dataTransfer,
+        ...sourceCoordinates,
+      });
+
+      assert
+        .dom(source)
+        .doesNotHaveClass(
+          "--dragging",
+          "an abandoned drag clears the source indicator"
+        );
+      assert
+        .dom(target)
+        .doesNotHaveClass(
+          "--drag-above",
+          "an abandoned drag clears the target's above indicator"
+        )
+        .doesNotHaveClass(
+          "--drag-below",
+          "an abandoned drag clears the target's below indicator"
+        )
+        .doesNotHaveClass(
+          "drag-above",
+          "an abandoned drag leaves no legacy above indicator"
+        )
+        .doesNotHaveClass(
+          "drag-below",
+          "an abandoned drag leaves no legacy below indicator"
+        );
+    });
+
+    test(`${REORDER_TEST}: refuses a self drop`, async function (assert) {
+      await renderForm(this);
+
+      const row = rowSelector("Primary 1");
+      const sharedDragIsRegistered =
+        find(row).hasAttribute("data-drag-source") &&
+        find(row).hasAttribute("data-drop-target");
+      const dataTransfer = new DataTransfer();
+      const sourceGrip = gripSelector("Primary 1");
+      const sourceCoordinates = centerOf(sourceGrip);
+      const rowRect = find(row).getBoundingClientRect();
+      const targetCoordinates = {
+        clientX: rowRect.left + rowRect.width / 2,
+        clientY: rowRect.top + 1,
+      };
+
+      assert.true(
+        sharedDragIsRegistered,
+        "the self-drop check runs on a row whose grip is its own source"
+      );
+
+      if (sharedDragIsRegistered) {
+        await dragEvent(sourceGrip, "dragstart", {
+          dataTransfer,
+          ...sourceCoordinates,
+        });
+        await dragEvent(row, "dragenter", {
+          dataTransfer,
+          ...targetCoordinates,
+        });
+        await dragEvent(row, "dragover", {
+          dataTransfer,
+          ...targetCoordinates,
+        });
+
+        assert
+          .dom(row)
+          .doesNotHaveClass(
+            "--drag-above",
+            "a row does not show a drop indicator for itself"
+          )
+          .doesNotHaveClass(
+            "--drag-below",
+            "a row does not resolve itself as a drop position"
+          );
+
+        await dragEvent(row, "drop", {
+          dataTransfer,
+          ...targetCoordinates,
+        });
+        await dragEvent(sourceGrip, "dragend", {
+          dataTransfer,
+          ...sourceCoordinates,
+        });
+      }
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 1", "Primary 2"],
+          secondary: ["Secondary 1", "Secondary 2"],
+        },
+        "dropping a link onto itself leaves both lists unchanged"
+      );
+    });
+
+    test(`${REORDER_TEST}: drags from the grip on mobile too`, async function (assert) {
+      // A touch screen has no keyboard, so the arrows are not a substitute here;
+      // taking the drag away on mobile left the surface with the arrows alone.
+      sinon.stub(this.site, "desktopView").value(false);
+      await renderForm(this);
+
+      const row = ".sidebar-section-form-link";
+      const grip = `${row} .draggable`;
+      const dataTransfer = new DataTransfer();
+
+      assert
+        .dom(grip)
+        .exists(
+          "the grip renders on mobile, so the drag has a target to press"
+        );
+      assert
+        .dom(row)
+        .hasAttribute(
+          "data-drag-source",
+          "",
+          "a mobile row carries an active drag-source registration"
+        );
+      assert
+        .dom(grip)
+        .hasAttribute(
+          "draggable",
+          "true",
+          "and the grip is what a touch press starts the drag from"
+        );
+
+      await dragEvent(grip, "dragstart", {
+        dataTransfer,
+        ...centerOf(grip),
+      });
+      assert
+        .dom(row)
+        .hasClass("--dragging", "a drag pressed on the grip starts on mobile");
+      await dragEvent(grip, "dragend", { dataTransfer, ...centerOf(grip) });
+    });
+
+    test(`${REORDER_TEST}: moves a link down its own list from the menu`, async function (assert) {
+      await renderForm(this);
+
+      await moveLink("Primary 1", "down");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 2", "Primary 1"],
+          secondary: ["Secondary 1", "Secondary 2"],
+        },
+        "the link swaps with the row below it and the other list is untouched"
+      );
+    });
+
+    test(`${REORDER_TEST}: moves a link up its own list from the menu`, async function (assert) {
+      await renderForm(this);
+
+      await moveLink("Secondary 2", "up");
+
+      assert.deepEqual(
+        renderedLinks(),
+        {
+          primary: ["Primary 1", "Primary 2"],
+          secondary: ["Secondary 2", "Secondary 1"],
+        },
+        "a secondary link swaps within Secondary rather than crossing into Primary"
+      );
+    });
+
+    test(`${REORDER_TEST}: offers only the reachable destinations at each list's boundaries`, async function (assert) {
+      await renderForm(this);
+
+      await openLinkMenu("Primary 1");
+      assert
+        .dom(moveItemSelector("up"))
+        .doesNotExist("the first link has nothing above it");
+      assert
+        .dom(moveItemSelector("down"))
+        .exists("a link with a row below it can still move down");
+      await triggerKeyEvent(document.activeElement, "keydown", "Escape");
+
+      await openLinkMenu("Primary 2");
+      assert
+        .dom(moveItemSelector("down"))
+        .doesNotExist("the last primary link has nothing below it");
+      await triggerKeyEvent(document.activeElement, "keydown", "Escape");
+
+      await openLinkMenu("Secondary 1");
+      assert
+        .dom(moveItemSelector("up"))
+        .doesNotExist("each list boundary is counted within that list");
+    });
+
+    test(`${REORDER_TEST}: steps over a link awaiting deletion`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      this.model = { section: sectionWithThreePrimaryLinks() };
+      await renderForm(this);
+
+      await click(`${rowSelector("Primary 2")} .delete-link`);
+      await moveLink("Primary 1", "down");
+
+      assert.deepEqual(
+        renderedLinks().primary,
+        ["Primary 3", "Primary 1"],
+        "the move swaps with the next visible link, not with the deleted one between them"
+      );
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Primary 1 to position 2 of 2",
+        "the position is counted within the visible list"
+      );
+    });
+
+    test(`${REORDER_TEST}: a drag over a link awaiting deletion that changes nothing announces nothing`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      this.model = { section: sectionWithThreePrimaryLinks() };
+      await renderForm(this);
+
+      await click(`${rowSelector("Primary 2")} .delete-link`);
+
+      const before = a11y.politeMessage;
+
+      // Below the link shown above it, which is the position it already holds.
+      // In the underlying array it reads as a move, because of the deleted link
+      // sitting between the two.
+      await dragLink("Primary 3", "Primary 1", "below");
+
+      assert.deepEqual(
+        renderedLinks().primary,
+        ["Primary 1", "Primary 3"],
+        "the visible list is the one it already was"
+      );
+      assert.strictEqual(
+        a11y.politeMessage,
+        before,
+        "so nothing is announced, rather than a position the link never left"
+      );
+    });
+
+    test(`${REORDER_TEST}: walks a link down the list with repeated presses`, async function (assert) {
+      this.model = { section: sectionWithThreePrimaryLinks() };
+      await renderForm(this);
+
+      await moveLink("Primary 1", "down");
+
+      // Through whatever holds focus, which is what a keyboard user presses a
+      // second time. Selecting by name instead would find the right control no
+      // matter where focus went, and so would pass even if the keyboard path
+      // were unusable: on an unkeyed list the row keeps its DOM node and takes
+      // on a different link, so the second press would move the wrong one back.
+      await triggerKeyEvent(document.activeElement, "keydown", "ArrowDown", {
+        altKey: true,
+      });
+
+      assert.deepEqual(
+        renderedLinks().primary,
+        ["Primary 2", "Primary 3", "Primary 1"],
+        "the link keeps moving instead of swapping back and forth"
+      );
+    });
+
+    test(`${REORDER_TEST}: announces a drag by the position the user can see`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      this.model = { section: sectionWithThreePrimaryLinks() };
+      await renderForm(this);
+
+      await click(`${rowSelector("Primary 1")} .delete-link`);
+      await dragLink("Primary 3", "Primary 2", "above");
+
+      assert.deepEqual(
+        renderedLinks().primary,
+        ["Primary 3", "Primary 2"],
+        "the drag reorders the visible list"
+      );
+      // The underlying array still holds the deleted link, so counting there
+      // would announce a position and a total the user cannot see.
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Primary 3 to position 1 of 2",
+        "and the announcement counts only the links still on screen"
+      );
+    });
+
+    test(`${REORDER_TEST}: announces where a menu move landed`, async function (assert) {
+      const a11y = getOwner(this).lookup("service:a11y");
+      await renderForm(this);
+
+      await moveLink("Secondary 2", "up");
+
+      assert.strictEqual(
+        a11y.politeMessage,
+        "Moved Secondary 2 to position 1 of 2",
+        "the announcement counts against the list the link moved within"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/simple-list-reorderable-test.gjs
+++ b/frontend/discourse/tests/integration/components/simple-list-reorderable-test.gjs
@@ -1,0 +1,242 @@
+import { tracked } from "@glimmer/tracking";
+import { getOwner } from "@ember/owner";
+import {
+  blur,
+  click,
+  fillIn,
+  render,
+  settled,
+  triggerKeyEvent,
+} from "@ember/test-helpers";
+import { module, test } from "qunit";
+import SimpleListReorderable from "discourse/admin/components/simple-list-reorderable";
+import DMenus from "discourse/float-kit/components/d-menus";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | SimpleList | reorderable", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    getOwner(this).lookup(
+      "service:site-settings"
+    ).enable_new_reordering_controls = true;
+  });
+
+  test("adding a value", async function (assert) {
+    const values = "vinkas\nosama";
+    await render(
+      <template>
+        <DMenus /><SimpleListReorderable @values={{values}} />
+      </template>
+    );
+
+    assert
+      .dom(".d-reorderable-list__handle")
+      .exists("the reorderable arm rendered");
+    assert.dom(".values .value").exists({ count: 2 });
+    assert.dom(".add-value-btn").isDisabled("disabled when input is empty");
+
+    await fillIn(".add-value-input", "penar");
+    await click(".add-value-btn");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+
+    assert
+      .dom(".values .value[data-reorderable-key='2'] .value-input")
+      .hasValue("penar", "sets the correct value for added item");
+
+    await fillIn(".add-value-input", "eviltrout");
+    await triggerKeyEvent(".add-value-input", "keydown", "Enter");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 4 }, "adds the value when pressing Enter");
+  });
+
+  test("adding a value when list is predefined", async function (assert) {
+    const values = "vinkas\nosama";
+    const choices = ["vinkas", "osama", "kris", "jeff"];
+
+    await render(
+      <template>
+        <DMenus />
+        <SimpleListReorderable
+          @values={{values}}
+          @allowAny={{false}}
+          @choices={{choices}}
+        />
+      </template>
+    );
+
+    await click(".add-value-input summary");
+    assert.dom(".select-kit-row").exists({ count: 2 });
+    await click(".select-kit-row");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+  });
+
+  test("changing a value", async function (assert) {
+    const done = assert.async();
+
+    const values = "vinkas\nosama";
+    const onChange = (collection) => {
+      assert.deepEqual(collection, ["vinkas", "jarek"]);
+      done();
+    };
+
+    await render(
+      <template>
+        <DMenus />
+        <SimpleListReorderable @values={{values}} @onChange={{onChange}} />
+      </template>
+    );
+
+    await fillIn(
+      ".values .value[data-reorderable-key='1'] .value-input",
+      "jarek"
+    );
+    await blur(".values .value[data-reorderable-key='1'] .value-input");
+
+    assert
+      .dom(".values .value[data-reorderable-key='1'] .value-input")
+      .hasValue("jarek");
+  });
+
+  test("removing a value", async function (assert) {
+    const values = "vinkas\nosama";
+    await render(
+      <template>
+        <DMenus /><SimpleListReorderable @values={{values}} />
+      </template>
+    );
+
+    await click(
+      ".values .value[data-reorderable-key='0'] .d-reorderable-list__remove"
+    );
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 1 }, "removes the value from the list of values");
+
+    assert
+      .dom(".values .value[data-reorderable-key='0'] .value-input")
+      .hasValue("osama", "removes the correct value");
+  });
+
+  test("delimiter support", async function (assert) {
+    await render(
+      <template>
+        <DMenus />
+        <SimpleListReorderable @values="vinkas|osama" @inputDelimiter="|" />
+      </template>
+    );
+
+    await fillIn(".add-value-input", "eviltrout");
+    await click(".add-value-btn");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+
+    assert
+      .dom(".values .value[data-reorderable-key='2'] .value-input")
+      .hasValue("eviltrout", "adds the correct value");
+  });
+
+  test("updates when values change", async function (assert) {
+    const state = new (class {
+      @tracked values = "vinkas|osama";
+    })();
+
+    await render(
+      <template>
+        <DMenus />
+        <SimpleListReorderable @values={{state.values}} @inputDelimiter="|" />
+      </template>
+    );
+
+    assert
+      .dom(".values .value[data-reorderable-key='0'] .value-input")
+      .hasValue("vinkas");
+
+    state.values = "kris|jeff";
+    await settled();
+
+    assert
+      .dom(".values .value[data-reorderable-key='0'] .value-input")
+      .hasValue("kris");
+  });
+
+  test("a closed set offers no editable field", async function (assert) {
+    const choices = ["latest", "new", "unread"];
+    const values = "latest|new";
+
+    await render(
+      <template>
+        <DMenus />
+        <SimpleListReorderable
+          @values={{values}}
+          @inputDelimiter="|"
+          @choices={{choices}}
+          @allowAny={{false}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".values input.value-input")
+      .doesNotExist(
+        "a value drawn from a fixed set has nothing to type into it"
+      );
+    assert
+      .dom(".values .value-input.--readonly")
+      .exists({ count: 2 }, "each value still reads as its own row");
+  });
+
+  test("a free-text list keeps its editable field", async function (assert) {
+    const values = "vinkas|osama";
+
+    await render(
+      <template>
+        <DMenus /><SimpleListReorderable
+          @values={{values}}
+          @inputDelimiter="|"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".values input.value-input")
+      .exists(
+        { count: 2 },
+        "an open list is still edited in place, not only added to"
+      );
+  });
+
+  test("removing a value names what it removes", async function (assert) {
+    const values = "vinkas|osama";
+
+    await render(
+      <template>
+        <DMenus /><SimpleListReorderable
+          @values={{values}}
+          @inputDelimiter="|"
+        />
+      </template>
+    );
+
+    assert
+      .dom(
+        ".values .value[data-reorderable-key='0'] .d-reorderable-list__remove"
+      )
+      .hasAria(
+        "label",
+        "Remove vinkas",
+        "the standard control says which value it drops"
+      );
+  });
+});

--- a/frontend/discourse/tests/integration/components/value-list-reorderable-test.gjs
+++ b/frontend/discourse/tests/integration/components/value-list-reorderable-test.gjs
@@ -1,0 +1,174 @@
+import { getOwner } from "@ember/owner";
+import { blur, click, fillIn, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import ValueListReorderable from "discourse/admin/components/value-list-reorderable";
+import DMenus from "discourse/float-kit/components/d-menus";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+
+module("Integration | Component | ValueList | reorderable", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    getOwner(this).lookup(
+      "service:site-settings"
+    ).enable_new_reordering_controls = true;
+  });
+
+  test("adding a value", async function (assert) {
+    this.set("values", "vinkas\nosama");
+
+    await render(
+      <template>
+        <DMenus /><ValueListReorderable @values={{this.values}} />
+      </template>
+    );
+
+    assert
+      .dom(".d-reorderable-list__handle")
+      .exists("the reorderable arm rendered");
+
+    await selectKit().expand();
+    await selectKit().fillInFilter("eviltrout");
+    await selectKit().keyboard("Enter");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+
+    assert.strictEqual(
+      this.values,
+      "vinkas\nosama\neviltrout",
+      "it adds the value to the list of values"
+    );
+  });
+
+  test("changing a value", async function (assert) {
+    this.set("values", "vinkas\nosama");
+
+    await render(
+      <template>
+        <DMenus /><ValueListReorderable @values={{this.values}} />
+      </template>
+    );
+
+    await fillIn(
+      ".values .value[data-reorderable-key='1'] .value-input",
+      "jarek"
+    );
+    await blur(".values .value[data-reorderable-key='1'] .value-input");
+
+    assert
+      .dom(".values .value[data-reorderable-key='1'] .value-input")
+      .hasValue("jarek");
+    assert.deepEqual(this.values, "vinkas\njarek", "updates the value list");
+  });
+
+  test("removing a value", async function (assert) {
+    this.set("values", "vinkas\nosama");
+
+    await render(
+      <template>
+        <DMenus /><ValueListReorderable @values={{this.values}} />
+      </template>
+    );
+
+    await click(
+      ".values .value[data-reorderable-key='0'] .d-reorderable-list__remove"
+    );
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 1 }, "removes the value from the list of values");
+
+    assert.strictEqual(this.values, "osama", "it removes the expected value");
+
+    await selectKit().expand();
+
+    assert
+      .dom(".select-kit-collection li.select-kit-row span.name")
+      .hasText("vinkas", "it adds the removed value to choices");
+  });
+
+  test("selecting a value", async function (assert) {
+    this.setProperties({
+      values: "vinkas\nosama",
+      choices: ["maja", "michael"],
+    });
+
+    await render(
+      <template>
+        <DMenus />
+        <ValueListReorderable
+          @values={{this.values}}
+          @choices={{this.choices}}
+        />
+      </template>
+    );
+
+    await selectKit().expand();
+    await selectKit().selectRowByValue("maja");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+
+    assert.strictEqual(
+      this.values,
+      "vinkas\nosama\nmaja",
+      "it adds the value to the list of values"
+    );
+  });
+
+  test("array support", async function (assert) {
+    this.set("values", ["vinkas", "osama"]);
+
+    await render(
+      <template>
+        <DMenus />
+        <ValueListReorderable @values={{this.values}} @inputType="array" />
+      </template>
+    );
+
+    this.set("values", ["vinkas", "osama"]);
+
+    await selectKit().expand();
+    await selectKit().fillInFilter("eviltrout");
+    await selectKit().selectRowByValue("eviltrout");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+
+    assert.deepEqual(
+      this.values,
+      ["vinkas", "osama", "eviltrout"],
+      "it adds the value to the list of values"
+    );
+  });
+
+  test("delimiter support", async function (assert) {
+    this.set("values", "vinkas|osama");
+
+    await render(
+      <template>
+        <DMenus />
+        <ValueListReorderable @values={{this.values}} @inputDelimiter="|" />
+      </template>
+    );
+
+    await selectKit().expand();
+    await selectKit().fillInFilter("eviltrout");
+    await selectKit().keyboard("Enter");
+
+    assert
+      .dom(".values .value")
+      .exists({ count: 3 }, "adds the value to the list of values");
+
+    assert.strictEqual(
+      this.values,
+      "vinkas|osama|eviltrout",
+      "it adds the value to the list of values"
+    );
+  });
+});

--- a/spec/system/admin_badges_spec.rb
+++ b/spec/system/admin_badges_spec.rb
@@ -150,4 +150,27 @@ describe "Admin Badges Page" do
       expect(page).to have_current_path("/admin/badges")
     end
   end
+
+  context "when enable_new_reordering_controls is enabled" do
+    fab!(:custom_grouping) { BadgeGrouping.create!(name: "Custom grouping", position: 10) }
+
+    before { SiteSetting.enable_new_reordering_controls = true }
+
+    it "draws edit and remove only on the groupings that accept them" do
+      badges_page.visit_page(Badge::Autobiographer).edit_groupings
+
+      expect(page).to have_css(".badge-grouping-item", minimum: 6)
+
+      system_row = find(".badge-grouping-item", text: "Getting Started")
+      custom_row = find(".badge-grouping-item", text: "Custom grouping")
+
+      # A system grouping can be neither renamed nor removed, so it draws neither
+      # control rather than drawing them disabled.
+      expect(system_row).to have_no_css(".btn .d-icon-pencil")
+      expect(system_row).to have_no_css(".d-reorderable-list__remove")
+
+      expect(custom_row).to have_css(".btn .d-icon-pencil")
+      expect(custom_row).to have_css(".d-reorderable-list__remove")
+    end
+  end
 end

--- a/spec/system/admin_dashboard_configure_spec.rb
+++ b/spec/system/admin_dashboard_configure_spec.rb
@@ -73,6 +73,47 @@ describe "Admin Dashboard Configure menu" do
       expect(dashboard).to have_first_section("reports")
       expect(dashboard.section_ids_in_order.first(2)).to eq(%w[reports highlights])
     end
+
+    # TODO (ui-kit-reorderable-list-cleanup) fold these over the examples above
+    # once the change ships and the arrow buttons are gone.
+    context "when enable_new_reordering_controls is enabled" do
+      before { SiteSetting.enable_new_reordering_controls = true }
+
+      it "reorders sections via the move menu on mobile", mobile: true do
+        dashboard.visit
+
+        dashboard.open_configure_menu.move_section_up_via_list("reports")
+
+        # reorder applies immediately, without closing the menu
+        expect(dashboard).to have_first_section("reports")
+        expect(dashboard.section_ids_in_order.first(2)).to eq(%w[reports highlights])
+      end
+
+      it "shows the drag handle on mobile", mobile: true do
+        # The rendering test only proves the handle is in the DOM. A touch screen
+        # reaches the menu as a modal rather than a popover, so this asserts it is
+        # actually visible there, which is the only thing a finger can act on.
+        dashboard.visit
+        dashboard.open_configure_menu
+
+        expect(page).to have_css(".d-reorderable-list__handle")
+      end
+
+      it "reorders sections with a real browser drag" do
+        dashboard.visit
+        dashboard.open_configure_menu
+
+        # Asserted before the drag: without it, a run where the two are already
+        # in the expected order passes whether or not the drag did anything.
+        expect(dashboard.section_ids_in_order.first(2)).to eq(%w[highlights reports])
+
+        dashboard.drag_section("reports", "highlights")
+
+        try_until_success do
+          expect(dashboard.section_ids_in_order.first(2)).to eq(%w[reports highlights])
+        end
+      end
+    end
   end
 
   context "as a moderator" do

--- a/spec/system/admin_dashboard_redesign/reports_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/reports_section_spec.rb
@@ -52,6 +52,68 @@ describe "Admin Dashboard Redesign | Reports section" do
     expect(modal).to have_disabled_move_down("core_report:topics")
   end
 
+  # TODO (ui-kit-reorderable-list-cleanup) fold these over the examples above
+  # once the change ships and the arrow buttons are gone.
+  context "when enable_new_reordering_controls is enabled" do
+    before { SiteSetting.enable_new_reordering_controls = true }
+
+    it "marks the unavailable destinations at the ends of the enabled list on mobile",
+       mobile: true do
+      AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+      AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+      page.visit("/admin")
+      dashboard.open_manage_reports_via_cog
+      expect(modal).to have_open
+
+      expect(modal).to have_no_move_up("core_report:signups")
+      expect(modal).to have_move_down("core_report:signups")
+      expect(modal).to have_move_up("core_report:topics")
+      expect(modal).to have_no_move_down("core_report:topics")
+    end
+
+    it "lets the admin select a report's text" do
+      # A row is a drag source, and a draggable element turns a press-drag into a
+      # drag rather than a selection. The grip is what should be draggable, so the
+      # title and description stay selectable like any other text.
+      #
+      # drag_with_pointer, not drag_and_drop: the latter goes through CDP drag
+      # interception, which suppresses the ordinary mouse moves a selection is
+      # made of. And a real pointer is the only thing that can select at all, as
+      # a synthetic drag never touches the browser's selection.
+      AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+      AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+      page.visit("/admin")
+      dashboard.open_manage_reports_via_cog
+      expect(modal).to have_open
+
+      drag_with_pointer(
+        from: ".manageable-row-list__row.--enabled .manageable-row-list__title",
+        by: {
+          x: 60,
+        },
+      )
+
+      expect(page.evaluate_script("window.getSelection().toString()")).to be_present
+    end
+
+    it "reorders reports with a real browser drag" do
+      AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+      AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+      page.visit("/admin")
+      dashboard.open_manage_reports_via_cog
+      expect(modal).to have_open
+
+      modal.drag_report("core_report:topics", "core_report:signups")
+
+      try_until_success do
+        expect(modal.enabled_identifiers).to eq(%w[core_report:topics core_report:signups])
+      end
+    end
+  end
+
   it "lets admins customize the reports section via the manage-reports modal" do
     AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
     AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)

--- a/spec/system/admin_site_setting_value_list_spec.rb
+++ b/spec/system/admin_site_setting_value_list_spec.rb
@@ -34,5 +34,87 @@ describe "Admin Site Setting Value Lists" do
         expect(settings_page).to have_visible_reorder_buttons("default_emoji_reactions")
       end
     end
+
+    # The reorder control used to be revealed on hover, which a touch screen has
+    # no way to trigger, so these settings were unreorderable on a phone. It is
+    # permanent on every device behind the change, and that parity is what the
+    # first four guard.
+    #
+    # TODO (ui-kit-reorderable-list-cleanup) fold these over the contexts above
+    # once the change ships.
+    context "when enable_new_reordering_controls is enabled" do
+      before { SiteSetting.enable_new_reordering_controls = true }
+
+      context "when on non-touch devices" do
+        it "shows the reorder handle for simple-list settings" do
+          settings_page.visit("top_menu")
+          expect(page).to have_css("html.discourse-no-touch")
+          expect(settings_page).to have_reorder_handle("top_menu")
+        end
+
+        it "shows the reorder handle for emoji-list settings" do
+          settings_page.visit("default_emoji_reactions")
+          expect(page).to have_css("html.discourse-no-touch")
+          expect(settings_page).to have_reorder_handle("default_emoji_reactions")
+        end
+      end
+
+      context "when on touch devices", mobile: true do
+        it "shows the same reorder handle for simple-list settings" do
+          settings_page.visit("top_menu")
+          expect(page).to have_css("html.discourse-touch")
+          expect(settings_page).to have_reorder_handle("top_menu")
+        end
+
+        it "shows the same reorder handle for emoji-list settings" do
+          settings_page.visit("default_emoji_reactions")
+          expect(page).to have_css("html.discourse-touch")
+          expect(settings_page).to have_reorder_handle("default_emoji_reactions")
+        end
+      end
+
+      # The menu is portaled and positioned asynchronously, so focusing a
+      # destination before it has been placed asks the browser to scroll to
+      # wherever the float still sits, which throws the reader to the top of the
+      # settings page they were working in.
+      it "does not scroll the page when the move menu opens" do
+        # Short enough that the settings page has somewhere to scroll from, which
+        # is the whole of what this measures.
+        resize_window(height: 700) do
+          settings_page.visit_category("basic")
+          expect(settings_page).to have_reorder_handle("top_menu")
+
+          page.execute_script(<<~JS)
+            document
+              .querySelector("[data-setting='top_menu'] .d-reorderable-list__handle")
+              .scrollIntoView({ block: "center" });
+          JS
+          before = page.evaluate_script("Math.round(window.scrollY)")
+          expect(before).to be > 0
+
+          settings_page.open_reorder_menu("top_menu")
+
+          expect(page).to have_css(".d-reorderable-list__move-item:focus")
+          expect(page.evaluate_script("Math.round(window.scrollY)")).to eq(before)
+        end
+      end
+
+      # A pointer press does not set focus-visible, and the menu places focus on
+      # a destination as it opens, so a highlight keyed on that alone leaves a
+      # mouse user with a focused item and no way to see which one it is.
+      it "highlights the focused destination when the menu is opened by pointer" do
+        settings_page.visit_category("basic")
+        expect(settings_page).to have_reorder_handle("top_menu")
+
+        settings_page.open_reorder_menu("top_menu")
+
+        expect(page).to have_css(".d-reorderable-list__move-item:focus")
+        background = page.evaluate_script(<<~JS)
+          getComputedStyle(document.querySelector(".d-reorderable-list__move-item:focus"))
+            .backgroundColor
+        JS
+        expect(background).not_to eq("rgba(0, 0, 0, 0)")
+      end
+    end
   end
 end

--- a/spec/system/admin_user_fields_spec.rb
+++ b/spec/system/admin_user_fields_spec.rb
@@ -123,5 +123,22 @@ describe "Admin User Fields" do
 
       expect(escaped).to eq(0)
     end
+
+    it "sizes the drag handle column to the handle" do
+      user_fields_page.visit
+
+      expect(page).to have_css(".admin-user_field-item", count: 2)
+
+      width = page.evaluate_script(<<~JS)
+          Math.round(
+            document
+              .querySelector(".d-reorderable-list__handle")
+              .closest("td")
+              .getBoundingClientRect().width
+          )
+        JS
+
+      expect(width).to be < 60
+    end
   end
 end

--- a/spec/system/admin_user_fields_spec.rb
+++ b/spec/system/admin_user_fields_spec.rb
@@ -103,4 +103,25 @@ describe "Admin User Fields" do
       expect(page).to have_no_text(I18n.t("admin_js.admin.user_fields.requirement.confirmation"))
     end
   end
+
+  context "when enable_new_reordering_controls is enabled" do
+    fab!(:field1) { Fabricate(:user_field, name: "Favourite colour") }
+    fab!(:field2) { Fabricate(:user_field, name: "Home town") }
+
+    before { SiteSetting.enable_new_reordering_controls = true }
+
+    it "keeps each row's controls anchored to its own row on mobile", mobile: true do
+      user_fields_page.visit
+
+      expect(page).to have_css(".admin-user_field-item", count: 2)
+
+      escaped = page.evaluate_script(<<~JS)
+          Array.from(document.querySelectorAll(".d-table__cell.--controls")).filter(
+            (cell) => cell.offsetParent !== cell.closest("tr")
+          ).length
+        JS
+
+      expect(escaped).to eq(0)
+    end
+  end
 end

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -303,6 +303,192 @@ describe "Custom sidebar sections" do
     expect(page).not_to have_css(".sidebar-section-form-link .draggable")
   end
 
+  # TODO (ui-kit-reorderable-list-cleanup) fold these over the examples above
+  # once the change ships.
+  context "when enable_new_reordering_controls is enabled" do
+    before { SiteSetting.enable_new_reordering_controls = true }
+
+    it "lets the user select text in a link's fields" do
+      # The row is a drag source, and a `draggable` element turns a press-drag into
+      # a drag rather than a selection. These rows are a form: the name and URL are
+      # text inputs whose contents a user edits and copies, so only the grip may be
+      # draggable.
+      #
+      # A selection inside a form control does not appear in `window.getSelection`,
+      # so this reads the input's own selection range.
+      sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
+
+      Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags").tap do |sidebar_url|
+        Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+      end
+
+      sign_in user
+      visit("/latest")
+      sidebar.edit_custom_section("My section")
+
+      url_field = ".sidebar-section-form-link input[name='link-url']"
+      # Leftwards and well past the field's edge: the press lands at its centre,
+      # which for a short value is beyond the end of the text, so a short sweep
+      # crosses no characters and would fail whether or not selection works. A
+      # drag running off the edge still selects back to the start.
+      drag_with_pointer(from: url_field, by: { x: -400 })
+
+      expect(
+        page.evaluate_script(
+          "(() => { const i = document.querySelector(\"#{url_field}\"); " \
+            "return i.selectionEnd - i.selectionStart; })()",
+        ),
+      ).to be > 0
+    end
+
+    it "lets the user reorder links in a custom section" do
+      sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
+
+      sidebar_url_1 =
+        Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags").tap do |sidebar_url|
+          Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+        end
+
+      sidebar_url_2 =
+        Fabricate(
+          :sidebar_url,
+          name: "Sidebar Categories",
+          value: "/categories",
+        ).tap do |sidebar_url|
+          Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+        end
+
+      sidebar_url_3 =
+        Fabricate(:sidebar_url, name: "Sidebar Latest", value: "/latest").tap do |sidebar_url|
+          Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+        end
+
+      sign_in user
+
+      visit("/latest")
+
+      expect(sidebar.primary_section_links("my-section")).to eq(
+        ["Sidebar Tags", "Sidebar Categories", "Sidebar Latest"],
+      )
+
+      sidebar.edit_custom_section("My section")
+
+      drag_and_drop(
+        source: ".sidebar-section-form-link:has(.draggable[data-link-name='Sidebar Tags'])",
+        # Press the grip, not the row centre: the centre is a text input, and a
+        # text-selection drag stalls after dragstart.
+        source_position: {
+          x: 16,
+          y: 20,
+        },
+        target: ".sidebar-section-form-link:has(.draggable[data-link-name='Sidebar Categories'])",
+        target_position: {
+          x: 100,
+          y: 55,
+        },
+      )
+      try_until_success do
+        expect(section_modal.link_names).to eq(
+          ["Sidebar Categories", "Sidebar Tags", "Sidebar Latest"],
+        )
+      end
+      section_modal.save
+      expect(section_modal).to be_closed
+
+      try_until_success do
+        expect(sidebar.primary_section_links("my-section")).to eq(
+          ["Sidebar Categories", "Sidebar Tags", "Sidebar Latest"],
+        )
+      end
+    end
+
+    it "lets the user reorder links with the keyboard" do
+      sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
+
+      ["Sidebar Tags", "Sidebar Categories", "Sidebar Latest"].each do |name|
+        Fabricate(:sidebar_url, name: name, value: "/#{name.parameterize}").tap do |sidebar_url|
+          Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+        end
+      end
+
+      sign_in user
+
+      visit("/latest")
+
+      sidebar.edit_custom_section("My section")
+
+      # Asserted before the move: without it, a run where the order already matched
+      # would pass whether or not the arrow did anything.
+      expect(section_modal.link_names).to eq(
+        ["Sidebar Tags", "Sidebar Categories", "Sidebar Latest"],
+      )
+
+      section_modal.move_link_down("Sidebar Tags")
+
+      try_until_success do
+        expect(section_modal.link_names).to eq(
+          ["Sidebar Categories", "Sidebar Tags", "Sidebar Latest"],
+        )
+      end
+
+      # Focus is where the keyboard path lives or dies: the row moves in the DOM
+      # under the pressed control, and a lost focus makes a second press
+      # impossible.
+      expect(section_modal.focused_link_name).to eq("Sidebar Tags")
+
+      # So the second press goes through whatever holds focus, not through another
+      # lookup by name, which would pass even if focus had been dropped.
+      section_modal.press_focused_link_move_down
+
+      try_until_success do
+        expect(section_modal.link_names).to eq(
+          ["Sidebar Categories", "Sidebar Latest", "Sidebar Tags"],
+        )
+      end
+
+      section_modal.save
+      expect(section_modal).to be_closed
+
+      try_until_success do
+        expect(sidebar.primary_section_links("my-section")).to eq(
+          ["Sidebar Categories", "Sidebar Latest", "Sidebar Tags"],
+        )
+      end
+    end
+
+    it "offers both the drag handle and the arrows on mobile", mobile: true do
+      sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
+
+      Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags").tap do |sidebar_url|
+        Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+      end
+
+      Fabricate(:sidebar_url, name: "Sidebar Categories", value: "/categories").tap do |sidebar_url|
+        Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+      end
+
+      sign_in user
+
+      visit("/latest")
+
+      sidebar.open_on_mobile
+      sidebar.edit_custom_section("My section")
+
+      # The handle renders on every viewport now that the drag begins on the grip
+      # rather than anywhere on the row, so a press meant to scroll still scrolls.
+      expect(page).to have_css(".sidebar-section-form-link .draggable")
+
+      # Neither path substitutes for the other: the menu behind the handle is the
+      # only route without a drag, and the drag is the only route without a
+      # keyboard.
+      section_modal.move_link_down("Sidebar Tags")
+
+      try_until_success do
+        expect(section_modal.link_names).to eq(["Sidebar Categories", "Sidebar Tags"])
+      end
+    end
+  end
+
   it "reorders links in the sidebar with drag and drop" do
     sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
     Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags").tap do |sidebar_url|

--- a/spec/system/editing_sidebar_community_section_spec.rb
+++ b/spec/system/editing_sidebar_community_section_spec.rb
@@ -56,6 +56,77 @@ RSpec.describe "Editing Sidebar Community Section" do
     )
   end
 
+  # TODO (ui-kit-reorderable-list-cleanup) fold this over the example above
+  # once the change ships.
+  context "when enable_new_reordering_controls is enabled" do
+    before { SiteSetting.enable_new_reordering_controls = true }
+
+    it "lets an admin reorder and reset the Community section" do
+      sign_in(admin)
+
+      visit("/latest")
+
+      expect(sidebar.primary_section_icons("community")).to eq(
+        %w[layer-group user inbox flag wrench paper-plane ellipsis-vertical],
+      )
+
+      modal = sidebar.click_community_section_more_button.click_customize_community_section_button
+      modal.fill_link("Topics", "/latest", "paper-plane")
+      drag_and_drop(
+        source: ".sidebar-section-form-link:has(.draggable[data-link-name='Topics'])",
+        # Press the grip, not the row centre: the centre is a text input, and a
+        # text-selection drag stalls after dragstart.
+        source_position: {
+          x: 16,
+          y: 20,
+        },
+        target: ".sidebar-section-form-link:has(.draggable[data-link-name='My messages'])",
+        target_position: {
+          x: 100,
+          y: 55,
+        },
+      )
+      try_until_success do
+        expect(modal.link_names).to eq(
+          ["My posts", "My messages", "Topics", "Review", "Admin", "Invite"],
+        )
+      end
+      modal.save
+      modal.confirm_update
+
+      page.refresh
+
+      try_until_success do
+        expect(sidebar.primary_section_links("community")).to eq(
+          ["My posts", "My messages", "Topics", "Review", "Admin", "Invite", "More"],
+        )
+      end
+
+      try_until_success do
+        expect(sidebar.primary_section_icons("community")).to eq(
+          %w[user inbox paper-plane flag wrench paper-plane ellipsis-vertical],
+        )
+      end
+
+      modal = sidebar.click_community_section_more_button.click_customize_community_section_button
+      modal.reset
+
+      expect(sidebar).to have_section("Community")
+
+      try_until_success do
+        expect(sidebar.primary_section_links("community")).to eq(
+          ["Topics", "My posts", "My messages", "Review", "Admin", "Invite", "More"],
+        )
+      end
+
+      try_until_success do
+        expect(sidebar.primary_section_icons("community")).to eq(
+          %w[layer-group user inbox flag wrench paper-plane ellipsis-vertical],
+        )
+      end
+    end
+  end
+
   it "lets an admin localize manually created Community section links" do
     SiteSetting.content_localization_enabled = true
     SiteSetting.content_localization_supported_locales = "ja"

--- a/spec/system/page_objects/components/manageable_row_list_modal.rb
+++ b/spec/system/page_objects/components/manageable_row_list_modal.rb
@@ -63,7 +63,8 @@ module PageObjects
 
       def toggle_for(identifier)
         PageObjects::Components::DToggleSwitch.new(
-          "#{@modal} #{ROW}[data-identifier='#{identifier}'], #{@modal} #{ROW}[data-reorderable-key='#{identifier}'] .d-toggle-switch__checkbox",
+          "#{@modal} #{ROW}[data-identifier='#{identifier}'] .d-toggle-switch__checkbox, " \
+            "#{@modal} #{ROW}[data-reorderable-key='#{identifier}'] .d-toggle-switch__checkbox",
         )
       end
 

--- a/spec/system/page_objects/components/manageable_row_list_modal.rb
+++ b/spec/system/page_objects/components/manageable_row_list_modal.rb
@@ -26,15 +26,19 @@ module PageObjects
       end
 
       def enabled_identifiers
-        all("#{@modal} #{ENABLED_ROW}").map { |el| el["data-identifier"] }
+        all("#{@modal} #{ENABLED_ROW}").map { |el| row_key(el) }
       end
 
       def has_all_row?(identifier)
-        has_css?("#{@modal} #{ROW}[data-identifier='#{identifier}']")
+        has_css?(
+          "#{@modal} #{ROW}[data-identifier='#{identifier}'], #{@modal} #{ROW}[data-reorderable-key='#{identifier}']",
+        )
       end
 
       def has_no_all_row?(identifier)
-        has_no_css?("#{@modal} #{ROW}[data-identifier='#{identifier}']")
+        has_no_css?(
+          "#{@modal} #{ROW}[data-identifier='#{identifier}'], #{@modal} #{ROW}[data-reorderable-key='#{identifier}']",
+        )
       end
 
       def toggle(identifier)
@@ -43,17 +47,23 @@ module PageObjects
       end
 
       def has_toggle_on?(identifier)
-        has_css?("#{@modal} #{ENABLED_ROW}[data-identifier='#{identifier}']")
+        has_css?(
+          "#{@modal} #{ENABLED_ROW}[data-identifier='#{identifier}'], #{@modal} #{ENABLED_ROW}[data-reorderable-key='#{identifier}']",
+        )
       end
 
       def has_toggle_off?(identifier)
-        has_css?("#{@modal} #{ROW}[data-identifier='#{identifier}']") &&
-          has_no_css?("#{@modal} #{ENABLED_ROW}[data-identifier='#{identifier}']")
+        has_css?(
+          "#{@modal} #{ROW}[data-identifier='#{identifier}'], #{@modal} #{ROW}[data-reorderable-key='#{identifier}']",
+        ) &&
+          has_no_css?(
+            "#{@modal} #{ENABLED_ROW}[data-identifier='#{identifier}'], #{@modal} #{ENABLED_ROW}[data-reorderable-key='#{identifier}']",
+          )
       end
 
       def toggle_for(identifier)
         PageObjects::Components::DToggleSwitch.new(
-          "#{@modal} #{ROW}[data-identifier='#{identifier}'] .d-toggle-switch__checkbox",
+          "#{@modal} #{ROW}[data-identifier='#{identifier}'], #{@modal} #{ROW}[data-reorderable-key='#{identifier}'] .d-toggle-switch__checkbox",
         )
       end
 
@@ -100,11 +110,75 @@ module PageObjects
           has_no_css?("#{@modal} .manageable-row-list__list.--reorderable")
       end
 
+      # Methods for when the enable_new_reordering_controls upcoming change is
+      # enabled. The disabled group above keeps main's behaviour; anything whose
+      # meaning differs is named separately rather than swapped in place.
+      #
+      # TODO (ui-kit-reorderable-list-cleanup) fold these over the disabled
+      # group once the change ships.
+
+      # The row's own reorderable list, for driving and inspecting its moves.
+      def reorderable(identifier)
+        PageObjects::Components::ReorderableList.new(reorderable_row_selector(identifier))
+      end
+
+      def has_move_up?(identifier)
+        reorderable(identifier).has_destination?(:up)
+      end
+
+      def has_no_move_up?(identifier)
+        reorderable(identifier).has_no_destination?(:up)
+      end
+
+      def has_move_down?(identifier)
+        reorderable(identifier).has_destination?(:down)
+      end
+
+      def has_no_move_down?(identifier)
+        reorderable(identifier).has_no_destination?(:down)
+      end
+
+      # Distinct from has_drag_controls?, which asks whether the legacy list is
+      # in its reorderable state. This asks whether a row offers a handle.
+      def has_reorderable_handles?
+        has_css?("#{@modal} #{ROW} .d-reorderable-list__handle")
+      end
+
+      def has_no_reorderable_handles?
+        has_css?("#{@modal} #{ROW}") && has_no_css?("#{@modal} #{ROW} .d-reorderable-list__handle")
+      end
+
+      # A real browser drag, which is the only way to prove the row is a
+      # registered drag source rather than merely carrying a handle.
+      def drag_report(source_identifier, target_identifier)
+        drag_and_drop(
+          source: "#{reorderable_row_selector(source_identifier)} .d-reorderable-list__handle",
+          target: reorderable_row_selector(target_identifier),
+          target_position: {
+            x: 100,
+            y: 1,
+          },
+        )
+        self
+      end
+
       def has_counter?(count, max)
         has_css?(
           "#{@modal} .manageable-row-list__counter",
           text: I18n.t(@counter_i18n_key, count:, max:),
         )
+      end
+
+      private
+
+      # Either arm's row identity: the legacy rows name it one way, the shared
+      # list names it another.
+      def row_key(element)
+        element["data-identifier"] || element["data-reorderable-key"]
+      end
+
+      def reorderable_row_selector(identifier)
+        "#{@modal} #{ROW}[data-reorderable-key='#{identifier}']"
       end
     end
   end

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -204,6 +204,54 @@ module PageObjects
         find(".draggable[data-link-name='Review']")
       end
 
+      # Methods for when the enable_new_reordering_controls upcoming change is
+      # enabled. topics_link/review_link above keep main's drag-source lookups.
+      #
+      # TODO (ui-kit-reorderable-list-cleanup) fold these over them once the change
+      # ships.
+
+      # Driven by the keyboard rather than clicked: the reorder control exists
+      # because a drag has no keyboard path, so the spec has to go through the
+      # keyboard to be testing the thing it was added for.
+      def move_link_up(name)
+        link_handle(name).send_keys(%i[alt up])
+      end
+
+      def move_link_down(name)
+        link_handle(name).send_keys(%i[alt down])
+      end
+
+      # Presses whatever the previous move left focused, rather than looking the
+      # handle up again. Finding it by name would pass even if focus had been lost,
+      # which is most of what there is to get wrong here.
+      def press_focused_link_move_down
+        page.driver.with_playwright_page { |pw_page| pw_page.keyboard.press("Alt+ArrowDown") }
+      end
+
+      def open_focused_link_menu
+        page.driver.with_playwright_page { |pw_page| pw_page.keyboard.press("Enter") }
+      end
+
+      # The link whose row currently holds focus. The row is the cursor's item, so
+      # this is what says focus survived a move; the handle inside it is a pointer
+      # affordance and never takes focus from the keyboard.
+      def focused_link_name
+        page.evaluate_script("document.activeElement?.dataset?.linkName")
+      end
+
+      def link_handle(name)
+        find("button[aria-label='Reorder #{name}']")
+      end
+
+      # Read from the name inputs, not from the drag handles, so it reports the
+      # order on a touch screen too, where no handle renders. Scoped away from the
+      # secondary list, which renders in a wrapper of its own.
+      def link_names
+        all(".sidebar-section-form__links-wrapper:not(.--secondary) input[name='link-name']").map(
+          &:value
+        )
+      end
+
       def has_source_language?(locale)
         page.has_css?(
           ".sidebar-section-form__source-locale-select option[value='#{locale}']:checked",

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -182,9 +182,10 @@ module PageObjects
       end
 
       def toggle_section(id)
-        within(".db-configure__row[data-section-id='#{id}']") do
-          find(".d-toggle-switch__label").click
-        end
+        within(
+          ".db-configure__row[data-section-id='#{id}'], " \
+            ".db-configure__row[data-reorderable-key='#{id}']",
+        ) { find(".d-toggle-switch__label").click }
         self
       end
 
@@ -192,6 +193,48 @@ module PageObjects
         within(".db-configure__row[data-section-id='#{id}']") do
           find(".db-configure__arrow:last-child").click
         end
+        self
+      end
+
+      # Methods for when the enable_new_reordering_controls upcoming change is
+
+      # enabled. move_section_up/down above keep main's arrow-button behaviour.
+
+      #
+
+      # TODO (ui-kit-reorderable-list-cleanup) fold these over them once the change
+
+      # ships.
+
+      def configure_reorderable(id)
+        PageObjects::Components::ReorderableList.new(
+          ".db-configure__row[data-reorderable-key='#{id}']",
+        )
+      end
+
+      def move_section_up_via_list(id)
+        configure_reorderable(id).move(:up)
+
+        self
+      end
+
+      def move_section_down_via_list(id)
+        configure_reorderable(id).move(:down)
+
+        self
+      end
+
+      def drag_section(source_id, target_id)
+        drag_and_drop(
+          source:
+            ".db-configure__row[data-reorderable-key='#{source_id}'] .d-reorderable-list__handle",
+          target: ".db-configure__row[data-reorderable-key='#{target_id}']",
+          target_position: {
+            x: 100,
+            y: 1,
+          },
+        )
+
         self
       end
 

--- a/spec/system/page_objects/pages/admin_flags.rb
+++ b/spec/system/page_objects/pages/admin_flags.rb
@@ -71,6 +71,28 @@ module PageObjects
         has_no_css?(".flag-menu-content")
       end
 
+      # Methods for when the enable_new_reordering_controls upcoming change is
+
+      # enabled. move_up/move_down above keep main's menu-driven behaviour.
+
+      #
+
+      # TODO (ui-kit-reorderable-list-cleanup) fold these over them once the
+
+      # change ships.
+
+      def reorderable(key)
+        PageObjects::Components::ReorderableList.new(".admin-flag-item.#{key}")
+      end
+
+      def move_up_via_list(key)
+        reorderable(key).move(:up)
+      end
+
+      def move_down_via_list(key)
+        reorderable(key).move(:down)
+      end
+
       def move_down(key)
         toggle_flag_menu(key)
         find(".admin-flag-item__move-down").click

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -205,6 +205,24 @@ module PageObjects
           has_css?("#{setting_row_selector(setting_name)} .shift-down-value-btn", visible: :hidden)
       end
 
+      # Methods for when the enable_new_reordering_controls upcoming change is
+      # enabled. The two predicates above keep main's arrow-button behaviour.
+      #
+      # TODO (ui-kit-reorderable-list-cleanup) fold these over them once the
+      # change ships.
+      def has_reorder_handle?(setting_name)
+        has_css?("#{setting_row_selector(setting_name)} .d-reorderable-list__handle")
+      end
+
+      def open_reorder_menu(setting_name)
+        find(
+          "#{setting_row_selector(setting_name)} .d-reorderable-list__handle",
+          match: :first,
+        ).click
+        has_css?(".d-reorderable-list__move-item")
+        self
+      end
+
       def category_setting(setting_name)
         PageObjects::Components::SelectKit.new(
           "#{setting_row_selector(setting_name)} .category-chooser",

--- a/spec/system/reordering_screenshots_spec.rb
+++ b/spec/system/reordering_screenshots_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Photographs every reordering surface with `enable_new_reordering_controls`
+# off and on, so the two arms can be compared side by side.
+#
+# TODO (ui-kit-reorderable-list-cleanup) delete this file once the change ships
+# and there is only one arm left to photograph.
+describe "Reordering surfaces" do
+  fab!(:admin)
+  fab!(:user_field) { Fabricate(:user_field, name: "Favourite colour") }
+  fab!(:second_user_field) { Fabricate(:user_field, name: "Home town") }
+
+  let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
+  let(:reports_dashboard) { PageObjects::Pages::AdminDashboardReports.new }
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  let(:user_fields_page) { PageObjects::Pages::AdminUserFields.new }
+  let(:badges_page) { PageObjects::Pages::AdminBadges.new }
+  let(:flags_page) { PageObjects::Pages::AdminFlags.new }
+  let(:section_modal) { PageObjects::Modals::SidebarSectionForm.new }
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
+
+  before do
+    SiteSetting.dashboard_improvements = true
+    sign_in(admin)
+  end
+
+  [false, true].each do |enabled|
+    suffix = enabled ? "on" : "off"
+
+    context "with the change #{suffix}" do
+      before { SiteSetting.enable_new_reordering_controls = enabled }
+
+      it "photographs the dashboard configure menu" do
+        dashboard.visit
+        dashboard.open_configure_menu
+
+        expect(page).to have_css(".db-configure__row")
+        screenshot_marker(label: "reorder-configure-menu-#{suffix}")
+      end
+
+      it "photographs the manage reports modal" do
+        AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+        AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+        page.visit("/admin")
+        reports_dashboard.open_manage_reports_via_cog
+
+        expect(page).to have_css(".manage-reports .manageable-row-list__row")
+        screenshot_marker(label: "reorder-manage-reports-#{suffix}")
+      end
+
+      it "photographs the compare groups modal" do
+        page.visit("/admin")
+        find(".db-whos-posting__add-group").click
+
+        expect(page).to have_css(".compare-groups .manageable-row-list__row")
+        screenshot_marker(label: "reorder-compare-groups-#{suffix}")
+      end
+
+      it "photographs a simple-list setting" do
+        settings_page.visit("top_menu")
+
+        expect(page).to have_css(".value-list .value")
+        screenshot_marker(label: "reorder-simple-list-#{suffix}")
+      end
+
+      it "photographs a value-list setting" do
+        SiteSetting.exclude_rel_nofollow_domains = "example.com|discourse.org"
+        settings_page.visit("exclude_rel_nofollow_domains")
+
+        expect(page).to have_css(".value-list .value")
+        screenshot_marker(label: "reorder-value-list-#{suffix}")
+      end
+
+      it "photographs an emoji-list setting" do
+        settings_page.visit("default_emoji_reactions")
+
+        expect(page).to have_css(".value-list")
+        screenshot_marker(label: "reorder-emoji-list-#{suffix}")
+      end
+
+      it "photographs the admin flags table" do
+        flags_page.visit
+
+        expect(page).to have_css(".admin-flag-item")
+        screenshot_marker(label: "reorder-admin-flags-#{suffix}")
+      end
+
+      it "photographs the user fields table" do
+        user_fields_page.visit
+
+        expect(page).to have_css(".admin-user_field-item")
+        screenshot_marker(label: "reorder-user-fields-#{suffix}")
+      end
+
+      it "photographs the badge groupings modal" do
+        badges_page.visit_page(Badge::Autobiographer).edit_groupings
+
+        expect(page).to have_css(".badge-grouping-item")
+        screenshot_marker(label: "reorder-badge-groupings-#{suffix}")
+      end
+
+      it "photographs the directory columns modal" do
+        page.visit("/u")
+        find(".open-edit-columns-btn").click
+
+        expect(page).to have_css(".edit-directory-column")
+        screenshot_marker(label: "reorder-directory-columns-#{suffix}")
+      end
+
+      it "photographs the sidebar section form" do
+        visit("/latest")
+        sidebar.click_add_section_button
+        expect(section_modal).to be_visible
+
+        section_modal.fill_name("My section")
+        section_modal.fill_link("Sidebar Tags", "/tags")
+        section_modal.add_link
+        section_modal.fill_last_link("Sidebar Categories", "/categories")
+
+        screenshot_marker(label: "reorder-sidebar-links-#{suffix}")
+      end
+    end
+  end
+end

--- a/spec/system/reordering_screenshots_spec.rb
+++ b/spec/system/reordering_screenshots_spec.rb
@@ -10,6 +10,10 @@ describe "Reordering surfaces" do
   fab!(:user_field) { Fabricate(:user_field, name: "Favourite colour") }
   fab!(:second_user_field) { Fabricate(:user_field, name: "Home town") }
 
+  # A non-system grouping, so the badge groupings shot shows a row that can be
+  # renamed and removed next to the ones that cannot.
+  fab!(:custom_grouping) { BadgeGrouping.create!(name: "Custom grouping", position: 10) }
+
   let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
   let(:reports_dashboard) { PageObjects::Pages::AdminDashboardReports.new }
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }


### PR DESCRIPTION
Eleven reorder surfaces move onto `DReorderableList`: the value, simple, URL and
emoji list settings, the dashboard configure menu, manage reports, compare
groups, badge groupings, admin flags, user fields, directory columns, and the
sidebar section form.

All of it sits behind `enable_new_reordering_controls`, an upcoming change that
is off by default. The old code stays and keeps running. Each migrated surface
gets a `-reorderable` sibling and the old component is left alone apart from a
cleanup marker, so `git diff` against the old files is the audit for the off
path. Cleanup is one grep: `TODO (ui-kit-reorderable-list-cleanup)`.

Replaying additively costs size. The two stacked PRs touch more files than the
single unsplit branch did, because both arms now exist. In exchange main's own
tests are an untouched oracle for the off path, and sites can opt in one at a
time.

Three behaviour changes ride the flag rather than shipping on their own. A
closed-set `simple_list` setting no longer renders an editable field. System
badge groupings draw neither an edit nor a remove control, where they used
to draw both disabled. A move renumbers the whole
list instead of swapping neighbours.

One caveat: a sibling resolves under a new name, so an out-of-repo
`modifyClass("component:value-list")` stops applying while the flag is on.
`emoji-value-list` keeps one class and branches in-file, because an in-repo
plugin patches it.

The flag ships at `status: "conceptual"`. Raising it to `experimental` needs a
meta topic for `learn_more_url`.

Both paths are covered: main's tests restored for the old arm, new tests for the
new one, and system specs in both flag states.

## Before and after

Foundation, light, desktop. Left is today, right is the flag on.

<details><summary>Site setting lists</summary>

![value-list](https://github.com/user-attachments/assets/0d743ab8-ad48-4a1f-b76c-fb638b448e86)
![simple-list](https://github.com/user-attachments/assets/b58da8fb-2d14-41e1-8114-4d74dec8f422)
![emoji-list](https://github.com/user-attachments/assets/31a28e24-7340-4b5a-9501-f343b44dc3e3)

</details>

<details><summary>Dashboard</summary>

![configure-menu](https://github.com/user-attachments/assets/80e04466-186c-46ec-a954-fbfb440830f1)
![manage-reports](https://github.com/user-attachments/assets/8132585b-bd47-4807-a607-7cb04dbff0c5)
![compare-groups](https://github.com/user-attachments/assets/bcd0bf6c-7e45-4a48-b9b5-7345a8e68ea5)

</details>

<details><summary>Admin config areas</summary>

![admin-flags](https://github.com/user-attachments/assets/a6f717df-7390-41af-bb26-cba00ba7b6cf)
![user-fields](https://github.com/user-attachments/assets/e05fdc6f-1bad-4dcf-be56-74c391b11d2d)
![badge-groupings](https://github.com/user-attachments/assets/f9e4c880-d6ef-496f-a239-8ab8685e0df0)

</details>

<details><summary>Directory columns and the sidebar section form</summary>

![directory-columns](https://github.com/user-attachments/assets/9873bf24-6e1a-4ae5-8720-a58a088f0377)
![sidebar-links](https://github.com/user-attachments/assets/cbb0032d-6d6b-40ca-853c-1511be412700)

</details>

