### PR TITLE
DEV: add transformer for icons in drafts dropdown

### DIFF
--- a/frontend/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/frontend/discourse/app/components/topic-drafts-dropdown.gjs
@@ -4,6 +4,7 @@ import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import getURL from "discourse/lib/get-url";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import DiscourseURL from "discourse/lib/url";
 import {
   NEW_PRIVATE_MESSAGE_KEY,
@@ -46,13 +47,17 @@ export default class TopicDraftsDropdown extends Component {
   }
 
   draftIcon(item) {
+    let icon;
+
     if (item.draft_key.startsWith(NEW_TOPIC_KEY)) {
-      return "layer-group";
+      icon = "layer-group";
     } else if (item.draft_key.startsWith(NEW_PRIVATE_MESSAGE_KEY)) {
-      return "envelope";
+      icon = "envelope";
     } else {
-      return "reply";
+      icon = "reply";
     }
+
+    return applyValueTransformer("draft-icon", icon, { draft: item });
   }
 
   @action

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -76,6 +76,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "create-topic-button-draft-menu-class",
   "create-topic-icon",
   "create-topic-label",
+  "draft-icon",
   "flag-button-disabled-state",
   "flag-button-dynamic-class",
   "flag-button-render-decision",

--- a/frontend/discourse/tests/acceptance/transformers/draft-icon-test.js
+++ b/frontend/discourse/tests/acceptance/transformers/draft-icon-test.js
@@ -1,0 +1,80 @@
+import { click, visit, waitFor } from "@ember/test-helpers";
+import { test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("draft-icon transformer", function (needs) {
+  needs.user();
+  needs.pretender((server, helper) => {
+    server.get("/drafts.json", () =>
+      helper.response({
+        drafts: [
+          {
+            draft_key: "new_private_message",
+            sequence: 0,
+            draft_username: "eviltrout",
+            username: "eviltrout",
+            user_id: 1,
+            data: '{"reply":"hello","action":"privateMessage","title":"A message draft","recipients":"charlie","archetypeId":"private_message"}',
+          },
+          {
+            draft_key: "new_topic",
+            sequence: 0,
+            draft_username: "eviltrout",
+            username: "eviltrout",
+            user_id: 1,
+            data: '{"reply":"hello","action":"createTopic","title":"A topic draft","archetypeId":"regular"}',
+          },
+        ],
+      })
+    );
+  });
+
+  async function openDraftsMenu() {
+    updateCurrentUser({ draft_count: 2 });
+
+    await visit("/");
+    await click("button.topic-drafts-menu-trigger");
+    await waitFor(".topic-drafts-menu-content");
+  }
+
+  test("renders the default icons", async function (assert) {
+    await openDraftsMenu();
+
+    assert.dom(".topic-drafts-item:first-child svg.d-icon-envelope").exists();
+    assert.dom(".topic-drafts-item:last-child svg.d-icon-layer-group").exists();
+  });
+
+  test("uses the icon returned by the transformer", async function (assert) {
+    withPluginApi((api) => {
+      api.registerValueTransformer("draft-icon", () => "star");
+    });
+
+    await openDraftsMenu();
+
+    assert.dom(".topic-drafts-item:first-child svg.d-icon-star").exists();
+    assert.dom(".topic-drafts-item:last-child svg.d-icon-star").exists();
+  });
+
+  test("the transformer receives the draft as context", async function (assert) {
+    withPluginApi((api) => {
+      api.registerValueTransformer("draft-icon", ({ value, context }) => {
+        return context.draft.draft_key === "new_private_message"
+          ? "star"
+          : value;
+      });
+    });
+
+    await openDraftsMenu();
+
+    assert
+      .dom(".topic-drafts-item:first-child svg.d-icon-star")
+      .exists("the message draft is transformed");
+    assert
+      .dom(".topic-drafts-item:last-child svg.d-icon-layer-group")
+      .exists("the topic draft keeps the default icon");
+  });
+});

--- a/frontend/discourse/tests/acceptance/transformers/draft-icon-test.js
+++ b/frontend/discourse/tests/acceptance/transformers/draft-icon-test.js
@@ -8,26 +8,16 @@ import {
 
 acceptance("draft-icon transformer", function (needs) {
   needs.user();
+
   needs.pretender((server, helper) => {
     server.get("/drafts.json", () =>
       helper.response({
         drafts: [
           {
             draft_key: "new_private_message",
-            sequence: 0,
-            draft_username: "eviltrout",
-            username: "eviltrout",
-            user_id: 1,
-            data: '{"reply":"hello","action":"privateMessage","title":"A message draft","recipients":"charlie","archetypeId":"private_message"}',
+            data: '{"title":"A message draft"}',
           },
-          {
-            draft_key: "new_topic",
-            sequence: 0,
-            draft_username: "eviltrout",
-            username: "eviltrout",
-            user_id: 1,
-            data: '{"reply":"hello","action":"createTopic","title":"A topic draft","archetypeId":"regular"}',
-          },
+          { draft_key: "new_topic", data: '{"title":"A topic draft"}' },
         ],
       })
     );
@@ -48,18 +38,7 @@ acceptance("draft-icon transformer", function (needs) {
     assert.dom(".topic-drafts-item:last-child svg.d-icon-layer-group").exists();
   });
 
-  test("uses the icon returned by the transformer", async function (assert) {
-    withPluginApi((api) => {
-      api.registerValueTransformer("draft-icon", () => "star");
-    });
-
-    await openDraftsMenu();
-
-    assert.dom(".topic-drafts-item:first-child svg.d-icon-star").exists();
-    assert.dom(".topic-drafts-item:last-child svg.d-icon-star").exists();
-  });
-
-  test("the transformer receives the draft as context", async function (assert) {
+  test("uses the icon returned by the transformer for the draft it receives", async function (assert) {
     withPluginApi((api) => {
       api.registerValueTransformer("draft-icon", ({ value, context }) => {
         return context.draft.draft_key === "new_private_message"

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-draft-icon.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-draft-icon.js
@@ -1,0 +1,16 @@
+import { apiInitializer } from "discourse/lib/api";
+import { isAiBotRecipient } from "../lib/ai-bot-helper";
+
+export default apiInitializer((api) => {
+  const currentUser = api.getCurrentUser();
+
+  if (!currentUser?.ai_enabled_chat_bots?.length) {
+    return;
+  }
+
+  api.registerValueTransformer("draft-icon", ({ value, context }) => {
+    return isAiBotRecipient(context.draft?.data?.recipients, currentUser)
+      ? "robot"
+      : value;
+  });
+});

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-bot-helper.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-bot-helper.js
@@ -57,3 +57,17 @@ export function showShareConversationModal(modal, topicId) {
     })
     .catch(popupAjaxError);
 }
+
+export function isAiBotRecipient(recipients, currentUser) {
+  if (!recipients) {
+    return false;
+  }
+
+  const usernames = recipients
+    .split(",")
+    .map((username) => username.trim().toLowerCase());
+
+  return !!currentUser?.ai_enabled_chat_bots?.some((bot) =>
+    usernames.includes(bot.username.toLowerCase())
+  );
+}

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-draft-icon-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-draft-icon-test.js
@@ -5,41 +5,10 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
-// a user only ever has one draft per key, so the message draft is the only
-// place a bot recipient can show up in this menu
-function draftsResponse(recipients) {
-  return {
-    drafts: [
-      {
-        draft_key: "new_private_message",
-        sequence: 0,
-        draft_username: "eviltrout",
-        username: "eviltrout",
-        user_id: 1,
-        data: JSON.stringify({
-          reply: "hello",
-          action: "privateMessage",
-          title: "A message draft",
-          recipients,
-          archetypeId: "private_message",
-        }),
-      },
-      {
-        draft_key: "topic_280",
-        sequence: 0,
-        draft_username: "eviltrout",
-        username: "eviltrout",
-        user_id: 1,
-        topic_id: 280,
-        title: "A reply draft",
-        data: '{"reply":"hello","action":"reply","archetypeId":"regular"}',
-      },
-    ],
-  };
-}
-
 acceptance("AI Bot - Drafts dropdown icon", function (needs) {
-  let recipients = "gpt4_bot";
+  // a user only ever has one draft per key, so the message draft is the only
+  // place a bot recipient can show up in this menu
+  let recipients;
 
   needs.user({
     ai_enabled_chat_bots: [{ id: -110, username: "gpt4_bot" }],
@@ -52,48 +21,41 @@ acceptance("AI Bot - Drafts dropdown icon", function (needs) {
 
   needs.pretender((server, helper) => {
     server.get("/drafts.json", () =>
-      helper.response(draftsResponse(recipients))
+      helper.response({
+        drafts: [
+          {
+            draft_key: "new_private_message",
+            sequence: 0,
+            draft_username: "eviltrout",
+            username: "eviltrout",
+            user_id: 1,
+            data: JSON.stringify({
+              reply: "hello",
+              action: "privateMessage",
+              title: "A message draft",
+              recipients,
+              archetypeId: "private_message",
+            }),
+          },
+        ],
+      })
     );
   });
 
-  async function openDraftsMenu() {
-    updateCurrentUser({ draft_count: 2 });
+  [
+    ["gpt4_bot", "robot"],
+    ["charlie,gpt4_bot", "robot"],
+    ["charlie", "envelope"],
+  ].forEach(([draftRecipients, icon]) => {
+    test(`a message draft addressed to ${draftRecipients} uses the ${icon} icon`, async function (assert) {
+      recipients = draftRecipients;
+      updateCurrentUser({ draft_count: 1 });
 
-    await visit("/");
-    await click("button.topic-drafts-menu-trigger");
-    await waitFor(".topic-drafts-menu-content");
-  }
+      await visit("/");
+      await click("button.topic-drafts-menu-trigger");
+      await waitFor(".topic-drafts-menu-content");
 
-  test("uses the robot icon for a message draft addressed to a bot", async function (assert) {
-    recipients = "gpt4_bot";
-
-    await openDraftsMenu();
-
-    assert
-      .dom(".topic-drafts-item:first-child svg.d-icon-robot")
-      .exists("bot message draft uses the robot icon");
-    assert
-      .dom(".topic-drafts-item:last-child svg.d-icon-reply")
-      .exists("other drafts keep their icon");
-  });
-
-  test("uses the robot icon when a bot is one of several recipients", async function (assert) {
-    recipients = "charlie,gpt4_bot";
-
-    await openDraftsMenu();
-
-    assert
-      .dom(".topic-drafts-item:first-child svg.d-icon-robot")
-      .exists("a message draft including a bot uses the robot icon");
-  });
-
-  test("keeps the envelope icon for a message draft without a bot", async function (assert) {
-    recipients = "charlie";
-
-    await openDraftsMenu();
-
-    assert
-      .dom(".topic-drafts-item:first-child svg.d-icon-envelope")
-      .exists("regular message draft keeps the envelope icon");
+      assert.dom(`.topic-drafts-item svg.d-icon-${icon}`).exists();
+    });
   });
 });

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-draft-icon-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-draft-icon-test.js
@@ -1,0 +1,99 @@
+import { click, visit, waitFor } from "@ember/test-helpers";
+import { test } from "qunit";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+
+// a user only ever has one draft per key, so the message draft is the only
+// place a bot recipient can show up in this menu
+function draftsResponse(recipients) {
+  return {
+    drafts: [
+      {
+        draft_key: "new_private_message",
+        sequence: 0,
+        draft_username: "eviltrout",
+        username: "eviltrout",
+        user_id: 1,
+        data: JSON.stringify({
+          reply: "hello",
+          action: "privateMessage",
+          title: "A message draft",
+          recipients,
+          archetypeId: "private_message",
+        }),
+      },
+      {
+        draft_key: "topic_280",
+        sequence: 0,
+        draft_username: "eviltrout",
+        username: "eviltrout",
+        user_id: 1,
+        topic_id: 280,
+        title: "A reply draft",
+        data: '{"reply":"hello","action":"reply","archetypeId":"regular"}',
+      },
+    ],
+  };
+}
+
+acceptance("AI Bot - Drafts dropdown icon", function (needs) {
+  let recipients = "gpt4_bot";
+
+  needs.user({
+    ai_enabled_chat_bots: [{ id: -110, username: "gpt4_bot" }],
+  });
+
+  needs.settings({
+    discourse_ai_enabled: true,
+    ai_bot_enabled: true,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/drafts.json", () =>
+      helper.response(draftsResponse(recipients))
+    );
+  });
+
+  async function openDraftsMenu() {
+    updateCurrentUser({ draft_count: 2 });
+
+    await visit("/");
+    await click("button.topic-drafts-menu-trigger");
+    await waitFor(".topic-drafts-menu-content");
+  }
+
+  test("uses the robot icon for a message draft addressed to a bot", async function (assert) {
+    recipients = "gpt4_bot";
+
+    await openDraftsMenu();
+
+    assert
+      .dom(".topic-drafts-item:first-child svg.d-icon-robot")
+      .exists("bot message draft uses the robot icon");
+    assert
+      .dom(".topic-drafts-item:last-child svg.d-icon-reply")
+      .exists("other drafts keep their icon");
+  });
+
+  test("uses the robot icon when a bot is one of several recipients", async function (assert) {
+    recipients = "charlie,gpt4_bot";
+
+    await openDraftsMenu();
+
+    assert
+      .dom(".topic-drafts-item:first-child svg.d-icon-robot")
+      .exists("a message draft including a bot uses the robot icon");
+  });
+
+  test("keeps the envelope icon for a message draft without a bot", async function (assert) {
+    recipients = "charlie";
+
+    await openDraftsMenu();
+
+    assert
+      .dom(".topic-drafts-item:first-child svg.d-icon-envelope")
+      .exists("regular message draft keeps the envelope icon");
+  });
+});

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-draft-icon-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-draft-icon-test.js
@@ -6,8 +6,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("AI Bot - Drafts dropdown icon", function (needs) {
-  // a user only ever has one draft per key, so the message draft is the only
-  // place a bot recipient can show up in this menu
   let recipients;
 
   needs.user({
@@ -25,37 +23,37 @@ acceptance("AI Bot - Drafts dropdown icon", function (needs) {
         drafts: [
           {
             draft_key: "new_private_message",
-            sequence: 0,
-            draft_username: "eviltrout",
-            username: "eviltrout",
-            user_id: 1,
-            data: JSON.stringify({
-              reply: "hello",
-              action: "privateMessage",
-              title: "A message draft",
-              recipients,
-              archetypeId: "private_message",
-            }),
+            data: JSON.stringify({ recipients }),
           },
         ],
       })
     );
   });
 
-  [
-    ["gpt4_bot", "robot"],
-    ["charlie,gpt4_bot", "robot"],
-    ["charlie", "envelope"],
-  ].forEach(([draftRecipients, icon]) => {
-    test(`a message draft addressed to ${draftRecipients} uses the ${icon} icon`, async function (assert) {
-      recipients = draftRecipients;
-      updateCurrentUser({ draft_count: 1 });
+  async function openDraftsMenu(draftRecipients) {
+    recipients = draftRecipients;
+    updateCurrentUser({ draft_count: 1 });
 
-      await visit("/");
-      await click("button.topic-drafts-menu-trigger");
-      await waitFor(".topic-drafts-menu-content");
+    await visit("/");
+    await click("button.topic-drafts-menu-trigger");
+    await waitFor(".topic-drafts-menu-content");
+  }
 
-      assert.dom(`.topic-drafts-item svg.d-icon-${icon}`).exists();
-    });
+  test("uses the robot icon for a draft addressed to a bot", async function (assert) {
+    await openDraftsMenu("gpt4_bot");
+
+    assert.dom(".topic-drafts-item svg.d-icon-robot").exists();
+  });
+
+  test("uses the robot icon when a bot is one of several recipients", async function (assert) {
+    await openDraftsMenu("charlie,gpt4_bot");
+
+    assert.dom(".topic-drafts-item svg.d-icon-robot").exists();
+  });
+
+  test("keeps the envelope icon when no recipient is a bot", async function (assert) {
+    await openDraftsMenu("charlie");
+
+    assert.dom(".topic-drafts-item svg.d-icon-envelope").exists();
   });
 });


### PR DESCRIPTION
Enables plugins to register a value transformer to set the icon in the drafts dropdown.

The initial use case is adding a robot icon for PMs with an AI bot as part of the Discourse AI plugin.

How it looks:

<img width="619" height="305" alt="ai-bot-draft-icon" src="https://github.com/user-attachments/assets/5173a7b5-89e5-48ed-a563-9ea312726408" />
