### PR TITLE
FIX: isolate hidden site setting specs from promoted upcoming changes

### DIFF
--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -892,8 +892,6 @@ RSpec.describe SiteSettingExtension do
       settings.refresh!
     end
 
-    after { DiscoursePluginRegistry.reset! }
-
     it "is in the `hidden_settings` collection" do
       expect(settings.hidden_settings.include?(:superman_identity)).to eq(true)
     end
@@ -915,25 +913,32 @@ RSpec.describe SiteSettingExtension do
     it "does not call the hidden_site_settings plugin modifier in a loop" do
       called = 0
       plugin = Plugin::Instance.new
-      plugin.register_modifier(:hidden_site_settings) do |defaults|
+      modifier = ->(defaults) do
         called += 1
         defaults + [:other_setting]
       end
+      plugin.register_modifier(:hidden_site_settings, &modifier)
+
       settings.all_settings(include_hidden: true)
       expect(called).to eq(1)
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(plugin, :hidden_site_settings, &modifier)
     end
 
     it "calls the site_setting_result modifier for each setting" do
       plugin = Plugin::Instance.new
-      plugin.register_modifier(:site_setting_result) do |opts|
+      modifier = ->(opts) do
         opts[:custom_attribute] = "test_value" if opts[:setting] == :other_setting
         opts
       end
+      plugin.register_modifier(:site_setting_result, &modifier)
 
       result = settings.all_settings
       other_setting = result.find { |s| s[:setting] == :other_setting }
 
       expect(other_setting[:custom_attribute]).to eq("test_value")
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(plugin, :site_setting_result, &modifier)
     end
   end
 

--- a/spec/lib/site_settings/hidden_provider_spec.rb
+++ b/spec/lib/site_settings/hidden_provider_spec.rb
@@ -1,51 +1,69 @@
 # frozen_string_literal: true
 
 RSpec.describe SiteSettings::HiddenProvider do
-  let(:provider_local) { SiteSettings::LocalProcessProvider.new }
-  let(:settings) { new_settings(provider_local) }
   let(:hidden_provider) { SiteSettings::HiddenProvider.new }
 
   describe "all" do
-    after { DiscoursePluginRegistry.clear_modifiers! }
-
     it "can return defaults" do
       hidden_provider.add_hidden(:secret_setting)
       hidden_provider.add_hidden(:internal_thing)
-      expect(hidden_provider.all).to contain_exactly(:secret_setting, :internal_thing)
+      expect(hidden_provider.all).to include(:secret_setting, :internal_thing)
 
       hidden_provider.remove_hidden(:secret_setting)
-      expect(hidden_provider.all).to contain_exactly(:internal_thing)
+      expect(hidden_provider.all).to include(:internal_thing)
+      expect(hidden_provider.all).not_to include(:secret_setting)
     end
 
     it "can return results from modifiers" do
       hidden_provider.add_hidden(:secret_setting)
       plugin = Plugin::Instance.new
-      plugin.register_modifier(:hidden_site_settings) { |defaults| defaults + [:other_setting] }
-      expect(hidden_provider.all).to contain_exactly(:secret_setting, :other_setting)
+      modifier = ->(defaults) { defaults + [:other_setting] }
+      plugin.register_modifier(:hidden_site_settings, &modifier)
+
+      expect(hidden_provider.all).to include(:secret_setting, :other_setting)
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(plugin, :hidden_site_settings, &modifier)
     end
 
-    it "includes settings hidden by an enabled upcoming change that declares hide_settings" do
-      mock_upcoming_change_metadata(
-        {
-          enable_upload_debug_mode: {
-            impact: "other,developers",
-            status: :experimental,
-            impact_type: "other",
-            impact_role: "developers",
-            hide_settings: %i[allow_uncategorized_topics],
+    context "with an upcoming change that declares hide_settings" do
+      # A name no real setting uses, so a change shipping `hide_settings` in
+      # `site_settings.yml` can never collide with these expectations.
+      let(:legacy_setting) { :stand_in_legacy_setting }
+
+      def mock_change_hiding_legacy_setting(status:)
+        mock_upcoming_change_metadata(
+          {
+            enable_upload_debug_mode: {
+              impact: "other,developers",
+              status: status,
+              impact_type: "other",
+              impact_role: "developers",
+              hide_settings: [legacy_setting],
+            },
           },
-        },
-      )
-      hidden_provider.add_hidden(:secret_setting)
+        )
+      end
 
-      expect(hidden_provider.all).to contain_exactly(:secret_setting)
+      it "hides them once an admin opts in" do
+        mock_change_hiding_legacy_setting(status: :experimental)
 
-      SiteSetting.enable_upload_debug_mode = true
+        expect(hidden_provider.all).not_to include(legacy_setting)
 
-      expect(hidden_provider.all).to contain_exactly(:secret_setting, :allow_uncategorized_topics)
-    ensure
-      SiteSetting.remove_override!(:enable_upload_debug_mode)
-      UpcomingChanges.clear_caches!
+        SiteSetting.enable_upload_debug_mode = true
+
+        expect(hidden_provider.all).to include(legacy_setting)
+      end
+
+      it "hides them when auto-promotion enables the change on its own" do
+        mock_change_hiding_legacy_setting(status: :beta)
+
+        SiteSetting.promote_upcoming_changes_on_status = :stable
+        expect(hidden_provider.all).not_to include(legacy_setting)
+
+        SiteSetting.promote_upcoming_changes_on_status = :beta
+
+        expect(hidden_provider.all).to include(legacy_setting)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, `hidden_provider_spec` asserted an exact hidden set and reused a real setting as its `hide_settings` stand-in, so the first upcoming change to declare `hide_settings` at or above `promote_upcoming_changes_on_status` made it fail ([#42772](https://github.com/discourse/discourse/pull/42772)).

This change asserts only on the settings each example controls and uses a setting name no real change can ship, so the spec is independent of which real changes are promoted; the global `DiscoursePluginRegistry` resets are also swapped for scoped `unregister_modifier` calls. 