### PR TITLE
FIX: Show the avatar a user was flagged for

### DIFF
--- a/app/serializers/reviewable_user_serializer.rb
+++ b/app/serializers/reviewable_user_serializer.rb
@@ -9,6 +9,7 @@ class ReviewableUserSerializer < ReviewableSerializer
     :name,
     :bio,
     :website,
+    :avatar_url,
     :scrubbed_by,
     :scrubbed_reason,
     :scrubbed_at,

--- a/spec/serializers/reviewable_user_serializer_spec.rb
+++ b/spec/serializers/reviewable_user_serializer_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe ReviewableUserSerializer do
     Jobs::CreateUserReviewable.new.execute(user_id: user.id)
   end
 
+  it "includes the avatar the user was flagged for" do
+    upload = Fabricate(:image_upload, user: user)
+    user.update!(uploaded_avatar_id: upload.id)
+    reviewable.update!(payload: ReviewableUser.payload_for(user.reload))
+
+    json = ReviewableUserSerializer.new(reviewable, scope: Guardian.new(admin), root: nil).as_json
+
+    expect(json[:payload]["avatar_url"]).to eq(Discourse.store.cdn_url(upload.reload.url))
+  end
+
   it "includes the user fields for review" do
     json = ReviewableUserSerializer.new(reviewable, scope: Guardian.new(admin), root: nil).as_json
     expect(json[:user_id]).to eq(reviewable.target_id)


### PR DESCRIPTION
The review queue template renders `payload.avatar_url`, but the serializer never whitelisted it, so the avatar block never appeared.

**BEFORE**

<img width="1058" height="711" alt="43006-review-queue-BEFORE" src="https://github.com/user-attachments/assets/3cfa0f76-7693-4e41-b964-45936bdc50e5" />

**AFTER**

<img width="1058" height="820" alt="43006-review-queue-AFTER" src="https://github.com/user-attachments/assets/be6f99dd-9c8d-4e5a-a230-97bc5173dc31" />

Follow-up to #42730 (got lost in the stack)
