### PR TITLE
FIX: Don't blow up on a prompt that references a deleted upload

### DIFF
--- a/plugins/discourse-ai/lib/completions/upload_encoder.rb
+++ b/plugins/discourse-ai/lib/completions/upload_encoder.rb
@@ -20,8 +20,10 @@ module DiscourseAi
       )
         uploads = []
         allowed_attachment_types = normalize_attachment_types(allowed_attachment_types)
+        uploads_by_id = Upload.where(id: upload_ids).index_by(&:id)
+
         upload_ids.each do |upload_id|
-          upload = Upload.find(upload_id)
+          upload = uploads_by_id[upload_id]
           next if upload.blank?
 
           extension = upload.extension&.downcase

--- a/plugins/discourse-ai/spec/lib/completions/upload_encoder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/upload_encoder_spec.rb
@@ -135,6 +135,12 @@ RSpec.describe DiscourseAi::Completions::UploadEncoder do
     expect(encoded[0][:mime_type]).to eq("image/jpeg")
   end
 
+  it "does not raise when an upload no longer exists" do
+    missing_id = Upload.maximum(:id).to_i + 1
+
+    expect(described_class.encode(upload_ids: [missing_id], max_pixels: 1_048_576)).to be_empty
+  end
+
   describe ".doc, .docx, .xls, and .xlsx uploads" do
     before { SiteSetting.authorized_extensions = "*" }
 


### PR DESCRIPTION
`Upload.find` raises when the row is gone, which made the `blank?` guard right below it dead code and turned a stale upload id into a 500 for the whole completion. Loading the batch up front also drops the query per upload.

Stacked on #43006.
