### PR TITLE
PERF: Preload access control posts when filtering prompt uploads

### DIFF
--- a/plugins/discourse-ai/lib/completions/prompt_messages_builder.rb
+++ b/plugins/discourse-ai/lib/completions/prompt_messages_builder.rb
@@ -290,22 +290,21 @@ module DiscourseAi
         return if upload_ids.blank?
 
         upload_ids = Array(upload_ids).compact.map(&:to_i)
-        uploads_by_id = Upload.where(id: upload_ids).index_by(&:id)
+        uploads_by_id = uploads_for_prompt(upload_ids).index_by(&:id)
 
-        filtered_upload_ids =
-          upload_ids.select do |upload_id|
-            upload = uploads_by_id[upload_id]
-            upload &&
-              upload_allowed_for_prompt?(
-                upload,
-                include_image_uploads: include_image_uploads,
-                include_document_uploads: include_document_uploads,
-                allowed_attachment_types: allowed_attachment_types,
-                guardian: guardian,
-              )
-          end
+        filtered_upload_ids_from_uploads(
+          upload_ids.filter_map { |upload_id| uploads_by_id[upload_id] },
+          include_image_uploads: include_image_uploads,
+          include_document_uploads: include_document_uploads,
+          allowed_attachment_types: allowed_attachment_types,
+          guardian: guardian,
+        )
+      end
 
-        filtered_upload_ids.presence
+      # Upload#access_control_post is deliberately wrapped in Post.unscoped so a deleted
+      # post still hides its uploads; a bare includes would bypass that and expose them
+      def self.uploads_for_prompt(upload_ids)
+        Post.unscoped { Upload.where(id: upload_ids).includes(:access_control_post).to_a }
       end
 
       def self.filtered_upload_ids_from_uploads(

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -7,6 +7,36 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
   fab!(:bot_user, :user)
   fab!(:other_user, :user)
 
+  describe ".filtered_upload_ids_for_prompt" do
+    def filter(upload_ids, guardian)
+      described_class.filtered_upload_ids_for_prompt(
+        upload_ids,
+        include_image_uploads: true,
+        include_document_uploads: false,
+        guardian: guardian,
+      )
+    end
+
+    it "does not load an access control post per secure upload" do
+      post = Fabricate(:post)
+      uploads =
+        3.times.map { Fabricate(:image_upload, secure: true, access_control_post_id: post.id) }
+
+      queries = track_sql_queries { filter(uploads.map(&:id), Guardian.new(Discourse.system_user)) }
+
+      expect(queries.count { |sql| sql.include?(%{FROM "posts"}) }).to eq(1)
+    end
+
+    it "still hides an upload whose access control post was deleted" do
+      post = Fabricate(:private_message_post)
+      upload = Fabricate(:image_upload)
+      upload.update!(access_control_post_id: post.id, secure: true)
+      post.trash!
+
+      expect(filter([upload.id], Fabricate(:user).guardian)).to be_nil
+    end
+  end
+
   fab!(:image_upload1) do
     Fabricate(:upload, user: user, original_filename: "image.png", extension: "png")
   end


### PR DESCRIPTION
Filtering ran a guardian check per upload, and each one lazily loaded that upload's access control post, so a post with a dozen secure images cost a dozen extra queries. Preload them instead.

The preload has to happen inside `Post.unscoped`, because `Upload` only unscopes in its own association reader: preloading outside it would resolve a deleted post to nil and hand the model an upload the guardian would otherwise have hidden. There's a regression test for that.

Stacked on #43010.
