### PR TITLE
FEATURE: Surface workflow executions that succeeded with warnings

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4822,7 +4822,8 @@ CREATE TABLE public.discourse_workflows_executions (
     started_at timestamp(6) without time zone,
     finished_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    warned boolean DEFAULT false NOT NULL
 );
 
 
@@ -23357,6 +23358,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260828152020'),
 ('20260826124054'),
 ('20260824091843'),
 ('20260824072257'),

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/execution/manager.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/execution/manager.gjs
@@ -26,8 +26,11 @@ const STATUS_ICONS = {
   waiting: "clock",
 };
 
-function statusIcon(status) {
-  return STATUS_ICONS[status] || "circle";
+function statusIcon(execution) {
+  if (execution.warned) {
+    return "triangle-exclamation";
+  }
+  return STATUS_ICONS[execution.status] || "circle";
 }
 
 function formatTime(timestamp) {
@@ -334,12 +337,13 @@ export default class ExecutionsManager extends Component {
               {{i18n "discourse_workflows.executions.status"}}
             </div>
             <span
-              class="workflows-executions-manager__status --{{execution.status}}"
+              class="workflows-executions-manager__status --{{execution.status}}
+                {{if execution.warned '--warned'}}"
             >
               {{#if (isRunning execution)}}
                 {{dLoadingSpinner size="small"}}
               {{else}}
-                {{dIcon (statusIcon execution.status)}}
+                {{dIcon (statusIcon execution)}}
               {{/if}}
               {{i18n
                 (concat
@@ -359,12 +363,13 @@ export default class ExecutionsManager extends Component {
               {{i18n "discourse_workflows.executions.status"}}
             </div>
             <span
-              class="workflows-executions-manager__status --{{execution.status}}"
+              class="workflows-executions-manager__status --{{execution.status}}
+                {{if execution.warned '--warned'}}"
             >
               {{#if (isRunning execution)}}
                 {{dLoadingSpinner size="small"}}
               {{else}}
-                {{dIcon (statusIcon execution.status)}}
+                {{dIcon (statusIcon execution)}}
               {{/if}}
               {{i18n
                 (concat

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/executions/detail.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/executions/detail.gjs
@@ -146,24 +146,20 @@ function conditionOperatorLabel(operator) {
   return i18n(`discourse_workflows.if.operators.${localeKeyPart(operator)}`);
 }
 
-function formatLogs(logs) {
-  return logs
-    .map((entry) => {
-      if (typeof entry === "string") {
-        return entry;
-      }
-      const prefix =
-        entry.level === "error"
-          ? "[error] "
-          : entry.level === "warn"
-            ? "[warn] "
-            : "";
-      if (entry.key !== undefined) {
-        return `${prefix}${entry.key}: ${entry.value}`;
-      }
-      return `${prefix}${entry.message}`;
-    })
-    .join("\n");
+function warningCount(step) {
+  return (step.metadata?.logs || []).filter((entry) => entry?.level === "warn")
+    .length;
+}
+
+function logEntries(logs) {
+  return logs.map((entry) => {
+    if (typeof entry === "string") {
+      return { level: "info", text: entry };
+    }
+    const text =
+      entry.key === undefined ? entry.message : `${entry.key}: ${entry.value}`;
+    return { level: entry.level || "info", text };
+  });
 }
 
 function nodeKind(nodeType) {
@@ -276,6 +272,13 @@ export default class ExecutionDetail extends Component {
 
   get isRunning() {
     return isRunning(this.execution);
+  }
+
+  get warningCount() {
+    return (this.execution?.steps || []).reduce(
+      (total, step) => total + warningCount(step),
+      0
+    );
   }
 
   get isActive() {
@@ -461,9 +464,10 @@ export default class ExecutionDetail extends Component {
       if (step.metadata?.logs?.length) {
         lines.push("  Console:");
         lines.push(
-          ...formatLogs(step.metadata.logs)
-            .split("\n")
-            .map((l) => `    ${l}`)
+          ...logEntries(step.metadata.logs).map(
+            ({ level, text }) =>
+              `    ${level === "info" ? text : `[${level}] ${text}`}`
+          )
         );
       }
 
@@ -517,6 +521,15 @@ export default class ExecutionDetail extends Component {
               )
             }}
           </span>
+          {{#if this.execution.warned}}
+            <span class="workflows-execution-detail__progress-warning">
+              {{dIcon "triangle-exclamation"}}
+              {{i18n
+                "discourse_workflows.executions.warnings_count"
+                count=this.warningCount
+              }}
+            </span>
+          {{/if}}
           <span class="workflows-execution-detail__progress-time">
             {{formatDuration
               this.execution.started_at
@@ -564,6 +577,7 @@ export default class ExecutionDetail extends Component {
         {{#each this.execution.steps as |step|}}
           <div
             class="workflows-execution-detail__step --{{step.status}}
+              {{if step.warned '--warned'}}
               --kind-{{nodeKind step.node_type}}"
           >
             <div class="workflows-execution-detail__step-header">
@@ -593,7 +607,8 @@ export default class ExecutionDetail extends Component {
                 }}
               </span>
               <span
-                class="workflows-execution-detail__step-badge --{{step.status}}"
+                class="workflows-execution-detail__step-badge --{{step.status}}
+                  {{if step.warned '--warned'}}"
               >
                 {{#if (isFilterStep step)}}
                   {{if
@@ -615,6 +630,15 @@ export default class ExecutionDetail extends Component {
                   }}
                 {{/if}}
               </span>
+              {{#if step.warned}}
+                <span class="workflows-execution-detail__step-warning">
+                  {{dIcon "triangle-exclamation"}}
+                  {{i18n
+                    "discourse_workflows.executions.warnings_count"
+                    count=(warningCount step)
+                  }}
+                </span>
+              {{/if}}
               <span class="workflows-execution-detail__step-time">
                 {{stepDuration step this.currentTime}}
                 {{#if step.metadata.js_elapsed_ms}}
@@ -685,7 +709,12 @@ export default class ExecutionDetail extends Component {
                   <summary>{{i18n
                       "discourse_workflows.executions.logs"
                     }}</summary>
-                  <pre>{{formatLogs step.metadata.logs}}</pre>
+                  <pre class="workflows-execution-detail__console">{{#each
+                      (logEntries step.metadata.logs)
+                      as |entry|
+                    }}<span
+                        class="workflows-execution-detail__log --{{entry.level}}"
+                      >{{entry.text}}</span>{{/each}}</pre>
                 </details>
               {{/if}}
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/index.gjs
@@ -356,6 +356,17 @@ export default class WorkflowsIndex extends Component {
                   >
                     {{dIcon "triangle-exclamation"}}
                   </span>
+                {{else if workflow.lastExecutionWarned}}
+                  <span
+                    class="workflows-index__warned"
+                    role="img"
+                    aria-label={{i18n
+                      "discourse_workflows.last_execution_warned"
+                    }}
+                    title={{i18n "discourse_workflows.last_execution_warned"}}
+                  >
+                    {{dIcon "triangle-exclamation"}}
+                  </span>
                 {{/if}}
               </LinkTo>
               {{#if workflow.tags.length}}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/stats.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/stats.gjs
@@ -17,6 +17,10 @@ export default <template>
         @formattedValue={{@stats.failed}}
       />
       <tiles.Tile
+        @label={{i18n "discourse_workflows.stats.warnings"}}
+        @formattedValue={{@stats.warned}}
+      />
+      <tiles.Tile
         @label={{i18n "discourse_workflows.stats.failure_rate"}}
         @formattedValue={{@stats.failure_rate}}
       />

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/models/discourse-workflows-workflow.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/models/discourse-workflows-workflow.js
@@ -29,6 +29,9 @@ export default class DiscourseWorkflowsWorkflow extends RestModel {
     if (Object.hasOwn(json, "last_execution_status")) {
       result.lastExecutionStatus = json.last_execution_status;
     }
+    if (Object.hasOwn(json, "last_execution_warned")) {
+      result.lastExecutionWarned = json.last_execution_warned;
+    }
     if (Object.hasOwn(json, "last_execution_at")) {
       result.lastExecutionAt = json.last_execution_at;
     }

--- a/plugins/discourse-workflows/app/models/discourse_workflows/execution.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/execution.rb
@@ -280,6 +280,7 @@ end
 #  timeout_action      :string(32)
 #  trigger_data        :jsonb
 #  waiting_until       :datetime
+#  warned              :boolean          default(FALSE), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  trigger_node_id     :string(100)

--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/execution_list_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/execution_list_serializer.rb
@@ -6,6 +6,7 @@ module DiscourseWorkflows
                :workflow_id,
                :workflow_name,
                :status,
+               :warned,
                :error,
                :run_time_ms,
                :started_at,

--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/execution_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/execution_serializer.rb
@@ -6,6 +6,7 @@ module DiscourseWorkflows
                :workflow_id,
                :workflow_name,
                :status,
+               :warned,
                :trigger_data,
                :error,
                :run_time_ms,
@@ -37,6 +38,7 @@ module DiscourseWorkflows
       node_type
       position
       status
+      warned
       input
       output
       error

--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/workflow_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/workflow_serializer.rb
@@ -18,6 +18,7 @@ module DiscourseWorkflows
                :created_at,
                :updated_at,
                :last_execution_status,
+               :last_execution_warned,
                :last_execution_at,
                :last_execution_run_data,
                :pin_data,
@@ -90,6 +91,14 @@ module DiscourseWorkflows
     def last_execution_at
       return unless object.attributes.key?("last_execution_at")
       object.attributes["last_execution_at"]
+    end
+
+    def last_execution_warned
+      object.attributes["last_execution_warned"] == true
+    end
+
+    def include_last_execution_warned?
+      object.attributes.key?("last_execution_warned")
     end
 
     def last_execution_status

--- a/plugins/discourse-workflows/app/services/discourse_workflows/stats/summary.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/stats/summary.rb
@@ -20,10 +20,11 @@ module DiscourseWorkflows
     end
 
     def compute_stats(recent_executions:)
-      total, failed, avg_seconds =
+      total, failed, warned, avg_seconds =
         recent_executions.pick(
           Arel.sql("COUNT(*)"),
           Arel.sql("COUNT(*) FILTER (WHERE status = #{Execution.statuses["error"]})"),
+          Arel.sql("COUNT(*) FILTER (WHERE warned)"),
           Arel.sql(
             "ROUND(AVG(EXTRACT(EPOCH FROM (finished_at - started_at))) FILTER (" \
               "WHERE finished_at IS NOT NULL AND started_at IS NOT NULL " \
@@ -36,7 +37,13 @@ module DiscourseWorkflows
       failure_rate = total > 0 ? (failed.to_f / total * 100).round(1) : 0
       avg_duration = avg_seconds < 1 ? "#{(avg_seconds * 1000).round}ms" : "#{avg_seconds}s"
 
-      { total: total, failed: failed, failure_rate: "#{failure_rate}%", avg_duration: avg_duration }
+      {
+        total: total,
+        failed: failed,
+        warned: warned,
+        failure_rate: "#{failure_rate}%",
+        avg_duration: avg_duration,
+      }
     end
   end
 end

--- a/plugins/discourse-workflows/app/services/discourse_workflows/workflow/list.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/workflow/list.rb
@@ -6,7 +6,7 @@ module DiscourseWorkflows
 
     LATEST_EXECUTION_JOIN = <<~SQL
       LEFT JOIN LATERAL (
-        SELECT status, discourse_workflows_executions.created_at AS executed_at
+        SELECT status, warned, discourse_workflows_executions.created_at AS executed_at
         FROM discourse_workflows_executions
         WHERE discourse_workflows_executions.workflow_id = discourse_workflows_workflows.id
         ORDER BY discourse_workflows_executions.created_at DESC, discourse_workflows_executions.id DESC
@@ -63,6 +63,7 @@ module DiscourseWorkflows
           .select(
             "discourse_workflows_workflows.*",
             "latest_execution.status AS last_execution_status_value",
+            "latest_execution.warned AS last_execution_warned",
             "latest_execution.executed_at AS last_execution_at",
           )
           .order(id: :desc)

--- a/plugins/discourse-workflows/assets/stylesheets/common/colors.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/colors.scss
@@ -36,6 +36,8 @@
   --workflow-status-success-low: light-dark(#dcfff1, #1c3329);
   --workflow-status-error: light-dark(#e2483d, #fd9891);
   --workflow-status-error-low: light-dark(#ffd5d2, #5d1f1a);
+  --workflow-status-warning: light-dark(#946f00, #f5cd47);
+  --workflow-status-warning-low: light-dark(#fff7d6, #4a3b0a);
   --workflow-status-running: light-dark(#0c66e4, #579dff);
   --workflow-status-running-low: light-dark(#cce0ff, #09326c);
   --workflow-status-waiting: light-dark(#6e5dc6, #9f8fef);

--- a/plugins/discourse-workflows/assets/stylesheets/common/executions/execution-detail.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/executions/execution-detail.scss
@@ -35,6 +35,11 @@
       border-color: var(--workflow-status-error);
     }
 
+    &.--warned {
+      border-color: var(--workflow-status-warning);
+      background: var(--workflow-status-warning-low);
+    }
+
     &.--running {
       border-color: var(--workflow-status-running);
     }
@@ -169,6 +174,11 @@
     &.--error {
       background: var(--workflow-status-error-low);
       color: var(--workflow-status-error);
+    }
+
+    &.--warned {
+      background: var(--workflow-status-warning-low);
+      color: var(--workflow-status-warning);
     }
 
     &.--running {
@@ -366,5 +376,36 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+  }
+
+  &__step-warning,
+  &__progress-warning {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--font-down-2);
+    font-weight: bold;
+    color: var(--workflow-status-warning);
+
+    .d-icon {
+      color: var(--workflow-status-warning);
+    }
+  }
+
+  &__console {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__log {
+    &.--warn {
+      color: var(--workflow-status-warning);
+      font-weight: bold;
+    }
+
+    &.--error {
+      color: var(--workflow-status-error);
+      font-weight: bold;
+    }
   }
 }

--- a/plugins/discourse-workflows/assets/stylesheets/common/executions/executions-manager.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/executions/executions-manager.scss
@@ -21,6 +21,10 @@
       color: var(--workflow-status-error);
     }
 
+    &.--warned .d-icon {
+      color: var(--workflow-status-warning);
+    }
+
     &.--running .d-icon {
       color: var(--workflow-status-running);
     }

--- a/plugins/discourse-workflows/assets/stylesheets/common/workflows-index.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/workflows-index.scss
@@ -42,11 +42,19 @@
     gap: var(--space-1);
   }
 
-  &__warning {
+  &__warning,
+  &__warned {
     display: inline-flex;
     align-items: center;
-    color: var(--workflow-status-error);
     line-height: 1;
+  }
+
+  &__warning {
+    color: var(--workflow-status-error);
+  }
+
+  &__warned {
+    color: var(--workflow-status-warning);
   }
 
   &__empty {

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -126,6 +126,7 @@ en:
       status: "Status"
       last_execution_never: "Never"
       last_execution_failed: "Last execution failed"
+      last_execution_warned: "Last execution completed with warnings"
       create_first_workflow: "Create your first workflow"
       empty_title: "%{username}, let's set up a workflow"
       empty_description: "Workflows automate tasks by connecting triggers, conditions, and actions into a visual flow"
@@ -1251,6 +1252,9 @@ en:
           original_bytes: "%{count} bytes before truncation"
           original_size: "%{count} items before truncation"
           max_bytes: "%{count} byte limit"
+        warnings_count:
+          one: "%{count} warning"
+          other: "%{count} warnings"
         statuses:
           pending: "Pending"
           running: "Running"
@@ -1271,6 +1275,7 @@ en:
       stats:
         executions: "Executions"
         failures: "Failures"
+        warnings: "Warnings"
         failure_rate: "Failure rate"
         avg_run_time: "Avg. run time"
         period: "Last 7 days"

--- a/plugins/discourse-workflows/db/migrate/20260828152020_add_warned_to_workflow_executions.rb
+++ b/plugins/discourse-workflows/db/migrate/20260828152020_add_warned_to_workflow_executions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWarnedToWorkflowExecutions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :discourse_workflows_executions, :warned, :boolean, null: false, default: false
+  end
+end

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor.rb
@@ -450,6 +450,7 @@ module DiscourseWorkflows
     def attach_step_log(step, step_log)
       return if step_log.nil? || step_log.empty?
 
+      step.warned = step_log.warnings?
       step.add_metadata("logs", step_log.as_json)
     end
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/execution_store.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/execution_store.rb
@@ -53,6 +53,7 @@ module DiscourseWorkflows
         save!(steps)
         execution.update!(
           status: :success,
+          warned: steps.any?(&:warned?),
           finished_at: Time.current,
           run_time_ms: Execution.compute_run_time_ms(steps),
           resume_token: nil,

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/step.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/step.rb
@@ -21,6 +21,7 @@ module DiscourseWorkflows
                   :error,
                   :finished_at
       attr_accessor :metadata
+      attr_writer :warned
 
       def initialize(
         node_id:,
@@ -49,6 +50,7 @@ module DiscourseWorkflows
       end
 
       def success? = status == SUCCESS
+      def warned? = @warned == true
       def error? = status == ERROR
       def waiting? = status == WAITING
       def filtered? = status == FILTERED
@@ -106,6 +108,7 @@ module DiscourseWorkflows
           "input" => input,
           "started_at" => started_at,
         }
+        h["warned"] = true if warned?
         h["output"] = output if output
         h["finished_at"] = finished_at if finished_at
         h["error"] = error if error

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/step_log.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/step_log.rb
@@ -10,6 +10,7 @@ module DiscourseWorkflows
       def initialize
         @entries = []
         @has_errors = false
+        @has_warnings = false
         @truncated = false
       end
 
@@ -22,17 +23,19 @@ module DiscourseWorkflows
       end
 
       def error(message)
-        @has_errors = true
         append("error", message: message)
       end
 
       def kv(key, value, level: "info")
-        @has_errors = true if level == "error"
         append(level, key: key, value: value.to_s)
       end
 
       def errors?
         @has_errors
+      end
+
+      def warnings?
+        @has_warnings
       end
 
       def empty?
@@ -57,8 +60,7 @@ module DiscourseWorkflows
             end
             break
           end
-          @has_errors = true if entry["level"] == "error"
-          @entries << entry
+          record(entry)
         end
       end
 
@@ -87,9 +89,17 @@ module DiscourseWorkflows
           end
           return
         end
-        @entries << { "level" => level, "at" => Time.current.utc.iso8601 }.merge(
-          fields.transform_keys(&:to_s),
+        record(
+          { "level" => level, "at" => Time.current.utc.iso8601 }.merge(
+            fields.transform_keys(&:to_s),
+          ),
         )
+      end
+
+      def record(entry)
+        @has_errors = true if entry["level"] == "error"
+        @has_warnings = true if entry["level"] == "warn"
+        @entries << entry
       end
     end
   end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor_spec.rb
@@ -933,6 +933,7 @@ RSpec.describe DiscourseWorkflows::Executor do
           execution = described_class.new(workflow, "trigger-1", { topic_id: topic.id }).run
 
           expect(execution.status).to eq("success")
+          expect(execution.warned).to eq(true)
 
           oversized_step = execution.execution_data.find_step(node_id: "oversized-1")
           expect(oversized_step["output"]).to eq([])

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/warning_status_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/warning_status_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Executor::StepLog do
+  subject(:log) { described_class.new }
+
+  it "reports warnings separately from errors" do
+    log.info("nothing to see")
+    expect(log.warnings?).to eq(false)
+
+    log.warn("something was dropped")
+
+    expect(log.warnings?).to eq(true)
+    expect(log.errors?).to eq(false)
+  end
+
+  it "keeps warnings when merging" do
+    other = described_class.new
+    other.warn("dropped")
+
+    log.merge(other)
+
+    expect(log.warnings?).to eq(true)
+  end
+end
+
+RSpec.describe DiscourseWorkflows::Executor::Step do
+  subject(:step) do
+    described_class.new(
+      node_id: "n",
+      node_name: "N",
+      node_type: "action:log",
+      position: 0,
+      input: [],
+    )
+  end
+
+  it "stays a success when it warned, and says so" do
+    step.warned = true
+    step.succeed!(output: [])
+
+    expect(step.status).to eq(described_class::SUCCESS)
+    expect(step.success?).to eq(true)
+    expect(step.warned?).to eq(true)
+    expect(step.to_h["warned"]).to eq(true)
+  end
+
+  it "does not claim a warning otherwise" do
+    step.succeed!(output: [])
+
+    expect(step.warned?).to eq(false)
+    expect(step.to_h).not_to have_key("warned")
+  end
+end
+
+RSpec.describe DiscourseWorkflows::ExecutionSerializer do
+  fab!(:workflow, :discourse_workflows_workflow)
+
+  it "exposes the warned flag on the execution and on every step that carries it" do
+    execution =
+      Fabricate(:discourse_workflows_execution, workflow: workflow, status: :success, warned: true)
+    Fabricate(
+      :discourse_workflows_execution_data,
+      execution: execution,
+      data: {
+        "entries" => {
+          "A" => [
+            {
+              "node_id" => "a",
+              "node_name" => "A",
+              "node_type" => "action:log",
+              "position" => 0,
+              "status" => "success",
+              "warned" => true,
+            },
+          ],
+        },
+      },
+    )
+
+    json = described_class.new(execution.reload, root: false).as_json
+
+    expect(json[:warned]).to eq(true)
+    expect(json[:steps].first[:warned]).to eq(true)
+  end
+end

--- a/plugins/discourse-workflows/spec/serializers/discourse_workflows/workflow_serializer_spec.rb
+++ b/plugins/discourse-workflows/spec/serializers/discourse_workflows/workflow_serializer_spec.rb
@@ -19,6 +19,27 @@ RSpec.describe DiscourseWorkflows::WorkflowSerializer do
       execution
     end
 
+    it "flags a workflow whose latest execution warned" do
+      Fabricate(
+        :discourse_workflows_execution,
+        workflow: workflow,
+        status: :success,
+        warned: true,
+        created_at: Time.current,
+      )
+
+      listed =
+        DiscourseWorkflows::Workflow::List
+          .call(params: { limit: 10 }, guardian: Discourse.system_user.guardian)
+          .workflows
+          .find { |w| w.id == workflow.id }
+
+      serialized = described_class.new(listed, root: false).as_json
+
+      expect(serialized[:last_execution_status]).to eq("success")
+      expect(serialized[:last_execution_warned]).to eq(true)
+    end
+
     it "returns run data from the latest execution when it failed" do
       successful_run_data = { "SQL" => [{ "outputs" => [{ "items" => [] }] }] }
       fabricate_execution_with_run_data(

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/stats/summary_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/stats/summary_spec.rb
@@ -22,7 +22,13 @@ RSpec.describe DiscourseWorkflows::Stats::Summary do
       it { is_expected.to run_successfully }
 
       it "returns zeroed stats" do
-        expect(result[:stats]).to eq(total: 0, failed: 0, failure_rate: "0%", avg_duration: "0ms")
+        expect(result[:stats]).to eq(
+          total: 0,
+          failed: 0,
+          warned: 0,
+          failure_rate: "0%",
+          avg_duration: "0ms",
+        )
       end
     end
 
@@ -78,7 +84,13 @@ RSpec.describe DiscourseWorkflows::Stats::Summary do
       it { is_expected.to run_successfully }
 
       it "does not count old executions" do
-        expect(result[:stats]).to eq(total: 0, failed: 0, failure_rate: "0%", avg_duration: "0ms")
+        expect(result[:stats]).to eq(
+          total: 0,
+          failed: 0,
+          warned: 0,
+          failure_rate: "0%",
+          avg_duration: "0ms",
+        )
       end
     end
 


### PR DESCRIPTION
A node that logged a warning still finished green, so the only way to learn something had gone sideways was to open the execution, expand the right step, and read its console.

Executions and steps now carry a `warned` flag, set from the step logs, and the index, execution list, detail view and stats tiles show it. Console lines are coloured by level so the warning is findable once you get there.

Warnings do not change the execution status: the run did succeed, and error handling and retries should keep treating it that way.

**BEFORE**
<img width="1058" height="80" alt="43013-1-workflows-index-BEFORE" src="https://github.com/user-attachments/assets/c4e38cf6-4552-43f8-9770-3435048f2242" />
<img width="1057" height="176" alt="43013-2-executions-list-BEFORE" src="https://github.com/user-attachments/assets/58dbf2d9-9aed-49db-a824-366c9626475e" />
<img width="1057" height="425" alt="43013-3-execution-detail-BEFORE" src="https://github.com/user-attachments/assets/334d44ee-0b91-4960-9112-d6ddb9fd8659" />
<img width="1057" height="64" alt="43013-4-stats-tiles-BEFORE" src="https://github.com/user-attachments/assets/7ccd51c0-eafd-4728-9be2-14233f602295" />


**AFTER**
<img width="1058" height="80" alt="43013-1-workflows-index-AFTER" src="https://github.com/user-attachments/assets/f167f027-a13b-4dbf-b9f2-11e65930f2c1" />
<img width="1057" height="176" alt="43013-2-executions-list-AFTER" src="https://github.com/user-attachments/assets/bf821248-a148-4449-9b55-b0d90427eff4" />
<img width="1057" height="425" alt="43013-3-execution-detail-AFTER" src="https://github.com/user-attachments/assets/76bb029d-bca6-4ac3-a280-41f5d7290362" />
<img width="1057" height="64" alt="43013-4-stats-tiles-AFTER" src="https://github.com/user-attachments/assets/912aa799-ee7b-4010-af16-2dadb2a30110" />




Stacked on #43012.
