### PR TITLE
FEATURE: Report the uploads an AI agent node could not send

### DIFF
--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -269,6 +269,10 @@ en:
           upload_ids: "Upload IDs"
           upload_ids_tooltip: "Optional upload IDs to attach to the prompt. Image uploads are included when the agent has vision enabled; document uploads are included when the selected LLM supports their file type."
           upload_ids_placeholder: "={{ $json.post.upload_ids }}"
+          on_unusable_upload: "When an upload cannot be sent"
+          on_unusable_upload_description: "Some uploads never reach the LLM, for example an unsupported image format or a file the workflow user cannot see. Choose whether to carry on without it or stop the node."
+          on_unusable_upload_skip: "Continue with a warning"
+          on_unusable_upload_fail: "Stop the node"
           select_agent: "Select an agent..."
 
       bot_chats:

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -300,10 +300,19 @@ en:
     discourse_workflows:
       ai_agent:
         errors:
+          agent_not_found: "AI agent with id %{agent_id} was not found."
+          agent_disabled: "AI agent '%{agent}' is disabled."
           invalid_mode: "'%{mode}' is not a supported AI agent execution mode."
           locked_default_llm_missing: "Agent '%{agent}' is locked to its default LLM, but no valid default LLM is configured"
           llm_not_found: "LLM model with id %{llm_model_id} not found"
           no_llm_configured: "No LLM is configured for agent '%{agent}'. Select an LLM model or configure an agent/site default LLM."
+        uploads:
+          not_found: "Upload %{upload_id} no longer exists and was not sent."
+          not_visible: "%{filename} is not visible to the user this workflow runs as, and was not sent."
+          vision_disabled: "%{filename} was not sent because agent '%{agent}' has vision disabled."
+          unsupported_image: "%{filename} cannot be sent to the LLM. Supported image formats: %{formats}."
+          not_allowed: "%{filename} was not sent because the selected LLM does not accept this file type."
+          encode_failed: "%{filename} could not be prepared for the LLM and was not sent: %{reason}."
 
     tools:
       custom_name: "%{name} (custom)"

--- a/plugins/discourse-ai/discourse_workflows/nodes/ai_agent/v1.rb
+++ b/plugins/discourse-ai/discourse_workflows/nodes/ai_agent/v1.rb
@@ -8,6 +8,13 @@ if defined?(DiscourseWorkflows)
           RUN_ONCE_FOR_ALL_ITEMS = "runOnceForAllItems"
           RUN_ONCE_FOR_EACH_ITEM = "runOnceForEachItem"
 
+          I18N_PREFIX = "discourse_ai.discourse_workflows.ai_agent"
+
+          PreparedPrompt = Data.define(:content, :sent_upload_ids, :unusable)
+
+          ON_UNUSABLE_UPLOAD_SKIP = "skip"
+          ON_UNUSABLE_UPLOAD_FAIL = "fail"
+
           description(
             name: "action:ai_agent",
             version: "1.0",
@@ -36,6 +43,23 @@ if defined?(DiscourseWorkflows)
                   "properties" => {
                     "result" => {
                       "type" => "string",
+                    },
+                    "unusable_uploads" => {
+                      "type" => "array",
+                      "items" => {
+                        "type" => "object",
+                        "properties" => {
+                          "upload_id" => {
+                            "type" => "integer",
+                          },
+                          "filename" => {
+                            "type" => "string",
+                          },
+                          "reason" => {
+                            "type" => "string",
+                          },
+                        },
+                      },
                     },
                   },
                 },
@@ -149,6 +173,13 @@ if defined?(DiscourseWorkflows)
                   expression: true,
                 },
               },
+              on_unusable_upload: {
+                type: :options,
+                required: false,
+                options: [ON_UNUSABLE_UPLOAD_SKIP, ON_UNUSABLE_UPLOAD_FAIL],
+                default: ON_UNUSABLE_UPLOAD_SKIP,
+                no_data_expression: true,
+              },
             },
           )
 
@@ -213,14 +244,14 @@ if defined?(DiscourseWorkflows)
 
             items =
               exec_ctx.input_items.map.with_index do |item, item_index|
-                result =
+                output =
                   run_agent(
                     agent_config(exec_ctx, item_index),
                     exec_ctx.log,
                     runner(exec_ctx, item_index),
                   )
 
-                wrap({ "result" => result }, paired_item: exec_ctx.paired_item_for(item))
+                wrap(output, paired_item: exec_ctx.paired_item_for(item))
               end
 
             [items]
@@ -229,10 +260,10 @@ if defined?(DiscourseWorkflows)
           private
 
           def run_once_for_all_items(exec_ctx)
-            result = run_agent(agent_config(exec_ctx, 0), exec_ctx.log, runner(exec_ctx, 0))
+            output = run_agent(agent_config(exec_ctx, 0), exec_ctx.log, runner(exec_ctx, 0))
 
             wrap(
-              { "result" => result },
+              output,
               paired_item: exec_ctx.input_items.map { |item| exec_ctx.paired_item_for(item) },
             )
           end
@@ -243,6 +274,12 @@ if defined?(DiscourseWorkflows)
               "llm_model_id" => exec_ctx.get_node_parameter("llm_model_id", item_index),
               "prompt" => exec_ctx.get_node_parameter("prompt", item_index),
               "upload_ids" => exec_ctx.get_node_parameter("upload_ids", item_index),
+              "on_unusable_upload" =>
+                exec_ctx.get_node_parameter(
+                  "on_unusable_upload",
+                  item_index,
+                  default: ON_UNUSABLE_UPLOAD_SKIP,
+                ),
             }
           end
 
@@ -253,9 +290,29 @@ if defined?(DiscourseWorkflows)
           def validate_mode!(mode)
             return if [RUN_ONCE_FOR_ALL_ITEMS, RUN_ONCE_FOR_EACH_ITEM].include?(mode)
 
-            raise_node_error!(
-              I18n.t("discourse_ai.discourse_workflows.ai_agent.errors.invalid_mode", mode: mode),
-            )
+            raise_node_error!(node_t("errors.invalid_mode", mode: mode))
+          end
+
+          # agent_id and llm_model_id cannot be per-item expressions, so a multi-item run
+          # resolves the same agent, agent class and LLM every time
+          def resolved_agent(agent_id, llm_model_id)
+            @resolved_agents ||= {}
+            @resolved_agents[[agent_id, llm_model_id]] ||= begin
+              agent_record = ::AiAgent.find_by(id: agent_id)
+              if agent_record.nil?
+                raise_node_error!(node_t("errors.agent_not_found", agent_id: agent_id))
+              end
+
+              if !agent_record.enabled
+                raise_node_error!(node_t("errors.agent_disabled", agent: agent_record.name))
+              end
+
+              [
+                agent_record,
+                agent_record.class_instance,
+                resolve_llm_model(agent_record, llm_model_id),
+              ]
+            end
           end
 
           def resolve_llm_model(agent_record, requested_llm_model_id)
@@ -265,10 +322,7 @@ if defined?(DiscourseWorkflows)
               return llm_model if llm_model.present?
 
               raise_node_error!(
-                I18n.t(
-                  "discourse_ai.discourse_workflows.ai_agent.errors.locked_default_llm_missing",
-                  agent: agent_record.name,
-                ),
+                node_t("errors.locked_default_llm_missing", agent: agent_record.name),
               )
             end
 
@@ -277,10 +331,7 @@ if defined?(DiscourseWorkflows)
               return llm_model if llm_model.present?
 
               raise_node_error!(
-                I18n.t(
-                  "discourse_ai.discourse_workflows.ai_agent.errors.llm_not_found",
-                  llm_model_id: requested_llm_model_id,
-                ),
+                node_t("errors.llm_not_found", llm_model_id: requested_llm_model_id),
               )
             end
 
@@ -289,33 +340,140 @@ if defined?(DiscourseWorkflows)
               return llm_model if llm_model.present?
             end
 
-            raise_node_error!(
-              I18n.t(
-                "discourse_ai.discourse_workflows.ai_agent.errors.no_llm_configured",
-                agent: agent_record.name,
-              ),
+            raise_node_error!(node_t("errors.no_llm_configured", agent: agent_record.name))
+          end
+
+          def prompt_content(config, agent_record, llm_model, guardian, log)
+            prompt = config["prompt"].to_s
+            requested = normalize_upload_ids(config["upload_ids"])
+            if requested.blank?
+              return PreparedPrompt.new(content: prompt, sent_upload_ids: [], unusable: [])
+            end
+
+            uploads =
+              ::DiscourseAi::Completions::PromptMessagesBuilder.uploads_for_prompt(
+                requested,
+              ).index_by(&:id)
+            sendable =
+              sendable_upload_ids(
+                requested.filter_map { |upload_id| uploads[upload_id] },
+                agent_record,
+                llm_model,
+                guardian,
+              )
+            log.info("Attachments: #{sendable.size} of #{requested.size} upload(s)")
+
+            unusable =
+              report_unusable_uploads(
+                requested - sendable,
+                uploads,
+                agent_record,
+                guardian,
+                log,
+                config["on_unusable_upload"],
+              )
+
+            content =
+              if sendable.blank?
+                prompt
+              else
+                [prompt, *sendable.map { |upload_id| { upload_id: upload_id } }]
+              end
+
+            PreparedPrompt.new(content: content, sent_upload_ids: sendable, unusable: unusable)
+          end
+
+          def sendable_upload_ids(uploads, agent_record, llm_model, guardian)
+            allowed_attachment_types = llm_model.allowed_attachment_types
+
+            ::DiscourseAi::Completions::PromptMessagesBuilder.filtered_upload_ids_from_uploads(
+              uploads,
+              include_image_uploads: agent_record.vision_enabled,
+              include_document_uploads: allowed_attachment_types.present?,
+              allowed_attachment_types: allowed_attachment_types,
+              guardian: guardian,
+            ).to_a
+          end
+
+          def report_unusable_uploads(
+            upload_ids,
+            uploads,
+            agent_record,
+            guardian,
+            log,
+            on_unusable_upload
+          )
+            return [] if upload_ids.blank?
+
+            records =
+              upload_ids.map do |upload_id|
+                unusable_upload_record(upload_id, uploads[upload_id], agent_record, guardian)
+              end
+            reasons = records.map { |record| record["reason"] }
+
+            raise_node_error!(reasons.join(" ")) if on_unusable_upload == ON_UNUSABLE_UPLOAD_FAIL
+
+            log_upload_messages(reasons, log, :warn)
+            records
+          end
+
+          def report_encode_failures(skips, sendable, log, on_unusable_upload)
+            skips = skips.select { |skip| sendable.include?(skip[:upload_id]) }
+            return [] if skips.blank?
+
+            records =
+              skips.map do |skip|
+                {
+                  "upload_id" => skip[:upload_id],
+                  "filename" => skip[:filename],
+                  "reason" =>
+                    node_t(
+                      "uploads.encode_failed",
+                      filename: skip[:filename].to_s.truncate(100),
+                      reason: skip[:message],
+                    ),
+                }
+              end
+
+            level = on_unusable_upload == ON_UNUSABLE_UPLOAD_FAIL ? :error : :warn
+            log_upload_messages(records.map { |record| record["reason"] }, log, level)
+            records
+          end
+
+          def log_upload_messages(messages, log, level)
+            messages.each { |message| log.public_send(level, message) }
+          end
+
+          def unusable_upload_record(upload_id, upload, agent_record, guardian)
+            {
+              "upload_id" => upload_id,
+              "filename" => upload&.original_filename,
+              "reason" => unusable_upload_message(upload_id, upload, agent_record, guardian),
+            }
+          end
+
+          def unusable_upload_message(upload_id, upload, agent_record, guardian)
+            return node_t("uploads.not_found", upload_id: upload_id) if upload.blank?
+
+            filename = (upload.original_filename.presence || "upload #{upload.id}").truncate(100)
+            encoder = ::DiscourseAi::Completions::UploadEncoder
+
+            return node_t("uploads.not_visible", filename:) if !guardian.can_see_upload?(upload)
+            return node_t("uploads.not_allowed", filename:) if !encoder.image?(upload)
+
+            if !agent_record.vision_enabled
+              return node_t("uploads.vision_disabled", filename:, agent: agent_record.name)
+            end
+
+            node_t(
+              "uploads.unsupported_image",
+              filename:,
+              formats: encoder::SUPPORTED_IMAGE_EXTENSIONS.join(", "),
             )
           end
 
-          def prompt_content(prompt, upload_ids, agent_record, llm_model, guardian, log)
-            upload_ids = filtered_upload_ids(upload_ids, agent_record, llm_model, guardian)
-            return prompt if upload_ids.blank?
-
-            log.info("Attachments: #{upload_ids.size} upload(s)")
-            [prompt, *upload_ids.map { |upload_id| { upload_id: upload_id } }]
-          end
-
-          def filtered_upload_ids(upload_ids, agent_record, llm_model, guardian)
-            upload_ids = normalize_upload_ids(upload_ids)
-            return [] if upload_ids.blank?
-
-            ::DiscourseAi::Completions::PromptMessagesBuilder.filtered_upload_ids_for_prompt(
-              upload_ids,
-              include_image_uploads: agent_record.vision_enabled,
-              include_document_uploads: llm_model.allowed_attachment_types.present?,
-              allowed_attachment_types: llm_model.allowed_attachment_types,
-              guardian: guardian,
-            ) || []
+          def node_t(key, **args)
+            I18n.t("#{I18N_PREFIX}.#{key}", **args)
           end
 
           def normalize_upload_ids(upload_ids)
@@ -342,18 +500,10 @@ if defined?(DiscourseWorkflows)
           end
 
           def run_agent(config, log, runner)
-            agent_id = config["agent_id"]
             prompt = config["prompt"].to_s
-
-            agent_record = ::AiAgent.find_by(id: agent_id)
-            raise_node_error!("AI Agent with id #{agent_id} not found") if agent_record.nil?
-
-            if !agent_record.enabled
-              raise_node_error!("AI Agent '#{agent_record.name}' is disabled")
-            end
-
-            agent_instance = agent_record.class_instance.new
-            llm_model = resolve_llm_model(agent_record, config["llm_model_id"])
+            agent_record, agent_class, llm_model =
+              resolved_agent(config["agent_id"], config["llm_model_id"])
+            agent_instance = agent_class.new
 
             log.info("Agent: #{agent_record.name}")
             log.info("Runner: #{runner.username}")
@@ -367,28 +517,22 @@ if defined?(DiscourseWorkflows)
                 model: llm_model,
               )
 
-            content =
-              prompt_content(
-                prompt,
-                config["upload_ids"],
-                agent_record,
-                llm_model,
-                runner.guardian,
-                log,
-              )
+            prepared = prompt_content(config, agent_record, llm_model, runner.guardian, log)
 
             bot_context =
               DiscourseAi::Agents::BotContext.new(
                 user: runner,
                 guardian: runner.guardian,
-                messages: [{ type: :user, content: content }],
+                messages: [{ type: :user, content: prepared.content }],
                 feature_name: "workflow",
               )
 
             result = +""
             tool_calls = 0
 
-            bot.reply(bot_context) do |partial, _, type|
+            execution_context = ::DiscourseAi::Completions::ExecutionContext.new
+
+            bot.reply(bot_context, execution_context: execution_context) do |partial, _, type|
               if type == :tool_call
                 tool_calls += 1
                 log.info("Tool call: #{partial}") if partial.is_a?(String)
@@ -399,10 +543,18 @@ if defined?(DiscourseWorkflows)
               end
             end
 
+            encode_failures =
+              report_encode_failures(
+                execution_context.upload_skips,
+                prepared.sent_upload_ids,
+                log,
+                config["on_unusable_upload"],
+              )
+
             log.info("Tool calls: #{tool_calls}") if tool_calls > 0
             log.info("Result length: #{result.size} chars")
 
-            result
+            { "result" => result, "unusable_uploads" => prepared.unusable + encode_failures }
           end
         end
       end

--- a/plugins/discourse-ai/spec/lib/discourse_workflows/nodes/ai_agent_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discourse_workflows/nodes/ai_agent_spec.rb
@@ -251,43 +251,151 @@ RSpec.describe DiscourseWorkflows::Nodes::AiAgent::V1 do
     expect(prompts).to eq([["Review the screenshot", { upload_id: upload.id }]])
   end
 
-  it "filters image upload IDs when the agent does not have vision enabled" do
-    agent.update!(vision_enabled: false)
-    upload = Fabricate(:image_upload)
+  it "resolves the agent and LLM once for a multi-item run" do
+    allow(LlmModel).to receive(:find_by).and_call_original
+    allow_any_instance_of(AiAgent).to receive(:class_instance).and_call_original
 
     execute_node_output(
       configuration: {
         "agent_id" => agent.id,
-        "prompt" => "Review the screenshot",
-        "upload_ids" => [upload.id],
+        "llm_model_id" => llm_model.id,
+        "prompt" => "Review",
       },
+      input_items: 3.times.map { |index| { "json" => { "index" => index } } },
     )
 
-    expect(prompts).to eq(["Review the screenshot"])
+    expect(prompts.length).to eq(3)
+    expect(LlmModel).to have_received(:find_by).once
   end
 
-  it "filters upload IDs the execution user cannot see" do
-    agent.update!(vision_enabled: true)
-    visible_upload = Fabricate(:image_upload)
-    hidden_upload = Fabricate(:image_upload)
-    owner = Fabricate(:user)
-    recipient = Fabricate(:user)
-    private_topic = Fabricate(:private_message_topic, user: owner, recipient: recipient)
-    private_post = Fabricate(:post, topic: private_topic, user: owner)
-    hidden_upload.update!(access_control_post_id: private_post.id)
+  describe "unusable uploads" do
+    before { agent.update!(vision_enabled: true) }
 
-    runner = Fabricate(:user)
+    let(:svg) { Fabricate(:upload, original_filename: "logo.svg", extension: "svg") }
 
-    execute_node_output(
-      configuration: {
-        "agent_id" => agent.id,
-        "runner_username" => runner.username,
-        "prompt" => "Review the screenshot",
-        "upload_ids" => [visible_upload.id, hidden_upload.id],
-      },
-    )
+    def log_for(**overrides)
+      configuration = { "agent_id" => agent.id, "prompt" => "Review" }.merge(overrides)
 
-    expect(prompts).to eq([["Review the screenshot", { upload_id: visible_upload.id }]])
+      log = nil
+      execute_node_output(configuration: configuration) { |ctx| log = ctx.log }
+      log
+    end
+
+    def messages(log)
+      log.entries.map { |entry| entry["message"] }
+    end
+
+    it "reports a clean run truthfully and says nothing more" do
+      upload = Fabricate(:image_upload)
+
+      log = nil
+      output =
+        execute_node_output(
+          configuration: {
+            "agent_id" => agent.id,
+            "prompt" => "Review",
+            "upload_ids" => [upload.id],
+          },
+        ) { |ctx| log = ctx.log }.first.first[
+          "json"
+        ]
+
+      expect(messages(log)).to include("Attachments: 1 of 1 upload(s)")
+      expect(output["unusable_uploads"]).to eq([])
+      expect(log.entries.select { |entry| entry["level"] != "info" }).to be_empty
+    end
+
+    it "warns when an image format cannot be sent, and reports it as branchable output" do
+      good = Fabricate(:image_upload)
+
+      log = nil
+      output =
+        execute_node_output(
+          configuration: {
+            "agent_id" => agent.id,
+            "prompt" => "Review",
+            "upload_ids" => [good.id, svg.id],
+          },
+        ) { |ctx| log = ctx.log }.first.first[
+          "json"
+        ]
+
+      expect(messages(log)).to include("Attachments: 1 of 2 upload(s)")
+      expect(messages(log)).to include(a_string_including("logo.svg", "cannot be sent"))
+      expect(prompts).to eq([["Review", { upload_id: good.id }]])
+      expect(output["unusable_uploads"]).to match(
+        [
+          {
+            "upload_id" => svg.id,
+            "filename" => "logo.svg",
+            "reason" => a_string_including("cannot be sent"),
+          },
+        ],
+      )
+      expect(log.errors?).to eq(false)
+    end
+
+    it "warns when the agent has vision disabled" do
+      agent.update!(vision_enabled: false)
+
+      upload = Fabricate(:image_upload)
+
+      log = log_for("upload_ids" => [upload.id])
+
+      expect(messages(log)).to include(a_string_including("vision"))
+      expect(prompts).to eq(["Review"])
+    end
+
+    it "warns when the runner cannot see the upload, and still sends the visible one" do
+      visible = Fabricate(:image_upload)
+      hidden = Fabricate(:image_upload)
+      hidden.update!(access_control_post_id: Fabricate(:private_message_post).id)
+
+      log =
+        log_for(
+          "runner_username" => Fabricate(:user).username,
+          "upload_ids" => [visible.id, hidden.id],
+        )
+
+      expect(messages(log)).to include(a_string_including("not visible"))
+      expect(prompts).to eq([["Review", { upload_id: visible.id }]])
+    end
+
+    it "warns when the upload no longer exists" do
+      missing_id = Upload.maximum(:id).to_i + 1
+
+      log = log_for("upload_ids" => [missing_id])
+
+      expect(messages(log)).to include(a_string_including(missing_id.to_s, "no longer exists"))
+    end
+
+    it "fails the step when configured to fail on unusable uploads" do
+      expect { log_for("upload_ids" => [svg.id], "on_unusable_upload" => "fail") }.to raise_error(
+        DiscourseWorkflows::NodeError,
+        /logo\.svg/,
+      )
+
+      expect(prompts).to be_empty
+    end
+
+    it "warns when an upload fails to encode at request time" do
+      upload = Fabricate(:large_image_upload)
+      allow_any_instance_of(Upload).to receive(:get_optimized_image).and_return(nil)
+
+      allow(bot).to receive(:reply) do |bot_context, execution_context:, &block|
+        prompt =
+          DiscourseAi::Completions::Prompt.new("system", messages: [bot_context.messages.first])
+        prompt.upload_skips = execution_context.upload_skips
+        prompt.encoded_uploads(prompt.messages.last)
+
+        block.call("ok", nil, nil)
+      end
+
+      log = log_for("upload_ids" => [upload.id])
+
+      expect(messages(log)).to include("Attachments: 1 of 1 upload(s)")
+      expect(messages(log)).to include(a_string_including(upload.original_filename, "could not be"))
+    end
   end
 
   it "resolves runner expressions per item" do


### PR DESCRIPTION
Closes the loop on [AI triage supporting check of user profiles](https://dev.discourse.org/t/144011/9).

The node quietly dropped uploads the model would never see -- an unsupported image format, a file the workflow user cannot read, an image attached while the agent has vision off -- so an agent would answer "I don't see an image" and the run still looked clean.

Every dropped upload is now logged as a warning naming the file and the reason, and returned on the node output as `unusable_uploads` so a workflow can branch on it. A new setting decides whether an unusable upload is a warning or stops the node, defaulting to the old carry-on behaviour.

Agent, agent class and LLM resolution moves out of the per-item loop: neither is a per-item expression, so a hundred-item run was doing a hundred identical lookups.

**BEFORE**
<img width="571" height="880" alt="43014-node-settings-BEFORE" src="https://github.com/user-attachments/assets/455d496f-a597-438f-86b1-5ba3150a7f2b" />


**AFTER**
<img width="571" height="880" alt="43014-node-settings-AFTER" src="https://github.com/user-attachments/assets/a180f0ef-3830-40fb-b074-9b47a2d25c2b" />



Stacked on #43013.
