### PR TITLE
FIX: Report rate limits during code signup instead of an invalid code

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -923,11 +923,26 @@ class SessionController < ApplicationController
       on_failed_policy(:required_full_name_provided) do
         render json: { error: I18n.t("login.missing_full_name") }
       end
+      # `ModelStep` turns any exception raised while building the model into an
+      # ordinary "not found" failure, so a rate limit tripped during account
+      # creation would otherwise be reported as an invalid code.
+      on_model_not_found(:user) { |model| render json: login_code_account_failure(model) }
       on_failed_contract do |contract|
         render json: failed_json.merge(errors: contract.errors.full_messages), status: :bad_request
       end
       on_failure { render json: invalid_login_code }
     end
+  end
+
+  def login_code_account_failure(model)
+    exception = model.try(:exception)
+    return invalid_login_code if !exception.is_a?(RateLimiter::LimitExceeded)
+
+    Rails.logger.warn(
+      "Email login code signup was rate limited on #{RailsMultisite::ConnectionManagement.current_db}: " \
+        "type=#{exception.type.inspect}, retry in #{exception.available_in}s",
+    )
+    { error: I18n.t("email_login_code.rate_limited") }
   end
 
   # Required signup details are only collected once the code has proven

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1098,6 +1098,7 @@ en:
 
   email_login_code:
     invalid_code: "That code is incorrect or has expired. Request a new code and try again."
+    rate_limited: "Too many attempts, please try again later."
 
   browsers:
     android_browser: "Android Browser"

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -849,6 +849,49 @@ RSpec.describe SessionController do
         expect(session[:current_user_id]).to eq(new_user.id)
       end
 
+      context "when account creation trips a rate limit" do
+        let(:fake_logger) { FakeLogger.new }
+
+        before do
+          Rails.logger.broadcast_to(fake_logger)
+          User::Action::CreateFromVerifiedEmail.stubs(:call).raises(
+            RateLimiter::LimitExceeded.new(42, "create-user"),
+          )
+        end
+
+        after { Rails.logger.stop_broadcasting_to(fake_logger) }
+
+        it "reports the rate limit rather than an invalid code" do
+          post "/session/login-code/verify.json", params: { email: "newuser@example.com", code: }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.rate_limited"))
+        end
+
+        it "logs the site the limit was hit on" do
+          post "/session/login-code/verify.json", params: { email: "newuser@example.com", code: }
+
+          expect(fake_logger.warnings.join("\n")).to include(
+            "Email login code signup was rate limited on #{RailsMultisite::ConnectionManagement.current_db}",
+          )
+        end
+
+        it "leaves the code unconsumed so a later attempt can still use it" do
+          post "/session/login-code/verify.json", params: { email: "newuser@example.com", code: }
+
+          expect(login_code.reload.consumed_at).to be_nil
+          expect(User.find_by_email("newuser@example.com")).to be_nil
+        end
+      end
+
+      it "still reports an invalid code for other account creation failures" do
+        User::Action::CreateFromVerifiedEmail.stubs(:call).raises(ActiveRecord::RecordInvalid)
+
+        post "/session/login-code/verify.json", params: { email: "newuser@example.com", code: }
+
+        expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+      end
+
       it "returns the flags the account-ready step needs" do
         post "/session/login-code/verify.json", params: { email: "newuser@example.com", code: }
 


### PR DESCRIPTION
**Previously**, a rate limit tripped while creating an account during email-code signup surfaced to the user as "That code is incorrect or has expired. Request a new code and try again." The code was perfectly valid, so the advice was wrong and the real cause was invisible: `Service::Base::ModelStep` rescues every exception raised while building a model and converts it into an ordinary "not found" failure, which the controller reported with its generic invalid-code message. Nothing was written to the logs either, so the same condition was equally opaque from the server side.

**In this update**, the redeem path inspects the exception captured on the failed `user` model step. When it is a `RateLimiter::LimitExceeded`, the response is now "Too many attempts, please try again later." and a warning is logged naming the site, the limiter type, and the retry window:

```
Email login code signup was rate limited on default: type="create-user", retry in 42s
```

Any other account-creation failure still reports an invalid code, so no new information is exposed about which addresses have accounts. The email address is deliberately kept out of the log line.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/raw/refs/heads/gh-attach-assets/a3b8b4f4-5216-48b0-b5f7-b0f3fa1b7285/before.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-qudm59.png) |
