### PR TITLE
DEV: Keep test stylesheets in the head so they gate the QUnit entrypoint

### DIFF
--- a/app/views/qunit/qunit.html.erb
+++ b/app/views/qunit/qunit.html.erb
@@ -27,12 +27,6 @@
         };
       </script>
 
-      <%= tag.iframe srcdoc: tag.script(
-        src: script_asset_path(EmberAssets.script_chunks["qunit-live-reload"].first),
-        nonce: csp_nonce_placeholder,
-        type: "module",
-      ), style: "display: none;" %>
-
       <%= preload_script "test-support" %>
 
       <%= render "layouts/plugin_js",
@@ -95,8 +89,16 @@
       </script>
 
       <%= preload_script "test-entrypoint", type_module: true %>
+
+      <%# Kept out of the head: an iframe there ends head parsing early and demotes every later stylesheet to the body, where it no longer blocks the entrypoint. %>
+      <%= tag.iframe srcdoc: tag.script(
+        src: script_asset_path(EmberAssets.script_chunks["qunit-live-reload"].first),
+        nonce: csp_nonce_placeholder,
+        type: "module",
+      ), style: "display: none;" %>
     <%- end %>
 
+    <%# Stays last on purpose: the test runner injects its own stylesheet into the head at runtime, and this one must follow it in the cascade to restyle the runner. %>
     <%= discourse_stylesheet_link_tag("qunit-custom", theme_id: nil) %>
   </body>
 </html>

--- a/frontend/discourse/tests/test-boot-ember-cli.js
+++ b/frontend/discourse/tests/test-boot-ember-cli.js
@@ -6,6 +6,32 @@ import { loadAdmin, loadThemesAndPlugins } from "discourse/app";
 import config from "discourse/config/environment";
 import setupTests from "discourse/tests/setup-tests";
 
+/**
+ * Resolves once the styles that computed-geometry assertions depend on are in
+ * place. `fonts.ready` only covers faces that were already requested, so the
+ * element's computed font is requested explicitly first; a face that fails to
+ * load must not block the run.
+ *
+ * @param {object} [options]
+ * @param {FontFaceSet} [options.fonts] The font set to wait on.
+ * @param {Element} [options.element] The element whose computed font is requested.
+ * @returns {Promise<void>}
+ */
+export async function awaitVisualReadiness({
+  fonts = document.fonts,
+  element = document.body,
+} = {}) {
+  const { fontWeight, fontSize, fontFamily } = getComputedStyle(element);
+
+  try {
+    await fonts.load(`${fontWeight} ${fontSize} ${fontFamily}`);
+  } catch {
+    // A missing face degrades rendering; it must not abort the test run.
+  }
+
+  await fonts.ready;
+}
+
 export async function startTests() {
   await loadAdmin();
   await loadThemesAndPlugins();
@@ -68,6 +94,8 @@ export async function startTests() {
       availableModules[key] = value.default;
     }
   }
+
+  await awaitVisualReadiness();
 
   startEmberExam({
     setupTestContainer: false,

--- a/frontend/discourse/tests/unit/test-boot/visual-readiness-test.js
+++ b/frontend/discourse/tests/unit/test-boot/visual-readiness-test.js
@@ -1,0 +1,114 @@
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { awaitVisualReadiness } from "discourse/tests/test-boot-ember-cli";
+
+/**
+ * Builds a stand-in for `document.fonts` whose `ready` promise the test
+ * controls, so the gate can be observed while still pending.
+ */
+function fakeFontSet({ load = sinon.stub().resolves([]) } = {}) {
+  let resolveReady;
+  const ready = new Promise((resolve) => (resolveReady = resolve));
+  return { fonts: { load, ready }, resolveReady };
+}
+
+/**
+ * Reports whether a promise has settled without waiting on it.
+ */
+async function isSettled(promise) {
+  const pending = Symbol("pending");
+  return (await Promise.race([promise, pending])) !== pending;
+}
+
+module("Unit | Test boot | visual readiness", function (hooks) {
+  hooks.beforeEach(function () {
+    this.element = document.createElement("div");
+    this.element.style.font = 'bold 17px "Readiness Probe Face"';
+    document.body.append(this.element);
+  });
+
+  hooks.afterEach(function () {
+    this.element.remove();
+  });
+
+  test("every app stylesheet is a boot prerequisite of the test entrypoint", function (assert) {
+    const entrypoint = document.querySelector(
+      'script[data-discourse-entrypoint="test-entrypoint"]'
+    );
+    const stylesheets = [
+      ...document.querySelectorAll('link[rel="stylesheet"]'),
+    ];
+    const targets = stylesheets.map((link) => link.dataset.target);
+
+    assert.true(
+      document.body.contains(entrypoint),
+      "the test entrypoint script is in the body"
+    );
+    assert.true(targets.includes("common"), "the common stylesheet is linked");
+
+    for (const link of stylesheets) {
+      // The runner's own restyling sheet is cosmetic and must stay last in the
+      // body so it follows the stylesheet the runner injects at runtime.
+      if (link.dataset.target === "qunit-custom") {
+        continue;
+      }
+
+      // A head stylesheet blocks the deferred module script in the body; any
+      // non-head element before it demotes the rest of the head to the body,
+      // where it blocks nothing.
+      assert.strictEqual(
+        link.parentElement,
+        document.head,
+        `${link.dataset.target ?? link.href} is linked from the head`
+      );
+    }
+  });
+
+  test("requests the computed font of the given element before waiting on the font set", async function (assert) {
+    const { fonts, resolveReady } = fakeFontSet();
+    const computed = getComputedStyle(this.element);
+
+    const readiness = awaitVisualReadiness({ fonts, element: this.element });
+
+    assert.true(
+      fonts.load.calledOnceWith(
+        `${computed.fontWeight} ${computed.fontSize} ${computed.fontFamily}`
+      ),
+      "the element's computed font is requested explicitly"
+    );
+
+    resolveReady();
+    await readiness;
+  });
+
+  test("does not resolve until the font set reports ready", async function (assert) {
+    const { fonts, resolveReady } = fakeFontSet();
+
+    const readiness = awaitVisualReadiness({ fonts, element: this.element });
+    await Promise.resolve();
+
+    assert.false(
+      await isSettled(readiness),
+      "readiness is still pending while the font set loads"
+    );
+
+    resolveReady();
+    await readiness;
+    assert.true(await isSettled(readiness), "readiness resolves once ready");
+  });
+
+  test("still resolves when the font request itself fails", async function (assert) {
+    const { fonts, resolveReady } = fakeFontSet({
+      load: sinon.stub().rejects(new Error("no such face")),
+    });
+
+    const readiness = awaitVisualReadiness({ fonts, element: this.element });
+    resolveReady();
+    await readiness;
+
+    assert.true(
+      await isSettled(readiness),
+      "a missing face must not block the test run"
+    );
+  });
+});


### PR DESCRIPTION
Three core frontend tests fail intermittently on `main` and on unrelated PRs: the DSkeleton static-fill test and the two input-size height comparisons. They assert computed style and geometry, and they could run before the common stylesheet had applied.

The QUnit page rendered a hidden live-reload iframe inside `<head>`. An iframe is not head content, so the browser closed the head there and parsed every later stylesheet into the body. Stylesheets in the head block the deferred test entrypoint module script until they load. Stylesheets in the body do not. The served HTML looked correct; only the live DOM showed the links under `<body>`.

This PR moves the iframe into the body after the entrypoint and makes `startTests()` request the computed body font and await `document.fonts.ready` before Ember Exam starts. The original assertions stay strict. `qunit-custom`, which only restyles the runner chrome, stays last in the body so it keeps overriding the stylesheet the runner injects at runtime.

A unit test now checks that every app stylesheet link on the runner page is a head child and that the font gate requests the computed font, waits for readiness, and tolerates a face that fails to load. It fails against the previous page layout.
