### PR TITLE
FIX: make chat recipient lookup case-insensitive

### DIFF
--- a/plugins/chat/app/queries/chat/users_from_usernames_and_groups_query.rb
+++ b/plugins/chat/app/queries/chat/users_from_usernames_and_groups_query.rb
@@ -11,8 +11,8 @@ module Chat
         .left_outer_joins(:groups)
         .where(user_options: opts)
         .where(
-          "username IN (?) OR (groups.name IN (?) AND group_users.user_id IS NOT NULL)",
-          usernames&.map(&:to_s),
+          "users.username_lower IN (?) OR (groups.name IN (?) AND group_users.user_id IS NOT NULL)",
+          usernames&.map { |username| User.normalize_username(username.to_s) },
           groups&.map(&:to_s),
         )
         .where.not(id: excluded_user_ids)

--- a/plugins/chat/spec/queries/chat/users_from_usernames_and_groups_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/users_from_usernames_and_groups_query_spec.rb
@@ -14,6 +14,14 @@ describe Chat::UsersFromUsernamesAndGroupsQuery do
       expect(result).to contain_exactly(user1, user4)
     end
 
+    it "matches usernames case-insensitively" do
+      user = Fabricate(:user, username: "MixedCase")
+
+      result = described_class.call(usernames: [user.username.downcase], groups: [])
+
+      expect(result).to contain_exactly(user)
+    end
+
     it "works with a number" do
       user = Fabricate(:user, username: 12_345_678)
       result = described_class.call(usernames: [12_345_678], groups: [])


### PR DESCRIPTION
Chat recipient lookups matched `users.username` case-sensitively, so normalized usernames could fail to open a direct message.

This change normalizes recipient usernames and queries `users.username_lower`, allowing chat links to resolve usernames regardless of case following what's currently done for the regular `new-message` route.