### PR TITLE
FEATURE: Add styleguide shortcut to dev tools

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -467,6 +467,7 @@ en:
         since: "(since %{version})"
       toggle_safe_mode: "Toggle safe mode"
       toggle_verbose_localization: "Toggle verbose localization"
+      open_styleguide: "Open styleguide"
       disable_dev_tools: "Disable dev tools"
       toggle_upcoming_changes_debug: "Toggle upcoming changes debug"
 

--- a/frontend/discourse/app/static/dev-tools/styleguide/button.gts
+++ b/frontend/discourse/app/static/dev-tools/styleguide/button.gts
@@ -1,0 +1,23 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import getURL from "discourse/lib/get-url";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+export default class StyleguideButton extends Component {
+  @service site;
+
+  <template>
+    {{#if this.site.can_see_styleguide}}
+      <a
+        href={{getURL "/styleguide"}}
+        title={{i18n "dev_tools.open_styleguide"}}
+        aria-label={{i18n "dev_tools.open_styleguide"}}
+        class="dev-tools-toolbar__link open-styleguide"
+        data-auto-route="true"
+      >
+        {{dIcon "paintbrush"}}
+      </a>
+    {{/if}}
+  </template>
+}

--- a/frontend/discourse/app/static/dev-tools/styles.css
+++ b/frontend/discourse/app/static/dev-tools/styles.css
@@ -42,35 +42,38 @@
   &.--dragging {
     opacity: 0.5;
   }
+}
 
-  button {
-    background: none;
-    border: none;
-    padding: 5px;
-    color: var(--primary-700);
+.dev-tools-toolbar button,
+.dev-tools-toolbar .dev-tools-toolbar__link {
+  background: none;
+  border: none;
+  padding: 5px;
+  color: var(--primary-700);
+  text-align: center;
+  text-decoration: none;
+
+  .d-icon {
+    color: inherit !important;
+  }
+
+  &:hover:not(.gripper) {
+    background-color: var(--primary-50);
+  }
+
+  &.gripper {
+    cursor: grab;
+    padding-block: 0;
+    border-bottom: 1px dotted var(--primary-low-mid);
+    color: var(--primary-500);
+  }
+
+  &.--active {
+    background-color: var(--primary-100);
+    color: var(--tertiary);
 
     .d-icon {
-      color: inherit !important;
-    }
-
-    &:hover:not(.gripper) {
-      background-color: var(--primary-50);
-    }
-
-    &.gripper {
-      cursor: grab;
-      padding-block: 0;
-      border-bottom: 1px dotted var(--primary-low-mid);
-      color: var(--primary-500);
-    }
-
-    &.--active {
-      background-color: var(--primary-100);
-      color: var(--tertiary);
-
-      .d-icon {
-        font-weight: bold;
-      }
+      font-weight: bold;
     }
   }
 }

--- a/frontend/discourse/app/static/dev-tools/tools.ts
+++ b/frontend/discourse/app/static/dev-tools/tools.ts
@@ -2,6 +2,7 @@ import type { ComponentLike } from "@glint/template";
 import BlockDebugButton from "./block-debug/button";
 import PluginOutletDebugButton from "./plugin-outlet-debug/button";
 import SafeModeButton from "./safe-mode/button";
+import StyleguideButton from "./styleguide/button";
 import UpcomingChangesDebugButton from "./upcoming-changes-debug/button";
 import VerboseLocalizationButton from "./verbose-localization/button";
 
@@ -23,4 +24,5 @@ export const CORE_TOOLS: readonly DevTool[] = [
   { id: "upcoming-changes-debug", component: UpcomingChangesDebugButton },
   { id: "safe-mode", component: SafeModeButton },
   { id: "verbose-localization", component: VerboseLocalizationButton },
+  { id: "styleguide", component: StyleguideButton },
 ];

--- a/frontend/discourse/tests/integration/components/dev-tools-toolbar-test.gjs
+++ b/frontend/discourse/tests/integration/components/dev-tools-toolbar-test.gjs
@@ -1,9 +1,11 @@
 import { find, render, triggerEvent } from "@ember/test-helpers";
+import "discourse/static/dev-tools/styles.css";
 import { module, test } from "qunit";
 import Toolbar from "discourse/static/dev-tools/toolbar";
 import { CORE_TOOLS } from "discourse/static/dev-tools/tools";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { stubPointerCapture } from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
+import { i18n } from "discourse-i18n";
 
 /**
  * The toolbar as it is meant to read, left to right. Spelled out rather than
@@ -18,6 +20,7 @@ const EXPECTED_ORDER = [
   "upcoming-changes-debug",
   "safe-mode",
   "verbose-localization",
+  "styleguide",
   "disable-dev-tools",
 ];
 
@@ -28,6 +31,7 @@ const SELECTORS = {
   "upcoming-changes-debug": ".toggle-upcoming-changes-menu",
   "safe-mode": ".toggle-safe-mode",
   "verbose-localization": ".toggle-verbose-localization",
+  styleguide: ".open-styleguide",
   "disable-dev-tools": ".disable-dev-tools",
 };
 
@@ -244,6 +248,8 @@ module("Integration | Component | DevTools | Toolbar", function (hooks) {
   });
 
   test("renders every tool, in order, between the gripper and the disable button", async function (assert) {
+    this.site.can_see_styleguide = true;
+
     await render(<template><Toolbar /></template>);
 
     assert.deepEqual(
@@ -259,6 +265,91 @@ module("Integration | Component | DevTools | Toolbar", function (hooks) {
       EXPECTED_ORDER.slice(1, -1),
       "the table lists exactly the tools the toolbar is expected to show, in that order"
     );
+  });
+
+  test("renders the styleguide link for visitors with access", async function (assert) {
+    this.site.can_see_styleguide = true;
+
+    await render(<template><Toolbar /></template>);
+
+    assert
+      .dom(".open-styleguide")
+      .hasAttribute("href", "/styleguide", "the link targets the styleguide")
+      .hasAttribute(
+        "title",
+        i18n("dev_tools.open_styleguide"),
+        "the link has a visible tooltip"
+      )
+      .hasAttribute(
+        "aria-label",
+        i18n("dev_tools.open_styleguide"),
+        "the icon-only link has an accessible name"
+      )
+      .hasAttribute(
+        "data-auto-route",
+        "true",
+        "the link performs a full navigation so filtered assets load"
+      );
+    assert
+      .dom(".open-styleguide .d-icon-paintbrush")
+      .exists("the link uses the styleguide icon");
+  });
+
+  test("styles links and buttons as consistent toolbar controls", async function (assert) {
+    this.site.can_see_styleguide = true;
+    const competingLinkStyle = document.createElement("style");
+    competingLinkStyle.textContent = "a:any-link { color: rgb(0 0 255); }";
+    document.head.append(competingLinkStyle);
+
+    await render(<template><Toolbar /></template>);
+
+    const buttonStyle = getComputedStyle(find(".toggle-plugin-outlets"));
+    const linkStyle = getComputedStyle(find(".open-styleguide"));
+    const buttonIconStyle = getComputedStyle(
+      find(".toggle-plugin-outlets .d-icon")
+    );
+    const linkIconStyle = getComputedStyle(find(".open-styleguide .d-icon"));
+
+    assert.strictEqual(
+      buttonStyle.borderTopWidth,
+      "0px",
+      "toolbar buttons have no native border"
+    );
+    assert.strictEqual(
+      buttonStyle.paddingTop,
+      "5px",
+      "toolbar buttons retain their compact padding"
+    );
+    assert.strictEqual(
+      linkStyle.borderTopWidth,
+      buttonStyle.borderTopWidth,
+      "toolbar links match the button border"
+    );
+    assert.strictEqual(
+      linkStyle.paddingTop,
+      buttonStyle.paddingTop,
+      "toolbar links match the button padding"
+    );
+    assert.strictEqual(
+      linkStyle.color,
+      buttonStyle.color,
+      "toolbar links match the button foreground color"
+    );
+    assert.strictEqual(
+      linkIconStyle.color,
+      buttonIconStyle.color,
+      "toolbar link icons match button icon colors"
+    );
+
+    competingLinkStyle.remove();
+  });
+
+  test("omits the styleguide link without access", async function (assert) {
+    await render(<template><Toolbar /></template>);
+
+    assert
+      .dom(".open-styleguide")
+      .doesNotExist("a missing capability does not expose the link");
   });
 
   test("the gripper and disable button render outside the tool list", async function (assert) {

--- a/plugins/styleguide/app/controllers/styleguide/styleguide_controller.rb
+++ b/plugins/styleguide/app/controllers/styleguide/styleguide_controller.rb
@@ -6,9 +6,7 @@ module Styleguide
     skip_before_action :check_xhr
 
     def index
-      if !guardian.in_any_groups?(SiteSetting.styleguide_allowed_groups_map)
-        return raise Discourse::NotFound
-      end
+      return raise Discourse::NotFound if !guardian.can_see_styleguide?
 
       render "default/empty"
     end

--- a/plugins/styleguide/plugin.rb
+++ b/plugins/styleguide/plugin.rb
@@ -18,6 +18,12 @@ require_relative "lib/styleguide/engine"
 Discourse::Application.routes.append { mount Styleguide::Engine, at: "/styleguide" }
 
 after_initialize do
+  add_to_class(:guardian, :can_see_styleguide?) do
+    SiteSetting.styleguide_enabled && in_any_groups?(SiteSetting.styleguide_allowed_groups_map)
+  end
+
+  add_to_serializer(:site, :can_see_styleguide) { scope.can_see_styleguide? }
+
   register_asset_filter do |type, request, opts|
     path = opts[:path]
 

--- a/plugins/styleguide/spec/integration/access_spec.rb
+++ b/plugins/styleguide/spec/integration/access_spec.rb
@@ -67,3 +67,28 @@ RSpec.describe "SiteSetting.styleguide_enabled" do
     end
   end
 end
+
+RSpec.describe "Styleguide site capability" do
+  before do
+    SiteSetting.styleguide_enabled = true
+    SiteSetting.styleguide_allowed_groups = Group::AUTO_GROUPS[:admins]
+  end
+
+  it "reflects whether the visitor can access the styleguide" do
+    sign_in(Fabricate(:admin))
+    get "/site.json"
+    expect(response.parsed_body["can_see_styleguide"]).to eq(true)
+
+    sign_in(Fabricate(:user))
+    get "/site.json"
+    expect(response.parsed_body["can_see_styleguide"]).to eq(false)
+  end
+
+  it "is omitted when the plugin is disabled" do
+    SiteSetting.styleguide_enabled = false
+
+    get "/site.json"
+
+    expect(response.parsed_body).not_to have_key("can_see_styleguide")
+  end
+end


### PR DESCRIPTION
Adds an access-aware styleguide shortcut to the dev tools toolbar. It uses full-page navigation so the styleguide assets load correctly.

Includes coverage for access, rendering, navigation, and styling.
