### PR TITLE
fixed admin active users list performing per user 2FA existence checks

### DIFF
--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -61,8 +61,7 @@ module SecondFactorManager
   end
 
   def totp_enabled?
-    !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins &&
-      user_second_factors&.totps&.exists?
+    !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins && totps&.any?
   end
 
   def backup_codes_enabled?
@@ -72,19 +71,13 @@ module SecondFactorManager
 
   def security_keys_enabled?
     !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins &&
-      security_keys&.where(
-        factor_type: UserSecurityKey.factor_types[:second_factor],
-        enabled: true,
-      )&.exists?
+      security_key_factor_enabled?(UserSecurityKey.factor_types[:second_factor])
   end
 
   def passkeys_available_as_second_factor?
     SiteSetting.allow_passkeys_for_2fa && SiteSetting.enable_passkeys &&
       !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins &&
-      security_keys&.where(
-        factor_type: UserSecurityKey.factor_types[:first_factor],
-        enabled: true,
-      )&.exists?
+      security_key_factor_enabled?(UserSecurityKey.factor_types[:first_factor])
   end
   alias_method :passkeys_for_2fa_enabled?, :passkeys_available_as_second_factor?
 
@@ -303,5 +296,15 @@ module SecondFactorManager
 
   def require_rotp
     require "rotp" if !defined?(ROTP)
+  end
+
+  private
+
+  def security_key_factor_enabled?(factor_type)
+    if security_keys.loaded?
+      security_keys.any? { |security_key| security_key.factor_type == factor_type }
+    else
+      security_keys.where(factor_type: factor_type).exists?
+    end
   end
 end

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -61,7 +61,7 @@ module SecondFactorManager
   end
 
   def totp_enabled?
-    !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins && totps&.any?
+    !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins && totps.any?
   end
 
   def backup_codes_enabled?

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -104,7 +104,7 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_second_factor_enabled?
     !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins &&
-      (object.totps.any? || second_factor_security_key_enabled?)
+      object.has_any_second_factor_methods_enabled?
   end
 
   def second_factor_enabled
@@ -141,13 +141,5 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_suspend_reason?
     @options[:include_suspend_reason]
-  end
-
-  private
-
-  def second_factor_security_key_enabled?
-    object.security_keys.any? do |security_key|
-      security_key.factor_type == UserSecurityKey.factor_types[:second_factor]
-    end
   end
 end

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -104,7 +104,7 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_second_factor_enabled?
     !SiteSetting.enable_discourse_connect && SiteSetting.enable_local_logins &&
-      object.has_any_second_factor_methods_enabled?
+      (object.totps.any? || second_factor_security_key_enabled?)
   end
 
   def second_factor_enabled
@@ -141,5 +141,13 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_suspend_reason?
     @options[:include_suspend_reason]
+  end
+
+  private
+
+  def second_factor_security_key_enabled?
+    object.security_keys.any? do |security_key|
+      security_key.factor_type == UserSecurityKey.factor_types[:second_factor]
+    end
   end
 end

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -66,7 +66,7 @@ class AdminUserIndexQuery
       order << "users.username"
     end
 
-    query = klass.includes(:totps).order(order.reject(&:blank?).join(","))
+    query = klass.includes(:security_keys, :totps).order(order.reject(&:blank?).join(","))
 
     query = query.includes(:user_stat) unless params[:stats].present? && params[:stats] == false
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe Admin::UsersController do
         expect(response.parsed_body).to be_present
       end
 
+      it "loads second-factor status in batches" do
+        Fabricate(:user_second_factor_totp, user: user)
+        Fabricate(:user_security_key, user: coding_horror)
+        Fabricate(:passkey_with_random_credential, user: moderator)
+
+        queries = track_sql_queries { get "/admin/users/list/active.json" }
+
+        users_by_id = response.parsed_body.index_by { |serialized_user| serialized_user["id"] }
+        expect(users_by_id[user.id]["second_factor_enabled"]).to eq(true)
+        expect(users_by_id[coding_horror.id]["second_factor_enabled"]).to eq(true)
+        expect(users_by_id[moderator.id]).not_to have_key("second_factor_enabled")
+        expect(queries.count { |query| query.include?('FROM "user_second_factors"') }).to eq(1)
+        expect(queries.count { |query| query.include?('FROM "user_security_keys"') }).to eq(1)
+      end
+
       it "returns silence reason when user is silenced" do
         silencer =
           UserSilencer.new(


### PR DESCRIPTION
## Why
The admin active-users endpoint `/admin/users/list/active.json`  performed per-user queries to determine 2FA status.

## Changes
This change  preloads TOTP and security-key records and uses them during serialization to fix the above N+1 issue.

I first thought changing `second_factor_manager.rb`, But reverted from the idea because it is used in many sensitive functions and I thought of this usecase:

```ruby
user.security_keys.load # [] 
UserSecurityKey.create!(user: user, ...)
user.security_keys_enabled? # false with the staged implementation
```
This is a non existing use case, It looks fine. But I decided not to do that on the first PR itself. It's for your thoughts.

## Performance
Tested locally in production mode with 75 active users over five runs and empty 2FA.

| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Server duration (ms) | 146.49 | 49.11 | -66.5% | 144.51 | 45.62 |
| SQL duration (ms) | 56.40 | 5.71 | -89.9% | 55.66 | 5.64 |
| Allocated objects | 61292 | 27292 | -55.5% | 61250 | 27289 |
| SQL events | 159 | 10 | -93.7% | 159 | 10 |
| Cached SQL events | 0 | 0 | n/a | 0 | 0 |
| Duplicate fingerprints | 148 | 0 | -100.0% | 148 | 0 |
| User second-factor queries | 76 | 1 | -98.7% | 76 | 1 |
| Security-key queries | 75 | 1 | -98.7% | 75 | 1 |
| TOTP existence queries | 75 | 0 | -100.0% | 75 | 0 |
| Security-key existence queries | 75 | 0 | -100.0% | 75 | 0 |