### PR TITLE
FEATURE: Add event attendance workflow action

### DIFF
--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -347,12 +347,21 @@ en:
       nodes:
         "trigger:event_ended": "Event ended"
         "trigger:event_participation_changed": "Event participation changed"
+        "action:event": "Event"
       node_descriptions:
         "trigger:event_ended": "Fires when an event occurrence reaches its end time"
         "trigger:event_participation_changed": "Fires when a user adds, changes, or withdraws their RSVP"
+        "action:event": "Close or open an event"
       post_event:
         topic_id: "Topic ID"
         topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
+      event:
+        operation: "Operation"
+        operations:
+          close: "Close event"
+          open: "Open event"
+        topic_id: "Topic ID"
+        actor_username: "Performed by user"
     discourse_post_event:
       new_event: "New Event"
       notifications:

--- a/plugins/discourse-events/config/locales/client.en.yml
+++ b/plugins/discourse-events/config/locales/client.en.yml
@@ -351,7 +351,7 @@ en:
       node_descriptions:
         "trigger:event_ended": "Fires when an event occurrence reaches its end time"
         "trigger:event_participation_changed": "Fires when a user adds, changes, or withdraws their RSVP"
-        "action:event": "Close or open an event"
+        "action:event": "Close, open, or update attendance for an event"
       post_event:
         topic_id: "Topic ID"
         topic_id_description: "Only trigger for events in this topic. Leave empty to match all events."
@@ -360,7 +360,15 @@ en:
         operations:
           close: "Close event"
           open: "Open event"
+          set_attendance: "Set attendance"
         topic_id: "Topic ID"
+        attendee_username: "Attendee"
+        attendance: "Attendance"
+        attendances:
+          going: "Going"
+          interested: "Interested"
+          not_going: "Not going"
+          remove: "Remove attendance"
         actor_username: "Performed by user"
     discourse_post_event:
       new_event: "New Event"

--- a/plugins/discourse-events/config/locales/server.en.yml
+++ b/plugins/discourse-events/config/locales/server.en.yml
@@ -16,6 +16,13 @@ en:
       labels:
         username: Username
 
+  discourse_workflows:
+    errors:
+      event:
+        unknown_operation: "Unknown event operation: %{operation}."
+        not_found: "No event found in topic %{topic_id}."
+        missing_event_block: "The event post does not contain an [event] block."
+
   discourse_automation:
     triggerables:
       event_started:

--- a/plugins/discourse-events/config/locales/server.en.yml
+++ b/plugins/discourse-events/config/locales/server.en.yml
@@ -20,6 +20,8 @@ en:
     errors:
       event:
         unknown_operation: "Unknown event operation: %{operation}."
+        unknown_attendance: "Unknown event attendance: %{attendance}."
+        attendance_failed: "Could not update event attendance."
         not_found: "No event found in topic %{topic_id}."
         missing_event_block: "The event post does not contain an [event] block."
 

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event/v1.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseWorkflows)
+  module DiscourseWorkflows
+    module Nodes
+      module Event
+        class V1 < NodeType
+          OPERATIONS = %w[close open].freeze
+
+          description(
+            name: "action:event",
+            version: "1.0",
+            defaults: {
+              icon: "calendar-days",
+              color: "purple",
+            },
+            group: "discourse_actions",
+            capabilities: {
+              run_scope: "per_item",
+            },
+            available: -> { SiteSetting.discourse_post_event_enabled },
+            properties: {
+              operation: {
+                type: :options,
+                required: true,
+                options: OPERATIONS,
+                default: "close",
+              },
+              topic_id: {
+                type: :string,
+                required: true,
+              },
+              actor_username: {
+                type: :string,
+                required: false,
+                default: "system",
+                ui: {
+                  control: :actor,
+                },
+              },
+            },
+          )
+
+          def execute(exec_ctx)
+            items =
+              exec_ctx.input_items.map.with_index do |_item, item_index|
+                config = {
+                  "operation" =>
+                    exec_ctx.get_node_parameter("operation", item_index, default: "close"),
+                  "topic_id" => exec_ctx.get_node_parameter("topic_id", item_index),
+                }
+
+                wrap(execute_with_config(exec_ctx, config, item_index))
+              end
+
+            [items]
+          end
+
+          private
+
+          def execute_with_config(exec_ctx, config, item_index)
+            operation = config["operation"]
+
+            if OPERATIONS.exclude?(operation)
+              raise_node_error!(
+                I18n.t("discourse_workflows.errors.event.unknown_operation", operation: operation),
+              )
+            end
+
+            topic = ::Topic.find(config["topic_id"])
+            actor = exec_ctx.actor_from_parameter("actor_username", item_index)
+
+            event = topic.first_post&.event
+            if event.blank?
+              raise_node_error!(
+                I18n.t("discourse_workflows.errors.event.not_found", topic_id: topic.id),
+              )
+            end
+
+            actor.guardian.ensure_can_act_on_discourse_post_event!(event)
+
+            desired_closed_state = operation == "close"
+
+            if event.closed? != desired_closed_state
+              new_raw = raw_with_closed_state(event.post.raw, closed: desired_closed_state)
+
+              post = exec_ctx.edit_post(user: actor, post_id: event.post.id, raw: new_raw)
+
+              post.association(:event).reload
+              event = post.event
+            end
+
+            {
+              event: event_data(event),
+              topic: exec_ctx.serialize_topic(topic, guardian: actor.guardian),
+              post: exec_ctx.serialize_post(event.post, guardian: actor.guardian),
+            }
+          end
+
+          def event_data(event)
+            {
+              id: event.id,
+              topic_id: event.post.topic_id,
+              post_id: event.post.id,
+              closed: event.closed?,
+            }
+          end
+
+          # Event state is derived from the [event] block in post.raw.
+          # Change the source BBCode, then let the normal post-edited hook
+          # synchronize the Event record.
+          def raw_with_closed_state(raw, closed:)
+            tag_range = event_opening_tag_range(raw)
+
+            if tag_range.nil?
+              raise_node_error!(I18n.t("discourse_workflows.errors.event.missing_event_block"))
+            end
+
+            opening_tag = raw[tag_range]
+            closed_range = attribute_range(opening_tag, "closed")
+
+            if closed
+              if closed_range
+                opening_tag[closed_range] = ' closed="true"'
+              else
+                opening_tag = opening_tag.sub(/\]\z/, ' closed="true"]')
+              end
+            elsif closed_range
+              opening_tag[closed_range] = ""
+            end
+
+            updated = raw.dup
+            updated[tag_range] = opening_tag
+            updated
+          end
+
+          # Locate the first real [event ...] opening tag while ignoring ]
+          # characters contained inside quoted attribute values.
+          def event_opening_tag_range(raw)
+            search_from = 0
+
+            loop do
+              start = raw.index("[event", search_from)
+              return if start.nil?
+
+              following = raw[start + 6]
+
+              unless following.nil? || following == "]" || following.match?(/\s/)
+                search_from = start + 6
+                next
+              end
+
+              index = start + 6
+              quote = nil
+              escaped = false
+
+              while index < raw.length
+                char = raw[index]
+
+                if quote
+                  if char == "\\" && !escaped
+                    escaped = true
+                  else
+                    quote = nil if char == quote && !escaped
+                    escaped = false
+                  end
+                elsif char == '"' || char == "'"
+                  quote = char
+                elsif char == "]"
+                  return start..index
+                end
+
+                index += 1
+              end
+
+              return
+            end
+          end
+
+          # Returns the range occupied by a named top-level BBCode
+          # attribute, including the whitespace immediately before it.
+          #
+          # Quoted values are consumed as a unit, so text such as:
+          #
+          #   location="Room closed=true"
+          #
+          # is not mistaken for a closed= attribute.
+          def attribute_range(tag, target_name)
+            index = 6 # immediately after "[event"
+            closing_index = tag.length - 1
+
+            while index < closing_index
+              whitespace_start = index
+              index += 1 while index < closing_index && tag[index].match?(/\s/)
+
+              break if index >= closing_index
+
+              name_start = index
+              index += 1 while index < closing_index && tag[index].match?(/[A-Za-z0-9_.-]/)
+
+              # Skip malformed/non-attribute characters safely.
+              if name_start == index
+                index += 1
+                next
+              end
+
+              name = tag[name_start...index]
+
+              index += 1 while index < closing_index && tag[index].match?(/\s/)
+
+              # Bare attribute/token.
+              if index >= closing_index || tag[index] != "="
+                index += 1 while index < closing_index && !tag[index].match?(/\s/)
+                next
+              end
+
+              index += 1
+              index += 1 while index < closing_index && tag[index].match?(/\s/)
+
+              if index < closing_index && %w[" '].include?(tag[index])
+                quote = tag[index]
+                index += 1
+                escaped = false
+
+                while index < closing_index
+                  char = tag[index]
+
+                  if char == "\\" && !escaped
+                    escaped = true
+                  else
+                    if char == quote && !escaped
+                      index += 1
+                      break
+                    end
+                    escaped = false
+                  end
+
+                  index += 1
+                end
+              else
+                index += 1 while index < closing_index && !tag[index].match?(/\s/)
+              end
+
+              return whitespace_start...index if name.casecmp(target_name).zero?
+            end
+
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-events/lib/discourse_workflows/nodes/event/v1.rb
+++ b/plugins/discourse-events/lib/discourse_workflows/nodes/event/v1.rb
@@ -5,7 +5,8 @@ if defined?(DiscourseWorkflows)
     module Nodes
       module Event
         class V1 < NodeType
-          OPERATIONS = %w[close open].freeze
+          OPERATIONS = %w[close open set_attendance].freeze
+          ATTENDANCE_OPTIONS = %w[going interested not_going remove].freeze
 
           description(
             name: "action:event",
@@ -30,6 +31,29 @@ if defined?(DiscourseWorkflows)
                 type: :string,
                 required: true,
               },
+              attendee_username: {
+                type: :string,
+                required: true,
+                display_options: {
+                  show: {
+                    operation: ["set_attendance"],
+                  },
+                },
+                ui: {
+                  control: :user,
+                },
+              },
+              attendance: {
+                type: :options,
+                required: true,
+                options: ATTENDANCE_OPTIONS,
+                default: "going",
+                display_options: {
+                  show: {
+                    operation: ["set_attendance"],
+                  },
+                },
+              },
               actor_username: {
                 type: :string,
                 required: false,
@@ -48,6 +72,10 @@ if defined?(DiscourseWorkflows)
                   "operation" =>
                     exec_ctx.get_node_parameter("operation", item_index, default: "close"),
                   "topic_id" => exec_ctx.get_node_parameter("topic_id", item_index),
+                  "attendee_username" =>
+                    exec_ctx.get_node_parameter("attendee_username", item_index),
+                  "attendance" =>
+                    exec_ctx.get_node_parameter("attendance", item_index, default: "going"),
                 }
 
                 wrap(execute_with_config(exec_ctx, config, item_index))
@@ -77,17 +105,23 @@ if defined?(DiscourseWorkflows)
               )
             end
 
-            actor.guardian.ensure_can_act_on_discourse_post_event!(event)
+            case operation
+            when "close", "open"
+              actor.guardian.ensure_can_act_on_discourse_post_event!(event)
 
-            desired_closed_state = operation == "close"
+              desired_closed_state = operation == "close"
 
-            if event.closed? != desired_closed_state
-              new_raw = raw_with_closed_state(event.post.raw, closed: desired_closed_state)
+              if event.closed? != desired_closed_state
+                new_raw = raw_with_closed_state(event.post.raw, closed: desired_closed_state)
 
-              post = exec_ctx.edit_post(user: actor, post_id: event.post.id, raw: new_raw)
+                post = exec_ctx.edit_post(user: actor, post_id: event.post.id, raw: new_raw)
 
-              post.association(:event).reload
-              event = post.event
+                post.association(:event).reload
+                event = post.event
+              end
+            when "set_attendance"
+              attendee = exec_ctx.find_user(username: config["attendee_username"])
+              set_attendance!(event:, attendee:, attendance: config["attendance"], actor:)
             end
 
             {
@@ -95,6 +129,83 @@ if defined?(DiscourseWorkflows)
               topic: exec_ctx.serialize_topic(topic, guardian: actor.guardian),
               post: exec_ctx.serialize_post(event.post, guardian: actor.guardian),
             }
+          end
+
+          def set_attendance!(event:, attendee:, attendance:, actor:)
+            if ATTENDANCE_OPTIONS.exclude?(attendance)
+              raise_node_error!(
+                I18n.t(
+                  "discourse_workflows.errors.event.unknown_attendance",
+                  attendance: attendance,
+                ),
+              )
+            end
+
+            invitee = event.invitees.find_by(user_id: attendee.id)
+
+            if attendance == "remove"
+              return if invitee.blank?
+
+              return destroy_invitee!(event:, invitee:, actor:)
+            end
+
+            status = attendance.to_sym
+
+            return if invitee && invitee.status == DiscourseEvents::Events::Invitee.statuses[status]
+
+            if invitee
+              update_invitee!(event:, invitee:, status:, actor:)
+            else
+              create_invitee!(event:, attendee:, status:, actor:)
+            end
+          end
+
+          def create_invitee!(event:, attendee:, status:, actor:)
+            DiscourseEvents::Events::CreateInvitee.call(
+              guardian: actor.guardian,
+              params: {
+                event_id: event.id,
+                user_id: attendee.id,
+                status: status,
+              },
+            ) do |result|
+              on_success { next }
+              on_failure { raise_attendance_error!(result) }
+            end
+          end
+
+          def update_invitee!(event:, invitee:, status:, actor:)
+            DiscourseEvents::Events::UpdateInvitee.call(
+              guardian: actor.guardian,
+              params: {
+                event_id: event.id,
+                invitee_id: invitee.id,
+                status: status,
+              },
+            ) do |result|
+              on_success { next }
+              on_failure { raise_attendance_error!(result) }
+            end
+          end
+
+          def destroy_invitee!(event:, invitee:, actor:)
+            DiscourseEvents::Events::DestroyInvitee.call(
+              guardian: actor.guardian,
+              params: {
+                post_id: event.id,
+                id: invitee.id,
+              },
+            ) do |result|
+              on_success { next }
+              on_failure { raise_attendance_error!(result) }
+            end
+          end
+
+          def raise_attendance_error!(result)
+            raise_node_error!(
+              I18n.t("discourse_workflows.errors.event.attendance_failed"),
+              description: result.inspect_steps,
+            )
           end
 
           def event_data(event)

--- a/plugins/discourse-events/plugin.rb
+++ b/plugins/discourse-events/plugin.rb
@@ -237,6 +237,7 @@ after_initialize do
       [
         DiscourseWorkflows::Nodes::EventEnded::V1,
         DiscourseWorkflows::Nodes::EventParticipationChanged::V1,
+        DiscourseWorkflows::Nodes::Event::V1,
       ]
     end
   end

--- a/plugins/discourse-events/spec/integration/workflows_event_action_spec.rb
+++ b/plugins/discourse-events/spec/integration/workflows_event_action_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../discourse-workflows/spec/support/node_execution_helpers"
+
+RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
+  fab!(:admin)
+
+  before do
+    SiteSetting.discourse_events_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.enable_discourse_workflows = true
+    DiscourseWorkflows::WorkflowDependency.clear_cache!
+  end
+
+  def create_event_post(closed: false)
+    closed_attribute = closed ? ' closed="true"' : ""
+
+    post =
+      PostCreator.create!(
+        admin,
+        title: "Workflow event integration",
+        raw:
+          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" timezone=\"UTC\"#{closed_attribute}]\n" \
+            "Event description\n" \
+            "[/event]",
+      )
+
+    post.reload
+    post.association(:event).reload
+    post
+  end
+
+  def execute_event_action(post, operation)
+    execute_node(
+      configuration: {
+        "operation" => operation,
+        "topic_id" => post.topic_id.to_s,
+        "actor_username" => admin.username,
+      },
+    )
+  end
+
+  def post_edited_workflow_job_count
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.count do |job|
+      job["args"].first["trigger_node_id"] == "post-edited-trigger"
+    end
+  end
+
+  def publish_post_edited_workflow
+    workflow =
+      Fabricate(
+        :discourse_workflows_workflow,
+        created_by: admin,
+        published: true,
+        **build_workflow_graph { |graph| graph.node "post-edited-trigger", "trigger:post_edited" },
+      )
+
+    DiscourseWorkflows::WorkflowDependencyIndexer.call(workflow)
+    workflow
+  end
+
+  it "closes an event through the real workflow execution context" do
+    post = create_event_post
+
+    expect(post.event).to be_present
+    expect(post.event.closed?).to eq(false)
+
+    result = execute_event_action(post, "close")
+
+    post.reload
+    post.association(:event).reload
+
+    expect(post.raw).to include('closed="true"')
+    expect(post.event.closed?).to eq(true)
+
+    expect(result["event"]).to include(
+      "id" => post.event.id,
+      "post_id" => post.id,
+      "topic_id" => post.topic_id,
+      "closed" => true,
+    )
+  end
+
+  it "opens an event through the real workflow execution context" do
+    post = create_event_post(closed: true)
+
+    expect(post.event).to be_present
+    expect(post.event.closed?).to eq(true)
+
+    result = execute_event_action(post, "open")
+
+    post.reload
+    post.association(:event).reload
+
+    expect(post.raw).not_to match(/\sclosed\s*=/i)
+    expect(post.event.closed?).to eq(false)
+
+    expect(result["event"]).to include(
+      "id" => post.event.id,
+      "post_id" => post.id,
+      "topic_id" => post.topic_id,
+      "closed" => false,
+    )
+  end
+
+  it "does not recursively trigger post edited workflows" do
+    post = create_event_post
+    publish_post_edited_workflow
+
+    before_count = post_edited_workflow_job_count
+
+    execute_event_action(post, "close")
+
+    expect(post_edited_workflow_job_count).to eq(before_count)
+    expect(post.reload.event.closed?).to eq(true)
+  end
+end

--- a/plugins/discourse-events/spec/integration/workflows_event_action_spec.rb
+++ b/plugins/discourse-events/spec/integration/workflows_event_action_spec.rb
@@ -5,6 +5,7 @@ require_relative "../../../discourse-workflows/spec/support/node_execution_helpe
 
 RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
   fab!(:admin)
+  fab!(:attendee, :user)
 
   before do
     SiteSetting.discourse_events_enabled = true
@@ -21,7 +22,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
         admin,
         title: "Workflow event integration",
         raw:
-          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" timezone=\"UTC\"#{closed_attribute}]\n" \
+          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" timezone=\"UTC\" status=\"public\"#{closed_attribute}]\n" \
             "Event description\n" \
             "[/event]",
       )
@@ -58,6 +59,106 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
 
     DiscourseWorkflows::WorkflowDependencyIndexer.call(workflow)
     workflow
+  end
+
+  it "sets an event author to going from a post created workflow" do
+    graph =
+      build_workflow_graph do |g|
+        g.node "post-created-attendance", "trigger:post_created"
+
+        g.node "first-post-only",
+               "condition:if",
+               configuration: {
+                 "conditions" => [
+                   {
+                     "id" => "1",
+                     "leftValue" => "={{ $json.post.post_number }}",
+                     "rightValue" => 1,
+                     "operator" => {
+                       "type" => "number",
+                       "operation" => "equals",
+                     },
+                   },
+                 ],
+                 "combinator" => "and",
+               }
+
+        g.node "set-event-attendance",
+               "action:event",
+               configuration: {
+                 "operation" => "set_attendance",
+                 "topic_id" => "={{ $trigger.topic.id }}",
+                 "attendee_username" => "={{ $trigger.user.username }}",
+                 "attendance" => "going",
+                 "actor_username" => "system",
+               }
+
+        g.chain "post-created-attendance", "first-post-only"
+        g.connect "first-post-only", "set-event-attendance", output: "true"
+      end
+
+    workflow =
+      Fabricate(
+        :discourse_workflows_workflow,
+        created_by: admin,
+        name: "Event author attendance",
+        **graph,
+      )
+
+    publish_workflow!(workflow)
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.clear
+
+    post =
+      PostCreator.create!(
+        admin,
+        title: "Automatically attend my event",
+        raw:
+          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" " \
+            "timezone=\"UTC\" status=\"public\"]\n" \
+            "Event description\n" \
+            "[/event]",
+      )
+
+    post.reload
+    post.association(:event).reload
+
+    # This assertion is deliberately before executing the workflow job.
+    # It proves the Events post-created listener synchronized the event first.
+    expect(post.event).to be_present
+    expect(post.event.invitees.find_by(user_id: admin.id)).to be_nil
+
+    job =
+      Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.find do |queued_job|
+        args = queued_job["args"].first
+        args["workflow_id"] == workflow.id && args["trigger_node_id"] == "post-created-attendance"
+      end
+
+    expect(job).to be_present
+
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.new.execute(job["args"].first.symbolize_keys)
+
+    invitee = post.event.invitees.find_by(user_id: admin.id)
+
+    expect(invitee).to be_present
+    expect(invitee.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+
+    # Replies also emit post_created, but must not register their authors
+    # as attendees. The first-post condition protects against that.
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.clear
+
+    PostCreator.create!(attendee, topic_id: post.topic_id, raw: "A reply to the event topic")
+
+    reply_job =
+      Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.find do |queued_job|
+        args = queued_job["args"].first
+        args["workflow_id"] == workflow.id && args["trigger_node_id"] == "post-created-attendance"
+      end
+
+    expect(reply_job).to be_present
+
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.new.execute(reply_job["args"].first.symbolize_keys)
+
+    expect(post.event.invitees.find_by(user_id: attendee.id)).to be_nil
   end
 
   it "closes an event through the real workflow execution context" do
@@ -101,6 +202,33 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
       "post_id" => post.id,
       "topic_id" => post.topic_id,
       "closed" => false,
+    )
+  end
+
+  it "sets attendance as the system user for another user" do
+    post = create_event_post
+
+    expect(post.event.invitees.find_by(user_id: attendee.id)).to be_nil
+
+    result =
+      execute_node(
+        configuration: {
+          "operation" => "set_attendance",
+          "topic_id" => post.topic_id.to_s,
+          "attendee_username" => attendee.username,
+          "attendance" => "going",
+          "actor_username" => "system",
+        },
+      )
+
+    invitee = post.event.invitees.find_by(user_id: attendee.id)
+
+    expect(invitee).to be_present
+    expect(invitee.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+    expect(result["event"]).to include(
+      "id" => post.event.id,
+      "post_id" => post.id,
+      "topic_id" => post.topic_id,
     )
   end
 

--- a/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event/v1_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event/v1_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../../../lib/discourse_workflows/nodes/event/v1"
+
+RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
+  fab!(:admin)
+
+  before { SiteSetting.discourse_post_event_enabled = true }
+
+  def create_event_post(closed: false)
+    closed_attribute = closed ? ' closed="true"' : ""
+
+    post =
+      PostCreator.create!(
+        admin,
+        title: "Workflow event topic",
+        raw:
+          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" timezone=\"UTC\"#{closed_attribute}]\n" \
+            "Event description\n" \
+            "[/event]",
+      )
+
+    # In this isolated node spec, explicitly perform the same synchronization
+    # that the Events plugin's post-created hook performs in normal operation.
+    DiscourseEvents::Events::Event::SyncFromPost.call(params: { post_id: post.id })
+
+    post.reload
+    post.association(:event).reload
+    post
+  end
+
+  def execution_context(topic:, operation:)
+    actor = admin
+
+    Class
+      .new do
+        define_method(:initialize) do |topic_arg, operation_arg, actor_arg|
+          @topic = topic_arg
+          @operation = operation_arg
+          @actor = actor_arg
+        end
+
+        define_method(:input_items) { [{ "json" => {} }] }
+
+        define_method(:get_node_parameter) do |name, _item_index, default: nil|
+          case name
+          when "operation"
+            @operation
+          when "topic_id"
+            @topic.id.to_s
+          else
+            default
+          end
+        end
+
+        define_method(:actor_from_parameter) { |_name, _item_index| @actor }
+
+        define_method(:edit_post) do |user:, post_id:, raw:|
+          post = Post.find(post_id)
+
+          revised = PostRevisor.new(post).revise!(user, { raw: raw }, skip_workflows: true)
+
+          raise "Post revision failed: #{post.errors.full_messages.join(", ")}" if !revised
+
+          # Emulate the Events plugin's :post_edited hook in this isolated
+          # node spec so the Event model is synchronized from post.raw.
+          DiscourseEvents::Events::Event::SyncFromPost.call(params: { post_id: post.id })
+
+          post.reload
+          post.association(:event).reload
+          post
+        end
+
+        define_method(:serialize_topic) do |topic_arg, guardian:, **_options|
+          { id: topic_arg.id, title: topic_arg.title }
+        end
+
+        define_method(:serialize_post) do |post, guardian:, **_options|
+          { id: post.id, post_number: post.post_number }
+        end
+      end
+      .new(topic, operation, actor)
+  end
+
+  it "closes the event by revising its source BBCode" do
+    post = create_event_post
+    topic = post.topic
+
+    expect(post.event).to be_present
+    expect(post.event.closed?).to eq(false)
+
+    described_class.new(parameters: {}).execute(execution_context(topic: topic, operation: "close"))
+
+    post.reload
+    post.association(:event).reload
+
+    expect(post.raw).to include('closed="true"')
+    expect(post.event.closed?).to eq(true)
+  end
+
+  it "opens a closed event by removing the closed attribute" do
+    post = create_event_post(closed: true)
+    topic = post.topic
+
+    expect(post.event).to be_present
+    expect(post.event.closed?).to eq(true)
+
+    described_class.new(parameters: {}).execute(execution_context(topic: topic, operation: "open"))
+
+    post.reload
+    post.association(:event).reload
+
+    expect(post.raw).not_to match(/\sclosed\s*=/i)
+    expect(post.event.closed?).to eq(false)
+  end
+
+  it "does not confuse closed= text inside another quoted attribute with the closed attribute" do
+    node = described_class.new(parameters: {})
+
+    raw =
+      "[event start=\"2030-04-24 14:15\" location=\"Room closed=true\"]\n" \
+        "Description\n" \
+        "[/event]"
+
+    updated = node.send(:raw_with_closed_state, raw, closed: true)
+
+    expect(updated).to include('location="Room closed=true"')
+    expect(updated).to include(' closed="true"]')
+  end
+
+  it "preserves another quoted attribute while opening an event" do
+    node = described_class.new(parameters: {})
+
+    raw =
+      "[event start=\"2030-04-24 14:15\" location=\"Room closed=true\" closed=\"true\"]\n" \
+        "Description\n" \
+        "[/event]"
+
+    updated = node.send(:raw_with_closed_state, raw, closed: false)
+
+    expect(updated).to include('location="Room closed=true"')
+    expect(updated).not_to match(/\sclosed\s*=\s*["']true["']/i)
+  end
+
+  it "is idempotent when the event is already closed" do
+    post = create_event_post(closed: true)
+    original_raw = post.raw.dup
+
+    described_class.new(parameters: {}).execute(
+      execution_context(topic: post.topic, operation: "close"),
+    )
+
+    expect(post.reload.raw).to eq(original_raw)
+    expect(post.event.closed?).to eq(true)
+  end
+end

--- a/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event/v1_spec.rb
+++ b/plugins/discourse-events/spec/lib/discourse_workflows/nodes/event/v1_spec.rb
@@ -5,6 +5,7 @@ require_relative "../../../../../lib/discourse_workflows/nodes/event/v1"
 
 RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
   fab!(:admin)
+  fab!(:attendee, :user)
 
   before { SiteSetting.discourse_post_event_enabled = true }
 
@@ -16,7 +17,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
         admin,
         title: "Workflow event topic",
         raw:
-          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" timezone=\"UTC\"#{closed_attribute}]\n" \
+          "[event start=\"2030-04-24 14:15\" end=\"2030-04-24 15:15\" timezone=\"UTC\" status=\"public\"#{closed_attribute}]\n" \
             "Event description\n" \
             "[/event]",
       )
@@ -30,14 +31,18 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
     post
   end
 
-  def execution_context(topic:, operation:)
+  def execution_context(topic:, operation:, attendee: nil, attendance: nil)
     actor = admin
 
     Class
       .new do
-        define_method(:initialize) do |topic_arg, operation_arg, actor_arg|
+        define_method(
+          :initialize,
+        ) do |topic_arg, operation_arg, attendee_arg, attendance_arg, actor_arg|
           @topic = topic_arg
           @operation = operation_arg
+          @attendee = attendee_arg
+          @attendance = attendance_arg
           @actor = actor_arg
         end
 
@@ -49,12 +54,18 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
             @operation
           when "topic_id"
             @topic.id.to_s
+          when "attendee_username"
+            @attendee&.username
+          when "attendance"
+            @attendance || default
           else
             default
           end
         end
 
         define_method(:actor_from_parameter) { |_name, _item_index| @actor }
+
+        define_method(:find_user) { |username:| User.find_by(username:) }
 
         define_method(:edit_post) do |user:, post_id:, raw:|
           post = Post.find(post_id)
@@ -80,7 +91,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
           { id: post.id, post_number: post.post_number }
         end
       end
-      .new(topic, operation, actor)
+      .new(topic, operation, attendee, attendance, actor)
   end
 
   it "closes the event by revising its source BBCode" do
@@ -153,5 +164,122 @@ RSpec.describe DiscourseWorkflows::Nodes::Event::V1 do
 
     expect(post.reload.raw).to eq(original_raw)
     expect(post.event.closed?).to eq(true)
+  end
+
+  it "creates attendance for a user" do
+    post = create_event_post
+
+    expect(post.event.invitees.find_by(user_id: attendee.id)).to be_nil
+
+    described_class.new(parameters: {}).execute(
+      execution_context(
+        topic: post.topic,
+        operation: "set_attendance",
+        attendee: attendee,
+        attendance: "going",
+      ),
+    )
+
+    invitee = post.event.invitees.find_by(user_id: attendee.id)
+
+    expect(invitee).to be_present
+    expect(invitee.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+  end
+
+  it "updates existing attendance for a user" do
+    post = create_event_post
+    invitee =
+      DiscourseEvents::Events::Invitee.create_attendance!(attendee.id, post.event.id, :interested)
+
+    described_class.new(parameters: {}).execute(
+      execution_context(
+        topic: post.topic,
+        operation: "set_attendance",
+        attendee: attendee,
+        attendance: "going",
+      ),
+    )
+
+    expect(invitee.reload.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+  end
+
+  it "removes attendance for a user" do
+    post = create_event_post
+    DiscourseEvents::Events::Invitee.create_attendance!(attendee.id, post.event.id, :going)
+
+    described_class.new(parameters: {}).execute(
+      execution_context(
+        topic: post.topic,
+        operation: "set_attendance",
+        attendee: attendee,
+        attendance: "remove",
+      ),
+    )
+
+    expect(post.event.invitees.find_by(user_id: attendee.id)).to be_nil
+  end
+
+  it "does not update attendance when it already matches" do
+    post = create_event_post
+    invitee =
+      DiscourseEvents::Events::Invitee.create_attendance!(attendee.id, post.event.id, :going)
+
+    allow(DiscourseEvents::Events::UpdateInvitee).to receive(:call).and_call_original
+
+    described_class.new(parameters: {}).execute(
+      execution_context(
+        topic: post.topic,
+        operation: "set_attendance",
+        attendee: attendee,
+        attendance: "going",
+      ),
+    )
+
+    expect(DiscourseEvents::Events::UpdateInvitee).not_to have_received(:call)
+    expect(invitee.reload.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+  end
+
+  it "does nothing when removing attendance that does not exist" do
+    post = create_event_post
+
+    allow(DiscourseEvents::Events::DestroyInvitee).to receive(:call).and_call_original
+
+    described_class.new(parameters: {}).execute(
+      execution_context(
+        topic: post.topic,
+        operation: "set_attendance",
+        attendee: attendee,
+        attendance: "remove",
+      ),
+    )
+
+    expect(DiscourseEvents::Events::DestroyInvitee).not_to have_received(:call)
+    expect(post.event.invitees.find_by(user_id: attendee.id)).to be_nil
+  end
+
+  it "fails when setting Going on an event at capacity" do
+    post = create_event_post
+    event = post.event
+    event.update!(max_attendees: 1)
+
+    event.create_invitees(
+      [{ user_id: admin.id, status: DiscourseEvents::Events::Invitee.statuses[:going] }],
+    )
+
+    expect do
+      described_class.new(parameters: {}).execute(
+        execution_context(
+          topic: post.topic,
+          operation: "set_attendance",
+          attendee: attendee,
+          attendance: "going",
+        ),
+      )
+    end.to raise_error(DiscourseWorkflows::NodeError) do |error|
+      expect(error.message).to include("Could not update event attendance.")
+      expect(error.message).to include("[policy] has_capacity")
+    end
+
+    expect(event.invitees.find_by(user_id: attendee.id)).to be_nil
   end
 end


### PR DESCRIPTION
Depends on #42932.

This is a stacked follow-up to #42932 adding `Set attendance` to the Event workflow action.

Until #42932 merges, GitHub's diff also contains the prerequisite Event action changes. Once #42932 is merged, this branch will be rebased onto the updated `main` so this PR contains only the attendance changes.
