### PR TITLE
FIX: Re-upload when dragging an image within the composer

### DIFF
--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
@@ -317,6 +317,14 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
           }
         },
         drop: (view, event) => {
+          if (view.dragging) {
+            // A drag from this editor is a move, but the browser exposes the
+            // dragged content as a file too, so keep it away from the upload
+            // drop target on an ancestor, which would upload it again.
+            event.stopPropagation();
+            return;
+          }
+
           if (
             [...event.dataTransfer.items].some((item) => item.kind === "file")
           ) {

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/image-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/image-test.js
@@ -1,7 +1,19 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { testRenderedMarkdown } from "discourse/tests/helpers/rich-editor-helper";
+import {
+  setupRichEditor,
+  testRenderedMarkdown,
+} from "discourse/tests/helpers/rich-editor-helper";
+
+// Dragging an image exposes it as a file, as the browser does.
+function dragEvent(type, target) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(new File(["x"], "image.png", { type: "image/png" }));
+  target.dispatchEvent(
+    new DragEvent(type, { dataTransfer, bubbles: true, cancelable: true })
+  );
+}
 
 module(
   "Integration | Component | prosemirror-editor - image extension",
@@ -154,6 +166,45 @@ module(
           a.dom("img").hasAttribute("alt", "_test_file_");
         }
       ).call(this, assert);
+    });
+
+    test("dragging an image within the editor is a move, not an upload", async function (assert) {
+      this.siteSettings.rich_editor = true;
+
+      const [{ view }] = await setupRichEditor(
+        assert,
+        "![alt text](https://example.com/image.jpg)"
+      );
+      const image = view.dom.querySelector("img");
+      let reachedUploadTarget = false;
+      view.dom.parentElement.addEventListener(
+        "drop",
+        () => (reachedUploadTarget = true)
+      );
+
+      dragEvent("dragstart", image);
+      assert.true(!!view.dragging, "the editor owns the drag");
+
+      dragEvent("drop", image);
+      assert.false(reachedUploadTarget, "the drop never reaches the uploader");
+      assert.strictEqual(view.dragging, null, "the editor handled the move");
+    });
+
+    test("a file dropped from outside still reaches the uploader", async function (assert) {
+      this.siteSettings.rich_editor = true;
+
+      const [{ view }] = await setupRichEditor(
+        assert,
+        "![alt text](https://example.com/image.jpg)"
+      );
+      let reachedUploadTarget = false;
+      view.dom.parentElement.addEventListener(
+        "drop",
+        () => (reachedUploadTarget = true)
+      );
+
+      dragEvent("drop", view.dom.querySelector("img"));
+      assert.true(reachedUploadTarget, "the drop reaches the uploader");
     });
   }
 );


### PR DESCRIPTION
Dragging an image already in the composer uploaded it again instead of moving it: the browser exposes the dragged image as a file, so the drop reached the composer's upload drop target as if the file had come from outside.

This change stops a drop the editor is already handling as a move from reaching that upload drop target.