### PR TITLE
FIX: Provide working ways to close chat channels on touch devices in desktop view

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -286,4 +286,18 @@
   &.--hovering .sidebar-section-hover-button {
     opacity: 1;
   }
+
+  // the tracked hovering state is not set on touch-capable devices
+  @media (hover: hover) {
+    &:hover .sidebar-section-hover-button {
+      opacity: 1;
+    }
+  }
+
+  // devices without hover can't reveal the button, so it stays visible
+  @media (hover: none) {
+    .sidebar-section-hover-button {
+      opacity: 1;
+    }
+  }
 }

--- a/frontend/discourse/app/components/sidebar/section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-link.gjs
@@ -142,7 +142,13 @@ export default class SectionLink extends Component {
   }
 
   get shouldRenderHoverAction() {
-    return this.args.hoverValue && !this.capabilities.touch;
+    if (!this.args.hoverValue) {
+      return false;
+    }
+
+    // on narrow touch layouts the affordance exists elsewhere; rendering
+    // the button would only clutter the panel
+    return !this.capabilities.touch || this.capabilities.viewport.sm;
   }
 
   @action
@@ -258,6 +264,7 @@ export default class SectionLink extends Component {
                   {{on "click" this.runHoverAction}}
                   type="button"
                   title={{@hoverTitle}}
+                  aria-label={{@hoverTitle}}
                   class="sidebar-section-hover-button btn-flat"
                 >
                   {{#if (eq @hoverType "icon")}}
@@ -325,6 +332,7 @@ export default class SectionLink extends Component {
                   {{on "click" this.runHoverAction}}
                   type="button"
                   title={{@hoverTitle}}
+                  aria-label={{@hoverTitle}}
                   class="sidebar-section-hover-button btn-flat"
                 >
                   {{#if (eq @hoverType "icon")}}

--- a/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
@@ -87,7 +87,29 @@ module("Integration | Component | Sidebar | SectionLink", function (hooks) {
     assert.dom(".sidebar-section-link-wrapper").hasClass("--hovering");
   });
 
-  test("hover action is not rendered on touch devices", async function (assert) {
+  test("hover action is not rendered on touch devices with a narrow viewport", async function (assert) {
+    setTouch(this.owner, true);
+    sinon
+      .stub(this.owner.lookup("service:capabilities"), "viewport")
+      .value({ sm: false });
+
+    const template = <template>
+      <SectionLink
+        @linkName="test"
+        @route="discovery.latest"
+        @hoverType="icon"
+        @hoverValue="ellipsis-vertical"
+      />
+    </template>;
+
+    await render(template);
+
+    assert
+      .dom(".sidebar-section-hover-button")
+      .doesNotExist("does not clutter the narrow layout with a button");
+  });
+
+  test("hover action is rendered on touch devices with a wide viewport, without the hovering state", async function (assert) {
     setTouch(this.owner, true);
 
     const template = <template>
@@ -101,10 +123,14 @@ module("Integration | Component | Sidebar | SectionLink", function (hooks) {
 
     await render(template);
 
-    assert.dom(".sidebar-section-hover-button").doesNotExist();
+    assert
+      .dom(".sidebar-section-hover-button")
+      .exists("the button is rendered without needing hover");
 
     await triggerEvent(".sidebar-section-link-wrapper", "mouseenter");
 
-    assert.dom(".sidebar-section-link-wrapper").doesNotHaveClass("--hovering");
+    assert
+      .dom(".sidebar-section-link-wrapper")
+      .doesNotHaveClass("--hovering", "emulated hover does not set the state");
   });
 });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
@@ -209,7 +209,9 @@ export default class ChatChannelRow extends Component {
   }
 
   get shouldHandleSwipe() {
-    if (!this.capabilities.touch) {
+    // layout mode, not viewport width: the swipe styles and animations only
+    // exist in the mobile stylesheet bundle
+    if (!this.capabilities.touch || !this.site.mobileView) {
       return false;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
@@ -686,10 +686,12 @@ export default class ChatMessage extends Component {
         {{on "mouseleave" this.onMouseLeave passive=true}}
         {{on "mousemove" this.onMouseMove passive=true}}
         {{this.toggleCheckIfPossible}}
+        {{! the long-press actions modal only has a mobile layout }}
         {{ChatOnLongPress
           this.onLongPressStart
           this.onLongPressEnd
           this.onLongPressCancel
+          enabled=this.site.mobileView
         }}
         ...attributes
       >

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -254,8 +254,6 @@ export default {
       return;
     }
 
-    this.capabilities = container.lookup("service:capabilities");
-
     withPluginApi((api) => {
       const chatStateManager = container.lookup("service:chat-state-manager");
 
@@ -395,17 +393,12 @@ export default {
           );
 
           const SidebarChatStarredChannelLink = class extends BaseStarredChannelLink {
-            constructor({ menuService, capabilities }) {
+            constructor({ menuService }) {
               super(...arguments);
               this.menuService = menuService;
-              this.capabilities = capabilities;
             }
 
             get hoverValue() {
-              if (this.capabilities.isIpadOS) {
-                return;
-              }
-
               return "ellipsis-vertical";
             }
 
@@ -414,10 +407,6 @@ export default {
             }
 
             get hoverAction() {
-              if (this.capabilities.isIpadOS) {
-                return noop;
-              }
-
               return (event, onMenuClose) => {
                 event.stopPropagation();
                 event.preventDefault();
@@ -451,7 +440,6 @@ export default {
                 "service:chat-channels-manager"
               );
               this.menuService = container.lookup("service:menu");
-              this.capabilities = container.lookup("service:capabilities");
             }
 
             get sectionLinks() {
@@ -464,7 +452,6 @@ export default {
                     siteSettings: this.siteSettings,
                     chatStateManager: this.chatStateManager,
                     menuService: this.menuService,
-                    capabilities: this.capabilities,
                   })
               );
             }
@@ -511,7 +498,6 @@ export default {
                 currentUser,
                 siteSettings,
                 menuService,
-                capabilities,
               }) {
                 super(...arguments);
                 this.channel = channel;
@@ -520,7 +506,6 @@ export default {
                 this.menuService = menuService;
                 this.chatStateManager = chatStateManager;
                 this.siteSettings = siteSettings;
-                this.capabilities = capabilities;
               }
 
               get hoverValue() {
@@ -528,7 +513,7 @@ export default {
                   return;
                 }
 
-                return this.capabilities.isIpadOS ? null : "ellipsis-vertical";
+                return "ellipsis-vertical";
               }
 
               get name() {
@@ -610,7 +595,7 @@ export default {
               }
 
               get hoverAction() {
-                if (!this.currentUser || this.capabilities.isIpadOS) {
+                if (!this.currentUser) {
                   return noop;
                 }
 
@@ -652,7 +637,6 @@ export default {
                 );
                 this.router = container.lookup("service:router");
                 this.menuService = container.lookup("service:menu");
-                this.capabilities = container.lookup("service:capabilities");
               }
 
               get sectionLinks() {
@@ -664,7 +648,6 @@ export default {
                       menuService: this.menuService,
                       currentUser: this.currentUser,
                       siteSettings: this.siteSettings,
-                      capabilities: this.capabilities,
                     })
                 );
               }
@@ -742,7 +725,6 @@ export default {
                 currentUser,
                 menuService,
                 siteSettings,
-                capabilities,
               }) {
                 super(...arguments);
                 this.channel = channel;
@@ -751,7 +733,6 @@ export default {
                 this.currentUser = currentUser;
                 this.chatStateManager = chatStateManager;
                 this.menuService = menuService;
-                this.capabilities = capabilities;
 
                 if (this.oneOnOneMessage) {
                   const user = this.channel.chatable.users[0];
@@ -769,7 +750,7 @@ export default {
               }
 
               get hoverValue() {
-                return this.capabilities.isIpadOS ? null : "ellipsis-vertical";
+                return "ellipsis-vertical";
               }
 
               get oneOnOneMessage() {
@@ -901,10 +882,6 @@ export default {
               }
 
               get hoverAction() {
-                if (this.capabilities.isIpadOS) {
-                  return noop;
-                }
-
                 return (event, onMenuClose) => {
                   event.stopPropagation();
                   event.preventDefault();
@@ -940,7 +917,6 @@ export default {
                   "service:chat-channels-manager"
                 );
                 this.menuService = container.lookup("service:menu");
-                this.capabilities = container.lookup("service:capabilities");
               }
 
               get hideSectionHeader() {
@@ -964,7 +940,6 @@ export default {
                         currentUser: this.currentUser,
                         menuService: this.menuService,
                         siteSettings: this.siteSettings,
-                        capabilities: this.capabilities,
                       })
                   );
                 } else {

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -11,7 +11,6 @@ function cancelEvent(event) {
 
 export default class ChatOnLongPress extends Modifier {
   @service capabilities;
-  @service site;
 
   constructor(owner, args) {
     super(owner, args);
@@ -19,10 +18,16 @@ export default class ChatOnLongPress extends Modifier {
   }
 
   get enabled() {
-    return this.capabilities.touch && this.site.mobileView;
+    return this.enabledByCaller && this.capabilities.touch;
   }
 
-  modify(element, [onLongPressStart, onLongPressEnd, onLongPressCancel]) {
+  modify(
+    element,
+    [onLongPressStart, onLongPressEnd, onLongPressCancel],
+    { enabled = true }
+  ) {
+    this.enabledByCaller = enabled;
+
     if (!this.enabled) {
       return;
     }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
@@ -20,6 +20,17 @@
     &:active {
       background: var(--primary-low);
     }
+
+    // no hover to reveal the button, so it stays visible
+    &.can-leave {
+      .toggle-channel-membership-button.-leave {
+        display: block;
+
+        > * {
+          pointer-events: auto;
+        }
+      }
+    }
   }
 
   @media (hover: hover) {
@@ -27,19 +38,19 @@
     &.active {
       background: var(--primary-very-low);
     }
-  }
 
-  &.can-leave:hover {
-    .toggle-channel-membership-button.-leave {
-      display: block;
+    &.can-leave:hover {
+      .toggle-channel-membership-button.-leave {
+        display: block;
 
-      > * {
-        pointer-events: auto;
+        > * {
+          pointer-events: auto;
+        }
       }
-    }
 
-    .chat-channel__metadata {
-      display: none;
+      .chat-channel__metadata {
+        display: none;
+      }
     }
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-index.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-index.scss
@@ -63,6 +63,15 @@
     }
   }
 
+  // keep the enlarged hit area from overlapping the adjacent metadata,
+  // a stray tap there shouldn't close the channel
+  @media (hover: none) {
+    .chat-channel-leave-btn::after {
+      inset-inline-start: 0;
+      width: 100%;
+    }
+  }
+
   &.starred-channels {
     padding-top: var(--space-2);
   }

--- a/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
@@ -3,6 +3,7 @@ import { getOwner } from "@ember/owner";
 import { find, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import DMenus from "discourse/float-kit/components/d-menus";
 import CoreFabricators from "discourse/lib/fabricators";
 import { forceMobile, resetMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -16,6 +17,10 @@ function forceTouch(owner) {
   });
 }
 
+function resetTouch(owner) {
+  delete owner.lookup("service:capabilities").touch;
+}
+
 async function swipeRowToThreshold(screenX = 10000) {
   const content = find(".chat-channel-row__content");
 
@@ -26,6 +31,7 @@ async function swipeRowToThreshold(screenX = 10000) {
   ]) {
     const event = new Event(type, { bubbles: true });
     event.changedTouches = [{ screenX: x }];
+    event.touches = type === "touchend" ? [] : [{ screenX: x }];
     content.dispatchEvent(event);
   }
 
@@ -40,6 +46,11 @@ module("Component | ChatChannelRow", function (hooks) {
     this.directMessageChannel = new ChatFabricators(
       getOwner(this)
     ).directMessageChannel();
+  });
+
+  hooks.afterEach(function () {
+    resetMobile();
+    resetTouch(this.owner);
   });
 
   test("links to correct channel", async function (assert) {
@@ -300,6 +311,7 @@ module("Component | ChatChannelRow", function (hooks) {
   });
 
   test("swiping a channel with notifications clears them", async function (assert) {
+    forceMobile();
     forceTouch(this.owner);
     const markAsRead = sinon
       .stub(this.owner.lookup("service:chat-api"), "markChannelAsRead")
@@ -328,6 +340,7 @@ module("Component | ChatChannelRow", function (hooks) {
   });
 
   test("channels without notifications are not swipeable", async function (assert) {
+    forceMobile();
     forceTouch(this.owner);
 
     await render(
@@ -342,6 +355,7 @@ module("Component | ChatChannelRow", function (hooks) {
   });
 
   test("swiping a direct message reveals the remove action", async function (assert) {
+    forceMobile();
     forceTouch(this.owner);
     const markAsRead = sinon.spy(
       this.owner.lookup("service:chat-api"),
@@ -359,5 +373,41 @@ module("Component | ChatChannelRow", function (hooks) {
     assert.dom(".chat-channel-row__action-btn.--remove").exists();
     assert.dom(".chat-channel-row__action-btn .d-icon-circle-xmark").exists();
     assert.true(markAsRead.notCalled, "does not clear notifications for a DM");
+  });
+
+  test("channels are not swipeable on touch devices in desktop view", async function (assert) {
+    forceTouch(this.owner);
+
+    await render(
+      <template>
+        <ChatChannelRow @channel={{this.directMessageChannel}} />
+      </template>
+    );
+
+    await swipeRowToThreshold();
+
+    assert
+      .dom(".chat-channel-row__action-btn")
+      .doesNotExist("swiping does not reveal the action button");
+  });
+
+  test("long-pressing opens the channel menu on touch devices in desktop view", async function (assert) {
+    forceTouch(this.owner);
+
+    await render(
+      <template>
+        <ChatChannelRow @channel={{this.directMessageChannel}} />
+        <DMenus />
+      </template>
+    );
+
+    const event = new Event("touchstart", { bubbles: true });
+    event.touches = [{}];
+    find(".chat-channel-row").dispatchEvent(event);
+    await settled();
+
+    assert
+      .dom('.fk-d-menu[data-identifier="chat-direct-message-channel-menu"]')
+      .exists("long-press opens the channel menu");
   });
 });


### PR DESCRIPTION
Previously, there was no reliable way to close or leave a chat channel on a tablet (touch + desktop view): the leave button required hover, the long-press menu only worked in mobile view, and the sidebar channel menu was hidden on all touch devices.

On touch devices that can't hover (`@media (hover: none)`) in desktop view, the leave button and the sidebar channel menu button are now always visible instead of hover-revealed, and long-press opens the channel menu. Swipe stays limited to the mobile layout, and narrow mobile view is untouched. The sidebar button had been hidden on touch (#41368, earlier #36969) so rows could be tapped to navigate without the hover reveal in the way. As a plainly visible button, row taps still navigate and the menu opens only from the button.

Reported in https://meta.discourse.org/t/close-a-chat/297444
