### PR TITLE
FIX: Auto-grid generic image upload placeholders in rich editor

### DIFF
--- a/frontend/discourse/app/static/prosemirror/lib/text-manipulation.ts
+++ b/frontend/discourse/app/static/prosemirror/lib/text-manipulation.ts
@@ -585,6 +585,15 @@ export default class ProsemirrorTextManipulation implements TextManipulation {
             placeholderNodes.push({ node, pos, filename: match[1] });
           }
         }
+      } else if (
+        node.type === this.schema.nodes.upload_placeholder &&
+        imagesToWrapGrid.has(node.attrs.filename)
+      ) {
+        placeholderNodes.push({
+          node,
+          pos,
+          filename: node.attrs.filename,
+        });
       }
     });
 
@@ -865,24 +874,22 @@ class ProsemirrorPlaceholderHandler implements PlaceholderHandler {
 
     // resolve transparent.png placeholders using the upload URL cache,
     // which was populated before success() was called
-    if (found.node.type === this.schema.nodes.image) {
-      tr.doc.nodesBetween(
-        found.pos,
-        found.pos + replacement.size,
-        (node, pos) => {
-          if (
-            node.type.name === "image" &&
-            node.attrs.originalSrc &&
-            node.attrs.src?.includes("transparent.png")
-          ) {
-            const cached = lookupCachedUploadUrl(node.attrs.originalSrc);
-            if (cached?.url) {
-              tr.setNodeMarkup(pos, null, { ...node.attrs, src: cached.url });
-            }
+    tr.doc.nodesBetween(
+      found.pos,
+      found.pos + replacement.size,
+      (node, pos) => {
+        if (
+          node.type.name === "image" &&
+          node.attrs.originalSrc &&
+          node.attrs.src?.includes("transparent.png")
+        ) {
+          const cached = lookupCachedUploadUrl(node.attrs.originalSrc);
+          if (cached?.url) {
+            tr.setNodeMarkup(pos, null, { ...node.attrs, src: cached.url });
           }
         }
-      );
-    }
+      }
+    );
 
     if (wasSelected) {
       const resolved = tr.doc.resolve(found.pos);

--- a/frontend/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/frontend/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -3,8 +3,10 @@ import {
   click,
   fillIn,
   find,
+  findAll,
   focus,
   settled,
+  triggerEvent,
   visit,
   waitFor,
 } from "@ember/test-helpers";
@@ -484,6 +486,94 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
       );
     assert.false(uppyEventFired, "uppy does not start uploading the file");
     done();
+  });
+});
+
+acceptance("Uppy Composer Attachment - Auto Image Grid", function (needs) {
+  needs.user({ "user_option.composition_mode": 1 });
+  needs.pretender(pretender);
+  needs.settings({
+    simultaneous_uploads: 3,
+    enable_auto_grid_images: true,
+    allow_uncategorized_topics: true,
+  });
+  needs.hooks.afterEach(() => {
+    uploadNumber = 1;
+  });
+
+  test("auto-grids previewable images immediately", async function (assert) {
+    await visit("/new-topic");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    const uploadsComplete = new Promise((resolve) => {
+      appEvents.one("composer:all-uploads-complete", resolve);
+    });
+    const dataTransfer = new DataTransfer();
+    ["image-1.png", "image-2.png", "image-3.png"].forEach((filename) => {
+      dataTransfer.items.add(createFile(filename));
+    });
+
+    await triggerEvent(".ProseMirror", "drop", { dataTransfer });
+    await waitFor(".composer-image-grid");
+
+    assert
+      .dom(".composer-image-grid .upload-placeholder.--image")
+      .exists({ count: 3 }, "previewable images are gridded while uploading");
+
+    await uploadsComplete;
+  });
+
+  test("auto-grids MIME-less images dropped from the filesystem", async function (assert) {
+    await visit("/new-topic");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    const uploadsComplete = new Promise((resolve) => {
+      appEvents.one("composer:all-uploads-complete", resolve);
+    });
+    const dataTransfer = new DataTransfer();
+    ["IMG_1.HEIC", "IMG_2.HEIC", "IMG_3.HEIC"].forEach((filename) => {
+      dataTransfer.items.add(createFile(filename, ""));
+    });
+
+    await triggerEvent(".ProseMirror", "drop", { dataTransfer });
+    await waitFor(".composer-image-grid .upload-placeholder.--file");
+
+    assert
+      .dom(".composer-image-grid")
+      .exists({ count: 1 }, "the image filenames create one grid immediately");
+    assert
+      .dom(".composer-image-grid .upload-placeholder.--file")
+      .exists(
+        { count: 3 },
+        "the pending HEIC uploads use file placeholders inside the grid"
+      );
+
+    await uploadsComplete;
+    await settled();
+
+    assert
+      .dom(".composer-image-node")
+      .exists({ count: 3 }, "all completed images are present");
+    assert.deepEqual(
+      findAll(".composer-image-node img").map((img) =>
+        img.getAttribute("data-orig-src")
+      ),
+      [
+        "upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg",
+        "upload://sdfljsdfgjlkwg4328.jpeg",
+        "upload://sdfljsdfgjlkwg4328.jpeg",
+      ],
+      "the final images retain their returned upload URLs"
+    );
+    assert
+      .dom(".composer-image-grid")
+      .exists({ count: 1 }, "the completed drop preserves the grid");
+    assert
+      .dom(".composer-image-grid .composer-image-node")
+      .exists({ count: 3 }, "the completed images are placed in the grid");
+    assert
+      .dom(".composer-image-grid .upload-placeholder.--file")
+      .doesNotExist("the completed uploads no longer use file placeholders");
   });
 });
 

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
@@ -1,4 +1,5 @@
-import { render } from "@ember/test-helpers";
+import { render, settled } from "@ember/test-helpers";
+import { cacheShortUploadUrl, resetCache } from "pretty-text/upload-short-url";
 import { module, test } from "qunit";
 import {
   clearRichEditorExtensions,
@@ -6,6 +7,9 @@ import {
 } from "discourse/lib/composer/rich-editor-extensions";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import ProsemirrorEditor from "discourse/static/prosemirror/components/prosemirror-editor";
+import grid from "discourse/static/prosemirror/extensions/grid";
+import image from "discourse/static/prosemirror/extensions/image";
+import uploadPlaceholder from "discourse/static/prosemirror/extensions/upload-placeholder";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
 
@@ -13,7 +17,10 @@ module("Integration | Component | ProsemirrorEditor", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(() => clearRichEditorExtensions());
-  hooks.afterEach(() => resetRichEditorExtensions());
+  hooks.afterEach(() => {
+    resetCache();
+    resetRichEditorExtensions();
+  });
 
   test("renders the editor", async function (assert) {
     await render(<template><ProsemirrorEditor /></template>);
@@ -40,6 +47,81 @@ module("Integration | Component | ProsemirrorEditor", function (hooks) {
     assert
       .dom(".ProseMirror strong")
       .exists("it renders the strong markdown as HTML");
+  });
+
+  test("auto-grids image filenames using generic placeholders", async function (assert) {
+    withPluginApi((api) => {
+      api.registerRichEditorExtension(grid);
+      api.registerRichEditorExtension(image);
+      api.registerRichEditorExtension(uploadPlaceholder);
+    });
+
+    let textManipulation;
+    const handleSetup = (value) => {
+      textManipulation = value;
+    };
+
+    await render(
+      <template><ProsemirrorEditor @onSetup={{handleSetup}} /></template>
+    );
+
+    const files = [1, 2, 3].map((number) => ({
+      id: `image-${number}`,
+      name: `IMG_${number}.HEIC`,
+      data: new File(["image"], `IMG_${number}.HEIC`),
+    }));
+
+    files.forEach((file) => {
+      textManipulation.placeholder.insert(file);
+    });
+    textManipulation.autoGridImages(files.map((file) => file.name));
+    await settled();
+
+    assert
+      .dom(".composer-image-grid")
+      .exists({ count: 1 }, "generic placeholders are wrapped immediately");
+    assert
+      .dom(".composer-image-grid .upload-placeholder.--file")
+      .exists(
+        { count: 3 },
+        "all pending images use generic placeholders inside the grid"
+      );
+
+    const shortUrls = files.map((file, index) => {
+      const shortUrl = `upload://heic-grid-${index}.jpeg`;
+      const resolvedUrl = `/images/heic-grid-${index}.jpeg`;
+      cacheShortUploadUrl(shortUrl, { url: resolvedUrl });
+      textManipulation.placeholder.success(
+        file,
+        `![IMG_${index + 1}](${shortUrl})`
+      );
+      return shortUrl;
+    });
+
+    let replacementImage;
+    textManipulation.view.state.doc.descendants((node) => {
+      if (
+        node.type.name === "image" &&
+        node.attrs.originalSrc === shortUrls[0]
+      ) {
+        replacementImage = node;
+        return false;
+      }
+    });
+    assert.strictEqual(
+      replacementImage?.attrs.src,
+      "/images/heic-grid-0.jpeg",
+      "the final image URL is resolved in the upload-success transaction"
+    );
+
+    await settled();
+
+    assert
+      .dom(".composer-image-grid")
+      .exists({ count: 1 }, "the completed images preserve the grid");
+    assert
+      .dom(".composer-image-grid .composer-image-node")
+      .exists({ count: 3 }, "all completed images are in the grid");
   });
 
   test("renders the editor with minimum extensions", async function (assert) {


### PR DESCRIPTION
Image uploads that used generic file placeholders were omitted from automatic image grids, commonly affecting HEIC/HEIF files with missing browser MIME metadata.

This change includes those placeholders in the rich editor’s existing auto-grid flow and replaces them with completed images in place.