### PR TITLE
Fixed site_settings#index loading huge JSON for every request

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::SiteSettingsController < Admin::AdminController
-  INDEX_CACHE_SIZE = 16
+  INDEX_CACHE_SIZE = 4
 
   def self.index_cache
     @index_cache ||= LruRedux::ThreadSafeCache.new(INDEX_CACHE_SIZE)

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class Admin::SiteSettingsController < Admin::AdminController
+  INDEX_CACHE_SIZE = 16
+
+  def self.index_cache
+    @index_cache ||= LruRedux::ThreadSafeCache.new(INDEX_CACHE_SIZE)
+  end
+
+  def self.clear_index_cache
+    @index_cache&.clear
+  end
+
   rescue_from Discourse::InvalidParameters do |e|
     render_json_error e.message, status: 422
   end
@@ -11,16 +21,37 @@ class Admin::SiteSettingsController < Admin::AdminController
 
   def index
     params.permit(:categories, :plugin, :names)
-    render_json_dump(
-      site_settings:
-        SiteSetting.all_settings(
-          filter_categories: params[:categories],
-          filter_plugin: params[:plugin],
-          filter_names: params[:names],
-        ),
-      default_theme:
-        BasicThemeSerializer.new(Theme.find_default, scope: guardian, root: false).as_json,
-    )
+
+    default_theme = Theme.find_default
+    cache_key = [
+      RailsMultisite::ConnectionManagement.current_db,
+      I18n.locale,
+      SiteSetting.current.hash,
+      SiteSetting.theme_site_settings[default_theme.id]&.hash,
+      default_theme.cache_key_with_version,
+      Array.wrap(params[:categories]).sort,
+      params[:plugin],
+      Array.wrap(params[:names]).sort,
+    ]
+
+    json =
+      self
+        .class
+        .index_cache
+        .getset(cache_key) do
+          MultiJson.dump(
+            site_settings:
+              SiteSetting.all_settings(
+                filter_categories: params[:categories],
+                filter_plugin: params[:plugin],
+                filter_names: params[:names],
+              ),
+            default_theme:
+              BasicThemeSerializer.new(default_theme, scope: guardian, root: false).as_json,
+          ).freeze
+        end
+
+    render json: json
   end
 
   def update

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Admin::SiteSettingsController do
   fab!(:moderator)
   fab!(:user)
 
+  before { described_class.clear_index_cache }
+
   describe "#index" do
     context "when logged in as an admin" do
       before { sign_in(admin) }
@@ -26,6 +28,24 @@ RSpec.describe Admin::SiteSettingsController do
         expect(
           response.parsed_body["site_settings"].find { |s| s["setting"] == "max_category_nesting" },
         ).to be_nil
+      end
+
+      it "returns updated values after the cache is populated" do
+        get "/admin/site_settings.json", params: { names: ["title"] }
+        original_title =
+          response.parsed_body["site_settings"].find { |setting| setting["setting"] == "title" }[
+            "value"
+          ]
+
+        SiteSetting.title = "Updated title"
+        get "/admin/site_settings.json", params: { names: ["title"] }
+        updated_title =
+          response.parsed_body["site_settings"].find { |setting| setting["setting"] == "title" }[
+            "value"
+          ]
+
+        expect(updated_title).to eq("Updated title")
+        expect(updated_title).not_to eq(original_title)
       end
 
       it "does not return settings from non-configurable plugins" do


### PR DESCRIPTION
## The issue
`/admin/site_settings.json` returns the complete schema for every visible site setting. In the profiled dataset, that meant roughly:
 - 1,400+ settings                                                                                                                                                                                                           
 - A 0.9–0.95 MB JSON response                                                                                                                                                                                               
 - About 238,000 Ruby object allocations                                                                                                                                                                                     
 - 332–578 ms server time                                                                                                                                                                                                    
 - Only around 3–4 ms spent in SQL  
Most of this output is identical between requests. Nevertheless, the endpoint rebuilt and serialized it every time

## The fix
`Admin::SiteSettingsController#index` now caches the fully serialized JSON string in a process-local, thread-safe LRU cache. 

## Performance

Measurements: 5 cold and 5 warm requests per revision after 3 warmups.
Route: `GET /admin/site_settings.json`; authenticated as an admin

The results are based on the test in my local machine.

### cold-cache

The scores are similar. No point in adding a table.

### warm cache

SQL was not the original bottleneck. But included that to indicate the changes and it is not the bottleneck.

| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Server duration (ms) | 308.41 | 10.06 | -96.7% | 277.25 | 9.73 |
| SQL duration (ms) | 5.87 | 2.52 | -57.1% | 6.11 | 2.52 |
| Allocated objects | 217843 | 3070 | -98.6% | 217811 | 3068 |
| SQL events | 10 | 5 | -50.0% | 10 | 5 |
| Cached SQL events | 0 | 0 | n/a | 0 | 0 |
| Duplicate fingerprints | 1 | 0 | -100.0% | 1 | 0 |