### PR TITLE
FIX: Show up to 100 subscription products

### DIFF
--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -14,7 +14,11 @@ module DiscourseSubscriptions
       products = []
 
       if product_ids.present? && is_stripe_configured?
-        response = ::Stripe::Product.list({ ids: product_ids, active: true }, stripe_request_opts)
+        response =
+          ::Stripe::Product.list(
+            { ids: product_ids, active: true, limit: 100 },
+            stripe_request_opts,
+          )
 
         products = response[:data].map { |p| serialize_product(p) }
       end

--- a/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
@@ -76,7 +76,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
       it "gets products" do
         ::Stripe::Product
           .expects(:list)
-          .with({ ids: product_ids, active: true }, DiscourseSubscriptions::Stripe.request_opts)
+          .with(
+            { ids: product_ids, active: true, limit: 100 },
+            DiscourseSubscriptions::Stripe.request_opts,
+          )
           .returns(data: [product])
 
         get "/s.json"
@@ -102,7 +105,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         ::Stripe::Product
           .expects(:list)
-          .with({ ids: product_ids, active: true }, DiscourseSubscriptions::Stripe.request_opts)
+          .with(
+            { ids: product_ids, active: true, limit: 100 },
+            DiscourseSubscriptions::Stripe.request_opts,
+          )
           .returns(data: [product])
 
         get "/s.json"
@@ -114,7 +120,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
         DiscourseSubscriptions::Customer.delete_all
         ::Stripe::Product
           .expects(:list)
-          .with({ ids: product_ids, active: true }, DiscourseSubscriptions::Stripe.request_opts)
+          .with(
+            { ids: product_ids, active: true, limit: 100 },
+            DiscourseSubscriptions::Stripe.request_opts,
+          )
           .returns(data: [product])
 
         get "/s.json"


### PR DESCRIPTION
## Problem

Admins can create and activate more than 10 subscription products, and the admin products endpoint requests up to 100 products from Stripe. However, only 10 products are displayed on the public `/s` page.

For example, after adding an eleventh active product, `/s` continues to show only 10. Deactivating one of the existing products allows another product to appear.

Stripe's product list API returns 10 products by default. Unlike the admin endpoint, the public subscriptions endpoint did not specify a limit, so additional active products were silently omitted.

## Solution

Request up to 100 products for the public subscriptions page, matching the existing admin product listing.

The request specs have been updated to cover the Stripe API parameter.