### PR TITLE
FIX: Do not close modal when DMenu closes

### DIFF
--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -13,18 +13,15 @@ import {
 import FloatKitInstance from "discourse/float-kit/lib/float-kit-instance";
 import type MenuService from "discourse/float-kit/services/menu";
 import { animateClosing } from "discourse/lib/animation-utils";
-import type ModalService from "discourse/services/modal";
 
 /**
  * The concrete float instance backing a menu. It holds the menu's options,
  * open/close state, and portal outlet, and implements the trigger and lifecycle
  * hooks that `FloatKitInstance` orchestrates. A menu refocuses its trigger when
- * it closes and, on mobile, closes through the modal service when it was shown
- * as a modal.
+ * it closes.
  */
 export default class DMenuInstance extends FloatKitInstance {
   @service declare menu: MenuService;
-  @service declare modal: ModalService;
 
   /** Whether the menu is currently open. */
   @tracked expanded = false;
@@ -115,10 +112,6 @@ export default class DMenuInstance extends FloatKitInstance {
     const ownedFocus = this.#ownsFocus;
 
     await animateClosing(this.content);
-
-    if (this.renderInModal && this.expanded) {
-      await this.modal.close();
-    }
 
     await this.menu.close(this);
 

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -21,11 +21,24 @@ import DMenu from "discourse/float-kit/components/d-menu";
 import DMenus from "discourse/float-kit/components/d-menus";
 import DTooltips from "discourse/float-kit/components/d-tooltips";
 import DMenuInstance from "discourse/float-kit/lib/d-menu-instance";
+import { getLockState } from "discourse/lib/body-scroll-lock";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
+import DModal from "discourse/ui-kit/d-modal";
 import dElement from "discourse/ui-kit/helpers/d-element";
+
+const ModalWithMenu = <template>
+  <DModal @closeModal={{@closeModal}} @inline={{true}}>
+    <span class="outer-modal-content">Outer modal</span>
+    <DMenu @inline={{true}} @modalForMobile={{true}} @label="Permission">
+      <:content as |menu|>
+        <DButton class="close-menu" @action={{menu.close}}>Viewer</DButton>
+      </:content>
+    </DMenu>
+  </DModal>
+</template>;
 
 module("Integration | Component | FloatKit | DMenu", function (hooks) {
   setupRenderingTest(hooks);
@@ -94,6 +107,57 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     await open();
 
     assert.dom(".fk-d-menu-modal[data-identifier='foo']").hasText("content");
+  });
+
+  test("closing a standalone mobile menu cleans up its modal", async function (assert) {
+    forceMobile();
+
+    const initialLockCount = getLockState().lockedNum;
+
+    await render(
+      <template>
+        <DMenu @inline={{true}} @modalForMobile={{true}} @label="Permission">
+          <:content as |menu|>
+            <DButton class="close-menu" @action={{menu.close}}>Viewer</DButton>
+          </:content>
+        </DMenu>
+      </template>
+    );
+
+    await open();
+
+    assert.strictEqual(
+      getLockState().lockedNum,
+      initialLockCount + 1,
+      "opening the menu locks body scrolling"
+    );
+
+    await click(".close-menu");
+
+    assert.dom(".fk-d-menu-modal").doesNotExist("the menu modal closes");
+    assert.strictEqual(
+      getLockState().lockedNum,
+      initialLockCount,
+      "closing the menu releases its body scroll lock"
+    );
+  });
+
+  test("closing a mobile menu preserves its containing modal", async function (assert) {
+    forceMobile();
+
+    await render(<template><ModalContainer /></template>);
+
+    const modal = getOwner(this).lookup("service:modal");
+    modal.show(ModalWithMenu);
+    await settled();
+
+    await open();
+    await click(".close-menu");
+
+    assert
+      .dom(".outer-modal-content")
+      .exists("the containing modal remains open");
+    assert.dom(".fk-d-menu-modal").doesNotExist("the menu modal closes");
   });
 
   test("DMenu uses a modal while DTooltip stays inline on mobile", async function (assert) {

--- a/spec/system/page_objects/components/d_menu.rb
+++ b/spec/system/page_objects/components/d_menu.rb
@@ -37,7 +37,7 @@ module PageObjects
         if @identifier.nil?
           "#d-menu-portals"
         else
-          "#d-menu-portals [data-identifier=\"#{@identifier}\"]"
+          "[data-content][data-identifier=\"#{@identifier}\"]"
         end
       end
 


### PR DESCRIPTION
Fixes an issue found in the DAccessControl component inside
a modal (in the kanban plugin). Selecting an option from the
permission dropdown for an ACL row on mobile would close the
whole modal. Now, this only happens when `@modalForMobile={{true}}`
is used on a DMenu outside a modal.
