### PR TITLE
FIX: Preserve table interactions in fullscreen

### DIFF
--- a/frontend/discourse/app/components/modal/fullscreen-table.gjs
+++ b/frontend/discourse/app/components/modal/fullscreen-table.gjs
@@ -1,16 +1,38 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
 
-const FullscreenTable = <template>
-  <DModal
-    @title={{i18n "fullscreen_table.view_table"}}
-    @closeModal={{@closeModal}}
-    class="fullscreen-table-modal --max"
-  >
-    <:body>
-      {{@model.tableHtml}}
-    </:body>
-  </DModal>
-</template>;
+export default class FullscreenTable extends Component {
+  tablePlaceholder;
 
-export default FullscreenTable;
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.tablePlaceholder?.replaceWith(this.args.model.table);
+  }
+
+  @action
+  mountTable(element) {
+    const table = this.args.model.table;
+    this.tablePlaceholder = document.createComment("fullscreen table");
+    table.replaceWith(this.tablePlaceholder);
+    element.appendChild(table);
+  }
+
+  <template>
+    <DModal
+      @title={{i18n "fullscreen_table.view_table"}}
+      @closeModal={{@closeModal}}
+      class="fullscreen-table-modal --max"
+    >
+      <:body>
+        <div
+          class="cooked {{if @model.displayFootnotesInline 'inline-footnotes'}}"
+          data-ref-post-id={{@model.postId}}
+          {{didInsert this.mountTable}}
+        ></div>
+      </:body>
+    </DModal>
+  </template>
+}

--- a/frontend/discourse/app/instance-initializers/post-decorations.js
+++ b/frontend/discourse/app/instance-initializers/post-decorations.js
@@ -145,18 +145,18 @@ export default {
 
       function generateFullScreenTableModal(event) {
         const { postId } = this;
-
         const table = event.currentTarget.parentElement.nextElementSibling;
-        const tempTable = table.cloneNode(true);
-        const cookedWrapper = document.createElement("div");
-        cookedWrapper.classList.add("cooked");
-        if (siteSettings.display_footnotes_inline) {
-          cookedWrapper.classList.add("inline-footnotes");
+
+        if (!table) {
+          return;
         }
-        cookedWrapper.dataset.refPostId = postId;
-        cookedWrapper.appendChild(tempTable);
+
         modal.show(FullscreenTableModal, {
-          model: { tableHtml: cookedWrapper },
+          model: {
+            table,
+            postId,
+            displayFootnotesInline: siteSettings.display_footnotes_inline,
+          },
         });
       }
 

--- a/frontend/discourse/tests/acceptance/post-table-wrapper-test.js
+++ b/frontend/discourse/tests/acceptance/post-table-wrapper-test.js
@@ -32,6 +32,12 @@ acceptance(
         "the wrapper buttons should not be in the cooked post's flow"
       );
 
+      const table = find(`${postWithLargeTable} table`);
+      let tableCellClicked = false;
+      table.querySelector("td").addEventListener("click", () => {
+        tableCellClicked = true;
+      });
+
       await click(
         `${postWithLargeTable} .fullscreen-table-wrapper .btn-expand-table`
       );
@@ -43,7 +49,19 @@ acceptance(
         .dom(".fullscreen-table-modal table")
         .exists("The table is present inside the modal");
 
+      await click(".fullscreen-table-modal td");
+      assert.true(
+        tableCellClicked,
+        "interactions attached to the table remain active in the modal"
+      );
+
       await click(".fullscreen-table-modal .modal-close");
+      assert.strictEqual(
+        find(`${postWithLargeTable} table`),
+        table,
+        "the table is restored to the post when the modal closes"
+      );
+
       await click(
         `${postWithLargeTable} .fullscreen-table-wrapper .btn-expand-table svg`
       );


### PR DESCRIPTION
Move the original table into the fullscreen modal and restore it when the
modal closes. This keeps event listeners and other runtime state that were
lost when the table was cloned.
