### PR TITLE
DEV: Lint symlinked plugins using relative paths

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -22,7 +22,9 @@ class ExternalLinter
 
   def initialize(root, files, fix:, verbose: false)
     @root = root
-    @files = files.map { |f| File.expand_path(f) }
+    root_path = Pathname.new(@root)
+    # Keep paths relative to the plugin root so linter exclusions work for symlinked plugins.
+    @files = files.map { |f| Pathname.new(File.expand_path(f)).relative_path_from(root_path).to_s }
     @fix = fix
     @verbose = verbose
     @results = []

--- a/bin/lint
+++ b/bin/lint
@@ -22,9 +22,9 @@ class ExternalLinter
 
   def initialize(root, files, fix:, verbose: false)
     @root = root
-    root_path = Pathname.new(@root)
+    root_path = Pathname.new(@root).realpath
     # Keep paths relative to the plugin root so linter exclusions work for symlinked plugins.
-    @files = files.map { |f| Pathname.new(File.expand_path(f)).relative_path_from(root_path).to_s }
+    @files = files.map { |f| Pathname.new(f).realpath.relative_path_from(root_path).to_s }
     @fix = fix
     @verbose = verbose
     @results = []
@@ -317,7 +317,7 @@ class LefthookLinter
 
     files.each do |f|
       if (root = external_plugin_root(f))
-        external_files[File.join(PROJECT_ROOT, root)] << f
+        external_files[root] << f
       else
         core_files << f
       end
@@ -326,16 +326,22 @@ class LefthookLinter
     [core_files, external_files]
   end
 
-  # Returns "plugins/<name>" if the file is in an unbundled plugin directory, else nil.
+  # Returns the plugin root if the file is in an unbundled plugin directory, else nil.
   def external_plugin_root(file)
     path = normalize_relative_path(file)
-    return nil unless path.start_with?("plugins/")
+    return standalone_plugin_root(file) unless path.start_with?("plugins/")
 
     parts = path.split("/")
     return nil if parts.length < 2
 
     plugin_dir = "plugins/#{parts[1]}"
-    bundled_plugins.include?(plugin_dir) ? nil : plugin_dir
+    File.join(PROJECT_ROOT, plugin_dir) if bundled_plugins.exclude?(plugin_dir)
+  end
+
+  def standalone_plugin_root(file)
+    file_path = Pathname.new(file).realpath
+    plugin_root = file_path.ascend.find { |path| path.join("plugin.rb").file? }
+    plugin_root&.to_s
   end
 
   def bundled_plugins


### PR DESCRIPTION
ExternalLinter runs from the plugin root, but previously passed absolute
file paths through the symlink under discourse/plugins. RuboCop expands
exclusion patterns relative to the plugin's real root, so those paths do
not match.

For example, discourse-kanban system specs incorrectly triggered
RSpec/DescribeClass even though spec/system is excluded. Pass file paths
relative to the plugin root so linter configuration matches symlinked
plugins correctly.
