### PR TITLE
DEV: Allow arguments for close() and onClose in DMenu/FloatKit

### DIFF
--- a/frontend/discourse/float-kit/components/d-menu.gts
+++ b/frontend/discourse/float-kit/components/d-menu.gts
@@ -9,6 +9,7 @@ import { modifier } from "ember-modifier";
 import DFloatBody from "discourse/float-kit/components/d-float-body";
 import {
   type FloatCallback,
+  type FloatCloseOptions,
   MENU,
   type MenuOptions,
 } from "discourse/float-kit/lib/constants";
@@ -22,7 +23,7 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 /** The object yielded to each of the menu's blocks and passed to a rendered component. */
 export interface DMenuComponentArgs<Data = unknown> {
   /** Closes the menu. */
-  close: FloatCallback;
+  close: (options?: FloatCloseOptions) => Promise<void>;
 
   /** Opens the menu. */
   show: FloatCallback;
@@ -55,7 +56,12 @@ type DMenuOptionArgs<Data> = Partial<
   data?: Data;
 
   /** A component rendered as the content; it receives the `@data` and `@close` arguments. */
-  component?: ComponentLike<{ Args: { data?: Data; close?: FloatCallback } }>;
+  component?: ComponentLike<{
+    Args: {
+      data?: Data;
+      close?: (options?: FloatCloseOptions) => Promise<void>;
+    };
+  }>;
 
   /** Called with the menu instance when it is created, so callers can control it programmatically. */
   onRegisterApi?: (instance: DMenuInstance) => void;

--- a/frontend/discourse/float-kit/lib/constants.ts
+++ b/frontend/discourse/float-kit/lib/constants.ts
@@ -66,6 +66,15 @@ export type FloatContentRole = "dialog" | "none" | "presentation";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- a relay callback must accept consumer functions of any argument shape; `unknown[]` would reject them.
 export type FloatCallback = (...args: any[]) => void;
 
+/** Options accepted when closing an anchored float. */
+export interface FloatCloseOptions {
+  /** Data passed to the float's `onClose` callback. */
+  data?: unknown;
+
+  /** Whether a menu restores focus to its trigger after closing. */
+  focusTrigger?: boolean;
+}
+
 /**
  * The events that open (or close) a float. Either a single list applied on every
  * viewport, or a split of `mobile`/`desktop` lists resolved against the current view.
@@ -170,7 +179,7 @@ export interface TooltipOptions {
   /** Whether to trap Tab focus within the content. */
   trapTab: boolean;
 
-  /** Called after the float closes. */
+  /** Called after the float closes, with any data supplied to `close`. */
   onClose: FloatCallback | null;
 
   /** Called after the float shows. */

--- a/frontend/discourse/float-kit/lib/d-menu-instance.ts
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.ts
@@ -6,6 +6,7 @@ import Owner, { getOwner, setOwner } from "@ember/owner";
 import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
 import {
+  type FloatCloseOptions,
   type FloatKitTrigger,
   MENU,
   type MenuOptions,
@@ -101,7 +102,7 @@ export default class DMenuInstance extends FloatKitInstance {
   }
 
   @action
-  async close(options = { focusTrigger: true }) {
+  async close(options: FloatCloseOptions = {}) {
     this.resetHoverCloseState();
     this.openedByDelayedHover = false;
 
@@ -119,7 +120,10 @@ export default class DMenuInstance extends FloatKitInstance {
     // say) still must not lose focus altogether. Recheck rather than trusting `ownedFocus`:
     // closing is animated, so by now the click may have deliberately focused something else,
     // and only focus left with no owner is ours to restore.
-    if (options.focusTrigger || (ownedFocus && this.#focusIsUnowned)) {
+    if (
+      (options.focusTrigger ?? true) ||
+      (ownedFocus && this.#focusIsUnowned)
+    ) {
       this.triggerElement?.focus();
     }
 

--- a/frontend/discourse/float-kit/lib/float-kit-instance.ts
+++ b/frontend/discourse/float-kit/lib/float-kit-instance.ts
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
 import type {
+  FloatCloseOptions,
   FloatKitTrigger,
   TooltipOptions,
 } from "discourse/float-kit/lib/constants";
@@ -119,12 +120,11 @@ export default abstract class FloatKitInstance {
   }
 
   @action
-  // `options` is part of the shared close contract (a menu uses it to decide whether to
-  // refocus its trigger); the base close has no trigger to refocus, so it ignores it.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async close(options?: { focusTrigger?: boolean }) {
+  // `options` is part of the shared close contract: the base relays its data, while a menu
+  // additionally uses it to decide whether to refocus its trigger.
+  async close(options?: FloatCloseOptions) {
     this.resetHoverCloseState();
-    await this.options.onClose?.();
+    await this.options.onClose?.(options?.data);
   }
 
   /** Drops any pending grace-period close, so the float stays open. */

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { array, hash } from "@ember/helper";
+import { array, fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -38,6 +38,13 @@ const ModalWithMenu = <template>
       </:content>
     </DMenu>
   </DModal>
+</template>;
+
+const CloseMenuWithData = <template>
+  <DButton
+    class="close-with-data"
+    @action={{fn @close (hash data=(hash saved=true))}}
+  />
 </template>;
 
 module("Integration | Component | FloatKit | DMenu", function (hooks) {
@@ -347,8 +354,9 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
   });
 
   test("@onClose", async function (assert) {
-    this.test = false;
-    this.onClose = () => (this.test = true);
+    const notClosed = Symbol("not closed");
+    this.closeData = notClosed;
+    this.onClose = (data) => (this.closeData = data);
 
     await render(
       <template><DMenu @inline={{true}} @onClose={{this.onClose}} /></template>
@@ -356,7 +364,60 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     await open();
     await close();
 
-    assert.true(this.test);
+    assert.strictEqual(
+      this.closeData,
+      undefined,
+      "an ordinary close supplies no data"
+    );
+  });
+
+  test("a service-created menu component can close with data", async function (assert) {
+    let closeData;
+
+    await render(
+      <template>
+        <button type="button" class="menu-trigger">Open</button>
+        <DMenus />
+      </template>
+    );
+
+    await getOwner(this)
+      .lookup("service:menu")
+      .show(find(".menu-trigger"), {
+        component: CloseMenuWithData,
+        onClose: (data) => (closeData = data),
+      });
+    await click(".close-with-data");
+
+    assert.deepEqual(
+      closeData,
+      { saved: true },
+      "onClose receives the data supplied by the rendered component"
+    );
+  });
+
+  test("close data preserves the default trigger focus", async function (assert) {
+    this.api = null;
+    this.onRegisterApi = (api) => (this.api = api);
+
+    await render(
+      <template>
+        <button type="button" class="outside-button">Outside</button>
+        <DMenu
+          @onRegisterApi={{this.onRegisterApi}}
+          @inline={{true}}
+          @label="Open"
+        />
+      </template>
+    );
+
+    await open();
+    await focus(".outside-button");
+    await this.api.close({ data: { saved: true } });
+
+    assert
+      .dom(".fk-d-menu__trigger")
+      .isFocused("supplying only data still restores focus to the trigger");
   });
 
   test("-expanded class", async function (assert) {


### PR DESCRIPTION
In some situations, you want to have something like a submenu
where the child menu can close either from:

* The user moving their mouse away from the submenu or
* The user clicking on an item in the submenu

In this case, if the parent has an onClose handler, and
some logic to close itself when the child closes, you
want to be able to pass an argument from the child to
the parent in case the parent should only close
if the child closes from a click, not just because the
mouse moved out of the child submenu.

Then you can do something like:

```
onClose(data) {
  if (data?.reason === 'saved') {
    this.close();
  }
}
```
