### PR TITLE
FIX: Allow checklists in anonymous quotes

### DIFF
--- a/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
+++ b/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
@@ -428,13 +428,21 @@ function addToggleBehavior(boxes, postModel, allBoxes = boxes) {
   };
 }
 
+function isInsideSourcedQuote(box) {
+  return Boolean(
+    box.closest(
+      "aside.quote[data-username], aside.quote[data-post], aside.quote[data-topic]"
+    )
+  );
+}
+
 export function checklistSyntax(elem, postDecorator) {
   const boxes = [...elem.getElementsByClassName("chcklst-box")];
   addUlClasses(boxes);
 
   const postModel = postDecorator?.getModel();
   const editable = postModel?.can_edit === true;
-  const interactiveBoxes = boxes.filter((box) => !box.closest("aside.quote"));
+  const interactiveBoxes = boxes.filter((box) => !isInsideSourcedQuote(box));
   const interactiveBoxSet = new Set(interactiveBoxes);
 
   boxes.forEach((box) =>

--- a/plugins/checklist/lib/checklist/checkbox_locator.rb
+++ b/plugins/checklist/lib/checklist/checkbox_locator.rb
@@ -29,7 +29,10 @@ module Checklist
 
     def build(cooked, targets)
       nodes =
-        Nokogiri::HTML5.fragment(cooked).css("span.chcklst-box").reject { |node| quoted?(node) }
+        Nokogiri::HTML5
+          .fragment(cooked)
+          .css("span.chcklst-box")
+          .reject { |node| inside_sourced_quote?(node) }
       if !source_hints_valid?(nodes)
         return targets.map { Location.new(count: nodes.size, checkbox: nil, needs_recook: true) }
       end
@@ -53,9 +56,10 @@ module Checklist
       Location.new(count: nodes.size, checkbox:, needs_recook: checkbox.nil?)
     end
 
-    def quoted?(node)
+    def inside_sourced_quote?(node)
       node.ancestors.any? do |ancestor|
-        ancestor.name == "aside" && ancestor.classes.include?("quote")
+        ancestor.name == "aside" && ancestor.classes.include?("quote") &&
+          %w[data-username data-post data-topic].any? { |attribute| ancestor.attribute(attribute) }
       end
     end
 

--- a/plugins/checklist/spec/lib/checklist/checkbox_locator_spec.rb
+++ b/plugins/checklist/spec/lib/checklist/checkbox_locator_spec.rb
@@ -71,19 +71,31 @@ RSpec.describe Checklist::CheckboxLocator do
       )
     end
 
-    it "excludes checkboxes copied into quote asides" do
+    it "excludes sourced quote checkboxes but maps anonymous quote checkboxes" do
       raw = <<~MARKDOWN
         [quote="Other user"]
-        [ ] quoted
+        [ ] attributed quote
+        [/quote]
+
+        [quote=", post: 1"]
+        [ ] post quote
+        [/quote]
+
+        [quote]
+        [ ] anonymous quote
         [/quote]
 
         [ ] own
       MARKDOWN
 
-      location = locate(raw, 0)
+      anonymous_quote = locate(raw, 0)
+      own = locate(raw, 1)
 
-      expect(location.count).to eq(1)
-      expect(location.checkbox.replace_in(raw, checked: true)).to end_with("[x] own\n")
+      expect(anonymous_quote.count).to eq(2)
+      expect(anonymous_quote.checkbox.replace_in(raw, checked: true)).to include(
+        "[x] anonymous quote",
+      )
+      expect(own.checkbox.replace_in(raw, checked: true)).to end_with("[x] own\n")
     end
 
     it "maps checkboxes in blockquotes, lists, and table cells" do

--- a/plugins/checklist/test/javascripts/lib/checklist-test.js
+++ b/plugins/checklist/test/javascripts/lib/checklist-test.js
@@ -592,29 +592,49 @@ Actual checkboxes:
       .hasAttribute("aria-label", "Checklist item", "the empty item is named");
   });
 
-  test("does not make quoted checkboxes interactive", async function (assert) {
-    const [quoted, own] = await prepare(
-      '[quote="Other user"]\n[ ] quoted task\n[/quote]\n\n[ ] own task'
+  test("only anonymous quote checkboxes are interactive", async function (assert) {
+    const [attributedQuote, postQuote, anonymousQuote, own] = await prepare(
+      '[quote="Other user"]\n[ ] attributed task\n[/quote]\n\n[quote=", post: 1"]\n[ ] post task\n[/quote]\n\n[quote]\n[ ] anonymous task\n[/quote]\n\n[ ] own task'
     );
 
-    assert
-      .dom(quoted)
-      .hasAttribute(
-        "aria-readonly",
-        "true",
-        "the quoted checkbox is read-only"
-      );
-    assert.dom(quoted).doesNotHaveAttribute("tabindex");
-    await click(quoted);
-    assert.strictEqual(requests.length, 0, "the quote sends no request");
+    for (const [quote, label] of [
+      [attributedQuote, "attributed"],
+      [postQuote, "post"],
+    ]) {
+      assert
+        .dom(quote)
+        .hasAttribute(
+          "aria-readonly",
+          "true",
+          `the ${label} quote checkbox is read-only`
+        );
+      assert
+        .dom(quote)
+        .doesNotHaveAttribute(
+          "tabindex",
+          `the ${label} quote checkbox is not focusable`
+        );
+      await click(quote);
+    }
+    assert.strictEqual(requests.length, 0, "sourced quotes send no request");
 
-    await click(own);
-    assert.strictEqual(requests.length, 1, "the post's own checkbox toggles");
+    assert
+      .dom(anonymousQuote)
+      .hasAttribute(
+        "tabindex",
+        "0",
+        "the anonymous quote checkbox is interactive"
+      );
+    await click(anonymousQuote);
+    assert.strictEqual(requests.length, 1, "the anonymous quote toggles");
     assert.strictEqual(
       requests[0].toggles[0].checkbox_index,
       0,
-      "quoted checkboxes are excluded from the rendered index"
+      "sourced quote checkboxes are excluded from the rendered index"
     );
+
+    await click(own);
+    assert.strictEqual(requests.length, 2, "the post's own checkbox toggles");
   });
 
   test("permanent and read-only checkboxes are not interactive", async function (assert) {


### PR DESCRIPTION
Treat checkboxes in anonymous quote blocks as part of the post so they remain interactive and map to their raw source. Continue excluding attributed, post, and topic quotes to prevent copied checkboxes from being toggled.
