### PR TITLE
FIX: Allow local backup downloads to resume

### DIFF
--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -95,16 +95,41 @@ class Admin::BackupsController < Admin::AdminController
   end
 
   def show
-    if !EmailBackupToken.compare(current_user.id, params.fetch(:token))
+    token = params.fetch(:token)
+    backup_id = params.fetch(:id)
+
+    email_token_valid = EmailBackupToken.compare(current_user.id, token)
+    resume_token_valid =
+      !email_token_valid &&
+        SiteSetting.backup_download_resume_window !=
+          BackupDownloadResumeWindowSiteSetting::DISABLED && request.headers["Range"].present? &&
+        BackupDownloadResumeToken.compare(current_user.id, backup_id, token)
+
+    if !email_token_valid && !resume_token_valid
       @error = I18n.t("download_backup_mailer.no_token")
       return render layout: "no_ember", status: :unprocessable_entity, formats: [:html]
     end
 
     store = BackupRestore::BackupStore.create
 
-    if backup = store.file(params.fetch(:id), include_download_source: true)
-      EmailBackupToken.del(current_user.id)
-      StaffActionLogger.new(current_user).log_backup_download(backup)
+    if backup = store.file(backup_id, include_download_source: true)
+      if email_token_valid
+        if !store.remote?
+          resume_ttl =
+            BackupDownloadResumeWindowSiteSetting.resume_ttl(
+              SiteSetting.backup_download_resume_window,
+              email_token_ttl: EmailBackupToken.ttl(current_user.id),
+            )
+
+          BackupDownloadResumeToken.set(current_user.id, backup_id, token, ttl: resume_ttl)
+        end
+
+        EmailBackupToken.del(current_user.id)
+        StaffActionLogger.new(current_user).log_backup_download(backup)
+      elsif store.remote?
+        @error = I18n.t("download_backup_mailer.no_token")
+        return render layout: "no_ember", status: :unprocessable_entity, formats: [:html]
+      end
 
       if store.remote?
         redirect_to backup.source, allow_other_host: true

--- a/app/models/backup_download_resume_window_site_setting.rb
+++ b/app/models/backup_download_resume_window_site_setting.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class BackupDownloadResumeWindowSiteSetting < EnumSiteSetting
+  DISABLED = "disabled"
+  ONE_HOUR = "1_hour"
+  SIX_HOURS = "6_hours"
+  TWELVE_HOURS = "12_hours"
+  UNTIL_EMAIL_TOKEN_EXPIRES = "until_email_token_expires"
+
+  def self.valid_value?(val)
+    values.any? { |v| v[:value] == val }
+  end
+
+  def self.values
+    @values ||= [
+      { name: "admin.backups.resume_window.disabled", value: DISABLED },
+      { name: "admin.backups.resume_window.one_hour", value: ONE_HOUR },
+      { name: "admin.backups.resume_window.six_hours", value: SIX_HOURS },
+      { name: "admin.backups.resume_window.twelve_hours", value: TWELVE_HOURS },
+      {
+        name: "admin.backups.resume_window.until_email_token_expires",
+        value: UNTIL_EMAIL_TOKEN_EXPIRES,
+      },
+    ]
+  end
+
+  def self.resume_ttl(value, email_token_ttl:)
+    email_token_ttl = email_token_ttl.to_i
+    return 0 if email_token_ttl <= 0
+
+    maximum_ttl =
+      case value
+      when DISABLED
+        0
+      when ONE_HOUR
+        1.hour.to_i
+      when SIX_HOURS
+        6.hours.to_i
+      when TWELVE_HOURS
+        12.hours.to_i
+      when UNTIL_EMAIL_TOKEN_EXPIRES
+        email_token_ttl
+      else
+        0
+      end
+
+    [email_token_ttl, maximum_ttl].min
+  end
+
+  def self.translate_names?
+    true
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8620,6 +8620,12 @@ en:
         location:
           local: "Local storage"
           s3: "S3"
+        resume_window:
+          disabled: "Disabled"
+          one_hour: "1 hour"
+          six_hours: "6 hours (recommended)"
+          twelve_hours: "12 hours"
+          until_email_token_expires: "Until the original email token expires"
         backup_storage_error: "Failed to access backup storage: %{error_message}"
 
       export_csv:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2278,6 +2278,7 @@ en:
     backup_time_of_day: "Time of day UTC when the backup should occur."
     backup_with_uploads: "Include uploads in scheduled backups. Disabling this will only backup the database."
     backup_location: "Location where backups are stored. IMPORTANT: S3 requires valid S3 credentials entered in <a href='%{base_path}/admin/site_settings/category/files'>Files settings</a>. When changing this to S3 from Local, you must run the `s3:ensure_cors_rules` rake task."
+    backup_download_resume_window: "How long an interrupted local backup download can be resumed by the same authenticated administrator for the same backup. 6 hours is recommended when enabling resumable downloads. Longer windows improve reliability on slow or frequently interrupted connections, but extend the period during which the already-authorized backup can be resumed. Resume authorization is capped to the remaining lifetime of the original emailed backup token when the download begins."
     backup_gzip_compression_level_for_uploads: "Gzip compression level used for compressing uploads."
     include_thumbnails_in_backups: "Include generated thumbnails in backups. Disabling this will make backups smaller, but requires a rebake of all posts after a restore."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3739,6 +3739,17 @@ backups:
     type: enum
     enum: "BackupLocationSiteSetting"
     client: true
+  backup_download_resume_window:
+    default: "disabled"
+    type: enum
+    enum: "BackupDownloadResumeWindowSiteSetting"
+    depends_on:
+      - backup_location
+    depends_on_values:
+      backup_location:
+        - local
+    depends_behavior: "hidden"
+    dependent_setting_display: "inline"
   maximum_backups:
     client: true
     default: 5

--- a/lib/backup_download_resume_token.rb
+++ b/lib/backup_download_resume_token.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class BackupDownloadResumeToken
+  def self.key(user_id, backup_filename)
+    filename_digest = Digest::SHA256.hexdigest(backup_filename)
+    "backup-download-resume-token:#{user_id}:#{filename_digest}"
+  end
+
+  def self.set(user_id, backup_filename, token, ttl:)
+    return if ttl.to_i <= 0
+
+    Discourse.redis.setex(key(user_id, backup_filename), ttl.to_i, token)
+  end
+
+  def self.compare(user_id, backup_filename, token)
+    token == Discourse.redis.get(key(user_id, backup_filename))
+  end
+end

--- a/lib/email_backup_token.rb
+++ b/lib/email_backup_token.rb
@@ -23,6 +23,11 @@ class EmailBackupToken
     Discourse.redis.del key(user_id)
   end
 
+  def self.ttl(user_id)
+    ttl = Discourse.redis.ttl(key(user_id)).to_i
+    ttl.positive? ? ttl : 0
+  end
+
   def self.compare(user_id, token)
     token == get(user_id)
   end

--- a/spec/lib/backup_download_resume_token_spec.rb
+++ b/spec/lib/backup_download_resume_token_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe BackupDownloadResumeToken do
+  let(:user_id) { 123 }
+  let(:backup_filename) { "example-2026-08-31.tar.gz" }
+  let(:other_backup_filename) { "other-2026-08-31.tar.gz" }
+  let(:token) { "secret-token" }
+
+  describe ".set and .compare" do
+    it "stores a token for the same user and backup" do
+      described_class.set(user_id, backup_filename, token, ttl: 1.hour)
+
+      expect(described_class.compare(user_id, backup_filename, token)).to eq(true)
+    end
+
+    it "does not authorize a different backup" do
+      described_class.set(user_id, backup_filename, token, ttl: 1.hour)
+
+      expect(described_class.compare(user_id, other_backup_filename, token)).to eq(false)
+    end
+
+    it "does not authorize a different user" do
+      described_class.set(user_id, backup_filename, token, ttl: 1.hour)
+
+      expect(described_class.compare(user_id + 1, backup_filename, token)).to eq(false)
+    end
+
+    it "does not store a token with a non-positive ttl" do
+      described_class.set(user_id, backup_filename, token, ttl: 0)
+
+      expect(described_class.compare(user_id, backup_filename, token)).to eq(false)
+    end
+
+    it "sets the requested expiry" do
+      described_class.set(user_id, backup_filename, token, ttl: 1.hour)
+
+      ttl = Discourse.redis.ttl(described_class.key(user_id, backup_filename))
+
+      expect(ttl).to be_between(1.hour.to_i - 2, 1.hour.to_i)
+    end
+  end
+end

--- a/spec/models/backup_download_resume_window_site_setting_spec.rb
+++ b/spec/models/backup_download_resume_window_site_setting_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe BackupDownloadResumeWindowSiteSetting do
+  describe ".valid_value?" do
+    it "accepts known values" do
+      expect(described_class.valid_value?(described_class::DISABLED)).to eq(true)
+      expect(described_class.valid_value?(described_class::SIX_HOURS)).to eq(true)
+    end
+
+    it "rejects unknown values" do
+      expect(described_class.valid_value?("forever")).to eq(false)
+    end
+  end
+
+  describe ".resume_ttl" do
+    it "returns zero when resume is disabled" do
+      expect(
+        described_class.resume_ttl(described_class::DISABLED, email_token_ttl: 1.day.to_i),
+      ).to eq(0)
+    end
+
+    it "returns the selected resume window when it is shorter than the email token lifetime" do
+      expect(
+        described_class.resume_ttl(described_class::SIX_HOURS, email_token_ttl: 1.day.to_i),
+      ).to eq(6.hours.to_i)
+    end
+
+    it "does not outlive the remaining email token lifetime" do
+      expect(
+        described_class.resume_ttl(described_class::SIX_HOURS, email_token_ttl: 30.minutes.to_i),
+      ).to eq(30.minutes.to_i)
+    end
+
+    it "uses the full remaining email token lifetime when selected" do
+      expect(
+        described_class.resume_ttl(
+          described_class::UNTIL_EMAIL_TOKEN_EXPIRES,
+          email_token_ttl: 3.hours.to_i,
+        ),
+      ).to eq(3.hours.to_i)
+    end
+
+    it "returns zero when the email token has expired" do
+      expect(described_class.resume_ttl(described_class::SIX_HOURS, email_token_ttl: 0)).to eq(0)
+    end
+
+    it "returns zero for an unknown value" do
+      expect(described_class.resume_ttl("forever", email_token_ttl: 1.day.to_i)).to eq(0)
+    end
+  end
+end

--- a/spec/requests/admin/backups_controller_spec.rb
+++ b/spec/requests/admin/backups_controller_spec.rb
@@ -217,6 +217,169 @@ RSpec.describe Admin::BackupsController do
         expect(response.headers["Content-Disposition"]).to match(/attachment; filename/)
       end
 
+      it "does not allow resuming a local backup download when resume is disabled" do
+        expect(SiteSetting.backup_download_resume_window).to eq(
+          BackupDownloadResumeWindowSiteSetting::DISABLED,
+        )
+
+        token = EmailBackupToken.set(admin.id)
+        create_backup_files(backup_filename)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+        expect(response.status).to eq(200)
+
+        get "/admin/backups/#{backup_filename}.json",
+            params: {
+              token: token,
+            },
+            headers: {
+              "Range" => "bytes=5-",
+            }
+
+        expect(response.status).to eq(422)
+      end
+
+      it "does not allow reusing a token for another full backup download" do
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::SIX_HOURS
+
+        token = EmailBackupToken.set(admin.id)
+        create_backup_files(backup_filename)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+        expect(response.status).to eq(200)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+
+        expect(response.status).to eq(422)
+      end
+
+      it "does not allow resuming a different backup with the same token" do
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::SIX_HOURS
+
+        token = EmailBackupToken.set(admin.id)
+        create_backup_files(backup_filename, backup_filename2)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+        expect(response.status).to eq(200)
+
+        get "/admin/backups/#{backup_filename2}.json",
+            params: {
+              token: token,
+            },
+            headers: {
+              "Range" => "bytes=5-",
+            }
+
+        expect(response.status).to eq(422)
+      end
+
+      it "allows resuming a local backup download with a range request" do
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::SIX_HOURS
+
+        token = EmailBackupToken.set(admin.id)
+        create_backup_files(backup_filename)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+        expect(response.status).to eq(200)
+
+        get "/admin/backups/#{backup_filename}.json",
+            params: {
+              token: token,
+            },
+            headers: {
+              "Range" => "bytes=5-",
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Disposition"]).to match(/attachment; filename/)
+      end
+
+      it "logs a resumed backup download only once" do
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::SIX_HOURS
+
+        token = EmailBackupToken.set(admin.id)
+        create_backup_files(backup_filename)
+
+        expect do
+          get "/admin/backups/#{backup_filename}.json", params: { token: token }
+        end.to change { UserHistory.where(action: UserHistory.actions[:backup_download]).count }.by(
+          1,
+        )
+
+        expect do
+          get "/admin/backups/#{backup_filename}.json",
+              params: {
+                token: token,
+              },
+              headers: {
+                "Range" => "bytes=5-",
+              }
+        end.not_to change { UserHistory.where(action: UserHistory.actions[:backup_download]).count }
+
+        expect(response.status).to eq(200)
+      end
+
+      it "stops allowing resume when the setting is disabled" do
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::SIX_HOURS
+
+        token = EmailBackupToken.set(admin.id)
+        create_backup_files(backup_filename)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+        expect(response.status).to eq(200)
+
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::DISABLED
+
+        get "/admin/backups/#{backup_filename}.json",
+            params: {
+              token: token,
+            },
+            headers: {
+              "Range" => "bytes=5-",
+            }
+
+        expect(response.status).to eq(422)
+      end
+
+      it "does not create a resume grant for a remote backup" do
+        setup_s3
+        SiteSetting.s3_backup_bucket = "test-backup-bucket"
+        SiteSetting.backup_location = BackupLocationSiteSetting::S3
+        SiteSetting.backup_download_resume_window = BackupDownloadResumeWindowSiteSetting::SIX_HOURS
+
+        token = EmailBackupToken.set(admin.id)
+        source = "https://example.com/backups/#{backup_filename}?presigned=true"
+        backup =
+          BackupFile.new(
+            filename: backup_filename,
+            size: 11,
+            last_modified: Time.zone.now,
+            source: source,
+          )
+
+        store = instance_double(BackupRestore::BackupStore, remote?: true)
+        allow(store).to receive(:file).with(
+          backup_filename,
+          include_download_source: true,
+        ).and_return(backup)
+        allow(BackupRestore::BackupStore).to receive(:create).and_return(store)
+
+        get "/admin/backups/#{backup_filename}.json", params: { token: token }
+
+        expect(response).to redirect_to(source)
+        expect(BackupDownloadResumeToken.compare(admin.id, backup_filename, token)).to eq(false)
+
+        get "/admin/backups/#{backup_filename}.json",
+            params: {
+              token: token,
+            },
+            headers: {
+              "Range" => "bytes=5-",
+            }
+
+        expect(response.status).to eq(422)
+      end
+
       it "returns 422 when token is bad" do
         get "/admin/backups/#{backup_filename}.json", params: { token: "bad_value" }
 


### PR DESCRIPTION
## Summary

Allows interrupted **local** backup downloads to resume with an HTTP `Range` request after the one-use emailed backup token has been consumed.

This addresses the case reported on Meta where a multi-GB local backup download was interrupted and the browser retried with `Range`, but the retry received `422` because `EmailBackupToken.del` had already consumed the token:

https://meta.discourse.org/t/backup-download-cannot-resume-after-interruption-because-email-token-has-already-been-consumed/411277

## Approach

The existing emailed token remains the only way to initiate a backup download. When resumable local downloads are enabled, the first authorized **local** download creates a narrower resume grant which is scoped to:

* the same authenticated administrator
* the same backup
* the same original emailed token value
* requests carrying a `Range` header
* a bounded expiry window

The original `EmailBackupToken` is still consumed after the initial request. Ordinary reuse of that token for another full download remains rejected, and the resume grant cannot be used for a different backup or user.

Remote/S3 backup downloads keep their existing presigned-URL redirect behavior and do not receive a local resume grant.

A resumed request is treated as a continuation of the same authorized download, so it does not create a second `backup_download` staff action entry.

## Resume window setting

Adds `backup_download_resume_window` as an enum rather than an unrestricted numeric duration, to avoid an administrator accidentally configuring an excessively long authorization window.

Options are:

* `disabled`
* `1_hour`
* `6_hours` — shown as **6 hours (recommended)** in the admin UI
* `12_hours`
* `until_email_token_expires`

The effective resume TTL is capped to the remaining lifetime of the original emailed token when the initial download begins.

The setting integrates with the existing backup settings and is only applicable to local storage:

<img width="960" height="850" alt="Backup download resume window shown beneath the local backup location setting" src="https://github.com/user-attachments/assets/abbbdf04-e2f5-4d7d-b66a-1c73caddd583" />

The available values are deliberately bounded, with the compatibility-preserving default disabled and 6 hours identified as the recommended enabled option:

<img width="341" height="426" alt="Backup download resume window enum showing Disabled, 1 hour, 6 hours recommended, 12 hours, and until the original email token expires" src="https://github.com/user-attachments/assets/4dd3dd5c-50e0-4df3-ac6e-9732b7878227" />

### Default vs recommended value

This PR intentionally distinguishes the **default** from the **recommended enabled option**.

The current Discourse behavior is equivalent to `disabled`: once the emailed token is consumed by the initial request, a subsequent `Range` retry is rejected. To preserve existing behavior for current sites, this PR therefore keeps `disabled` as the default.

For admins who choose to enable resumable local downloads, `6_hours` is labelled as the recommended enum option.

There is precedent for preserving existing behavior when introducing an enum setting in #36014: the previously hard-coded calendar view remained the default value of the new enum setting.

**Maintainer question:** given the concrete interrupted-download case in the linked Meta topic, would you prefer the default to remain `disabled` for backwards compatibility, or should the recommended `6_hours` option become the default as part of fixing the issue?

By “recommended” here I mean the admin-facing recommendation attached to one enum option, not a separate setting or an unrestricted duration value.

## Tests

Added coverage for:

* default/disabled behavior remaining unchanged
* successful same-backup `Range` resume when enabled
* rejection of ordinary token reuse
* rejection of cross-backup resume
* immediate revocation when the setting is disabled
* no local resume grant for S3 backups
* one audit entry across the initial download and resume
* resume-token user/backup scoping and Redis expiry
* enum validation and TTL capping

Local focused test run:

`94 examples, 0 failures`

Ruby, YAML, and i18n linters also pass.
