### PR TITLE
DEV: Rate limit `check_username` requests per IP

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -612,6 +612,12 @@ class UsersController < ApplicationController
   # Used for checking availability of a username and will return suggestions
   # if the username is not available.
   def check_username
+    begin
+      RateLimiter.new(nil, "check-username-#{request.remote_ip}", 10, 1.minute).performed!
+    rescue RateLimiter::LimitExceeded
+      return render json: failed_json.merge(errors: [I18n.t("rate_limiter.slow_down")])
+    end
+
     if !params[:username].present?
       params.require(:username) if !params[:email].present?
       return render(json: success_json)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -613,7 +613,7 @@ class UsersController < ApplicationController
   # if the username is not available.
   def check_username
     begin
-      RateLimiter.new(nil, "check-username-#{request.remote_ip}", 10, 1.minute).performed!
+      RateLimiter.new(current_user, "check-username-#{request.remote_ip}", 10, 1.minute).performed!
     rescue RateLimiter::LimitExceeded
       return render json: failed_json.merge(errors: [I18n.t("rate_limiter.slow_down")])
     end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2190,6 +2190,16 @@ RSpec.describe UsersController do
       expect(response.parsed_body["errors"]).to contain_exactly(I18n.t("rate_limiter.slow_down"))
     end
 
+    it "does not rate limit staff" do
+      RateLimiter.enable
+      sign_in(moderator)
+
+      11.times { get "/u/check_username.json", params: { username: "available" } }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["available"]).to eq(true)
+    end
+
     shared_examples "when username is unavailable" do
       it "should return available as false in the JSON and return a suggested username" do
         expect(response.status).to eq(200)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2179,6 +2179,17 @@ RSpec.describe UsersController do
       expect(response.status).to eq(400)
     end
 
+    it "rate limits requests per IP" do
+      RateLimiter.enable
+
+      10.times { get "/u/check_username.json", params: { username: "available" } }
+      get "/u/check_username.json", params: { username: "available" }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).not_to have_key("available")
+      expect(response.parsed_body["errors"]).to contain_exactly(I18n.t("rate_limiter.slow_down"))
+    end
+
     shared_examples "when username is unavailable" do
       it "should return available as false in the JSON and return a suggested username" do
         expect(response.status).to eq(200)


### PR DESCRIPTION
**Previously**, `check_username` had no rate limiter, while the neighbouring `check_email` endpoint has been limited to 10 requests per minute per IP.

**In this update**, `check_username` applies the same 10 per minute per IP limit and returns the standard "slow down" message in `errors`, which the signup and username preference forms already render inline.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/raw/refs/heads/gh-attach-assets/63c5fa8e-ea45-4bbc-8860-1d8d305acfd0/before.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-fdwge1.png) |