### PR TITLE
FIX: Preserve newlines in form template composer preview

### DIFF
--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -179,11 +179,13 @@ export default class FormTemplateFieldComposer extends Component {
         @onSetup={{this.onEditorSetup}}
       />
       {{! the editor is not a form control, so this stands in for it to carry the
-      value and native validation. must stay last: the error tip is only
-      inserted after a field with no next sibling }}
-      <input
+      value and native validation. a textarea (not an input) is required so
+      newlines survive value assignment — text inputs strip CR/LF per the HTML
+      value-sanitisation rules, which flattens the composer preview on edit.
+      must stay last: the error tip is only inserted after a field with no
+      next sibling }}
+      <textarea
         id={{this.validationInputId}}
-        type="text"
         name={{@id}}
         value={{this.composerValue}}
         required={{if @validations.required "required" ""}}
@@ -192,7 +194,7 @@ export default class FormTemplateFieldComposer extends Component {
         aria-hidden="true"
         {{on "invalid" this.handleInvalid}}
         {{on "input" this.handleValidationInput}}
-      />
+      ></textarea>
     </div>
   </template>
 }

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -10,7 +10,10 @@ import { test } from "qunit";
 import sinon from "sinon";
 import { cloneJSON } from "discourse/lib/object";
 import TopicFixtures from "discourse/tests/fixtures/topic";
-import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import pretender, {
+  parsePostData,
+  response,
+} from "discourse/tests/helpers/create-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
@@ -322,6 +325,42 @@ acceptance("Composer Form Template", function (needs) {
         i18n("form_templates.errors.value_missing.default"),
         "the replacement editor is still connected to the visible error"
       );
+  });
+
+  test("preserves newlines from a composer field in the generated post body", async function (assert) {
+    let capturedRaw;
+    pretender.post("/posts", (request) => {
+      capturedRaw = parsePostData(request.requestBody).raw;
+      return response(200, {
+        success: true,
+        action: "create_post",
+        post: { id: 42, topic_id: 960, topic_slug: "x" },
+      });
+    });
+
+    await visit("/");
+
+    const composer = this.owner.lookup("service:composer");
+    await composer.openNewTopic({ formTemplate: FORM_TEMPLATES[2] });
+    await settled();
+
+    const multiline = "## Heading\n\nParagraph one.\n\n- item a\n- item b";
+    await fillIn("#reply-title", "A title that is long enough to be valid");
+    await fillIn(".d-editor-input", multiline);
+    await click("#reply-control button.create");
+
+    // normalise CRLF (from FormData's textarea handling) to LF so the
+    // assertions describe the shape, not the transport encoding
+    const raw = capturedRaw.replace(/\r\n/g, "\n");
+
+    assert.true(
+      raw.includes("## Heading\n\nParagraph one."),
+      "the multi-line composer field survives to the submitted post body"
+    );
+    assert.true(
+      raw.includes("- item a\n- item b"),
+      "list items from the composer field reach the post body on separate lines"
+    );
   });
 
   test("blocks topic creation when a required composer field is empty even if other fields are filled", async function (assert) {

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -296,7 +296,7 @@ module(
       await settled();
 
       const expected = "before ![image|10x10, 75%](upload://abc.png) after";
-      assert.dom("input[name='field-1']").hasValue(expected);
+      assert.dom("textarea[name='field-1']").hasValue(expected);
       assert.dom(".d-editor-input").hasValue(expected);
       assert.true(onChange.called, "onChange fires after the replacement");
     });
@@ -330,11 +330,11 @@ module(
 
       const expected =
         "![image|10x10, 75%](upload://abc.png) and ![image|10x10](upload://abc.png)";
-      assert.dom("input[name='field-1']").hasValue(expected);
+      assert.dom("textarea[name='field-1']").hasValue(expected);
       assert.dom(".d-editor-input").hasValue(expected);
     });
 
-    test("marks the backing input as required when the field is required", async function (assert) {
+    test("marks the backing textarea as required when the field is required", async function (assert) {
       stubAllowUpload(this, true);
 
       await render(
@@ -348,15 +348,15 @@ module(
       );
 
       assert
-        .dom("input[name='field-1']")
+        .dom("textarea[name='field-1']")
         .hasAttribute(
           "required",
           { any: true },
-          "the backing input is required"
+          "the backing textarea is required"
         );
     });
 
-    test("does not mark the backing input as required when the field is not required", async function (assert) {
+    test("does not mark the backing textarea as required when the field is not required", async function (assert) {
       stubAllowUpload(this, true);
 
       await render(
@@ -364,8 +364,35 @@ module(
       );
 
       assert
-        .dom("input[name='field-1']")
-        .doesNotHaveAttribute("required", "the backing input is not required");
+        .dom("textarea[name='field-1']")
+        .doesNotHaveAttribute(
+          "required",
+          "the backing textarea is not required"
+        );
+    });
+
+    test("the backing textarea preserves newlines in the field value", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const multiline = "## Heading\n\nParagraph one.\n\n- item a\n- item b";
+      this.set("initialValue", multiline);
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @value={{this.initialValue}}
+            @onChange={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom("textarea[name='field-1']")
+        .hasValue(
+          multiline,
+          "newlines survive on the stand-in control, so the reply assembled from it stays multi-line"
+        );
     });
 
     test("labels the editor with the field label", async function (assert) {
@@ -466,7 +493,7 @@ module(
 
       await settled();
 
-      assert.dom("input[name='field-1']").hasValue("no images here");
+      assert.dom("textarea[name='field-1']").hasValue("no images here");
       assert.dom(".d-editor-input").hasValue("no images here");
       assert.false(onChange.called, "onChange does not fire");
     });


### PR DESCRIPTION
Follow up to #42192, which switched the composer field's hidden validation stand-in from `type="hidden"` to `type="text"` so `required` would fire on submit. Text inputs strip CR/LF on value assignment per the HTML value-sanitization rules, and the reply body is assembled from these controls via `new FormData(form)`, so multi-line composer input came out flattened in the edit preview. Saved posts were unaffected because the raw source is read from the editor directly.

Swap the stand-in to a visually hidden `<textarea>`. Textareas participate in constraint validation just like text inputs, preserving the required-field enforcement from #42192, but do not sanitize newlines, so multi-line content survives in the preview.