### PR TITLE
FIX: Constrain Graphviz nodes in the rich editor -

### DIFF
--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -11,8 +11,9 @@ div.graphviz.is-loading,
   }
 }
 
-// floor for a diagram not yet typed; the block supplies the frame
-.composer-graphviz-node .composer-preview-node__preview {
+// Match the cooked diagram frame and keep long source inside it.
+.composer-graphviz-node {
+  aspect-ratio: 16 / 9;
   min-height: 3em;
 }
 

--- a/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
@@ -1,3 +1,4 @@
+import { find } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import {
   registerRichEditorExtension,
@@ -11,6 +12,10 @@ import {
 import richEditorExtension from "discourse/plugins/discourse-graphviz/discourse/lib/rich-editor-extension";
 
 const GRAPH = "[graphviz]\ndigraph G {\n  a -> b;\n}\n[/graphviz]";
+const TALL_GRAPH = `[graphviz]\ndigraph G {\n${Array.from(
+  { length: 50 },
+  (_, index) => `  // node ${index}`
+).join("\n")}\n  a -> b;\n}\n[/graphviz]`;
 
 module(
   "Integration | Component | prosemirror-editor - graphviz extension",
@@ -45,6 +50,19 @@ module(
         editorClass.value.trim(),
         "[graphviz engine=neato]\ndigraph G {\n  a -> b;\n  b -> c;\n}\n[/graphviz]",
         "the source survives the round trip through cooked HTML"
+      );
+    });
+
+    test("constrains a diagram with tall source", async function (assert) {
+      await setupRichEditor(assert, TALL_GRAPH);
+
+      const { height, width } = find(
+        ".composer-graphviz-node"
+      ).getBoundingClientRect();
+
+      assert.true(
+        Math.abs(height / width - 9 / 16) < 0.01,
+        "the diagram uses the same aspect ratio as its cooked preview"
       );
     });
 


### PR DESCRIPTION
Graphviz nodes in the rich editor expanded to the height of long hidden source content.

This change constrains them to the same 16:9 frame used by cooked Graphviz diagrams.