### PR TITLE
FIX: Report account creation failures during email code signup

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -923,6 +923,7 @@ class SessionController < ApplicationController
       on_failed_policy(:required_full_name_provided) do
         render json: { error: I18n.t("login.missing_full_name") }
       end
+      on_model_errors(:user) { |user| render json: login_code_account_error(user) }
       on_failed_contract do |contract|
         render json: failed_json.merge(errors: contract.errors.full_messages), status: :bad_request
       end
@@ -1026,6 +1027,20 @@ class SessionController < ApplicationController
 
   def invalid_login_code
     { error: I18n.t("email_login_code.invalid_code") }
+  end
+
+  def login_code_account_error(user)
+    ip_error =
+      user.errors.find do |error|
+        error.attribute == :ip_address &&
+          error.type.in?(%i[blocked max_new_accounts_per_registration_ip])
+      end
+
+    if ip_error
+      { error: I18n.t("email_login_code.account_creation_failed") }
+    else
+      invalid_login_code
+    end
   end
 
   def invalid_credentials

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1098,6 +1098,7 @@ en:
 
   email_login_code:
     invalid_code: "That code is incorrect or has expired. Request a new code and try again."
+    account_creation_failed: "We couldn't create your account. Please try again later or contact a staff member."
 
   browsers:
     android_browser: "Android Browser"

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -960,6 +960,29 @@ RSpec.describe SessionController do
         expect(session[:current_user_id]).to be_nil
       end
 
+      it "renders the account limit error when the request IP has created too many accounts" do
+        ip_address = "192.0.2.1"
+        SiteSetting.max_new_accounts_per_registration_ip = 2
+        2.times { Fabricate(:user, ip_address:, trust_level: TrustLevel[0]) }
+
+        post "/session/login-code/verify.json",
+             params: {
+               email: "newuser@example.com",
+               code:,
+             },
+             env: {
+               REMOTE_ADDR: ip_address,
+             }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["error"]).to eq(
+          I18n.t("email_login_code.account_creation_failed"),
+        )
+        expect(User.find_by_email("newuser@example.com")).to be_nil
+        expect(session[:current_user_id]).to be_nil
+        expect(login_code.reload.consumed_at).to be_nil
+      end
+
       context "when required signup fields exist" do
         fab!(:user_field)
 


### PR DESCRIPTION
Previously, email code signup reported a valid code as incorrect when account creation was rejected by an IP restriction.

This change reports a generic account-creation failure after email ownership is verified, while keeping the restriction details private.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/discourse-login-code-before.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/discourse-login-code-after-vague.png) |
