### PR TITLE
FIX: Log failed browser pageview events as warnings

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -813,7 +813,7 @@ class Middleware::RequestTracker
         raise
       end
     rescue => e
-      Rails.logger.error(
+      Rails.logger.warn(
         "Failed to create BrowserPageviewEvent with payload #{payload}: #{e.message}",
       )
     end


### PR DESCRIPTION
Previously, failures when creating `BrowserPageviewEvent` records were logged as errors, causing non-critical analytics failures to be treated as application errors.

This change logs these failures as warnings so they remain visible without triggering error-level reporting.