### PR TITLE
UX: Bound a preview block's source face

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -365,6 +365,11 @@
       visibility: hidden;
     }
 
+    // a long source scrolls within a bounded face instead of growing the block
+    &__source {
+      max-height: 14lh;
+    }
+
     &__source pre {
       margin: 0;
       height: 100%;


### PR DESCRIPTION
A long source (a chart's data rows, a big diagram) grew the preview block without limit when the source face was shown. The face now caps at 14 lines and scrolls, so the block keeps a workable footprint whatever the source length. Applies to every preview block consumer (graphviz in-tree, discourse-chart).