### PR TITLE
SECURITY: Constrain mailing-list mirror reply threading to the addressed mirror category

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -224,7 +224,7 @@ module Email
         # the email is a reply to *something*
         if category = post.topic&.category
           # it's a topic in a category
-          if category.mailinglist_mirror?
+          if sent_to_mailinglist_mirror?(category)
             # replies to categories that are mailing mirrors should work,
             # even if reply_by_email is not otherwise enabled
           elsif !SiteSetting.reply_by_email_enabled
@@ -852,15 +852,11 @@ module Email
         all_destinations.map { |d| Email::Receiver.check_address(d, is_bounce?) }.reject(&:blank?)
     end
 
-    def sent_to_mailinglist_mirror?
-      @sent_to_mailinglist_mirror ||=
-        begin
-          destinations.each do |destination|
-            return true if destination.is_a?(Category) && destination.mailinglist_mirror?
-          end
-
-          false
-        end
+    def sent_to_mailinglist_mirror?(category = nil)
+      destinations.any? do |destination|
+        destination.is_a?(Category) && destination.mailinglist_mirror? &&
+          (category.nil? || destination == category)
+      end
     end
 
     def self.check_address(address, include_verp = false)
@@ -1263,7 +1259,13 @@ module Email
       message_ids = Email::Receiver.extract_reply_message_ids(@mail, max_message_id_count: 5)
       return if message_ids.empty?
 
-      Email::MessageIdService.find_post_from_message_ids(message_ids)
+      post = Email::MessageIdService.find_post_from_message_ids(message_ids)
+      if !force && SiteSetting.find_related_post_with_key &&
+           !(post&.topic&.category && sent_to_mailinglist_mirror?(post.topic.category))
+        return
+      end
+
+      post
     end
 
     def self.extract_reply_message_ids(mail, max_message_id_count:)
@@ -1509,7 +1511,10 @@ module Email
 
       add_elided_to_raw!(options)
 
-      if sent_to_mailinglist_mirror?
+      topic_category = options[:topic]&.category
+      topic_category ||= Category.find_by(id: options[:category]) if options[:category]
+
+      if topic_category && sent_to_mailinglist_mirror?(topic_category)
         options[:skip_validations] = true
         options[:skip_guardian] = true
       else

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1432,6 +1432,39 @@ RSpec.describe Email::Receiver do
       expect { process(:mailinglist_reply) }.to change { topic.posts.count }
     end
 
+    it "does not use a mirror destination to reply to a private message" do
+      private_message_author = Fabricate(:user, refresh_auto_groups: true)
+      private_message_recipient = Fabricate(:user, refresh_auto_groups: true)
+      attacker_recipient = Fabricate(:user, email: "attacker-recipient@example.com")
+      private_message =
+        Fabricate(
+          :private_message_topic,
+          user: private_message_author,
+          recipient: private_message_recipient,
+        )
+      private_post = create_post(topic: private_message, user: private_message_author)
+      attacker_email = <<~EMAIL
+        From: attacker@example.com
+        To: list@example.com
+        Cc: #{attacker_recipient.email}
+        Subject: Re: private message
+        In-Reply-To: <discourse/post/#{private_post.id}@#{Email::MessageIdService.host}>
+        References: <discourse/post/#{private_post.id}@#{Email::MessageIdService.host}>
+        Message-ID: <attacker-private-message@example.com>
+        Date: Wed, 11 Mar 2026 10:00:00 +0000
+
+        Attacker-controlled private message content.
+      EMAIL
+
+      expect { Email::Receiver.new(attacker_email).process! }.not_to change {
+        private_message.posts.count
+      }
+      expect(private_message.allowed_users).to contain_exactly(
+        private_message_author,
+        private_message_recipient,
+      )
+    end
+
     it "should skip validations for staged users" do
       Fabricate(:user, email: "alice@foo.com", staged: true)
       expect { process(:mailinglist_short_message) }.to change { Topic.count }


### PR DESCRIPTION
## Summary

Previously, any inbound email addressed to a mailing-list mirror destination could leverage predictable Discourse Message-IDs to append attacker-controlled content to an unrelated private message and add attacker-selected recipients to that conversation. The fix binds mirror threading and guardian-bypassing reply creation to the addressed mirror category, preventing a mirror address from authorizing writes to unrelated topics or private messages while preserving legitimate replies within the intended mirror category.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/2441

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>