### PR TITLE
DEV: Minor fixes for granular_anonymous_and_logged_in_groups_permissions upcoming change

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -219,7 +219,7 @@ class Site
         @guardian.user,
         "groups.name ASC",
         include_everyone: !SiteSetting.granular_anonymous_and_logged_in_groups_permissions,
-        include_pseudogroups: SiteSetting.granular_anonymous_and_logged_in_groups_permissions,
+        include_pseudogroups: true,
       ).includes(:flair_upload)
     query = DiscoursePluginRegistry.apply_modifier(:site_groups_query, query, self)
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -795,15 +795,15 @@ class Theme < ActiveRecord::Base
   end
 
   def cached_settings
-    Theme.get_set_cache "settings_for_theme_#{id}" do
+    Theme.get_set_cache "settings_for_theme_#{id}_#{group_setting_alias_enabled?}" do
       build_settings_hash
     end
   end
 
   def cached_default_settings
-    Theme.get_set_cache "default_settings_for_theme_#{id}" do
+    Theme.get_set_cache "default_settings_for_theme_#{id}_#{group_setting_alias_enabled?}" do
       settings_hash = {}
-      settings.each { |name, setting| settings_hash[name] = setting.default }
+      settings.each { |name, setting| settings_hash[name] = setting.default_value }
 
       theme_uploads = build_theme_uploads_hash
       settings_hash["theme_uploads"] = theme_uploads if theme_uploads.present?
@@ -1139,6 +1139,10 @@ class Theme < ActiveRecord::Base
   private
 
   attr_accessor :theme_setting_requests_refresh
+
+  def group_setting_alias_enabled?
+    SiteSetting.granular_anonymous_and_logged_in_groups_permissions
+  end
 
   def theme_fields_to_tree(theme_fields_scope)
     theme_fields_scope.reduce({}) do |tree, theme_field|

--- a/app/serializers/theme_settings_serializer.rb
+++ b/app/serializers/theme_settings_serializer.rb
@@ -32,7 +32,7 @@ class ThemeSettingsSerializer < ApplicationSerializer
   end
 
   def value
-    object.value
+    object.value_for_editing
   end
 
   def description

--- a/frontend/discourse/admin/components/site-settings/group-list.gjs
+++ b/frontend/discourse/admin/components/site-settings/group-list.gjs
@@ -40,7 +40,9 @@ export default class GroupList extends Component {
     return choiceIds
       .map((id) => {
         const group = groupsById[id];
-        return group ? { name: group.name, id } : null;
+        const name =
+          group.name === "everyone" ? "everyone (legacy)" : group.name;
+        return group ? { name, id } : null;
       })
       .filter(Boolean);
   }

--- a/frontend/discourse/admin/components/site-settings/group.gjs
+++ b/frontend/discourse/admin/components/site-settings/group.gjs
@@ -15,7 +15,10 @@ export default class Group extends Component {
 
     return (this.site.groups || [])
       .filter((g) => !disallowed.includes(g.id.toString()))
-      .map((g) => ({ name: g.name, id: g.id.toString() }));
+      .map((g) => {
+        const name = g.name === "everyone" ? "everyone (legacy)" : g.name;
+        return { name, id: g.id.toString() };
+      });
   }
 
   @action

--- a/frontend/discourse/app/components/setting-field/group-list.gjs
+++ b/frontend/discourse/app/components/setting-field/group-list.gjs
@@ -37,7 +37,9 @@ export default class SettingFieldGroupList extends Component {
     )
       .map((id) => {
         const group = groupsById[id];
-        return group ? { name: group.name, id } : null;
+        const name =
+          group.name === "everyone" ? "everyone (legacy)" : group.name;
+        return group ? { name, id } : null;
       })
       .filter(Boolean);
   }

--- a/frontend/discourse/app/components/setting-field/group.gjs
+++ b/frontend/discourse/app/components/setting-field/group.gjs
@@ -13,7 +13,10 @@ export default class SettingFieldGroup extends Component {
 
     return (this.site.groups || [])
       .filter((group) => !disallowed.includes(group.id.toString()))
-      .map((group) => ({ name: group.name, id: group.id.toString() }));
+      .map((g) => {
+        const name = g.name === "everyone" ? "everyone (legacy)" : g.name;
+        return { name, id: g.id.toString() };
+      });
   }
 
   get groupId() {

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -103,7 +103,10 @@ class Guardian
 
     def in_any_groups?(group_ids)
       if !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
-        return group_ids.include?(Group::AUTO_GROUPS[:everyone])
+        return(
+          group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+            group_ids.include?(Group::AUTO_GROUPS[:anonymous_users])
+        )
       end
 
       group_ids.include?(Group::AUTO_GROUPS[:anonymous_users])

--- a/lib/theme_settings_manager.rb
+++ b/lib/theme_settings_manager.rb
@@ -36,7 +36,15 @@ class ThemeSettingsManager
   end
 
   def value
-    has_record? ? db_record.value : default
+    configured_value
+  end
+
+  def default_value
+    default
+  end
+
+  def value_for_editing
+    value
   end
 
   def type_name
@@ -105,5 +113,11 @@ class ThemeSettingsManager
   def has_max?
     max = @opts[:max]
     (max.is_a?(::Integer) || max.is_a?(::Float)) && max != ::Float::INFINITY
+  end
+
+  protected
+
+  def configured_value
+    has_record? ? db_record.value : default
   end
 end

--- a/lib/theme_settings_manager/list.rb
+++ b/lib/theme_settings_manager/list.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 class ThemeSettingsManager::List < ThemeSettingsManager
+  def value
+    alias_everyone_to_logged_in_users(super)
+  end
+
+  def default_value
+    alias_everyone_to_logged_in_users(super)
+  end
+
+  def value_for_editing
+    return super if list_type != "group"
+
+    configured_value
+  end
+
   def list_type
     @opts[:list_type]
   end
@@ -16,5 +30,18 @@ class ThemeSettingsManager::List < ThemeSettingsManager
     end
 
     super
+  end
+
+  private
+
+  def alias_everyone_to_logged_in_users(value)
+    if list_type != "group" || !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
+      return value
+    end
+
+    everyone_id = Group::AUTO_GROUPS[:everyone].to_s
+    logged_in_users_id = Group::AUTO_GROUPS[:logged_in_users].to_s
+
+    value.to_s.split("|").map { |id| id == everyone_id ? logged_in_users_id : id }.uniq.join("|")
   end
 end

--- a/spec/lib/theme_settings_manager_spec.rb
+++ b/spec/lib/theme_settings_manager_spec.rb
@@ -159,6 +159,44 @@ RSpec.describe ThemeSettingsManager do
       expect(theme.reload.settings[:groups_setting].value).to eq("2|3")
     end
 
+    it "aliases everyone to logged_in_users at read time for group list settings" do
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+      yaml = <<~YAML
+        groups_setting:
+          type: list
+          list_type: group
+          default: "0|5|2"
+      YAML
+      theme.set_field(target: :settings, name: "yaml", value: yaml)
+      theme.save!
+
+      setting = theme.settings[:groups_setting]
+      setting.value = "0|5|1"
+      setting = theme.reload.settings[:groups_setting]
+
+      expect(setting.value).to eq("5|1")
+      expect(setting.default_value).to eq("5|2")
+      expect(setting.value_for_editing).to eq("0|5|1")
+      expect(theme.theme_settings.find_by(name: "groups_setting").value).to eq("0|5|1")
+    end
+
+    it "leaves everyone unchanged when granular group permissions are disabled" do
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false
+      yaml = <<~YAML
+        groups_setting:
+          type: list
+          list_type: group
+          default: "0|1"
+      YAML
+      theme.set_field(target: :settings, name: "yaml", value: yaml)
+      theme.save!
+
+      setting = theme.settings[:groups_setting]
+
+      expect(setting.value).to eq("0|1")
+      expect(setting.default_value).to eq("0|1")
+    end
+
     describe "#resolve_group_membership?" do
       it "returns true when opted-in with list_type group" do
         yaml = <<~YAML

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -329,6 +329,24 @@ RSpec.describe Theme do
       expect(theme.reload.cached_settings).to include(name: "bill")
     end
 
+    it "updates cached group list aliases when granular group permissions change" do
+      theme.set_field(target: :settings, name: :yaml, value: <<~YAML)
+        allowed_groups:
+          type: list
+          list_type: group
+          default: "0|1"
+      YAML
+      theme.save!
+
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false
+      expect(theme.cached_settings[:allowed_groups]).to eq("0|1")
+      expect(theme.cached_default_settings[:allowed_groups]).to eq("0|1")
+
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+      expect(theme.cached_settings[:allowed_groups]).to eq("5|1")
+      expect(theme.cached_default_settings[:allowed_groups]).to eq("5|1")
+    end
+
     it "records the plugins a theme statically imports from" do
       theme.set_field(target: :extra_js, name: "discourse/initializers/my-init.js", value: <<~JS)
           import Thing from "discourse/plugins/some-plugin/lib/thing";

--- a/spec/serializers/theme_settings_serializer_spec.rb
+++ b/spec/serializers/theme_settings_serializer_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe ThemeSettingsSerializer do
     end
   end
 
+  describe "#value" do
+    it "serializes the unaliased group list value for editing" do
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+      theme.set_field(target: :settings, name: "yaml", value: <<~YAML)
+        groups_setting:
+          type: list
+          list_type: group
+          default: "0|1"
+      YAML
+      theme.save!
+      theme.settings[:groups_setting].value = "0|2"
+
+      payload = ThemeSettingsSerializer.new(theme.reload.settings[:groups_setting]).as_json
+
+      expect(payload[:theme_settings][:value]).to eq("0|2")
+    end
+  end
+
   describe "#valid_values" do
     fab!(:theme_with_enum, :theme)
 


### PR DESCRIPTION
The following fixes are made here to make the transition to
`granular_anonymous_and_logged_in_groups_permissions` being
permanently enabled easier for people.

- **DEV: Show logged_in_users and anonymous_users in setting list**
  - Previously, these groups would only show if `granular_anonymous_and_logged_in_groups_permissions` is enabled,
     but they are usable now everywhere in core, and this will help ease the transition for themes + settings.
- **DEV: Add everyone -> logged_in_users map for theme settings**
  - Theme settings now copy the same pattern as site settings, where previously selected `everyone`
     is dynamically changed to `logged_in_users` when `granular_anonymous_and_logged_in_groups_permissions`
     is enabled.
- **DEV: Show everyone group as everyone (legacy) in site setting group list pickers**
  - Makes it clearer this group will soon not be supported
- **DEV: Allow anonymous_users in AnonymousUser#in_any_groups?**
  - Anon users should return true for `in_any_groups?` for `anonymous_users` regardless of whether `granular_anonymous_and_logged_in_groups_permissions` is on
