### PR TITLE
DEV: Remove both preview stylesheets in color scheme test

### DIFF
--- a/frontend/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -361,6 +361,7 @@ acceptance(
         .hasAttribute("href", "3.css", "correct stylesheet loaded");
 
       document.querySelector("link#cs-preview-light").remove();
+      document.querySelector("link#cs-preview-dark").remove();
 
       await visit("/u/charlie/preferences/interface");
 


### PR DESCRIPTION
Selecting a light color scheme also previews it as the dark scheme, so the test needs to clean up both the cs-preview-light and cs-preview-dark links it creates. Leaving the dark one behind was leaking a stylesheet into document.body for the rest of the QUnit run, which sometimes tripped an unrelated boot-readiness check depending on test order.