### PR TITLE
DEV: Enable route-splitting for discourse-workflows

### DIFF
--- a/plugins/discourse-workflows/about.json
+++ b/plugins/discourse-workflows/about.json
@@ -1,0 +1,5 @@
+{
+  "frontend": {
+    "staticModules": true
+  }
+}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/discourse-workflows-route-map.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/discourse-workflows-route-map.js
@@ -1,6 +1,8 @@
 export default {
   resource: "admin.adminPlugins.show",
   path: "/plugins",
+  bundleName: "workflows-admin",
+
   map() {
     this.route("discourse-workflows", { path: "workflows" }, function () {
       this.route("new");

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/node-output-schemas.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/node-output-schemas.js
@@ -1,26 +1,13 @@
+import summarize from "./output-schemas/summarize";
+
 // Nodes whose output keys come from what the author typed cannot declare them as a contract, so
 // they compute them in Ruby and name an editor-side counterpart through `output_schema_resolver`.
-const RESOLVER_MODULE = /\/admin\/lib\/workflows\/output-schemas\/([\w-]+)$/;
-
-let cache;
-
-function resolverFor(name) {
-  cache ??= Object.keys(require.entries).reduce((resolvers, moduleName) => {
-    const match = moduleName.match(RESOLVER_MODULE);
-    if (match) {
-      resolvers[match[1]] = moduleName;
-    }
-    return resolvers;
-  }, {});
-
-  const moduleName = cache[name];
-  return moduleName ? require(moduleName).default : null;
-}
+const RESOLVERS = { summarize };
 
 export function outputSchemasFromResolver(resolver, configuration = {}) {
   if (!resolver) {
     return null;
   }
 
-  return resolverFor(resolver)?.(configuration || {}) || null;
+  return RESOLVERS[resolver]?.(configuration || {}) || null;
 }

--- a/plugins/discourse-workflows/assets/javascripts/discourse/discourse-workflows-public-route-map.js
+++ b/plugins/discourse-workflows/assets/javascripts/discourse/discourse-workflows-public-route-map.js
@@ -1,4 +1,10 @@
 export default function () {
-  this.route("workflows-form", { path: "/workflows/form/:uuid" });
-  this.route("workflows-form-test", { path: "/workflows/form-test/:token" });
+  this.route("workflows-form", {
+    path: "/workflows/form/:uuid",
+    bundleName: "workflows-form",
+  });
+  this.route("workflows-form-test", {
+    path: "/workflows/form-test/:token",
+    bundleName: "workflows-form",
+  });
 }


### PR DESCRIPTION
JS loaded at boot for discourse-workflows drops from 552 kB (96 kB brotli) to 24 kB (6.8 kB brotli); the remaining 512 kB (88 kB brotli) loads on demand when a workflows route is visited.