### PR TITLE
FIX: Make review queue silences traceable and correctly scoped

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -267,7 +267,9 @@ class ReviewableFlaggedPost < Reviewable
       notify_poster(performed_by)
       post.acting_user = performed_by
       post.unhide!
-      UserSilencer.unsilence(post.user) if UserSilencer.was_silenced_for?(post)
+      if UserSilencer.was_silenced_for?(post)
+        UserSilencer.unsilence(post.user, performed_by, reviewable_id: id)
+      end
     end
 
     create_result(:success, :rejected, actions.map(&:user_id), false)

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -97,6 +97,8 @@ class UserSilencer
   end
 
   def unsilence
+    return false if @user.silenced_till.blank?
+
     @user.silenced_till = nil
     if @user.save
       DiscourseEvent.trigger(:user_unsilenced, user: @user, by_user: @by_user)

--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -36,6 +36,16 @@ module Chat
       @flagged_by_user_ids ||= reviewable_scores.map(&:user_id)
     end
 
+    def silenced_for_this_message?
+      return false if !chat_message_creator&.silenced?
+
+      UserHistory.exists?(
+        action: UserHistory.actions[:silence_user],
+        target_user_id: chat_message_creator.id,
+        reviewable_id: id,
+      )
+    end
+
     def post
       nil
     end
@@ -110,11 +120,11 @@ module Chat
     end
 
     def perform_disagree_and_restore(performed_by, args)
-      disagree { chat_message.recover! }
+      disagree(performed_by) { chat_message.recover! }
     end
 
     def perform_disagree(performed_by, args)
-      disagree
+      disagree(performed_by)
     end
 
     def perform_ignore(performed_by, args)
@@ -139,10 +149,12 @@ module Chat
       end
     end
 
-    def disagree
+    def disagree(performed_by)
       yield if block_given?
 
-      UserSilencer.unsilence(chat_message_creator)
+      if silenced_for_this_message?
+        UserSilencer.unsilence(chat_message_creator, performed_by, reviewable_id: id)
+      end
 
       create_result(:success, :rejected) do |result|
         result.update_flag_stats = { status: :disagreed, user_ids: flagged_by_user_ids }

--- a/plugins/chat/lib/chat/review_queue.rb
+++ b/plugins/chat/lib/chat/review_queue.rb
@@ -114,6 +114,7 @@ module Chat
         Discourse.system_user,
         silenced_till: auto_silence_duration.minutes.from_now,
         reason: I18n.t("chat.errors.auto_silence_from_flags"),
+        reviewable_id: reviewable.id,
       )
     end
 

--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -405,6 +405,33 @@ describe Chat::ReviewQueue do
         expect(message_poster.reload.silenced?).to eq(true)
       end
 
+      it "attributes the silence to the reviewable it came from" do
+        SiteSetting.chat_auto_silence_from_flags_duration = 1
+        flagger.update!(trust_level: TrustLevel[4]) # Increase Score due to TL Bonus.
+
+        queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+        history =
+          UserHistory.find_by(
+            action: UserHistory.actions[:silence_user],
+            target_user_id: message_poster.id,
+          )
+
+        expect(history.reviewable_id).to eq(Chat::ReviewableMessage.find_by(target: message).id)
+      end
+
+      it "lifts the silence when a moderator disagrees with the flag" do
+        SiteSetting.chat_auto_silence_from_flags_duration = 1
+        flagger.update!(trust_level: TrustLevel[4]) # Increase Score due to TL Bonus.
+
+        queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+        expect(message_poster.reload.silenced?).to eq(true)
+
+        Chat::ReviewableMessage.find_by(target: message).perform(admin, :disagree)
+
+        expect(message_poster.reload.silenced?).to eq(false)
+      end
+
       it "does nothing if the new score is less than the auto-silence threshold" do
         SiteSetting.chat_auto_silence_from_flags_duration = 50
 

--- a/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
@@ -63,13 +63,14 @@ RSpec.describe Chat::ReviewableMessage, type: :model do
     expect(chat_message.reload.deleted_at).not_to be_present
   end
 
-  context "when the flagged message author is silenced" do
+  context "when the flagged message author was silenced for this message" do
     before do
       UserSilencer.silence(
         user,
         Discourse.system_user,
         silenced_till: 10.minutes.from_now,
         reason: I18n.t("chat.errors.auto_silence_from_flags"),
+        reviewable_id: reviewable.id,
       )
     end
 
@@ -84,6 +85,33 @@ RSpec.describe Chat::ReviewableMessage, type: :model do
       reviewable.perform(moderator, :disagree_and_restore)
 
       expect(user.reload.silenced?).to eq(false)
+    end
+
+    it "attributes the unsilence to the moderator and the reviewable" do
+      reviewable.perform(moderator, :disagree)
+
+      history =
+        UserHistory.find_by(action: UserHistory.actions[:unsilence_user], target_user_id: user.id)
+
+      expect(history.acting_user_id).to eq(moderator.id)
+      expect(history.reviewable_id).to eq(reviewable.id)
+    end
+  end
+
+  context "when the flagged message author was silenced for something else" do
+    before do
+      UserSilencer.silence(
+        user,
+        Discourse.system_user,
+        silenced_till: 10.minutes.from_now,
+        reason: "unrelated reason",
+      )
+    end
+
+    it "perform_disagree leaves the user silenced" do
+      reviewable.perform(moderator, :disagree)
+
+      expect(user.reload.silenced?).to eq(true)
     end
   end
 end

--- a/plugins/discourse-ai/lib/ai_moderation/spam_scanner.rb
+++ b/plugins/discourse-ai/lib/ai_moderation/spam_scanner.rb
@@ -444,10 +444,11 @@ module DiscourseAi
                 flagging_user,
                 message: :too_many_spam_flags,
                 post_id: post.id,
+                reviewable_id: result.reviewable&.id,
                 reason: reason,
                 keep_posts: true,
               )
-            silencer.silence
+            silencer.auto_silence
 
             # silencer will not hide tl1 posts, so we do this here
             hide_post(post)

--- a/plugins/discourse-ai/spec/lib/modules/ai_moderation/spam_scanner_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_moderation/spam_scanner_spec.rb
@@ -336,6 +336,20 @@ RSpec.describe DiscourseAi::AiModeration::SpamScanner do
 
     before { Jobs.run_immediately! }
 
+    it "notifies moderators when the site asks to be notified about auto silences" do
+      SiteSetting.notify_mods_when_user_silenced = true
+
+      allow(GroupMessage).to receive(:create)
+
+      described_class.new_post(post)
+      DiscourseAi::Completions::Llm.with_prepared_responses(
+        [{ spam: true, reason: "spam detected" }],
+      ) { post.rebake! }
+
+      expect(GroupMessage).to have_received(:create).at_least(:once)
+      expect(post.user.reload).to be_silenced
+    end
+
     it "can correctly run tests" do
       prompts = nil
       result =
@@ -411,6 +425,9 @@ RSpec.describe DiscourseAi::AiModeration::SpamScanner do
 
       expect(log.reviewable).to be_present
       expect(log.reviewable.created_by_id).to eq(described_class.flagging_user.id)
+
+      expect(history.post_id).to eq(post.id)
+      expect(history.reviewable_id).to eq(log.reviewable.id)
 
       log.reviewable.perform(moderator, :disagree_and_restore)
 

--- a/plugins/discourse-post-voting/app/models/reviewable_post_voting_comment.rb
+++ b/plugins/discourse-post-voting/app/models/reviewable_post_voting_comment.rb
@@ -125,7 +125,9 @@ class ReviewablePostVotingComment < Reviewable
   def disagree(performed_by)
     yield if block_given?
 
-    UserSilencer.unsilence(comment_creator, performed_by) if UserSilencer.was_silenced_for?(post)
+    if UserSilencer.was_silenced_for?(post)
+      UserSilencer.unsilence(comment_creator, performed_by, reviewable_id: id)
+    end
 
     create_result(:success, :rejected) do |result|
       result.update_flag_stats = { status: :disagreed, user_ids: flagged_by_user_ids }

--- a/plugins/discourse-post-voting/spec/models/reviewable_post_voting_comment_spec.rb
+++ b/plugins/discourse-post-voting/spec/models/reviewable_post_voting_comment_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe ReviewablePostVotingComment, type: :model do
 
         expect(comment_poster.reload.silenced?).to eq(false)
       end
+
+      it "attributes the unsilence to the reviewable" do
+        reviewable.perform(moderator, :disagree)
+
+        history =
+          UserHistory.find_by(
+            action: UserHistory.actions[:unsilence_user],
+            target_user_id: comment_poster.id,
+          )
+
+        expect(history.acting_user_id).to eq(moderator.id)
+        expect(history.reviewable_id).to eq(reviewable.id)
+      end
     end
 
     context "when the user was silenced for a different reason" do

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -613,6 +613,28 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(target_user.reload.silenced?).to eq(false)
     end
 
+    it "attributes the unsilence to the moderator and the reviewable" do
+      reviewable = Fabricate(:reviewable_flagged_post)
+      target_user = reviewable.post.user
+      reviewable.post.update(
+        hidden: true,
+        hidden_at: Time.zone.now,
+        hidden_reason_id: PostActionType.types[:spam],
+      )
+      UserSilencer.silence(target_user, moderator, post_id: reviewable.post.id)
+
+      reviewable.perform(moderator, :disagree_and_restore)
+
+      history =
+        UserHistory.find_by(
+          action: UserHistory.actions[:unsilence_user],
+          target_user_id: target_user.id,
+        )
+
+      expect(history.acting_user_id).to eq(moderator.id)
+      expect(history.reviewable_id).to eq(reviewable.id)
+    end
+
     context "with category group moderator" do
       fab!(:group)
       fab!(:category_moderator) { Fabricate(:user, refresh_auto_groups: true) }

--- a/spec/services/user_silencer_spec.rb
+++ b/spec/services/user_silencer_spec.rb
@@ -142,5 +142,27 @@ RSpec.describe UserSilencer do
 
       expect(count).to eq(1)
     end
+
+    it "does nothing when the user is not silenced" do
+      expect(UserSilencer.unsilence(user, admin)).to eq(false)
+
+      expect(user.topics_allowed.count).to eq(0)
+      expect(UserHistory.where(action: UserHistory.actions[:unsilence_user]).count).to eq(0)
+    end
+
+    it "is idempotent when called twice" do
+      user.update!(silenced_till: 1.year.from_now)
+
+      UserSilencer.unsilence(user, admin)
+      UserSilencer.unsilence(user, admin)
+
+      expect(UserHistory.where(action: UserHistory.actions[:unsilence_user]).count).to eq(1)
+      expect(
+        user
+          .topics_allowed
+          .where(title: I18n.t("system_messages.unsilenced.subject_template"))
+          .count,
+      ).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Automated tooling silences a post author before any moderator sees the
flag, but nothing tied that silence back to the flag that caused it, and
nothing recorded who lifted it. That left moderators unable to tell why
an author was silenced, or whether their own action had done it.

- The spam scanner recorded the silence against the post but not against
  the reviewable, so there was no way to ask "did this flag cause this
  silence?". It now passes `reviewable_id`.

- The spam scanner called `silence` rather than `auto_silence`, so
  `notify_mods_when_user_silenced` never fired on that path. A site that
  enabled the setting to learn about automatic silences was told nothing.

- Disagreeing with a flag unsilenced the author with no acting user and
  no reviewable, so the staff action log could not say who reinstated
  them. Core and post voting now attribute it.

- Chat unsilenced the author of any disagreed flag, even when the silence
  came from somewhere else entirely, because it never checked what caused
  it. A chat message is not a post, so the only possible link is the
  reviewable: the queue now records one and only lifts a silence it owns.

- `UserSilencer#unsilence` acted on a user who was not silenced, sending
  them a "you have been unsilenced" message and writing a staff log entry
  for something that never happened.

