### PR TITLE
DEV: Expose an author's active penalties on a reviewable

### DIFF
--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -57,7 +57,12 @@ module ReviewableActionBuilder
       action.confirm_message = "#{prefix}.confirm" if confirm
       action.completed_message = "#{prefix}.complete"
       action.require_reject_reason = require_reject_reason
+      action.penalty_effect = penalty_effect_for(id)
     end
+  end
+
+  def penalty_effect_for(_action_id)
+    nil
   end
 
   def build_penalty_actions(actions, bundle:, silence:, suspend:, user: target_user)
@@ -120,20 +125,6 @@ module ReviewableActionBuilder
   end
 
   private
-
-  # Returns the post associated with the reviewable, if applicable.
-  # This method assumes that the including class has a `target` that is a Post or
-  # a `target_id` that can be used to look up the Post.
-  #
-  # @return [Post, nil] The post associated with the reviewable, or nil if not found.
-  def target_post
-    @post ||=
-      if defined?(target) && target.is_a?(Post)
-        target
-      elsif defined?(target_id)
-        Post.with_deleted.find_by(id: target_id)
-      end
-  end
 
   # Options for deleting a user, used by perform_delete_user and perform_delete_and_block_user.
   def delete_opts

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -342,6 +342,10 @@ class Reviewable < ActiveRecord::Base
     )
   end
 
+  def author_penalties
+    @author_penalties ||= AuthorPenalty.all_for(target_created_by, target_post:, reviewable_id: id)
+  end
+
   def actions_for(guardian, args = nil)
     args ||= {}
     built_actions =
@@ -960,6 +964,12 @@ class Reviewable < ActiveRecord::Base
   end
 
   private
+
+  def target_post
+    return if target_type != "Post"
+
+    @post ||= target || Post.with_deleted.find_by(id: target_id)
+  end
 
   def delete_user_action?(action_id)
     resolved_action = (aliases[action_id] || action_id).to_sym

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -179,6 +179,30 @@ class ReviewableFlaggedPost < Reviewable
     )
   end
 
+  def author_silenced?
+    !!target_created_by&.silenced?
+  end
+
+  def disagree_lifts_silence?
+    post&.hidden? && author_silenced? && UserSilencer.was_silenced_for?(post)
+  end
+
+  def penalty_effect_for(action_id)
+    return if author_penalties.empty?
+
+    lifts_silence =
+      case action_id
+      when :disagree, :disagree_and_restore
+        disagree_lifts_silence?
+      when :unsilence_user_and_ignore
+        user_silenced_for_post?
+      else
+        false
+      end
+
+    lifts_silence ? :lifts_penalty : :retains_penalty
+  end
+
   def perform_ignore_and_do_nothing(performed_by, args)
     actions =
       PostAction

--- a/app/serializers/reviewable_action_serializer.rb
+++ b/app/serializers/reviewable_action_serializer.rb
@@ -12,7 +12,8 @@ class ReviewableActionSerializer < ApplicationSerializer
              :server_action,
              :client_action,
              :require_reject_reason,
-             :completed_message
+             :completed_message,
+             :penalty_effect
 
   def label
     I18n.t(object.label)
@@ -52,5 +53,9 @@ class ReviewableActionSerializer < ApplicationSerializer
 
   def include_require_reject_reason?
     object.require_reject_reason.present?
+  end
+
+  def include_penalty_effect?
+    object.penalty_effect.present?
   end
 end

--- a/app/serializers/reviewable_author_penalty_serializer.rb
+++ b/app/serializers/reviewable_author_penalty_serializer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class ReviewableAuthorPenaltySerializer < ApplicationSerializer
+  attributes :kind,
+             :forever,
+             :expires_at,
+             :reason,
+             :applied_at,
+             :automatic,
+             :from_this_target,
+             :can_lift
+
+  has_one :applied_by, serializer: BasicUserSerializer, embed: :objects
+
+  def kind
+    object.kind.to_s
+  end
+
+  def can_lift
+    if object.kind == :suspension
+      scope.can_unsuspend?(object.user)
+    else
+      scope.can_unsilence_user?(object.user)
+    end
+  end
+
+  def include_expires_at?
+    !object.forever
+  end
+
+  def include_reason?
+    object.reason.present?
+  end
+end

--- a/app/serializers/reviewable_serializer.rb
+++ b/app/serializers/reviewable_serializer.rb
@@ -35,6 +35,7 @@ class ReviewableSerializer < ApplicationSerializer
   has_many :bundled_actions, serializer: ReviewableBundledActionSerializer
   has_many :reviewable_notes, serializer: ReviewableNoteSerializer
   has_many :reviewable_histories, serializer: ReviewableHistorySerializer
+  has_many :author_penalties, serializer: ReviewableAuthorPenaltySerializer, embed: :objects
   has_one :claimed_by, serializer: ReviewableClaimedTopicSerializer
 
   # Used to keep track of our payload attributes

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -51,7 +51,8 @@ class Reviewable < ActiveRecord::Base
                     :client_action,
                     :require_reject_reason,
                     :custom_modal,
-                    :completed_message
+                    :completed_message,
+                    :penalty_effect
 
       def initialize(id, icon = nil, button_class = nil, label = nil)
         super(id)

--- a/lib/reviewable/author_penalty.rb
+++ b/lib/reviewable/author_penalty.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class Reviewable < ActiveRecord::Base
+  class AuthorPenalty
+    include ActiveModel::Serialization
+
+    FOREVER_THRESHOLD = 100.years
+
+    attr_reader :user, :kind, :history, :expires_at
+
+    def self.all_for(user, target_post: nil, reviewable_id: nil)
+      return [] if user.blank?
+
+      penalties = []
+
+      if user.silenced?
+        penalties << new(
+          user: user,
+          kind: :silence,
+          history: user.silenced_record,
+          expires_at: user.silenced_till,
+          target_post: target_post,
+          reviewable_id: reviewable_id,
+        )
+      end
+
+      if user.suspended?
+        penalties << new(
+          user: user,
+          kind: :suspension,
+          history: user.suspend_record,
+          expires_at: user.suspended_till,
+          target_post: target_post,
+          reviewable_id: reviewable_id,
+        )
+      end
+
+      penalties
+    end
+
+    def initialize(user:, kind:, history:, expires_at:, target_post:, reviewable_id:)
+      @user = user
+      @kind = kind
+      @history = history
+      @expires_at = expires_at
+      @target_post = target_post
+      @reviewable_id = reviewable_id
+    end
+
+    def forever
+      expires_at.present? && expires_at > FOREVER_THRESHOLD.from_now
+    end
+
+    def applied_at
+      history&.created_at
+    end
+
+    def applied_by
+      history&.acting_user
+    end
+
+    def automatic
+      applied_by.present? && applied_by.bot?
+    end
+
+    def reason
+      User.format_penalty_reason(history&.details)
+    end
+
+    def from_this_target
+      return false if history.blank?
+      return true if @reviewable_id.present? && history.reviewable_id == @reviewable_id
+
+      @target_post.present? && history.post_id == @target_post.id
+    end
+  end
+end

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -545,6 +545,109 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
     end
   end
 
+  describe "penalty_effect" do
+    fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:flagged_post) { Fabricate(:post, user: author) }
+
+    let!(:reviewable) { PostActionCreator.spam(user, flagged_post).reviewable }
+    let(:guardian) { Guardian.new(moderator) }
+
+    def effect_for(action_id)
+      action = reviewable.actions_for(guardian).to_a.find { |a| a.server_action == action_id.to_s }
+
+      raise "no #{action_id} action was built" if action.nil?
+
+      action.penalty_effect
+    end
+
+    it "is absent when the author has no penalty" do
+      flagged_post.update!(hidden: true, hidden_at: Time.zone.now)
+
+      expect(effect_for(:delete_and_agree)).to eq(nil)
+      expect(effect_for(:disagree_and_restore)).to eq(nil)
+    end
+
+    it "marks actions that keep a silence that was applied for this post" do
+      flagged_post.update!(hidden: true, hidden_at: Time.zone.now)
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+
+      expect(effect_for(:delete_and_agree)).to eq(:retains_penalty)
+      expect(effect_for(:agree_and_keep_hidden)).to eq(:retains_penalty)
+      expect(effect_for(:delete_and_ignore)).to eq(:retains_penalty)
+      expect(effect_for(:disagree_and_restore)).to eq(:lifts_penalty)
+    end
+
+    it "does not promise a lift when the silence is not linked to this post" do
+      flagged_post.update!(hidden: true, hidden_at: Time.zone.now)
+      other_post = Fabricate(:post, user: author)
+      UserSilencer.silence(author, moderator, post_id: other_post.id)
+
+      expect(effect_for(:disagree_and_restore)).to eq(:retains_penalty)
+    end
+
+    it "does not promise a lift for a suspension" do
+      flagged_post.update!(hidden: true, hidden_at: Time.zone.now)
+      UserSuspender.new(
+        author,
+        suspended_till: 5.days.from_now,
+        reason: "spam",
+        by_user: moderator,
+        post_id: flagged_post.id,
+      ).suspend
+
+      expect(effect_for(:disagree_and_restore)).to eq(:retains_penalty)
+    end
+  end
+
+  describe "#author_penalties" do
+    fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:flagged_post) { Fabricate(:post, user: author) }
+
+    let!(:reviewable) { PostActionCreator.spam(user, flagged_post).reviewable }
+
+    it "is empty when the author has no penalty" do
+      expect(reviewable.author_penalties).to eq([])
+    end
+
+    it "describes a silence applied for this post" do
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id, reason: "spammy")
+
+      penalty = reviewable.author_penalties.sole
+
+      expect(penalty.kind).to eq(:silence)
+      expect(penalty.from_this_target).to eq(true)
+      expect(penalty.applied_by).to eq(moderator)
+      expect(penalty.automatic).to eq(false)
+      expect(penalty.reason).to include("spammy")
+      expect(penalty.applied_at).to be_present
+    end
+
+    it "marks a penalty applied by a bot as automatic" do
+      UserSilencer.silence(author, Discourse.system_user, post_id: flagged_post.id)
+
+      expect(reviewable.author_penalties.sole.automatic).to eq(true)
+    end
+
+    it "reports a silence that was not applied for this post" do
+      other_post = Fabricate(:post, user: author)
+      UserSilencer.silence(author, moderator, post_id: other_post.id)
+
+      expect(reviewable.author_penalties.sole.from_this_target).to eq(false)
+    end
+
+    it "reports both a silence and a suspension" do
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+      UserSuspender.new(
+        author,
+        suspended_till: 5.days.from_now,
+        reason: "spam",
+        by_user: moderator,
+      ).suspend
+
+      expect(reviewable.author_penalties.map(&:kind)).to contain_exactly(:silence, :suspension)
+    end
+  end
+
   describe "#perform_unsilence_user_and_ignore" do
     it "unsilences the user and resolves the reviewable without restoring the deleted post" do
       reviewable = Fabricate(:reviewable_flagged_post)


### PR DESCRIPTION
A moderator reviewing a flag cannot see that the author is already
silenced or suspended, because a reviewable only describes the flagged
content. Nothing in the payload says a penalty exists, where it came
from, or whether resolving this flag would lift it.

This adds `Reviewable#author_penalties`, which reports each penalty the
target's author currently carries along with who applied it, whether it
was automated, and whether it was applied for the very thing under
review. Each action also gains a `penalty_effect` describing what
performing it leaves behind, so the queue can state the consequence
rather than making moderators infer it.

Nothing renders this yet.

`target_post` moves from `ReviewableActionBuilder` to `Reviewable`,
because the base class now needs it and four reviewable types do not
include that concern. This also drops a third name for a concept that
already had two.

