### PR TITLE
UX: Show a flagged author's active penalties in the review queue

### DIFF
--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -196,6 +196,10 @@
     border-bottom: 1px solid var(--content-border-color);
   }
 
+  .reviewable-penalty-icon {
+    color: var(--danger);
+  }
+
   &__meta-content {
     display: grid;
     gap: var(--space-4);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1227,7 +1227,17 @@ en:
         view_conversation: "view PM"
         note_added: "Moderator note"
         note_added_by: "Moderator note by %{username} · %{relativeDate}"
+        author_silenced_by: "Author silenced by %{username} · %{relativeDate}"
+        author_silenced_automatically: "Author silenced automatically · %{relativeDate}"
+        author_suspended_by: "Author suspended by %{username} · %{relativeDate}"
+        author_suspended_automatically: "Author suspended automatically · %{relativeDate}"
         no_events: "No timeline events to display"
+      author_penalty:
+        effect:
+          retains_silence: "The author stays silenced."
+          retains_suspension: "The author stays suspended."
+          retains_silence_and_suspension: "The author stays silenced and suspended."
+          lifts_silence: "The author will be unsilenced."
       notes:
         add_note_description: "Add a note to provide context to other moderators."
         add_note_button: "Add note"
@@ -1914,7 +1924,6 @@ en:
       admin: "%{user} is an admin"
       moderator_tooltip: "This user is a moderator"
       admin_tooltip: "This user is an admin"
-      silenced_tooltip: "This user is silenced"
       suspended_notice: "This user is suspended until %{date}."
       suspended_permanently: "This user is suspended."
       suspended_reason: "Reason: "

--- a/frontend/discourse/app/components/reviewable-bundled-action.gjs
+++ b/frontend/discourse/app/components/reviewable-bundled-action.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
+import { penaltyEffectDescription } from "discourse/lib/reviewable-penalty";
 import { isRTL } from "discourse/lib/text-direction";
 import DropdownSelectBox from "discourse/select-kit/components/dropdown-select-box";
 import DButton from "discourse/ui-kit/d-button";
@@ -13,6 +14,26 @@ export default class ReviewableBundledAction extends Component {
 
   get multiple() {
     return this.args.bundle.actions.length > 1;
+  }
+
+  get bundleActions() {
+    return this.args.bundle.actions.map((bundledAction) => {
+      const effect = penaltyEffectDescription(
+        bundledAction,
+        this.args.authorPenalties
+      );
+
+      if (!effect) {
+        return bundledAction;
+      }
+
+      return {
+        ...bundledAction,
+        description: [bundledAction.description, effect]
+          .filter(Boolean)
+          .join(" "),
+      };
+    });
   }
 
   get first() {
@@ -43,7 +64,7 @@ export default class ReviewableBundledAction extends Component {
       <DropdownSelectBox
         @nameProperty="label"
         @valueProperty="action_name"
-        @content={{@bundle.actions}}
+        @content={{this.bundleActions}}
         @onChange={{this.perform}}
         @options={{hash
           showCaret=true

--- a/frontend/discourse/app/components/reviewable-created-by-name.gjs
+++ b/frontend/discourse/app/components/reviewable-created-by-name.gjs
@@ -1,27 +1,52 @@
+import Component from "@glimmer/component";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
+import { longDate } from "discourse/lib/formatter";
+import {
+  penaltyIcon,
+  penaltyPastTense,
+} from "discourse/lib/reviewable-penalty";
 import DUserLink from "discourse/ui-kit/d-user-link";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-const ReviewableCreatedByName = <template>
-  <div class="names">
-    <span class="username">
-      {{#if @user}}
-        <DUserLink @user={{@user}}>{{@user.username}}</DUserLink>
-        {{#if @user.silenced}}
-          {{dIcon "ban" title="user.silenced_tooltip"}}
-        {{/if}}
-      {{else}}
-        {{i18n "review.deleted_user"}}
-      {{/if}}
-    </span>
-    <PluginOutlet
-      @name="after-reviewable-post-user"
-      @connectorTagName="div"
-      @outletArgs={{lazyHash user=@user}}
-    />
-  </div>
-</template>;
+export default class ReviewableCreatedByName extends Component {
+  get penalties() {
+    return (this.args.penalties ?? []).map((penalty) => ({
+      icon: penaltyIcon(penalty.kind),
+      title: this.#title(penalty),
+    }));
+  }
 
-export default ReviewableCreatedByName;
+  #title(penalty) {
+    const state = penaltyPastTense(penalty.kind);
+
+    return penalty.forever
+      ? i18n(`user.${state}_permanently`)
+      : i18n(`user.${state}_notice`, { date: longDate(penalty.expires_at) });
+  }
+
+  <template>
+    <div class="names">
+      <span class="username">
+        {{#if @user}}
+          <DUserLink @user={{@user}}>{{@user.username}}</DUserLink>
+          {{#each this.penalties as |penalty|}}
+            {{dIcon
+              penalty.icon
+              class="reviewable-penalty-icon"
+              translatedTitle=penalty.title
+            }}
+          {{/each}}
+        {{else}}
+          {{i18n "review.deleted_user"}}
+        {{/if}}
+      </span>
+      <PluginOutlet
+        @name="after-reviewable-post-user"
+        @connectorTagName="div"
+        @outletArgs={{lazyHash user=@user}}
+      />
+    </div>
+  </template>
+}

--- a/frontend/discourse/app/components/reviewable/created-by.gjs
+++ b/frontend/discourse/app/components/reviewable/created-by.gjs
@@ -21,7 +21,7 @@ export default <template>
   <div class="created-by">
     {{#if @user}}
       <DUserLink @user={{@user}}>{{dAvatar @user imageSize="small"}}</DUserLink>
-      <ReviewableCreatedByName @user={{@user}} />
+      <ReviewableCreatedByName @user={{@user}} @penalties={{@penalties}} />
     {{else}}
       <div class="deleted-user">
         {{dIcon "trash-can" class="deleted-user-avatar"}}

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -837,6 +837,7 @@ export default class ReviewableItem extends Component {
                       @bundle={{bundle}}
                       @performAction={{this.perform}}
                       @reviewableUpdating={{this.disabled}}
+                      @authorPenalties={{@reviewable.author_penalties}}
                     />
                   {{/each}}
 

--- a/frontend/discourse/app/components/reviewable/post.gjs
+++ b/frontend/discourse/app/components/reviewable/post.gjs
@@ -60,7 +60,10 @@ export default class ReviewablePost extends Component {
       <div class="review-item__meta-label">{{this.userLabel}}</div>
 
       <div class="review-item__meta-flagged-user">
-        <ReviewableCreatedBy @user={{@reviewable.target_created_by}} />
+        <ReviewableCreatedBy
+          @user={{@reviewable.target_created_by}}
+          @penalties={{@reviewable.author_penalties}}
+        />
       </div>
     </div>
 

--- a/frontend/discourse/app/components/reviewable/queued-post.gjs
+++ b/frontend/discourse/app/components/reviewable/queued-post.gjs
@@ -57,7 +57,10 @@ export default class ReviewableQueuedPost extends Component {
       <div class="review-item__meta-label">{{i18n "review.review_user"}}</div>
 
       <div class="review-item__meta-flagged-user">
-        <ReviewableCreatedBy @user={{@reviewable.target_created_by}} />
+        <ReviewableCreatedBy
+          @user={{@reviewable.target_created_by}}
+          @penalties={{@reviewable.author_penalties}}
+        />
       </div>
     </div>
 

--- a/frontend/discourse/app/components/reviewable/timeline.gjs
+++ b/frontend/discourse/app/components/reviewable/timeline.gjs
@@ -8,6 +8,10 @@ import ReviewableNoteForm from "discourse/components/reviewable/note-form";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import escape from "discourse/lib/escape";
+import {
+  penaltyIcon,
+  penaltyPastTense,
+} from "discourse/lib/reviewable-penalty";
 import { sanitize } from "discourse/lib/text";
 import { CLAIMED, UNCLAIMED } from "discourse/models/reviewable-history";
 import { and, eq } from "discourse/truth-helpers";
@@ -141,6 +145,25 @@ export default class ReviewableTimeline extends Component {
         }
       });
     }
+
+    this.args.reviewable.author_penalties?.forEach((penalty) => {
+      if (!penalty.from_this_target || !penalty.applied_at) {
+        return;
+      }
+
+      events.push({
+        type: `author_${penaltyPastTense(penalty.kind)}`,
+        date: penalty.applied_at,
+        user: penalty.applied_by,
+        icon: penaltyIcon(penalty.kind),
+        titleKey: penalty.automatic
+          ? `review.timeline.author_${penaltyPastTense(penalty.kind)}_automatically`
+          : `review.timeline.author_${penaltyPastTense(penalty.kind)}_by`,
+        description: penalty.reason
+          ? trustHTML(sanitize(penalty.reason))
+          : null,
+      });
+    });
 
     // Add notes events
     this.args.reviewable.reviewable_notes?.forEach((note) => {

--- a/frontend/discourse/app/lib/reviewable-penalty.js
+++ b/frontend/discourse/app/lib/reviewable-penalty.js
@@ -1,0 +1,38 @@
+import { i18n } from "discourse-i18n";
+
+const LIFTS_PENALTY = "lifts_penalty";
+
+export const SILENCE = "silence";
+export const SUSPENSION = "suspension";
+
+const PAST_TENSE = { [SILENCE]: "silenced", [SUSPENSION]: "suspended" };
+
+const ICONS = { [SILENCE]: "microphone-slash", [SUSPENSION]: "ban" };
+
+export function penaltyPastTense(kind) {
+  return PAST_TENSE[kind];
+}
+
+export function penaltyIcon(kind) {
+  return ICONS[kind];
+}
+
+export function penaltyEffectDescription(action, penalties) {
+  if (!action?.penalty_effect || !penalties?.length) {
+    return null;
+  }
+
+  if (action.penalty_effect === LIFTS_PENALTY) {
+    return i18n("review.author_penalty.effect.lifts_silence");
+  }
+
+  const kinds = new Set(penalties.map((penalty) => penalty.kind));
+
+  if (kinds.has(SILENCE) && kinds.has(SUSPENSION)) {
+    return i18n("review.author_penalty.effect.retains_silence_and_suspension");
+  }
+
+  return kinds.has(SUSPENSION)
+    ? i18n("review.author_penalty.effect.retains_suspension")
+    : i18n("review.author_penalty.effect.retains_silence");
+}

--- a/frontend/discourse/app/models/reviewable.js
+++ b/frontend/discourse/app/models/reviewable.js
@@ -22,6 +22,7 @@ export default class Reviewable extends RestModel {
     return json;
   }
 
+  @tracked author_penalties;
   @tracked blank_post;
   @tracked bundled_actions;
   @tracked can_edit;

--- a/frontend/discourse/tests/unit/lib/reviewable-penalty-test.js
+++ b/frontend/discourse/tests/unit/lib/reviewable-penalty-test.js
@@ -1,0 +1,62 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  penaltyEffectDescription,
+  penaltyIcon,
+  penaltyPastTense,
+} from "discourse/lib/reviewable-penalty";
+import { i18n } from "discourse-i18n";
+
+const SILENCE = { kind: "silence" };
+const SUSPENSION = { kind: "suspension" };
+
+module("Unit | Lib | reviewable-penalty", function (hooks) {
+  setupTest(hooks);
+
+  test("penaltyPastTense", function (assert) {
+    assert.strictEqual(penaltyPastTense("silence"), "silenced");
+    assert.strictEqual(penaltyPastTense("suspension"), "suspended");
+    assert.strictEqual(penaltyPastTense("nope"), undefined);
+  });
+
+  test("penaltyIcon", function (assert) {
+    assert.strictEqual(penaltyIcon("silence"), "microphone-slash");
+    assert.strictEqual(penaltyIcon("suspension"), "ban");
+    assert.strictEqual(penaltyIcon("nope"), undefined);
+  });
+
+  test("penaltyEffectDescription is absent without an effect or a penalty", function (assert) {
+    assert.strictEqual(penaltyEffectDescription(null, [SILENCE]), null);
+    assert.strictEqual(penaltyEffectDescription({}, [SILENCE]), null);
+    assert.strictEqual(
+      penaltyEffectDescription({ penalty_effect: "retains_penalty" }, []),
+      null
+    );
+  });
+
+  test("penaltyEffectDescription names the penalty an action lifts", function (assert) {
+    assert.strictEqual(
+      penaltyEffectDescription({ penalty_effect: "lifts_penalty" }, [SILENCE]),
+      i18n("review.author_penalty.effect.lifts_silence")
+    );
+  });
+
+  test("penaltyEffectDescription names every penalty an action leaves behind", function (assert) {
+    const retains = { penalty_effect: "retains_penalty" };
+
+    assert.strictEqual(
+      penaltyEffectDescription(retains, [SILENCE]),
+      i18n("review.author_penalty.effect.retains_silence")
+    );
+
+    assert.strictEqual(
+      penaltyEffectDescription(retains, [SUSPENSION]),
+      i18n("review.author_penalty.effect.retains_suspension")
+    );
+
+    assert.strictEqual(
+      penaltyEffectDescription(retains, [SILENCE, SUSPENSION]),
+      i18n("review.author_penalty.effect.retains_silence_and_suspension")
+    );
+  });
+});

--- a/plugins/chat/assets/javascripts/discourse/components/reviewable/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/reviewable/chat-message.gjs
@@ -64,7 +64,10 @@ export default class ReviewableRefreshChatMessage extends Component {
       <div class="review-item__meta-label">{{i18n "review.review_user"}}</div>
 
       <div class="review-item__meta-flagged-user">
-        <ReviewableCreatedBy @user={{@reviewable.target_created_by}} />
+        <ReviewableCreatedBy
+          @user={{@reviewable.target_created_by}}
+          @penalties={{@reviewable.author_penalties}}
+        />
       </div>
     </div>
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/reviewable/ai-chat-message.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/reviewable/ai-chat-message.gjs
@@ -57,7 +57,10 @@ export default class ReviewableRefreshAiChatMessage extends Component {
       <div class="review-item__meta-label">{{i18n "review.review_user"}}</div>
 
       <div class="review-item__meta-flagged-user">
-        <ReviewableCreatedBy @user={{@reviewable.target_created_by}} />
+        <ReviewableCreatedBy
+          @user={{@reviewable.target_created_by}}
+          @penalties={{@reviewable.author_penalties}}
+        />
       </div>
     </div>
 

--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/reviewable/post-voting-comment.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/reviewable/post-voting-comment.gjs
@@ -16,7 +16,10 @@ export default <template>
     <div class="review-item__meta-label">{{i18n "review.review_user"}}</div>
 
     <div class="review-item__meta-flagged-user">
-      <ReviewableCreatedBy @user={{@reviewable.target_created_by}} />
+      <ReviewableCreatedBy
+        @user={{@reviewable.target_created_by}}
+        @penalties={{@reviewable.author_penalties}}
+      />
     </div>
   </div>
 

--- a/plugins/voice/assets/javascripts/discourse/components/reviewable/voice-user.gjs
+++ b/plugins/voice/assets/javascripts/discourse/components/reviewable/voice-user.gjs
@@ -15,7 +15,10 @@ export default <template>
     <div class="review-item__meta-label">{{i18n "review.review_user"}}</div>
 
     <div class="review-item__meta-flagged-user">
-      <ReviewableCreatedBy @user={{@reviewable.target_created_by}} />
+      <ReviewableCreatedBy
+        @user={{@reviewable.target_created_by}}
+        @penalties={{@reviewable.author_penalties}}
+      />
     </div>
   </div>
 

--- a/spec/system/review_author_penalty_spec.rb
+++ b/spec/system/review_author_penalty_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe "Review queue | author penalty" do
+  fab!(:admin)
+  fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:author) { Fabricate(:user, username: "spammer99", refresh_auto_groups: true) }
+  fab!(:flagged_post) { Fabricate(:post, user: author) }
+
+  let!(:reviewable) { PostActionCreator.spam(flagger, flagged_post).reviewable }
+  let(:review_page) { PageObjects::Pages::Review.new }
+
+  before { sign_in(admin) }
+
+  def silence_author!(post_id: flagged_post.id)
+    UserSilencer.silence(
+      author,
+      Discourse.system_user,
+      post_id: post_id,
+      reason: "Silenced automatically",
+    )
+  end
+
+  it "says nothing when the author has no penalty" do
+    review_page.visit_reviewable(reviewable)
+
+    expect(review_page).to have_reviewable_action_dropdown
+    expect(page).to have_no_css(
+      ".review-item__meta-flagged-user .d-icon-microphone-slash",
+      visible: :all,
+    )
+  end
+
+  context "when automated tooling silenced the author for this post" do
+    before do
+      flagged_post.update!(hidden: true, hidden_at: Time.zone.now)
+      silence_author!
+    end
+
+    it "marks the flagged user as silenced" do
+      review_page.visit_reviewable(reviewable)
+
+      expect(page).to have_css(
+        ".review-item__meta-flagged-user .d-icon-microphone-slash",
+        visible: :all,
+      )
+      expect(page).to have_css(
+        ".review-item__meta-flagged-user .svg-icon-title[title='This user is silenced.']",
+        visible: :all,
+      )
+    end
+
+    it "records the penalty in the timeline" do
+      review_page.visit_reviewable(reviewable)
+      review_page.click_timeline_tab
+
+      expect(page).to have_css(".timeline-event__title", text: "Author silenced automatically")
+    end
+  end
+end


### PR DESCRIPTION
Automated tooling can silence an author seconds after they post, long
before a moderator opens the queue. The queue showed no sign of it, so a
moderator who deleted the flagged post reasonably concluded that their
own click had silenced the author.

The flagged username now carries an icon for each active penalty, with
the same icons and wording the user card and profile already use, and a
suspended author is marked at all — previously only silence was shown,
and with the icon meaning "suspended".

The penalty also appears in the timeline, which records who applied it
and when, so a moderator can see it happened before they arrived.

Finally, each action in the dropdown states what it leaves behind:
"Delete post" now says the author stays silenced, and "Restore post"
says they will be unsilenced. That was the missing fact. Only one action
lifts a silence, and nothing said which.

