### PR TITLE
FEATURE: Let moderators lift an automated silence from the review queue

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -52,7 +52,6 @@ class ReviewableFlaggedPost < Reviewable
   end
 
   def build_combined_actions(actions, guardian, args)
-    # existing combined logic
     agree_bundle =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
 
@@ -110,10 +109,22 @@ class ReviewableFlaggedPost < Reviewable
     end
 
     post_visible_or_system_user = !post.hidden? || guardian.user.is_system_user?
-    # We must return early in this case otherwise we can end up with a bundle
-    # with no associated actions, which is not valid on the client.
-    return if !can_delete_post_or_topic && !post_visible_or_system_user && post.hidden?
+    if can_delete_post_or_topic || post_visible_or_system_user || !post.hidden?
+      build_disagree_bundle(
+        actions,
+        can_delete_existing_post_or_topic:,
+        post_visible_or_system_user:,
+      )
+    end
 
+    build_unsilence_action(actions, guardian)
+  end
+
+  def build_disagree_bundle(
+    actions,
+    can_delete_existing_post_or_topic:,
+    post_visible_or_system_user:
+  )
     disagree_bundle =
       actions.add_bundle(
         "#{id}-disagree",
@@ -153,8 +164,21 @@ class ReviewableFlaggedPost < Reviewable
     end
   end
 
+  def build_unsilence_action(actions, guardian)
+    return if !author_silenced?
+    return if !guardian.can_unsilence_user?(target_created_by)
+
+    build_action(actions, :unsilence_user, icon: "microphone-slash")
+  end
+
   def perform_ignore(performed_by, args)
     perform_ignore_and_do_nothing(performed_by, args)
+  end
+
+  def perform_unsilence_user(performed_by, _args)
+    UserSilencer.unsilence(target_user, performed_by, reviewable_id: id)
+
+    create_result(:success) { |result| result.remove_reviewable_ids = [] }
   end
 
   def perform_unsilence_user_and_ignore(performed_by, args)
@@ -196,6 +220,8 @@ class ReviewableFlaggedPost < Reviewable
         disagree_lifts_silence?
       when :unsilence_user_and_ignore
         user_silenced_for_post?
+      when :unsilence_user
+        author_silenced?
       else
         false
       end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1238,6 +1238,10 @@ en:
           retains_suspension: "The author stays suspended."
           retains_silence_and_suspension: "The author stays silenced and suspended."
           lifts_silence: "The author will be unsilenced."
+        toast:
+          still_silenced: "%{username} is still silenced."
+          undo: "Undo"
+          undone: "%{username} is no longer silenced."
       notes:
         add_note_description: "Add a note to provide context to other moderators."
         add_note_button: "Add note"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6342,6 +6342,10 @@ en:
         title: "Unsilence user and ignore"
         description: "Unsilence the user and remove the flag from the queue without restoring the deleted post."
         complete: "User unsilenced and flag ignored."
+      unsilence_user:
+        title: "Unsilence author"
+        description: "Lift the silence on the author. This flag stays in the queue."
+        complete: "Author unsilenced."
       approve:
         title: "Yes"
         complete: "Post approved."

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -31,6 +31,7 @@ import { bind } from "discourse/lib/decorators";
 import { getAbsoluteURL } from "discourse/lib/get-url";
 import optionalService from "discourse/lib/optional-service";
 import { showAlert } from "discourse/lib/post-action-feedback";
+import { survivingPenalty } from "discourse/lib/reviewable-penalty";
 import { resolveReviewableComponent } from "discourse/lib/reviewable-registry";
 import { clipboardCopy } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
@@ -410,9 +411,7 @@ export default class ReviewableItem extends Component {
     }
 
     if (performableAction.completed_message) {
-      this.toasts.success({
-        data: { message: performableAction.completed_message },
-      });
+      this.#showCompletedToast(performableAction, reviewable);
     }
 
     if (this.args.remove && result.remove_reviewable_ids?.length > 0) {
@@ -424,6 +423,58 @@ export default class ReviewableItem extends Component {
 
       return this.store.find("reviewable", reviewable.id);
     }
+  }
+
+  #showCompletedToast(performableAction, reviewable) {
+    const penalty = survivingPenalty(
+      performableAction,
+      reviewable.author_penalties
+    );
+    const author = reviewable.target_created_by;
+
+    if (!penalty || !author) {
+      this.toasts.success({
+        data: { message: performableAction.completed_message },
+      });
+      return;
+    }
+
+    this.toasts.success({
+      autoClose: false,
+      data: {
+        title: performableAction.completed_message,
+        message: i18n("review.author_penalty.toast.still_silenced", {
+          username: author.username,
+        }),
+        actions: [
+          {
+            label: i18n("review.author_penalty.toast.undo"),
+            class: "btn-transparent reviewable-undo-penalty",
+            action: ({ close }) => this.#liftPenalty(author, close),
+          },
+        ],
+      },
+    });
+  }
+
+  async #liftPenalty(author, close) {
+    try {
+      await ajax(`/admin/users/${author.id}/unsilence`, { type: "PUT" });
+    } catch (error) {
+      return popupAjaxError(error);
+    }
+
+    close();
+
+    this.toasts.success({
+      data: {
+        message: i18n("review.author_penalty.toast.undone", {
+          username: author.username,
+        }),
+      },
+    });
+
+    this.store.find("reviewable", this.args.reviewable.id);
   }
 
   @action

--- a/frontend/discourse/app/lib/reviewable-penalty.js
+++ b/frontend/discourse/app/lib/reviewable-penalty.js
@@ -1,5 +1,6 @@
 import { i18n } from "discourse-i18n";
 
+const RETAINS_PENALTY = "retains_penalty";
 const LIFTS_PENALTY = "lifts_penalty";
 
 export const SILENCE = "silence";
@@ -35,4 +36,16 @@ export function penaltyEffectDescription(action, penalties) {
   return kinds.has(SUSPENSION)
     ? i18n("review.author_penalty.effect.retains_suspension")
     : i18n("review.author_penalty.effect.retains_silence");
+}
+
+export function survivingPenalty(action, penalties) {
+  if (action?.penalty_effect !== RETAINS_PENALTY) {
+    return null;
+  }
+
+  return (
+    penalties?.find(
+      (penalty) => penalty.kind === "silence" && penalty.can_lift
+    ) ?? null
+  );
 }

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -545,6 +545,58 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
     end
   end
 
+  describe "#perform_unsilence_user" do
+    fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:flagged_post) { Fabricate(:post, user: author) }
+
+    let!(:reviewable) { PostActionCreator.spam(user, flagged_post).reviewable }
+    let(:guardian) { Guardian.new(moderator) }
+
+    it "is offered whenever the author is currently silenced" do
+      expect(reviewable.actions_for(guardian).has?(:unsilence_user)).to eq(false)
+
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+
+      expect(reviewable.reload.actions_for(guardian).has?(:unsilence_user)).to eq(true)
+    end
+
+    it "is offered even when the silence is not linked to this post" do
+      other_post = Fabricate(:post, user: author)
+      UserSilencer.silence(author, moderator, post_id: other_post.id)
+
+      expect(UserSilencer.was_silenced_for?(flagged_post)).to eq(false)
+      expect(reviewable.actions_for(guardian).has?(:unsilence_user)).to eq(true)
+    end
+
+    it "lifts the silence without resolving the reviewable" do
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+
+      result = reviewable.perform(moderator, :unsilence_user)
+
+      expect(author.reload.silenced?).to eq(false)
+      expect(reviewable.reload).to be_pending
+      expect(result.remove_reviewable_ids).to eq([])
+    end
+
+    it "attributes the unsilence to the moderator and the reviewable" do
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+
+      reviewable.perform(moderator, :unsilence_user)
+
+      history =
+        UserHistory.find_by(action: UserHistory.actions[:unsilence_user], target_user_id: author.id)
+
+      expect(history.acting_user_id).to eq(moderator.id)
+      expect(history.reviewable_id).to eq(reviewable.id)
+    end
+
+    it "is not offered to a moderator who cannot unsilence the author" do
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+
+      expect(reviewable.actions_for(Guardian.new(user)).has?(:unsilence_user)).to eq(false)
+    end
+  end
+
   describe "penalty_effect" do
     fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:flagged_post) { Fabricate(:post, user: author) }
@@ -575,6 +627,7 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(effect_for(:agree_and_keep_hidden)).to eq(:retains_penalty)
       expect(effect_for(:delete_and_ignore)).to eq(:retains_penalty)
       expect(effect_for(:disagree_and_restore)).to eq(:lifts_penalty)
+      expect(effect_for(:unsilence_user)).to eq(:lifts_penalty)
     end
 
     it "does not promise a lift when the silence is not linked to this post" do
@@ -583,6 +636,22 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       UserSilencer.silence(author, moderator, post_id: other_post.id)
 
       expect(effect_for(:disagree_and_restore)).to eq(:retains_penalty)
+      expect(effect_for(:unsilence_user)).to eq(:lifts_penalty)
+    end
+
+    it "still promises to unsilence when the author is also suspended" do
+      flagged_post.update!(hidden: true, hidden_at: Time.zone.now)
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+      UserSuspender.new(
+        author,
+        suspended_till: 5.days.from_now,
+        reason: "spam",
+        by_user: moderator,
+      ).suspend
+
+      expect(effect_for(:unsilence_user)).to eq(:lifts_penalty)
+      expect(effect_for(:disagree_and_restore)).to eq(:lifts_penalty)
+      expect(effect_for(:delete_and_agree)).to eq(:retains_penalty)
     end
 
     it "does not promise a lift for a suspension" do

--- a/spec/system/review_author_penalty_spec.rb
+++ b/spec/system/review_author_penalty_spec.rb
@@ -28,6 +28,7 @@ describe "Review queue | author penalty" do
       ".review-item__meta-flagged-user .d-icon-microphone-slash",
       visible: :all,
     )
+    expect(page).to have_no_css(".reviewable-action.post-unsilence-user")
   end
 
   context "when automated tooling silenced the author for this post" do
@@ -54,6 +55,41 @@ describe "Review queue | author penalty" do
       review_page.click_timeline_tab
 
       expect(page).to have_css(".timeline-event__title", text: "Author silenced automatically")
+    end
+
+    it "lifts the silence without resolving the flag" do
+      review_page.visit_reviewable(reviewable)
+
+      find(".reviewable-action.post-unsilence-user").click
+
+      expect(page).to have_no_css(
+        ".review-item__meta-flagged-user .d-icon-microphone-slash",
+        visible: :all,
+      )
+      expect(author.reload).not_to be_silenced
+      expect(reviewable.reload).to be_pending
+    end
+
+    it "names the surviving penalty after an action that keeps it" do
+      review_page.visit_reviewable(reviewable)
+
+      review_page.select_bundled_action(reviewable, "post-delete_and_agree", bundle_index: 1)
+
+      expect(page).to have_css(".fk-d-default-toast__message", text: "spammer99 is still silenced.")
+      expect(author.reload).to be_silenced
+    end
+
+    it "offers an undo on that toast" do
+      review_page.visit_reviewable(reviewable)
+
+      review_page.select_bundled_action(reviewable, "post-delete_and_agree", bundle_index: 1)
+      find(".reviewable-undo-penalty").click
+
+      expect(page).to have_css(
+        ".fk-d-default-toast__message",
+        text: "spammer99 is no longer silenced.",
+      )
+      expect(author.reload).not_to be_silenced
     end
   end
 end


### PR DESCRIPTION
A moderator who disagrees with a flag can restore the post, and that
lifts the silence with it. Every other outcome leaves the author
silenced, and there was no way to reinstate them without leaving the
queue for the admin pages — which is what made an automated silence feel
like a trap.

"Unsilence author" lifts the silence and deliberately leaves the flag
pending, because deciding about the author and deciding about the post
are separate decisions and the queue should not force them together.

The action is only offered to a moderator who is allowed to unsilence,
so a category moderator sees the penalty without being handed a control
they cannot use.

Acting on a flag that leaves the author silenced now says so, and offers
the reversal in place. The message does not close on its own: a
moderation decision should not expire while it is being read.

