### PR TITLE
SECURITY: Reject Data Explorer parameters inside PostgreSQL dollar-quoted literals

### DIFF
--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -47,8 +47,12 @@ module DiscourseDataExplorer
         return { error: e, duration_nanos: 0 }
       end
 
-      # a parameter value could otherwise break out of a comment
-      executable_sql = interpolate_params(strip_comments(query.sql), query_args)
+      executable_sql = strip_comments(query.sql)
+      if params_in_dollar_quoted_literal?(executable_sql, query_args)
+        err = ValidationError.new("Parameters cannot be used inside dollar-quoted literals")
+        return { error: err, duration_nanos: 0 }
+      end
+      executable_sql = interpolate_params(executable_sql, query_args)
 
       time_start, time_end, explain, err, result = nil
       begin
@@ -109,7 +113,56 @@ module DiscourseDataExplorer
       # not DB.param_encoder, which quotes some types differently
       encoder = MiniSql::InlineParamEncoder.new(ActiveRecord::Base.connection.raw_connection)
       values = params.transform_keys(&:to_s)
-      sql.gsub(PARAM_REGEX) { values.key?($1) ? encoder.quote_val(values[$1]) : $& }
+      replace_params = ->(fragment) do
+        fragment.gsub(PARAM_REGEX) { values.key?($1) ? encoder.quote_val(values[$1]) : $& }
+      end
+      scanner = StringScanner.new(sql)
+      result = +""
+
+      until scanner.eos?
+        if scanner.match?(/'/)
+          # backslash escapes only apply to E'' strings
+          pattern = result.match?(/(?<![\w"])[eE]\z/) ? /'(?:''|[^'\\]|\\.)*'/m : /'(?:''|[^'])*'/
+          result << replace_params.call(scanner.scan(pattern) || scan_rest(scanner))
+        elsif scanner.match?(/"/)
+          result << replace_params.call(scanner.scan(/"(?:""|[^"])*"/) || scan_rest(scanner))
+        elsif scanner.match?(/\$\w*\$/)
+          result << (scanner.scan(/\$(\w*)\$.*?\$\1\$/m) || scan_rest(scanner))
+        else
+          result << replace_params.call(scanner.scan(/[^'"$]+/) || scanner.getch)
+        end
+      end
+
+      result
+    end
+
+    def self.params_in_dollar_quoted_literal?(sql, params)
+      values = params.transform_keys(&:to_s)
+      scanner = StringScanner.new(sql)
+
+      until scanner.eos?
+        if scanner.match?(/'/)
+          # backslash escapes only apply to E'' strings
+          pattern =
+            (
+              if scanner.string[0...scanner.pos].match?(/(?<![\w"])[eE]\z/)
+                /'(?:''|[^'\\]|\\.)*'/m
+              else
+                /'(?:''|[^'])*'/
+              end
+            )
+          scanner.scan(pattern) || scan_rest(scanner)
+        elsif scanner.match?(/"/)
+          scanner.scan(/"(?:""|[^"])*"/) || scan_rest(scanner)
+        elsif scanner.match?(/\$\w*\$/)
+          literal = scanner.scan(/\$(\w*)\$.*?\$\1\$/m) || scan_rest(scanner)
+          return true if literal.scan(PARAM_REGEX).any? { |parameter| values.key?(parameter.first) }
+        else
+          scanner.getch
+        end
+      end
+
+      false
     end
 
     # Literals, quoted identifiers, and dollar-quoted strings are left untouched,

--- a/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
+++ b/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
@@ -27,6 +27,16 @@ describe DiscourseDataExplorer::DataExplorer do
     end
   end
 
+  describe ".params_in_dollar_quoted_literal?" do
+    it "ignores dollar quote syntax inside a standard string literal" do
+      sql = "SELECT '$sql$:value$sql$'"
+
+      expect(
+        described_class.params_in_dollar_quoted_literal?(sql, { value: "expected value" }),
+      ).to eq(false)
+    end
+  end
+
   describe ".run_query" do
     fab!(:topic)
 

--- a/plugins/discourse-data-explorer/spec/requests/query_execution_security_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_execution_security_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+describe "Data Explorer group report query execution" do
+  fab!(:user) do
+    Fabricate(:user, username: SecureRandom.hex(8), email: "#{SecureRandom.hex(8)}@example.com")
+  end
+  fab!(:group) { Fabricate(:group, name: SecureRandom.hex(8), users: [user]) }
+
+  before do
+    SiteSetting.data_explorer_enabled = true
+    sign_in(user)
+  end
+
+  it "rejects a group member's parameter inside a dollar-quoted literal" do
+    victim =
+      Fabricate(:user, username: SecureRandom.hex(8), email: "#{SecureRandom.hex(8)}@example.com")
+    query = DiscourseDataExplorer::Query.create!(name: "Parameterized Query", sql: <<~SQL)
+          -- [params]
+          -- string :value
+          SELECT $sql$:value$sql$ AS value
+        SQL
+    query.query_groups.create!(group: group)
+    payload = <<~SQL.chomp
+      harmless$sql$) SELECT * FROM query;
+      WITH query AS (
+      SELECT email FROM user_emails WHERE user_id = #{victim.id} --
+    SQL
+
+    post "/g/#{group.name}/reports/#{query.id}/run.json", params: { params: { value: payload } }
+
+    expect(response.status).to eq(422)
+    expect(response.parsed_body).to eq(
+      {
+        "success" => false,
+        "errors" => [
+          "DiscourseDataExplorer::ValidationError: Parameters cannot be used inside dollar-quoted literals",
+        ],
+      },
+    )
+    expect(response.body).not_to include(victim.email)
+  end
+
+  it "rejects a benign group report parameter inside a dollar-quoted literal" do
+    query = DiscourseDataExplorer::Query.create!(name: "Parameterized Query", sql: <<~SQL)
+          -- [params]
+          -- string :value
+          SELECT $sql$:value$sql$ AS value
+        SQL
+    query.query_groups.create!(group: group)
+
+    post "/g/#{group.name}/reports/#{query.id}/run.json",
+         params: {
+           params: {
+             value: "expected value",
+           },
+         }
+
+    expect(response.status).to eq(422)
+    expect(response.parsed_body).to eq(
+      {
+        "success" => false,
+        "errors" => [
+          "DiscourseDataExplorer::ValidationError: Parameters cannot be used inside dollar-quoted literals",
+        ],
+      },
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Prevent a group member from exploiting a Data Explorer report parameter declared inside a PostgreSQL dollar-quoted literal to escape the literal and append arbitrary SQL. The patch now scans queries for declared parameter markers inside complete dollar-quoted literals and rejects such queries with a stable validation error before execution, preventing previously silent parameter marker corruption and SQL injection via the group-report route.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/2405

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>