### PR TITLE
SECURITY: bind Data Explorer report parameters instead of inlining them [backport 2026.1]

### DIFF
--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -24,6 +24,15 @@ module DiscourseDataExplorer
     #   duration_nanos - the query duration, in nanoseconds
     #   explain - the query
     def self.run_query(query, req_params = {}, opts = {})
+      run_query_with_values(query, query.cast_params(req_params, opts), opts)
+    rescue ValidationError => e
+      { error: e, duration_nanos: 0 }
+    end
+
+    # Execute a query binding an already-resolved hash of parameter values,
+    # skipping the declared-parameter casting `run_query` does. Callers with
+    # undeclared parameters, such as a workflow's raw SQL node, use this directly.
+    def self.run_query_with_values(query, values = {}, opts = {})
       # Safety checks
       # see test 'doesn't allow you to modify the database #2'
       if query.sql =~ /;/
@@ -31,15 +40,13 @@ module DiscourseDataExplorer
         return { error: err, duration_nanos: 0 }
       end
 
-      query_args = {}
+      executable_sql = nil
+      binds = []
       begin
-        query_args = query.cast_params(req_params, opts)
+        executable_sql, binds = rewrite_to_binds(strip_comments(query.sql), values)
       rescue ValidationError => e
         return { error: e, duration_nanos: 0 }
       end
-
-      # a parameter value could otherwise break out of a comment
-      executable_sql = interpolate_params(strip_comments(query.sql), query_args)
 
       time_start, time_end, explain, err, result = nil
       begin
@@ -66,13 +73,18 @@ module DiscourseDataExplorer
 
           time_start = Time.now
 
-          result = ActiveRecord::Base.connection.raw_connection.async_exec(sql)
+          result = ActiveRecord::Base.connection.raw_connection.async_exec_params(sql, binds)
           result.check # make sure it's done
           time_end = Time.now
 
           if opts[:explain]
             explain =
-              DB.query_hash("EXPLAIN #{executable_sql}").map { |row| row["QUERY PLAN"] }.join "\n"
+              ActiveRecord::Base
+                .connection
+                .raw_connection
+                .async_exec_params("EXPLAIN #{executable_sql}", binds)
+                .map { |row| row["QUERY PLAN"] }
+                .join("\n")
           end
 
           # All done. Issue a rollback anyways, just in case
@@ -89,49 +101,131 @@ module DiscourseDataExplorer
         pg_result: result,
         duration_secs: time_end - time_start,
         explain: explain,
-        params_full: query_args,
+        params_full: values,
       }
     end
 
-    # Single pass, so that a substituted value is never rescanned.
-    def self.interpolate_params(sql, params)
-      return sql if params.blank?
-
-      # not DB.param_encoder, which quotes some types differently
-      encoder = MiniSql::InlineParamEncoder.new(ActiveRecord::Base.connection.raw_connection)
-      values = params.transform_keys(&:to_s)
-      sql.gsub(PARAM_REGEX) { values.key?($1) ? encoder.quote_val(values[$1]) : $& }
-    end
-
-    # Literals, quoted identifiers, and dollar-quoted strings are left untouched,
-    # as are unterminated constructs, so that PostgreSQL reports the syntax error.
-    def self.strip_comments(sql)
+    # Walk the SQL once with PostgreSQL's own lexical rules, yielding each span
+    # as [type, text] in order. `type` is one of :code, :string, :identifier,
+    # :dollar_quote, :line_comment, :block_comment. Only :code spans hold syntax
+    # a parameter marker can affect; every literal kind is reported so callers
+    # can leave it alone. Unterminated constructs are yielded whole so that
+    # PostgreSQL reports the syntax error.
+    def self.scan_sql_segments(sql)
       scanner = StringScanner.new(sql)
-      result = +""
 
       until scanner.eos?
+        start = scanner.pos
         if scanner.scan(/--[^\n]*/)
-          # dropped, the newline is kept
+          yield :line_comment, scanner.matched
         elsif scanner.scan(%r{/\*})
           depth = 1
           while depth > 0 && scanner.skip_until(%r{\*/|/\*})
             depth += scanner.matched == "/*" ? 1 : -1
           end
           scanner.terminate if depth > 0
-          result << " "
+          yield :block_comment, sql[start...scanner.pos]
         elsif scanner.match?(/'/)
           # backslash escapes only apply to E'' strings
-          pattern = result.match?(/(?<![\w"])[eE]\z/) ? /'(?:''|[^'\\]|\\.)*'/m : /'(?:''|[^'])*'/
-          result << (scanner.scan(pattern) || scan_rest(scanner))
+          e_string = sql[0...scanner.pos].match?(/(?<![\w"])[eE]\z/)
+          pattern = e_string ? /'(?:''|[^'\\]|\\.)*'/m : /'(?:''|[^'])*'/
+          yield :string, scanner.scan(pattern) || scan_rest(scanner)
         elsif scanner.match?(/"/)
-          result << (scanner.scan(/"(?:""|[^"])*"/) || scan_rest(scanner))
+          yield :identifier, scanner.scan(/"(?:""|[^"])*"/) || scan_rest(scanner)
         elsif scanner.match?(/\$\w*\$/)
-          result << (scanner.scan(/\$(\w*)\$.*?\$\1\$/m) || scan_rest(scanner))
+          yield :dollar_quote, scanner.scan(/\$(\w*)\$.*?\$\1\$/m) || scan_rest(scanner)
         else
-          result << (scanner.scan(%r{[^-/'"$]+}) || scanner.getch)
+          yield :code, scanner.scan(%r{[^-/'"$]+}) || scanner.getch
+        end
+      end
+    end
+    private_class_method :scan_sql_segments
+
+    # Rewrite each `:name` marker that sits in code position to a positional
+    # `$N` placeholder and collect its value, so PostgreSQL binds the values out
+    # of band instead of us splicing them into the SQL text. Markers inside any
+    # literal are left untouched. A list value expands to a comma-separated run
+    # of placeholders so `IN (:ids)` keeps working, and an empty list becomes
+    # `NULL`. A marker inside a dollar-quoted literal cannot be bound at all, so
+    # it is rejected rather than silently left as literal text.
+    def self.rewrite_to_binds(sql, params)
+      return sql, [] if params.blank?
+
+      values = params.transform_keys(&:to_s)
+      binds = []
+      slots = {}
+      result = +""
+
+      scan_sql_segments(sql) do |type, text|
+        case type
+        when :code
+          result << text.gsub(PARAM_REGEX) do |matched|
+            name = $1
+            values.key?(name) ? (slots[name] ||= placeholders_for(values[name], binds)) : matched
+          end
+        when :dollar_quote
+          if text.scan(PARAM_REGEX).any? { |match| values.key?(match.first) }
+            raise ValidationError.new("Parameters cannot be used inside dollar-quoted literals")
+          end
+          result << text
+        else
+          result << text
         end
       end
 
+      [result, binds]
+    end
+
+    def self.placeholders_for(value, binds)
+      if value.is_a?(Array)
+        return "NULL" if value.empty?
+        value
+          .map do |element|
+            binds << bind_for(element)
+            "$#{binds.length}"
+          end
+          .join(", ")
+      else
+        binds << bind_for(value)
+        "$#{binds.length}"
+      end
+    end
+    private_class_method :placeholders_for
+
+    # Mirror how an inlined literal used to be typed: numbers and booleans carry
+    # their PostgreSQL type so results decode back to the same Ruby class, while
+    # everything else binds as an unknown-typed literal that the surrounding
+    # expression coerces and that reads back as text.
+    def self.bind_for(value)
+      case value
+      when Integer
+        { value: value.to_s, type: 20 }
+      when Float
+        { value: value.to_s, type: 701 }
+      when true, false
+        { value: value.to_s, type: 16 }
+      when nil
+        { value: nil, type: 0 }
+      when Time
+        { value: value.utc.iso8601, type: 0 }
+      else
+        { value: value.to_s, type: 0 }
+      end
+    end
+    private_class_method :bind_for
+
+    def self.strip_comments(sql)
+      result = +""
+      scan_sql_segments(sql) do |type, text|
+        case type
+        when :line_comment
+          # dropped; its trailing newline is a separate code span
+        when :block_comment
+          result << " "
+        else
+          result << text
+        end
+      end
       result
     end
 

--- a/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
+++ b/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
@@ -27,6 +27,52 @@ describe DiscourseDataExplorer::DataExplorer do
     end
   end
 
+  describe ".rewrite_to_binds" do
+    it "rewrites a code-position parameter to a positional placeholder" do
+      sql, binds = described_class.rewrite_to_binds("SELECT :id", { "id" => 7 })
+
+      expect(sql).to eq("SELECT $1")
+      expect(binds).to eq([{ value: "7", type: 20 }])
+    end
+
+    it "reuses one placeholder and one bind for a repeated parameter" do
+      sql, binds = described_class.rewrite_to_binds("SELECT :id, :id", { "id" => 7 })
+
+      expect(sql).to eq("SELECT $1, $1")
+      expect(binds.size).to eq(1)
+    end
+
+    it "expands a list parameter into a run of placeholders" do
+      sql, binds = described_class.rewrite_to_binds("WHERE id IN (:ids)", { "ids" => [1, 2, 3] })
+
+      expect(sql).to eq("WHERE id IN ($1, $2, $3)")
+      expect(binds.map { |bind| bind[:value] }).to eq(%w[1 2 3])
+    end
+
+    it "leaves a marker inside a string literal untouched" do
+      sql, binds = described_class.rewrite_to_binds("SELECT ':id'", { "id" => 7 })
+
+      expect(sql).to eq("SELECT ':id'")
+      expect(binds).to be_empty
+    end
+
+    it "ignores dollar-quote syntax that appears inside a string literal" do
+      sql, binds = described_class.rewrite_to_binds("SELECT '$sql$:id$sql$'", { "id" => 7 })
+
+      expect(sql).to eq("SELECT '$sql$:id$sql$'")
+      expect(binds).to be_empty
+    end
+
+    it "rejects a parameter inside a dollar-quoted literal" do
+      expect {
+        described_class.rewrite_to_binds("SELECT $sql$:id$sql$", { "id" => 7 })
+      }.to raise_error(
+        DiscourseDataExplorer::ValidationError,
+        "Parameters cannot be used inside dollar-quoted literals",
+      )
+    end
+  end
+
   describe ".run_query" do
     fab!(:topic)
 
@@ -82,6 +128,38 @@ describe DiscourseDataExplorer::DataExplorer do
       expect(result[:error]).to eq(nil)
       expect(result[:pg_result].to_a.size).to eq(1)
       expect(result[:pg_result][0]["id"]).to eq(topic2.id)
+    end
+
+    it "runs a list parameter through an IN clause" do
+      topic2 = Fabricate(:topic)
+      topic3 = Fabricate(:topic)
+
+      query = DiscourseDataExplorer::Query.create!(name: "list query", sql: <<~SQL)
+            -- [params]
+            -- int_list :ids
+            SELECT id FROM topics WHERE id IN (:ids) ORDER BY id
+          SQL
+
+      result = described_class.run_query(query, { "ids" => "#{topic.id},#{topic3.id}" })
+
+      expect(result[:error]).to eq(nil)
+      expect(result[:pg_result].to_a.map { |row| row["id"] }).to eq([topic.id, topic3.id].sort)
+    end
+
+    it "rejects, without executing, a parameter inside a dollar-quoted literal" do
+      query = DiscourseDataExplorer::Query.create!(name: "dollar query", sql: <<~SQL)
+            -- [params]
+            -- string :value
+            SELECT $sql$:value$sql$ AS value
+          SQL
+
+      result = described_class.run_query(query, { "value" => "harmless$sql$) SELECT 1 --" })
+
+      expect(result[:error]).to be_a(DiscourseDataExplorer::ValidationError)
+      expect(result[:error].message).to eq(
+        "Parameters cannot be used inside dollar-quoted literals",
+      )
+      expect(result[:pg_result]).to eq(nil)
     end
 
     it "adds query instrumentation after removing stored comments" do

--- a/plugins/discourse-data-explorer/spec/requests/query_execution_security_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_execution_security_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe "Data Explorer group report query execution" do
+  fab!(:user) do
+    Fabricate(:user, username: SecureRandom.hex(8), email: "#{SecureRandom.hex(8)}@example.com")
+  end
+  fab!(:group) { Fabricate(:group, name: SecureRandom.hex(8), users: [user]) }
+
+  before do
+    SiteSetting.data_explorer_enabled = true
+    sign_in(user)
+  end
+
+  def create_report
+    query = DiscourseDataExplorer::Query.create!(name: "Parameterized Query", sql: <<~SQL)
+          -- [params]
+          -- string :value
+          SELECT $sql$:value$sql$ AS value
+        SQL
+    query.query_groups.create!(group: group)
+    query
+  end
+
+  it "rejects a group member's parameter inside a dollar-quoted literal" do
+    victim =
+      Fabricate(:user, username: SecureRandom.hex(8), email: "#{SecureRandom.hex(8)}@example.com")
+    query = create_report
+    payload = <<~SQL.chomp
+      harmless$sql$) SELECT * FROM query;
+      WITH query AS (
+      SELECT email FROM user_emails WHERE user_id = #{victim.id} --
+    SQL
+
+    post "/g/#{group.name}/reports/#{query.id}/run.json", params: { params: { value: payload } }
+
+    expect(response.status).to eq(422)
+    expect(response.parsed_body["errors"]).to eq(
+      [
+        "DiscourseDataExplorer::ValidationError: Parameters cannot be used inside dollar-quoted literals",
+      ],
+    )
+    expect(response.body).not_to include(victim.email)
+  end
+
+  it "rejects a benign group report parameter inside a dollar-quoted literal" do
+    query = create_report
+
+    post "/g/#{group.name}/reports/#{query.id}/run.json",
+         params: {
+           params: {
+             value: "expected value",
+           },
+         }
+
+    expect(response.status).to eq(422)
+    expect(response.parsed_body["errors"]).to eq(
+      [
+        "DiscourseDataExplorer::ValidationError: Parameters cannot be used inside dollar-quoted literals",
+      ],
+    )
+  end
+end


### PR DESCRIPTION
Data Explorer used to splice report parameter values straight into the saved SQL as escaped literals. When a report placed a parameter inside a PostgreSQL dollar-quoted literal, a value could close that literal with its own `$tag$` and append a second statement, because single-quote escaping means nothing inside a dollar quote. A group member running such a report through `POST /g/:group_name/reports/:id/run.json` could use this to read any row the report's database role can see, such as another user's email.

Values now reach PostgreSQL as bind parameters rather than as text. `run_query` rewrites each `:name` marker that sits in real code to a positional `$N` placeholder, collects the values, and passes them to `async_exec_params`, so a value can never be parsed as SQL no matter what it contains. This also closes the multi-statement path, since `exec_params` refuses more than one command.

While the lexer is still regex-based, it is no longer part of the security paradigm of data-explorer.

- A single lexer, `scan_sql_segments`, walks the SQL once and tells the rewriter which `:name` markers are real code and which sit inside a string, comment, or dollar-quoted literal that must be left alone.
- A parameter inside a dollar-quoted literal cannot be a bind, so it is rejected with a clear error instead of being silently mishandled.
- A list value expands to a run of placeholders, so `IN (:ids)` keeps working.
- The workflow raw SQL node runs through the same bind path via `run_query_with_values`, and the old inline `interpolate_params` and its escaping are gone.