### PR TITLE
FIX: Fit both faces of a preview block to its frame

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -351,6 +351,11 @@
 
     > * {
       grid-area: 1 / 1;
+
+      // a face fits the block and scrolls its own overflow, rather than
+      // sizing the shared cell to fit its content
+      min-width: 0;
+      min-height: 0;
     }
 
     &.ProseMirror-selectednode {
@@ -365,9 +370,10 @@
       visibility: hidden;
     }
 
-    // a long source scrolls within a bounded face instead of growing the block
+    // a long source scrolls within a bounded face instead of growing the block.
+    // A preview that frames itself overrides the bound to match that frame.
     &__source {
-      max-height: 14lh;
+      max-height: var(--composer-preview-node-source-max-height, 14lh);
     }
 
     &__source pre {

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/preview-node-view-test.gjs
@@ -193,6 +193,24 @@ module(
       );
     });
 
+    test("keeps a long source line inside the block", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      await insertBlock(editorClass.view, "x".repeat(400));
+      await toggleSource(editorClass.view);
+
+      const block = document.querySelector(".composer-preview-node");
+      const source = document.querySelector(".composer-preview-node__source");
+
+      assert.true(
+        source.clientWidth <= block.clientWidth,
+        "the source face stays within the block rather than widening it"
+      );
+      assert.true(
+        block.clientWidth <= block.parentElement.clientWidth,
+        "so the block stays within the editor"
+      );
+    });
+
     test("renders again when the source changes under a shown preview", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, "");
       await insertBlock(editorClass.view, "before");

--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -11,10 +11,11 @@ div.graphviz.is-loading,
   }
 }
 
-// Match the cooked diagram frame and keep long source inside it.
+// The block frames the diagram as the cooked wrapper does, so both faces fit
+// that frame and scroll whatever does not fit inside it.
 .composer-graphviz-node {
+  --composer-preview-node-source-max-height: 100%;
   aspect-ratio: 16 / 9;
-  min-height: 3em;
 }
 
 // Hide the raw DOT source until the client replaces the placeholder.

--- a/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/discourse-graphviz/test/javascripts/integration/rich-editor-extension-test.js
@@ -56,13 +56,24 @@ module(
     test("constrains a diagram with tall source", async function (assert) {
       await setupRichEditor(assert, TALL_GRAPH);
 
-      const { height, width } = find(
-        ".composer-graphviz-node"
-      ).getBoundingClientRect();
+      const block = find(".composer-graphviz-node");
+      const source = find(".composer-preview-node__source");
+      const pre = source.querySelector("pre");
+      const { height, width } = block.getBoundingClientRect();
 
       assert.true(
         Math.abs(height / width - 9 / 16) < 0.01,
         "the diagram uses the same aspect ratio as its cooked preview"
+      );
+
+      assert.true(
+        Math.abs(source.clientHeight - block.clientHeight) <= 1,
+        "the source face fills the frame, neither overflowing nor falling short"
+      );
+
+      assert.true(
+        pre.scrollHeight > pre.clientHeight,
+        "the source scrolls within the frame"
       );
     });
 


### PR DESCRIPTION
Previously, a preview block's height came from two rules that did not know about each other: the feature framed the block, while core capped the source face at `14lh`. Whichever was shorter lost, so a Graphviz diagram left dead space under its source on desktop and cut the bottom of the source off on mobile, and a long source line pushed the block wider than the editor.

This lets a face fit the block instead of sizing the shared cell to its own content, and exposes the source cap as `--composer-preview-node-source-max-height`, which a feature that frames itself sets to `100%`.