### PR TITLE
PERF: Skip the chat hotlinked images job when nothing is hotlinked

### DIFF
--- a/lib/hotlinked_media.rb
+++ b/lib/hotlinked_media.rb
@@ -28,6 +28,26 @@ module HotlinkedMedia
     src
   end
 
+  # Whether +src+ points somewhere this site does not serve, and so is a
+  # candidate for downloading. Cheap by design: no database or network access.
+  def self.remote_src?(src)
+    return false if src.blank?
+    return false if src.downcase.start_with?("data:")
+    return false if src.start_with?("/") && !src.start_with?("//")
+    return false if Discourse.store.has_been_uploaded?(src)
+
+    !PostHotlinkedMedia.normalize_src(src).start_with?(*local_bases)
+  end
+
+  def self.local_bases
+    [
+      Discourse.base_url.presence,
+      Discourse.asset_host.presence,
+      SiteSetting.external_emoji_url.presence,
+    ].compact.map { |base| PostHotlinkedMedia.normalize_src(base) }
+  end
+  private_class_method :local_bases
+
   # Downloads +src+ for +user_id+, returning [status, upload]. The status is the
   # one to record against the target; upload is nil unless it is :downloaded.
   def self.download(src, user_id, tmp_file_name:)

--- a/plugins/chat/app/jobs/regular/chat/process_message.rb
+++ b/plugins/chat/app/jobs/regular/chat/process_message.rb
@@ -4,6 +4,8 @@ module Jobs
   module Chat
     class ProcessMessage < ::Jobs::Base
       def execute(args = {})
+        hotlinked_media_pending = false
+
         ::DistributedMutex.synchronize(
           "jobs_chat_process_message_#{args[:chat_message_id]}",
           validity: 10.minutes,
@@ -28,10 +30,9 @@ module Jobs
             )
           end
 
-          chat_message
-            .hotlinked_media
-            .where.not(id: processor.used_hotlinked_media_ids.to_a)
-            .destroy_all
+          stale_ids = processor.stale_hotlinked_media_ids
+          chat_message.hotlinked_media.where(id: stale_ids).destroy_all if stale_ids.present?
+          hotlinked_media_pending = processor.hotlinked_media_pending?
 
           # we don't process mentions when creating/updating message so we always have to do it
           chat_message.upsert_mentions
@@ -52,8 +53,8 @@ module Jobs
 
         # outside the mutex: the pull job re-cooks through this job, and would
         # block on the lock we still hold whenever jobs run inline
-        if !args[:skip_pull_hotlinked_images] && SiteSetting.download_remote_images_to_local? &&
-             SiteSetting.chat_allow_uploads?
+        if hotlinked_media_pending && !args[:skip_pull_hotlinked_images] &&
+             SiteSetting.download_remote_images_to_local? && SiteSetting.chat_allow_uploads?
           ::Jobs.enqueue(::Jobs::Chat::PullHotlinkedImages, chat_message_id: args[:chat_message_id])
         end
       end

--- a/plugins/chat/app/jobs/regular/chat/process_message.rb
+++ b/plugins/chat/app/jobs/regular/chat/process_message.rb
@@ -32,7 +32,11 @@ module Jobs
 
           stale_ids = processor.stale_hotlinked_media_ids
           chat_message.hotlinked_media.where(id: stale_ids).destroy_all if stale_ids.present?
-          hotlinked_media_pending = processor.hotlinked_media_pending?
+          # the pull job's own re-cook comes back with skip_pull set, and the
+          # check walks the doc and resolves every local upload URL
+          if !args[:skip_pull_hotlinked_images]
+            hotlinked_media_pending = processor.hotlinked_media_pending?
+          end
 
           # we don't process mentions when creating/updating message so we always have to do it
           chat_message.upsert_mentions
@@ -53,8 +57,8 @@ module Jobs
 
         # outside the mutex: the pull job re-cooks through this job, and would
         # block on the lock we still hold whenever jobs run inline
-        if hotlinked_media_pending && !args[:skip_pull_hotlinked_images] &&
-             SiteSetting.download_remote_images_to_local? && SiteSetting.chat_allow_uploads?
+        if hotlinked_media_pending && SiteSetting.download_remote_images_to_local? &&
+             SiteSetting.chat_allow_uploads?
           ::Jobs.enqueue(::Jobs::Chat::PullHotlinkedImages, chat_message_id: args[:chat_message_id])
         end
       end

--- a/plugins/chat/app/jobs/regular/chat/pull_hotlinked_images.rb
+++ b/plugins/chat/app/jobs/regular/chat/pull_hotlinked_images.rb
@@ -10,8 +10,6 @@ module Jobs
         raise Discourse::InvalidParameters.new(:chat_message_id) if @chat_message_id.blank?
         return if !SiteSetting.chat_allow_uploads?
 
-        disable_if_low_on_disk_space
-
         if Jobs.run_immediately?
           pull
         else
@@ -41,7 +39,7 @@ module Jobs
             next if node.name != "img"
 
             download_src = HotlinkedMedia.download_src_for(node)
-            next if !should_download?(download_src)
+            next if !::Chat::MessageHotlinkedMedia.downloadable?(download_src)
 
             normalized_src = ::Chat::MessageHotlinkedMedia.normalize_src(download_src)
             if (existing = hotlinked_map[normalized_src])
@@ -50,6 +48,8 @@ module Jobs
               needs_recook = true if existing.downloaded? && existing.upload
               next
             end
+
+            next if !enough_disk_space?
 
             status, upload =
               HotlinkedMedia.download(
@@ -85,7 +85,9 @@ module Jobs
           <<~SQL,
           INSERT INTO chat_message_hotlinked_media (chat_message_id, url, status, upload_id, created_at, updated_at)
           VALUES (:chat_message_id, :url, :status, :upload_id, NOW(), NOW())
-          ON CONFLICT (chat_message_id, md5(url)) DO NOTHING
+          ON CONFLICT (chat_message_id, md5(url)) DO UPDATE
+          SET status = EXCLUDED.status, upload_id = EXCLUDED.upload_id, updated_at = NOW()
+          WHERE chat_message_hotlinked_media.upload_id IS NULL AND EXCLUDED.upload_id IS NOT NULL
         SQL
           chat_message_id: chat_message.id,
           url: normalized_src,
@@ -95,40 +97,13 @@ module Jobs
         ::Chat::MessageHotlinkedMedia.find_by(chat_message_id: chat_message.id, url: normalized_src)
       end
 
-      def should_download?(src)
-        return false if src.blank?
-        return false if !SiteSetting.download_remote_images_to_local?
-        return false if !SiteSetting.chat_allow_uploads?
-        return false if src.start_with?("data:")
-        # Downloading these means signing an S3 path for the underlying upload.
-        # Posts gate that on the author seeing the access-control post; chat
-        # messages have none, so there is nothing to authorize against.
-        return false if Upload.secure_uploads_url?(src)
+      # `df` forks a process, so only pay for it once there is something to
+      # download; the overwhelming majority of messages have nothing.
+      def enough_disk_space?
+        return @enough_disk_space if defined?(@enough_disk_space)
 
-        local_bases =
-          [
-            Discourse.base_url,
-            Discourse.asset_host,
-            SiteSetting.external_emoji_url.presence,
-          ].compact.map { |s| ::Chat::MessageHotlinkedMedia.normalize_src(s) }
-
-        if Discourse.store.has_been_uploaded?(src) ||
-             ::Chat::MessageHotlinkedMedia.normalize_src(src).start_with?(*local_bases) ||
-             src =~ %r{\A/[^/]}i
-          return false if src !~ %r{/uploads/}
-          # pass nil: chat messages have no access-control post to reuse against
-          upload = Upload.consider_for_reuse(Upload.get_from_url(src), nil)
-          return !upload.present?
-        end
-
-        begin
-          uri = URI.parse(src)
-        rescue URI::Error
-          return false
-        end
-        return false if uri.hostname.blank?
-
-        SiteSetting.should_download_images?(src)
+        disable_if_low_on_disk_space
+        @enough_disk_space = SiteSetting.download_remote_images_to_local?
       end
 
       def disable_if_low_on_disk_space

--- a/plugins/chat/app/models/chat/message_hotlinked_media.rb
+++ b/plugins/chat/app/models/chat/message_hotlinked_media.rb
@@ -19,6 +19,35 @@ module Chat
     def self.normalize_src(src, reset_scheme: true)
       PostHotlinkedMedia.normalize_src(src, reset_scheme: reset_scheme)
     end
+
+    # Whether the pull job would fetch +src+. The cook consults this too, to
+    # decide whether handing the message to that job is worth a job slot.
+    def self.downloadable?(src)
+      return false if src.blank?
+      return false if !SiteSetting.download_remote_images_to_local?
+      return false if !SiteSetting.chat_allow_uploads?
+      return false if src.downcase.start_with?("data:")
+      # Host-agnostic on purpose: the downloader signs our own S3 path for any
+      # URL shaped like this, whoever serves it. Posts gate that on the author
+      # seeing the access-control post; chat messages have none, so there is
+      # nothing to authorize against.
+      return false if Upload.secure_uploads_url?(src)
+
+      if !HotlinkedMedia.remote_src?(src)
+        return false if src !~ %r{/uploads/}
+        # pass nil: chat messages have no access-control post to reuse against
+        return !Upload.consider_for_reuse(Upload.get_from_url(src), nil).present?
+      end
+
+      begin
+        uri = URI.parse(src)
+      rescue URI::Error
+        return false
+      end
+      return false if uri.hostname.blank?
+
+      SiteSetting.should_download_images?(src)
+    end
   end
 end
 

--- a/plugins/chat/lib/chat/message_processor.rb
+++ b/plugins/chat/lib/chat/message_processor.rb
@@ -5,7 +5,7 @@ module Chat
     include ::CookedProcessorMixin
     IMG_FILETYPES = %w[jpg jpeg gif png heic heif webp]
 
-    attr_reader :used_hotlinked_media_ids
+    attr_reader :stale_hotlinked_media_ids
 
     def initialize(chat_message, opts = {})
       @model = chat_message
@@ -14,6 +14,7 @@ module Chat
       @size_cache = {}
       @opts = opts
       @used_hotlinked_media_ids = Set.new
+      @stale_hotlinked_media_ids = []
 
       cook_opts = {
         user_id: chat_message.last_editor_id,
@@ -35,23 +36,43 @@ module Chat
 
     # Unlike posts, chat keeps the hotlinked src when a download fails or is too large.
     def process_hotlinked_image(img)
-      normalized_src =
-        Chat::MessageHotlinkedMedia.normalize_src(HotlinkedMedia.download_src_for(img))
-      info = hotlinked_media_map[normalized_src]
-      used_hotlinked_media_ids << info.id if info
+      download_src = HotlinkedMedia.download_src_for(img)
+      info = hotlinked_media_map[Chat::MessageHotlinkedMedia.normalize_src(download_src)]
+      @used_hotlinked_media_ids << info.id if info
 
       if info&.downloaded? && (upload = info.upload)
         img["src"] = UrlHelper.cook_url(upload.url, secure: upload.secure?)
         img["data-base62-sha1"] = upload.base62_sha1
         img["data-dominant-color"] = upload.dominant_color(calculate_if_missing: true).presence
         img.delete(PrettyText::BLOCKED_HOTLINKED_SRC_ATTR)
+        img.delete(PrettyText::BLOCKED_HOTLINKED_SRCSET_ATTR)
       end
 
       true
     end
 
     def process_hotlinked_images
-      extract_images.each { |img| process_hotlinked_image(img) }
+      images = extract_images
+      # snapshot the tracked rows here rather than at sweep time, so a row the
+      # pull job inserts while we work is not carried away as unused
+      tracked_ids = hotlinked_media_map.each_value.map(&:id)
+      images.each { |img| process_hotlinked_image(img) }
+      @stale_hotlinked_media_ids = tracked_ids - @used_hotlinked_media_ids.to_a
+    end
+
+    # The pull job costs a job slot, a lock and a disk check per message, so let
+    # the cook decide whether there is anything for it to do. Mirrors the job's
+    # own loop: anything looser enqueues for nothing, anything tighter leaves an
+    # image hotlinked for good.
+    def hotlinked_media_pending?
+      return true if @used_hotlinked_media_ids.any?
+
+      HotlinkedMedia
+        .extract_candidates(@doc)
+        .any? do |node|
+          node.name == "img" &&
+            Chat::MessageHotlinkedMedia.downloadable?(HotlinkedMedia.download_src_for(node))
+        end
     end
 
     def process_thumbnails
@@ -92,23 +113,35 @@ module Chat
         .css("img")
         .each do |img|
           if img["class"]&.include?("emoji") || img["class"]&.include?("avatar") ||
-               img["data-base62-sha1"].blank? || img.ancestors(".onebox, .onebox-body").any?
+               img["data-base62-sha1"].blank? || img.classes.include?("onebox") ||
+               img.ancestors(".onebox, .onebox-body").any?
             next
           end
 
-          sha1 = Upload.sha1_from_base62_encoded(img["data-base62-sha1"])
-          if upload = Upload.find_by(sha1: sha1)
-            img["data-large-src"] = UrlHelper.cook_url(upload.url, secure: upload.secure?)
-            img["data-download-href"] = upload.short_path
-            img["data-target-width"] = upload.width
-            img["data-target-height"] = upload.height
-            img["class"] = "#{img["class"]} lightbox".strip
-          end
+          upload = upload_for_base62_sha1(img["data-base62-sha1"])
+          next if upload.blank?
+
+          img["data-large-src"] = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+          img["data-download-href"] = upload.short_path
+          img["data-target-width"] = upload.width
+          img["data-target-height"] = upload.height
+          img["class"] = "#{img["class"]} lightbox".strip
         end
     end
 
     def hotlinked_media_map
       @hotlinked_media_map ||= @model.hotlinked_media.preload(:upload).index_by(&:url)
+    end
+
+    def upload_for_base62_sha1(base62_sha1)
+      hotlinked_uploads.fetch(base62_sha1) do
+        Upload.find_by(sha1: Upload.sha1_from_base62_encoded(base62_sha1))
+      end
+    end
+
+    def hotlinked_uploads
+      @hotlinked_uploads ||=
+        hotlinked_media_map.each_value.filter_map(&:upload).index_by(&:base62_sha1)
     end
 
     def large_images

--- a/plugins/chat/lib/chat/message_processor.rb
+++ b/plugins/chat/lib/chat/message_processor.rb
@@ -65,13 +65,16 @@ module Chat
     # own loop: anything looser enqueues for nothing, anything tighter leaves an
     # image hotlinked for good.
     def hotlinked_media_pending?
-      return true if @used_hotlinked_media_ids.any?
-
       HotlinkedMedia
         .extract_candidates(@doc)
         .any? do |node|
-          node.name == "img" &&
-            Chat::MessageHotlinkedMedia.downloadable?(HotlinkedMedia.download_src_for(node))
+          next false if node.name != "img"
+
+          download_src = HotlinkedMedia.download_src_for(node)
+          next false if !Chat::MessageHotlinkedMedia.downloadable?(download_src)
+
+          normalized_src = Chat::MessageHotlinkedMedia.normalize_src(download_src)
+          !hotlinked_media_map.key?(normalized_src)
         end
     end
 

--- a/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
@@ -97,9 +97,7 @@ describe Jobs::Chat::ProcessMessage do
       end
     end
 
-    # the job also repairs a stored cooked that lost its localization, so keep
-    # handing it messages whose media the cook already localized
-    it "enqueues the pull job for a message that already tracks hotlinked media" do
+    it "does not enqueue the pull job when tracked media is localized during processing" do
       SiteSetting.download_remote_images_to_local = true
       Chat::MessageHotlinkedMedia.create!(
         chat_message: hotlinked_message,
@@ -108,12 +106,22 @@ describe Jobs::Chat::ProcessMessage do
         upload: Fabricate(:upload),
       )
 
-      expect_enqueued_with(
-        job: Jobs::Chat::PullHotlinkedImages,
-        args: {
-          chat_message_id: hotlinked_message.id,
-        },
-      ) { described_class.new.execute(chat_message_id: hotlinked_message.id) }
+      expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
+        described_class.new.execute(chat_message_id: hotlinked_message.id)
+      end
+    end
+
+    it "does not enqueue the pull job for tracked media with a terminal failure" do
+      SiteSetting.download_remote_images_to_local = true
+      Chat::MessageHotlinkedMedia.create!(
+        chat_message: hotlinked_message,
+        url: Chat::MessageHotlinkedMedia.normalize_src(image_url),
+        status: :too_large,
+      )
+
+      expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
+        described_class.new.execute(chat_message_id: hotlinked_message.id)
+      end
     end
 
     it "enqueues the pull job for a local upload URL that resolves to nothing" do

--- a/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
@@ -192,6 +192,9 @@ describe Jobs::Chat::ProcessMessage do
     # the two jobs enqueueing each other
     it "does not enqueue the pull job when it was the pull job that asked for the re-cook" do
       SiteSetting.download_remote_images_to_local = true
+      # the check walks the doc and resolves every local upload URL, so don't
+      # pay for it when the answer is already ignored
+      Chat::MessageProcessor.any_instance.expects(:hotlinked_media_pending?).never
 
       expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
         described_class.new.execute(

--- a/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
@@ -71,22 +71,79 @@ describe Jobs::Chat::ProcessMessage do
   end
 
   describe "pull hotlinked images" do
+    let(:image_url) { "https://example.com/img.png" }
+    fab!(:hotlinked_message) do
+      Fabricate(:chat_message, message: "![](https://example.com/img.png)")
+    end
+
     it "enqueues the pull job when download_remote_images_to_local is enabled" do
       SiteSetting.download_remote_images_to_local = true
 
       expect_enqueued_with(
         job: Jobs::Chat::PullHotlinkedImages,
         args: {
-          chat_message_id: chat_message.id,
+          chat_message_id: hotlinked_message.id,
         },
-      ) { described_class.new.execute(chat_message_id: chat_message.id) }
+      ) { described_class.new.execute(chat_message_id: hotlinked_message.id) }
+    end
+
+    # the job costs a slot, a lock and a disk check, and the overwhelming
+    # majority of messages have nothing external in them
+    it "does not enqueue the pull job for a message with nothing to fetch" do
+      SiteSetting.download_remote_images_to_local = true
+
+      expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
+        described_class.new.execute(chat_message_id: chat_message.id)
+      end
+    end
+
+    # the job also repairs a stored cooked that lost its localization, so keep
+    # handing it messages whose media the cook already localized
+    it "enqueues the pull job for a message that already tracks hotlinked media" do
+      SiteSetting.download_remote_images_to_local = true
+      Chat::MessageHotlinkedMedia.create!(
+        chat_message: hotlinked_message,
+        url: Chat::MessageHotlinkedMedia.normalize_src(image_url),
+        status: :downloaded,
+        upload: Fabricate(:upload),
+      )
+
+      expect_enqueued_with(
+        job: Jobs::Chat::PullHotlinkedImages,
+        args: {
+          chat_message_id: hotlinked_message.id,
+        },
+      ) { described_class.new.execute(chat_message_id: hotlinked_message.id) }
+    end
+
+    it "enqueues the pull job for a local upload URL that resolves to nothing" do
+      SiteSetting.download_remote_images_to_local = true
+      orphan_url = "#{Discourse.base_url}/uploads/default/original/1X/#{SecureRandom.hex(20)}.png"
+      message = Fabricate(:chat_message, message: "![](#{orphan_url})")
+
+      expect_enqueued_with(
+        job: Jobs::Chat::PullHotlinkedImages,
+        args: {
+          chat_message_id: message.id,
+        },
+      ) { described_class.new.execute(chat_message_id: message.id) }
+    end
+
+    it "does not enqueue the pull job for an image that is already a local upload" do
+      SiteSetting.download_remote_images_to_local = true
+      upload = Fabricate(:upload)
+      message = Fabricate(:chat_message, message: "![](#{upload.url})")
+
+      expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
+        described_class.new.execute(chat_message_id: message.id)
+      end
     end
 
     it "does not enqueue the pull job when download_remote_images_to_local is disabled" do
       SiteSetting.download_remote_images_to_local = false
 
       expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
-        described_class.new.execute(chat_message_id: chat_message.id)
+        described_class.new.execute(chat_message_id: hotlinked_message.id)
       end
     end
 
@@ -95,7 +152,7 @@ describe Jobs::Chat::ProcessMessage do
       SiteSetting.chat_allow_uploads = false
 
       expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
-        described_class.new.execute(chat_message_id: chat_message.id)
+        described_class.new.execute(chat_message_id: hotlinked_message.id)
       end
     end
 
@@ -130,7 +187,7 @@ describe Jobs::Chat::ProcessMessage do
 
       expect_not_enqueued_with(job: Jobs::Chat::PullHotlinkedImages) do
         described_class.new.execute(
-          chat_message_id: chat_message.id,
+          chat_message_id: hotlinked_message.id,
           skip_pull_hotlinked_images: true,
         )
       end
@@ -152,6 +209,33 @@ describe Jobs::Chat::ProcessMessage do
     expect { described_class.new.execute(chat_message_id: message.id) }.to change {
       Chat::MessageHotlinkedMedia.exists?(record.id)
     }.from(true).to(false)
+  end
+
+  # the pull job inserts rows while we cook, so sweeping everything the cook did
+  # not use would carry away a row that did not exist yet when it read them
+  it "keeps hotlinked media inserted after the cook read the tracked rows" do
+    image_url = "https://example.com/late.png"
+    message = Fabricate(:chat_message, message: "![](#{image_url})")
+    record = nil
+    insert_late_row =
+      Proc.new do
+        record ||=
+          Chat::MessageHotlinkedMedia.create!(
+            chat_message: message,
+            url: Chat::MessageHotlinkedMedia.normalize_src(image_url),
+            status: :downloaded,
+            upload: Fabricate(:upload),
+          )
+      end
+
+    DiscourseEvent.on(:chat_message_processed, &insert_late_row)
+    begin
+      described_class.new.execute(chat_message_id: message.id)
+    ensure
+      DiscourseEvent.off(:chat_message_processed, &insert_late_row)
+    end
+
+    expect(Chat::MessageHotlinkedMedia.exists?(record.id)).to eq(true)
   end
 
   describe "skip_notifications" do

--- a/plugins/chat/spec/jobs/regular/chat/pull_hotlinked_images_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/pull_hotlinked_images_spec.rb
@@ -67,6 +67,35 @@ describe Jobs::Chat::PullHotlinkedImages do
       expect(message.upload_references).to be_empty
     end
 
+    # a racing job can insert the row between our download and our insert; the
+    # upload we just created has no other reference, so the row has to claim it
+    it "claims the download when a racing job already recorded a failure" do
+      stub_image_size
+      message = fabricate_chat_message("![longcat](#{image_url})")
+      record =
+        Chat::MessageHotlinkedMedia.create!(
+          chat_message: message,
+          url: Chat::MessageHotlinkedMedia.normalize_src(image_url),
+          status: :download_failed,
+        )
+      # the pull reads its map before the racing row lands
+      Chat::Message.any_instance.stubs(:hotlinked_media).returns(Chat::MessageHotlinkedMedia.none)
+
+      described_class.new.execute(chat_message_id: message.id)
+
+      record.reload
+      expect(record).to be_downloaded
+      expect(record.upload).to eq(Upload.last)
+      expect(Chat::MessageHotlinkedMedia.where(chat_message_id: message.id).count).to eq(1)
+    end
+
+    it "does not run the disk space check when there is nothing to download" do
+      message = fabricate_chat_message("just text")
+      DiskSpace.expects(:percent_free).never
+
+      described_class.new.execute(chat_message_id: message.id)
+    end
+
     it "records terminal failures without changing the message or retrying" do
       raw = "![broken](#{broken_image_url})"
       message = fabricate_chat_message(raw)
@@ -249,6 +278,29 @@ describe Jobs::Chat::PullHotlinkedImages do
           }
           expect(message.reload.hotlinked_media).to be_empty
         end
+        expect(WebMock).not_to have_requested(:get, /amazonaws\.com/)
+      end
+
+      # the downloader signs our own S3 path for anything shaped like a secure
+      # upload URL, so a foreign host serving that path must be rejected too
+      it "does not rehost a secure upload path served by another host" do
+        global_setting :allow_unsecure_chat_uploads, true
+        SiteSetting.chat_allow_uploads = true
+        foreign_url =
+          "https://attacker.example/secure-uploads/original/1X/1234567890abcdef1234567890abcdef12345678.png"
+        stub_request(:get, foreign_url).to_return(
+          body: gif,
+          headers: {
+            "Content-Type" => "image/gif",
+          },
+        )
+        stub_image_size
+        message = fabricate_chat_message("![](#{foreign_url})")
+
+        expect { described_class.new.execute(chat_message_id: message.id) }.not_to change {
+          Upload.count
+        }
+        expect(message.reload.hotlinked_media).to be_empty
         expect(WebMock).not_to have_requested(:get, /amazonaws\.com/)
       end
     end

--- a/plugins/chat/spec/lib/chat/message_processor_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_processor_spec.rb
@@ -105,6 +105,21 @@ RSpec.describe Chat::MessageProcessor do
       end
     end
 
+    it "clears both blocked-hotlinked attributes once the image is localized" do
+      create_downloaded_record(message)
+      Chat::Message.stubs(:cook).returns(<<~HTML)
+        <p><img #{PrettyText::BLOCKED_HOTLINKED_SRC_ATTR}="#{image_url}" #{PrettyText::BLOCKED_HOTLINKED_SRCSET_ATTR}="#{image_url} 2x"></p>
+      HTML
+
+      processor = described_class.new(message)
+      processor.run!
+
+      img = processor.instance_variable_get(:@doc).at_css("img")
+      expect(img["src"]).to eq(UrlHelper.cook_url(upload.url, secure: upload.secure?))
+      expect(img[PrettyText::BLOCKED_HOTLINKED_SRC_ATTR]).to be_nil
+      expect(img[PrettyText::BLOCKED_HOTLINKED_SRCSET_ATTR]).to be_nil
+    end
+
     it "leaves the hotlinked src for failed or oversized downloads" do
       Chat::MessageHotlinkedMedia.create!(
         chat_message: message,
@@ -145,6 +160,19 @@ RSpec.describe Chat::MessageProcessor do
       expect(img["data-download-href"]).to eq(upload.short_path)
       expect(img["data-target-width"]).to eq(upload.width.to_s)
       expect(img["data-target-height"]).to eq(upload.height.to_s)
+    end
+
+    it "does not lightbox an image the onebox engine already wrapped" do
+      cooked_html =
+        "<p><img class=\"onebox\" src=\"#{upload.url}\" data-base62-sha1=\"#{base62}\"></p>"
+
+      Chat::Message.stubs(:cook).returns(cooked_html)
+      processor = described_class.new(message)
+
+      processor.run!
+
+      img = processor.instance_variable_get(:@doc).at_css("img")
+      expect(img["class"]).not_to include("lightbox")
     end
 
     context "with secure uploads enabled" do


### PR DESCRIPTION
Every chat message enqueued `Jobs::Chat::PullHotlinkedImages`, which forked `df` and took a distributed lock before discovering the message had no external images, and its tracking rows could be swept away by a re-cook running concurrently with the download.

This change lets the cook decide whether the job has anything to do, defers the disk check to the first download, and sweeps from a snapshot taken during the cook so a row inserted meanwhile survives.