### PR TITLE
FIX: Block restricted code signups before OTP

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -502,8 +502,13 @@ class SessionController < ApplicationController
     # the behavior for emails we refuse to deliver to.
     return render json: success_json if login_code_honeypot_fails?
 
-    EmailLoginCode::Request.call(service_params) do |result|
+    EmailLoginCode::Request.call(
+      service_params.deep_merge(ip_address: request.remote_ip),
+    ) do |result|
       on_success { render json: success_json }
+      on_failed_policy(:can_register_from_ip) do
+        render json: login_code_registration_ip_limit_error
+      end
       on_failed_contract do |contract|
         render json: failed_json.merge(errors: contract.errors.full_messages), status: :bad_request
       end
@@ -1029,6 +1034,15 @@ class SessionController < ApplicationController
     { error: I18n.t("email_login_code.invalid_code") }
   end
 
+  def login_code_registration_ip_limit_error
+    {
+      error:
+        I18n.t(
+          "activerecord.errors.models.user.attributes.ip_address.max_new_accounts_per_registration_ip",
+        ),
+    }
+  end
+
   def login_code_account_error(user)
     ip_error =
       user.errors.find do |error|
@@ -1036,11 +1050,7 @@ class SessionController < ApplicationController
           error.type.in?(%i[blocked max_new_accounts_per_registration_ip])
       end
 
-    if ip_error
-      { error: I18n.t("email_login_code.account_creation_failed") }
-    else
-      invalid_login_code
-    end
+    ip_error ? { error: ip_error.message } : invalid_login_code
   end
 
   def invalid_credentials

--- a/app/services/email_login_code/request.rb
+++ b/app/services/email_login_code/request.rb
@@ -5,6 +5,7 @@ class EmailLoginCode::Request
 
   params do
     attribute :email, :string
+    attribute :signup, :boolean, default: false
 
     before_validation { self.email = email.to_s.strip.downcase }
 
@@ -18,6 +19,7 @@ class EmailLoginCode::Request
               }
   end
 
+  only_if(:signup?) { policy :can_register_from_ip }
   model :user, optional: true
   only_if(:existing_account?) { step :trigger_before_email_login }
 
@@ -27,6 +29,14 @@ class EmailLoginCode::Request
   end
 
   private
+
+  def signup?(params:)
+    params.signup
+  end
+
+  def can_register_from_ip(ip_address:)
+    !SpamHandler.should_prevent_registration_from_ip?(ip_address)
+  end
 
   def fetch_user(params:)
     User.real.where(staged: false).with_email(params.email).first

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1098,7 +1098,6 @@ en:
 
   email_login_code:
     invalid_code: "That code is incorrect or has expired. Request a new code and try again."
-    account_creation_failed: "We couldn't create your account. Please try again later or contact a staff member."
 
   browsers:
     android_browser: "Android Browser"

--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -567,14 +567,20 @@ export default class CodeLoginForm extends Component {
 
     try {
       const honeypot = await ajax("/session/hp.json");
-      await ajax("/session/login-code", {
+      const result = await ajax("/session/login-code", {
         type: "POST",
         data: {
           email: this.email,
+          signup: this.isSignup,
           password_confirmation: honeypot.value,
           challenge: honeypot.challenge.split("").reverse().join(""),
         },
       });
+
+      if (result?.error) {
+        this.codeError = result.error;
+        return false;
+      }
 
       this.step = "code";
       this.startResendCooldown();
@@ -678,6 +684,12 @@ export default class CodeLoginForm extends Component {
           >
             <field.Control autofocus="autofocus" autocomplete="username" />
           </form.Field>
+
+          {{#if this.codeError}}
+            <div class="code-login-form__error" aria-live="polite" role="alert">
+              {{this.codeError}}
+            </div>
+          {{/if}}
 
           <div class="code-login-form__email-actions">
             <form.Submit

--- a/frontend/discourse/tests/integration/components/code-login-form-test.gjs
+++ b/frontend/discourse/tests/integration/components/code-login-form-test.gjs
@@ -62,6 +62,56 @@ module("Integration | Component | CodeLoginForm", function (hooks) {
     assert.dom(".code-login-form__resend").exists();
   });
 
+  test("signup requests declare their intent", async function (assert) {
+    let signup;
+    pretender.get("/session/hp.json", () =>
+      response({ value: "hp-value", challenge: "abc", expires_in: 300 })
+    );
+    pretender.post("/session/login-code", (request) => {
+      signup = new URLSearchParams(request.requestBody).get("signup");
+      return response({ success: "OK" });
+    });
+
+    await render(<template><CodeLoginForm @context="signup" /></template>);
+    await fillIn(
+      ".code-login-form__email-step .form-kit__control-input",
+      "user@example.com"
+    );
+    await formKit().submit();
+
+    assert.strictEqual(signup, "true", "the request identifies signup intent");
+    assert
+      .dom(".code-login-form__code-step")
+      .exists("the form advances after the request succeeds");
+  });
+
+  test("shows a request error without advancing to the code step", async function (assert) {
+    const error =
+      "New registrations are not allowed from your IP address (maximum limit reached). Contact a staff member.";
+    pretender.get("/session/hp.json", () =>
+      response({ value: "hp-value", challenge: "abc", expires_in: 300 })
+    );
+    pretender.post("/session/login-code", () => response({ error }));
+
+    await render(<template><CodeLoginForm @context="signup" /></template>);
+    await fillIn(
+      ".code-login-form__email-step .form-kit__control-input",
+      "user@example.com"
+    );
+    await formKit().submit();
+
+    assert
+      .dom(".code-login-form__email-step")
+      .exists("the email step remains visible");
+    assert
+      .dom(".code-login-form__error")
+      .hasText(error, "the account limit error is shown inline");
+    assert
+      .dom(".code-login-form__code-step")
+      .doesNotExist("the code step is not rendered");
+    assert.dom(".d-otp-input").doesNotExist("the code input is not rendered");
+  });
+
   test("keeps a hidden email field for password managers after the email step", async function (assert) {
     stubCodeRequest();
 

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -657,6 +657,56 @@ RSpec.describe SessionController do
       expect(response.body).to eq(existing_email_body)
     end
 
+    context "when the signup IP has reached the account limit" do
+      let(:ip_address) { "192.0.2.1" }
+
+      before do
+        Fabricate(:user, ip_address:, trust_level: TrustLevel[0])
+        SiteSetting.max_new_accounts_per_registration_ip = 1
+      end
+
+      it "returns the account limit error without sending a code for any email" do
+        expect_not_enqueued_with(job: :send_email_login_code) do
+          post "/session/login-code.json",
+               params: honeypot_magic(email: user.email, signup: true),
+               env: {
+                 REMOTE_ADDR: ip_address,
+               }
+          existing_email_response = response.parsed_body
+
+          post "/session/login-code.json",
+               params: honeypot_magic(email: "unknown@example.com", signup: true),
+               env: {
+                 REMOTE_ADDR: ip_address,
+               }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body).to eq(existing_email_response)
+          expect(response.parsed_body["error"]).to eq(
+            I18n.t(
+              "activerecord.errors.models.user.attributes.ip_address.max_new_accounts_per_registration_ip",
+            ),
+          )
+        end
+
+        expect(EmailLoginCode.count).to eq(0)
+      end
+
+      it "continues to send login codes for existing accounts" do
+        expect_enqueued_with(job: :send_email_login_code, args: { to_address: user.email }) do
+          post "/session/login-code.json",
+               params: honeypot_magic(email: user.email, signup: false),
+               env: {
+                 REMOTE_ADDR: ip_address,
+               }
+        end
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+        expect(EmailLoginCode.for_email(user.email).count).to eq(1)
+      end
+    end
+
     context "when rate limited" do
       before { RateLimiter.enable }
 
@@ -976,7 +1026,9 @@ RSpec.describe SessionController do
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["error"]).to eq(
-          I18n.t("email_login_code.account_creation_failed"),
+          I18n.t(
+            "activerecord.errors.models.user.attributes.ip_address.max_new_accounts_per_registration_ip",
+          ),
         )
         expect(User.find_by_email("newuser@example.com")).to be_nil
         expect(session[:current_user_id]).to be_nil

--- a/spec/services/email_login_code/request_spec.rb
+++ b/spec/services/email_login_code/request_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe EmailLoginCode::Request do
     it { is_expected.to validate_length_of(:email).is_at_most(513) }
     it { is_expected.to allow_values("foo@example.com", "Foo.Bar@example.com").for(:email) }
     it { is_expected.not_to allow_values("not-an-email", "foo@").for(:email) }
+
+    it "defaults signup to false and coerces string booleans" do
+      expect(described_class.new(email: "foo@example.com").signup).to be(false)
+      expect(described_class.new(email: "foo@example.com", signup: "true").signup).to be(true)
+      expect(described_class.new(email: "foo@example.com", signup: "false").signup).to be(false)
+    end
   end
 
   describe ".call" do
@@ -21,6 +27,44 @@ RSpec.describe EmailLoginCode::Request do
       let(:email) { "not-an-email" }
 
       it { is_expected.to fail_a_contract }
+    end
+
+    context "when the signup IP has reached the account limit" do
+      let(:email) { "newuser@example.com" }
+      let(:ip_address) { "192.0.2.1" }
+      let(:dependencies) { { ip_address: } }
+      let(:params) { { email:, signup: "true" } }
+
+      before do
+        Fabricate(:user, ip_address:, trust_level: TrustLevel[0])
+        SiteSetting.max_new_accounts_per_registration_ip = 1
+      end
+
+      it { is_expected.to fail_a_policy(:can_register_from_ip) }
+
+      it "does not generate or enqueue a login code" do
+        expect_not_enqueued_with(job: :send_email_login_code) { result }
+
+        expect(EmailLoginCode.for_email(email)).to be_empty
+      end
+    end
+
+    context "when a login IP has reached the account limit" do
+      let(:ip_address) { "192.0.2.1" }
+      let(:dependencies) { { ip_address: } }
+      let(:params) { { email:, signup: "false" } }
+
+      before do
+        Fabricate(:user, ip_address:, trust_level: TrustLevel[0])
+        SiteSetting.max_new_accounts_per_registration_ip = 1
+      end
+
+      it "generates and enqueues a login code for an existing account" do
+        expect_enqueued_with(job: :send_email_login_code, args: { to_address: email }) { result }
+
+        expect(result).to run_successfully
+        expect(EmailLoginCode.for_email(email).count).to eq(1)
+      end
     end
 
     context "when the email belongs to an existing user" do


### PR DESCRIPTION
**Previously**, signup via email code did not discover IP account limits until after a user entered the OTP.

**In this update**, signup requests check the registration IP before sending a code, show the same account-limit error as password signup, and keep login requests unaffected.

| Before | After |
| --- | --- |
| Signup advances to the OTP step before discovering the restriction. | Signup is stopped on the email step with the account-limit reason before a code is sent. |
| ![Before: signup advances to the email-code step](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/discourse-login-code-before-account-limit.png) | ![After: signup shows the account-limit error on the email step](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/discourse-login-code-after-account-limit.png) |
