### PR TITLE
FIX: Preserve poll settings in the rich text editor

### DIFF
--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
@@ -4,7 +4,7 @@ import { i18n } from "discourse-i18n";
 const DATA_PREFIX = "data-poll-";
 const DEFAULT_POLL = { name: "poll", status: "open" };
 const DEFAULT_MAXIMUM_OPTIONS = 20;
-const ALLOWED_ATTRIBUTES = [
+export const ALLOWED_ATTRIBUTES = [
   "chartType",
   "close",
   "groups",

--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
@@ -32,8 +32,18 @@ function addNumberListItems(state, pollTokens, min, max, step, maximumOptions) {
   ) {
     pollTokens.push(new state.Token("list_item_open", "li", 1));
 
-    let token = new state.Token("text", "", 0);
+    // hidden paragraphs leave the rendered output untouched while giving
+    // parsers with stricter list item content the block they require
+    let token = new state.Token("paragraph_open", "p", 1);
+    token.hidden = true;
+    pollTokens.push(token);
+
+    token = new state.Token("text", "", 0);
     token.content = String(i);
+    pollTokens.push(token);
+
+    token = new state.Token("paragraph_close", "p", -1);
+    token.hidden = true;
     pollTokens.push(token);
 
     pollTokens.push(new state.Token("list_item_close", "li", -1));

--- a/plugins/poll/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/poll/assets/javascripts/lib/rich-editor-extension.js
@@ -27,21 +27,27 @@ const extension = {
       parseDOM: [
         {
           tag: "div.poll",
-          getAttrs: (dom) => ({
-            type: dom.getAttribute("data-poll-type"),
-            results: dom.getAttribute("data-poll-results"),
-            public: dom.getAttribute("data-poll-public"),
-            name: dom.getAttribute("data-poll-name"),
-            chartType: dom.getAttribute("data-poll-chart-type"),
-            close: dom.getAttribute("data-poll-close"),
-            groups: dom.getAttribute("data-poll-groups"),
-            dynamic: dom.getAttribute("data-poll-dynamic"),
-            max: dom.getAttribute("data-poll-max"),
-            min: dom.getAttribute("data-poll-min"),
-            status: dom.getAttribute("data-poll-status"),
-            order: dom.getAttribute("data-poll-order"),
-            step: dom.getAttribute("data-poll-step"),
-          }),
+          getAttrs: (dom) => {
+            const name = dom.getAttribute("data-poll-name");
+            const status = dom.getAttribute("data-poll-status");
+
+            return {
+              type: dom.getAttribute("data-poll-type"),
+              results: dom.getAttribute("data-poll-results"),
+              public: dom.getAttribute("data-poll-public"),
+              // cooking always writes the defaults out, the markdown doesn't need them
+              name: name === "poll" ? null : name,
+              chartType: dom.getAttribute("data-poll-charttype"),
+              close: dom.getAttribute("data-poll-close"),
+              groups: dom.getAttribute("data-poll-groups"),
+              dynamic: dom.getAttribute("data-poll-dynamic"),
+              max: dom.getAttribute("data-poll-max"),
+              min: dom.getAttribute("data-poll-min"),
+              status: status === "open" ? null : status,
+              order: dom.getAttribute("data-poll-order"),
+              step: dom.getAttribute("data-poll-step"),
+            };
+          },
         },
       ],
       toDOM: (node) => [
@@ -52,7 +58,7 @@ const extension = {
           "data-poll-results": node.attrs.results,
           "data-poll-public": node.attrs.public,
           "data-poll-name": node.attrs.name,
-          "data-poll-chart-type": node.attrs.chartType,
+          "data-poll-charttype": node.attrs.chartType,
           "data-poll-close": node.attrs.close,
           "data-poll-groups": node.attrs.groups,
           "data-poll-dynamic": node.attrs.dynamic,

--- a/plugins/poll/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/poll/assets/javascripts/lib/rich-editor-extension.js
@@ -15,6 +15,9 @@ const extension = {
         max: { default: null },
         min: { default: null },
         dynamic: { default: null },
+        status: { default: null },
+        order: { default: null },
+        step: { default: null },
       },
       content: "heading? bullet_list poll_info?",
       group: "block",
@@ -35,6 +38,9 @@ const extension = {
             dynamic: dom.getAttribute("data-poll-dynamic"),
             max: dom.getAttribute("data-poll-max"),
             min: dom.getAttribute("data-poll-min"),
+            status: dom.getAttribute("data-poll-status"),
+            order: dom.getAttribute("data-poll-order"),
+            step: dom.getAttribute("data-poll-step"),
           }),
         },
       ],
@@ -52,6 +58,9 @@ const extension = {
           "data-poll-dynamic": node.attrs.dynamic,
           "data-poll-max": node.attrs.max,
           "data-poll-min": node.attrs.min,
+          "data-poll-status": node.attrs.status,
+          "data-poll-order": node.attrs.order,
+          "data-poll-step": node.attrs.step,
         },
         0,
       ],
@@ -70,6 +79,8 @@ const extension = {
       getAttrs: (token) => ({
         ...token.poll_attrs,
         name: token.poll_attrs.name === "poll" ? null : token.poll_attrs.name,
+        status:
+          token.poll_attrs.status === "open" ? null : token.poll_attrs.status,
       }),
     },
     poll_container: { ignore: true },
@@ -87,7 +98,14 @@ const extension = {
     poll(state, node) {
       const attrs = buildBBCodeAttrs(node.attrs);
       state.write(`[poll${attrs ? ` ${attrs}` : ""}]\n`);
-      state.renderContent(node);
+      if (node.attrs.type === "number") {
+        // options are generated from the range, they are not authored content
+        if (node.firstChild?.type.name === "heading") {
+          state.render(node.firstChild, node, 0);
+        }
+      } else {
+        state.renderContent(node);
+      }
       state.write("[/poll]\n\n");
     },
     poll_info() {},

--- a/plugins/poll/spec/lib/pretty_text_spec.rb
+++ b/plugins/poll/spec/lib/pretty_text_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe PrettyText do
     MD
 
     expect(cooked.scan("<li").length).to eq(20)
+    expect(cooked).to include('<li data-poll-option-id="4d8a15e3cc35750f016ce15a43937620">1</li>')
   end
 
   it "can properly bake 2 polls" do

--- a/plugins/poll/test/javascripts/component/rich-editor-extension-test.js
+++ b/plugins/poll/test/javascripts/component/rich-editor-extension-test.js
@@ -12,10 +12,9 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    hooks.beforeEach(function () {
-      resetRichEditorExtensions().then(() => {
-        registerRichEditorExtension(richEditorExtension);
-      });
+    hooks.beforeEach(async function () {
+      await resetRichEditorExtensions();
+      registerRichEditorExtension(richEditorExtension);
     });
 
     const voters =
@@ -46,6 +45,21 @@ module(
         "[poll chartType=bar]\n* Option 1\n* Option 2\n[/poll]",
         `<div class="poll" data-poll-chart-type="bar"><ul data-tight="true"><li><p>Option 1</p></li><li><p>Option 2</p></li></ul>${voters}</div>`,
         "[poll chartType=bar]\n* Option 1\n* Option 2\n\n[/poll]\n\n",
+      ],
+      "closed poll with a set option order": [
+        "[poll status=closed order=asc]\n* Option 1\n* Option 2\n[/poll]",
+        `<div class="poll" data-poll-status="closed" data-poll-order="asc"><ul data-tight="true"><li><p>Option 1</p></li><li><p>Option 2</p></li></ul>${voters}</div>`,
+        "[poll status=closed order=asc]\n* Option 1\n* Option 2\n\n[/poll]\n\n",
+      ],
+      "number poll": [
+        "[poll type=number min=0 max=4 step=2]\n[/poll]",
+        `<div class="poll" data-poll-type="number" data-poll-max="4" data-poll-min="0" data-poll-step="2"><ul data-tight="true"><li><p>0</p></li><li><p>2</p></li><li><p>4</p></li></ul>${voters}</div>`,
+        "[poll type=number max=4 min=0 step=2]\n[/poll]\n\n",
+      ],
+      "number poll with a title": [
+        "[poll type=number min=1 max=2]\n# How many?\n[/poll]",
+        `<div class="poll" data-poll-type="number" data-poll-max="2" data-poll-min="1"><h1>How many?</h1><ul data-tight="true"><li><p>1</p></li><li><p>2</p></li></ul>${voters}</div>`,
+        "[poll type=number max=2 min=1]\n# How many?\n\n[/poll]\n\n",
       ],
     }).forEach(([name, [markdown, html, expectedMarkdown]]) => {
       test(name, async function (assert) {

--- a/plugins/poll/test/javascripts/component/rich-editor-extension-test.js
+++ b/plugins/poll/test/javascripts/component/rich-editor-extension-test.js
@@ -5,6 +5,7 @@ import {
 } from "discourse/lib/composer/rich-editor-extensions";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
+import { ALLOWED_ATTRIBUTES } from "discourse/plugins/poll/lib/discourse-markdown/poll";
 import richEditorExtension from "discourse/plugins/poll/lib/rich-editor-extension";
 
 module(
@@ -38,12 +39,12 @@ module(
       ],
       "poll with name, results, close date, groups": [
         "[poll name=PollName chartType=pie results=always anonymous=true close=2021-01-01 groups=group1,group2]\n* Option 1\n* Option 2\n[/poll]",
-        `<div class="poll" data-poll-results="always" data-poll-name="PollName" data-poll-chart-type="pie" data-poll-close="2021-01-01" data-poll-groups="group1,group2"><ul data-tight="true"><li><p>Option 1</p></li><li><p>Option 2</p></li></ul>${voters}</div>`,
+        `<div class="poll" data-poll-results="always" data-poll-name="PollName" data-poll-charttype="pie" data-poll-close="2021-01-01" data-poll-groups="group1,group2"><ul data-tight="true"><li><p>Option 1</p></li><li><p>Option 2</p></li></ul>${voters}</div>`,
         "[poll results=always name=PollName chartType=pie close=2021-01-01 groups=group1,group2]\n* Option 1\n* Option 2\n\n[/poll]\n\n",
       ],
       "poll with bar chart type": [
         "[poll chartType=bar]\n* Option 1\n* Option 2\n[/poll]",
-        `<div class="poll" data-poll-chart-type="bar"><ul data-tight="true"><li><p>Option 1</p></li><li><p>Option 2</p></li></ul>${voters}</div>`,
+        `<div class="poll" data-poll-charttype="bar"><ul data-tight="true"><li><p>Option 1</p></li><li><p>Option 2</p></li></ul>${voters}</div>`,
         "[poll chartType=bar]\n* Option 1\n* Option 2\n\n[/poll]\n\n",
       ],
       "closed poll with a set option order": [
@@ -68,3 +69,39 @@ module(
     });
   }
 );
+
+module("Unit | Lib | poll rich editor extension", function () {
+  const { attrs, parseDOM } = richEditorExtension.nodeSpec.poll;
+
+  test("carries every attribute the markdown rule allows", function (assert) {
+    assert.deepEqual(
+      Object.keys(attrs).sort(),
+      [...ALLOWED_ATTRIBUTES].sort(),
+      "the poll node keeps up with the markdown rule"
+    );
+  });
+
+  test("reads the settings off cooked HTML", function (assert) {
+    const container = document.createElement("div");
+    container.innerHTML =
+      '<div class="poll" data-poll-status="open" data-poll-name="poll" ' +
+      'data-poll-results="always" data-poll-charttype="bar" ' +
+      'data-poll-type="number" data-poll-order="asc" data-poll-step="2"></div>';
+
+    const parsed = parseDOM[0].getAttrs(container.firstChild);
+
+    assert.deepEqual(
+      Object.fromEntries(
+        Object.entries(parsed).filter(([, value]) => value !== null)
+      ),
+      {
+        type: "number",
+        results: "always",
+        chartType: "bar",
+        order: "asc",
+        step: "2",
+      },
+      "keeps the settings and drops the ones cooking always supplies"
+    );
+  });
+});


### PR DESCRIPTION
Editing a post in the rich text editor dropped the poll attributes its node didn't carry: closed polls came back open, custom option orders were lost. Number polls also lost their generated options, which removed the poll on the next cook.

The node now keeps status, order and step, and reads the chart type under the name cooking emits. Number options are wrapped in hidden paragraphs so the editor gets valid list content, then skipped on the way back to markdown since they come from the range.
