### PR TITLE
FEATURE: Add generic rich-editor block drag handle

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/_index.scss
+++ b/app/assets/stylesheets/common/rich-editor/_index.scss
@@ -1,2 +1,3 @@
 @import "rich-editor";
 @import "composer-image-gallery";
+@import "composer-drag-handle";

--- a/app/assets/stylesheets/common/rich-editor/composer-drag-handle.scss
+++ b/app/assets/stylesheets/common/rich-editor/composer-drag-handle.scss
@@ -1,0 +1,135 @@
+.composer-drag-handle {
+  position: fixed;
+  z-index: 1;
+  display: grid;
+  width: 1.25rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 0;
+  border-radius: var(--token-radius-normal);
+  opacity: 0;
+  background-color: transparent;
+  color: var(--token-color-icon-subtle);
+  cursor: grab;
+  place-items: center;
+  pointer-events: none;
+  transition:
+    opacity 0.12s ease,
+    background-color 0.12s ease;
+
+  &.--visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  &:hover {
+    background-color: var(--token-color-surface-hovered);
+    color: var(--token-color-icon-default);
+  }
+
+  &:active {
+    cursor: grabbing;
+    background-color: var(--token-color-surface-pressed);
+  }
+
+  &.is-dragging {
+    opacity: 1;
+    cursor: grabbing;
+    pointer-events: none;
+  }
+
+  &:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+    outline: 2px solid var(--token-color-border-focused);
+    outline-offset: 2px;
+  }
+
+  .d-icon {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  @media (forced-colors: active) {
+    border: 1px solid ButtonText;
+
+    &:focus-visible {
+      outline-color: Highlight;
+    }
+  }
+}
+
+.composer-drag-handle__drop-indicator {
+  position: fixed;
+  z-index: 2;
+  height: 0.25rem;
+  border-radius: 999px;
+  opacity: 0;
+  background-color: var(--tertiary-high);
+  pointer-events: none;
+  transform: translateY(-50%);
+
+  &.--visible {
+    opacity: 1;
+  }
+
+  @media (forced-colors: active) {
+    background-color: Highlight;
+  }
+}
+
+.composer-node-menu {
+  min-width: 12rem;
+  gap: 0;
+  padding: var(--space-1);
+
+  .dropdown-menu__divider {
+    margin-block: var(--space-1);
+    border-color: var(--token-color-border-default);
+  }
+
+  .btn {
+    justify-content: flex-start;
+    width: 100%;
+    min-height: 2.125rem;
+    height: auto;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    border: 0;
+    border-radius: var(--token-radius-normal);
+    background: transparent;
+    color: var(--token-color-text-default);
+    font-size: var(--font-down-1);
+
+    .d-icon {
+      width: 1rem;
+      color: var(--token-color-icon-subtle);
+      font-size: var(--font-down-1);
+    }
+
+    &:hover,
+    &:focus-visible {
+      background-color: var(--token-color-surface-hovered);
+    }
+
+    &.--dangerous:hover,
+    &.--dangerous:focus-visible {
+      background-color: var(--danger-low);
+      color: var(--danger);
+
+      .d-icon {
+        color: var(--token-color-icon-danger);
+      }
+    }
+  }
+}
+
+.fk-d-menu[data-identifier="composer-node-menu"] {
+  // the composer sits above the default dropdown layer
+  z-index: z("composer", "dropdown");
+  user-select: none;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3801,6 +3801,17 @@ en:
         show_source: "Show source"
         show_preview: "Show preview"
 
+      node:
+        handle: "Drag to move, click for actions"
+        move_up: "Move up"
+        move_down: "Move down"
+        duplicate: "Duplicate"
+        delete: "Delete"
+        moved_up: "Block moved up"
+        moved_down: "Block moved down"
+        duplicated: "Block duplicated"
+        deleted: "Block deleted"
+
       unsupported_token: "The rich text editor doesn’t support all features used in this post; switching you to the Markdown editor."
 
     notifications:

--- a/frontend/discourse/app/components/composer/node-menu.gjs
+++ b/frontend/discourse/app/components/composer/node-menu.gjs
@@ -1,0 +1,47 @@
+import { fn } from "@ember/helper";
+import DButton from "discourse/ui-kit/d-button";
+import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import DShortcut from "discourse/ui-kit/d-shortcut";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+
+/**
+ * Dropdown of actions for a node in the rich editor, shown from its action
+ * trigger.
+ *
+ * Purely presentational: items are plain objects because the callers are
+ * ProseMirror plugins rather than components, and build them next to the
+ * commands they run. `@data.className` names the list so each caller keeps its
+ * own styling hook.
+ */
+const NodeMenu = <template>
+  <DDropdownMenu class={{@data.className}} as |dropdown|>
+    {{#each @data.items as |item|}}
+      {{#if item.divider}}
+        <dropdown.divider />
+      {{else}}
+        <dropdown.item>
+          <DShortcut @keys={{item.shortcutKeys}} as |shortcut|>
+            <DButton
+              aria-keyshortcuts={{shortcut.aria}}
+              class={{dConcatClass
+                item.className
+                (if item.active "--active")
+                (if item.dangerous "--dangerous")
+              }}
+              @icon={{item.icon}}
+              @ariaPressed={{item.active}}
+              @action={{fn @data.run item}}
+            >
+              <span class="d-button-label">
+                <span class="d-button-label__text">{{item.label}}</span>
+                <shortcut.Kbd class="shortcut" />
+              </span>
+            </DButton>
+          </DShortcut>
+        </dropdown.item>
+      {{/if}}
+    {{/each}}
+  </DDropdownMenu>
+</template>;
+
+export default NodeMenu;

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -112,6 +112,8 @@ export interface PluginParams {
   pmSchemaList: typeof import("prosemirror-schema-list");
   /** Schema used by the editor instance. */
   schema: Schema;
+  /** Extensions active in the editor instance. */
+  extensions: readonly RichEditorExtension[];
   /** Returns application context for the editor instance. */
   getContext: () => PluginContext;
 }
@@ -410,16 +412,17 @@ export function getExtensions(): RichEditorExtension[] {
 }
 
 /**
- * Every action registered for a node type, followed by those registered for all
- * blocks. Read at the moment the menu opens so an extension registered late is
- * still honoured.
+ * Every action in the supplied extension set for a node type, followed by those
+ * registered for all blocks. Read at the moment the menu opens so an extension
+ * registered late is still honoured.
  */
 export function nodeActionsFor(
   nodeName: string,
-  params: NodeActionsParams
+  params: NodeActionsParams,
+  extensions: readonly RichEditorExtension[] = registeredExtensions
 ): NodeAction[] {
   const collect = (key: string) =>
-    registeredExtensions.flatMap(
+    extensions.flatMap(
       (extension) => extension.nodeActions?.[key]?.(params) ?? []
     );
 

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -22,6 +22,7 @@ import type MenuService from "discourse/float-kit/services/menu";
 import type ToastsService from "discourse/float-kit/services/toasts";
 import type Session from "discourse/models/session";
 import type Site from "discourse/models/site";
+import type A11yService from "discourse/services/a11y";
 import type AppEventsService from "discourse/services/app-events";
 import type { CapabilitiesService } from "discourse/services/capabilities";
 import type ModalService from "discourse/services/modal";
@@ -60,6 +61,8 @@ export interface PluginContext {
   siteSettings: Record<string, unknown>;
   /** Application event bus. */
   appEvents: AppEventsService;
+  /** Service used to announce editor changes to assistive technology. */
+  a11y: A11yService;
   /** Service used to show confirmation and alert dialogs. */
   dialog: DialogService;
   /** Replaces or restores the toolbar displayed by the editor container. */
@@ -269,6 +272,57 @@ export interface MarkSerializerSpec {
   escape?: boolean;
 }
 
+/** An actionable entry in a node's drag-handle menu. */
+export interface NodeActionItem {
+  /** Icon name shown before the label. */
+  icon?: string;
+  /** Already-translated label. */
+  label: string;
+  /** Class applied to the button, for styling and for tests to target. */
+  className?: string;
+  /** Shortcut hint, in `DShortcut` form, e.g. `"mod+d"`. */
+  shortcutKeys?: string;
+  /** Draws the entry as destructive. */
+  dangerous?: boolean;
+  /** Draws the entry as the current choice. */
+  active?: boolean;
+  /** Already-translated result announced after the action runs. */
+  announcement?: string;
+  /** Runs the entry. */
+  action: () => void;
+  /** Distinguishes actions from divider entries. */
+  divider?: false;
+}
+
+/** A separator between groups in a node's drag-handle menu. */
+export interface NodeActionDivider {
+  divider: true;
+}
+
+/** One entry in a node's drag-handle menu. */
+export type NodeAction = NodeActionItem | NodeActionDivider;
+
+export interface NodeActionsParams {
+  /** The node the handle belongs to. */
+  node: Node;
+  /** Its position in the document. */
+  pos: number;
+  /** Editor view containing the node. */
+  view: EditorView;
+  /** Extension API for the editor instance. */
+  pluginParams: PluginParams;
+}
+
+/**
+ * Actions contributed to a block's drag-handle menu, keyed by node type name.
+ * Callbacks run when the menu opens. The `*` key applies to every block, and
+ * its entries come last.
+ */
+export type NodeActionsSpec = Record<
+  string,
+  (params: NodeActionsParams) => NodeAction[]
+>;
+
 export type KeymapSpec = Record<string, Command>;
 export type RichKeymap = KeymapSpec | ((params: PluginParams) => KeymapSpec);
 
@@ -306,6 +360,8 @@ export interface RichEditorExtension {
   commands?: (params: PluginParams) => Record<string, RichCommand>;
   /** Custom toolbar state contributed by the extension. */
   state?: StateFunction;
+  /** Entries this extension adds to a block's drag-handle menu. */
+  nodeActions?: NodeActionsSpec;
 }
 
 const registeredExtensions: RichEditorExtension[] = [];
@@ -351,4 +407,26 @@ export async function resetRichEditorExtensions() {
  */
 export function getExtensions(): RichEditorExtension[] {
   return registeredExtensions;
+}
+
+/**
+ * Every action registered for a node type, followed by those registered for all
+ * blocks. Read at the moment the menu opens so an extension registered late is
+ * still honoured.
+ */
+export function nodeActionsFor(
+  nodeName: string,
+  params: NodeActionsParams
+): NodeAction[] {
+  const collect = (key: string) =>
+    registeredExtensions.flatMap(
+      (extension) => extension.nodeActions?.[key]?.(params) ?? []
+    );
+
+  const specific = collect(nodeName);
+  const shared = collect("*");
+
+  return specific.length && shared.length
+    ? [...specific, { divider: true }, ...shared]
+    : [...specific, ...shared];
 }

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -3669,6 +3669,22 @@ class _PluginApi {
    *
    * EXPERIMENTAL: This API will change without warning
    *
+   * Extensions can contribute actions to the drag-handle menu for a node type.
+   * Use `*` for actions that apply to every top-level block.
+   *
+   * @example
+   * api.registerRichEditorExtension({
+   *   nodeActions: {
+   *     paragraph: ({ node }) => [
+   *       {
+   *         icon: "circle-info",
+   *         label: i18n("my_plugin.inspect_block"),
+   *         action: () => inspectBlock(node),
+   *       },
+   *     ],
+   *   },
+   * });
+   *
    * @param {RichEditorExtension} extension
    */
   registerRichEditorExtension(extension) {

--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
@@ -47,6 +47,7 @@ import type Site from "discourse/models/site";
 import type User from "discourse/models/user";
 import forceScrollingElementPosition from "discourse/modifiers/force-scrolling-element-position";
 import { focusOffScreen } from "discourse/modifiers/prevent-scroll-on-focus";
+import type A11yService from "discourse/services/a11y";
 import type AppEventsService from "discourse/services/app-events";
 import type { CapabilitiesService } from "discourse/services/capabilities";
 import type ModalService from "discourse/services/modal";
@@ -148,6 +149,7 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
   @service declare siteSettings: SiteSettings;
 
   @service declare appEvents: AppEventsService;
+  @service declare a11y: A11yService;
   @service declare currentUser: User;
 
   schema: Schema = createSchema(this.extensions, this.args.includeDefault);
@@ -190,6 +192,7 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
         site: this.site,
         siteSettings: this.siteSettings,
         appEvents: this.appEvents,
+        a11y: this.a11y,
         dialog: this.dialog,
         replaceToolbar: this.args.replaceToolbar,
         markdownOptions: this.args.markdownOptions,

--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gts
@@ -173,6 +173,7 @@ export default class ProsemirrorEditor extends Component<ProsemirrorEditorSignat
         toggleRichEditor: this.args.toggleRichEditor,
       },
       schema: this.schema,
+      extensions: this.extensions,
       pmState: ProsemirrorState,
       pmModel: ProsemirrorModel,
       pmView: ProsemirrorView,

--- a/frontend/discourse/app/static/prosemirror/extensions/drag-handle.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/drag-handle.js
@@ -1,0 +1,896 @@
+import { NodeSelection } from "prosemirror-state";
+import NodeMenu from "discourse/components/composer/node-menu";
+import { nodeActionsFor } from "discourse/lib/composer/rich-editor-extensions";
+import { iconElement } from "discourse/lib/icon-library";
+import { registerPointerDrag } from "discourse/ui-kit/modifiers/d-pointer-drag";
+import { i18n } from "discourse-i18n";
+import dragAutoscroll from "../lib/drag-autoscroll";
+
+const MENU_IDENTIFIER = "composer-node-menu";
+
+const DESKTOP_HANDLE_OFFSET_REM = 0.5;
+const DRAG_THRESHOLD = 4;
+const POINTER_RELEASE_DELAY = 200;
+const TOUCH_HANDLE_GAP = 6;
+
+let handleSequence = 0;
+
+// macOS has neither a ContextMenu key nor F-keys that reach the page by
+// default, so Alt+Enter carries the same meaning there.
+function opensMenu(event) {
+  return (
+    event.key === "ContextMenu" ||
+    (event.key === "F10" && event.shiftKey) ||
+    (event.key === "Enter" && event.altKey && !event.ctrlKey && !event.metaKey)
+  );
+}
+
+/**
+ * A grip beside the block under the pointer, for dragging that block elsewhere
+ * or opening the actions registered for it.
+ *
+ * The handle lives outside the editable element, so it captures the pointer and
+ * moves the selected block directly when the pointer is released.
+ */
+class DragHandleView {
+  #view;
+  #pluginParams;
+  #NodeSelection;
+  #touchFirst;
+  #previousAriaKeyShortcuts;
+  #pointerTarget = null;
+  #pointerReleaseTimer = null;
+  #caretTarget = null;
+  #target = null;
+  #menu = null;
+  #openingMenu = false;
+  #dragOffsetY = null;
+  #dragTarget = null;
+  #dragAutoscroll = null;
+  #lastDragEvent = null;
+  #dropIndicator;
+  #dragEndedAt = null;
+  #cleanupPointerDrag;
+  #destroyed = false;
+
+  // The handle lives outside the editable element, so reaching for it fires
+  // `pointerleave` on the editor. Dropping the target there would make the
+  // handle impossible to click.
+  #releasePointer = (event) => {
+    const to = event?.relatedTarget;
+    if (
+      to instanceof Node &&
+      (this.handle.contains(to) || this.#view.dom.contains(to))
+    ) {
+      this.#cancelPointerRelease();
+      return;
+    }
+
+    this.#cancelPointerRelease();
+    this.#pointerReleaseTimer = window.setTimeout(() => {
+      this.#pointerReleaseTimer = null;
+      this.#pointerTarget = null;
+      this.#render();
+    }, POINTER_RELEASE_DELAY);
+  };
+
+  #holdPointer = () => this.#cancelPointerRelease();
+
+  #releaseFocus = (event) => {
+    if (event.relatedTarget === this.handle) {
+      return;
+    }
+
+    this.#render();
+  };
+
+  #track = (event) => {
+    if (!this.#view.editable || this.#menu?.expanded) {
+      return;
+    }
+
+    this.#cancelPointerRelease();
+    if (this.#pointerInTargetCorridor(event)) {
+      return;
+    }
+
+    this.#pointerTarget = this.#blockAt(event);
+    this.#render();
+  };
+
+  #onViewportChange = () => {
+    if (this.#dragTarget && this.#lastDragEvent) {
+      this.#placeDraggedHandle(this.#lastDragEvent);
+      this.#showDropIndicator(this.#lastDragEvent);
+      return;
+    }
+
+    this.#cancelPointerRelease();
+    this.#pointerTarget = null;
+    this.#hideDropIndicator();
+    this.#render();
+  };
+
+  #render = () => {
+    if (
+      this.#destroyed ||
+      this.#dragTarget ||
+      this.#openingMenu ||
+      this.#menu?.expanded
+    ) {
+      return;
+    }
+
+    const target = this.#view.editable
+      ? (this.#pointerTarget ??
+        (this.#touchFirst || this.handle.matches(":focus")
+          ? this.#caretTarget
+          : null))
+      : null;
+
+    this.#target = target;
+
+    if (!target) {
+      this.#hideHandle();
+      return;
+    }
+
+    this.handle.tabIndex = 0;
+    this.handle.setAttribute("aria-hidden", "false");
+    this.#place(target);
+  };
+
+  #onDragStart = (event) => {
+    if (!this.#view.editable || !this.#target) {
+      return false;
+    }
+
+    this.#cancelPointerRelease();
+    const bounds = this.handle.getBoundingClientRect();
+    this.#dragTarget = this.#target;
+    this.#dragOffsetY = event.clientY - bounds.top;
+  };
+
+  #onDrag = (event) => {
+    if (this.#dragOffsetY === null || !this.#dragTarget) {
+      return;
+    }
+
+    if (!this.handle.classList.contains("is-dragging")) {
+      this.#select(this.#dragTarget);
+      this.#view.dom.classList.add("is-dragging-block");
+      this.handle.classList.add("is-dragging", "--visible");
+      this.#pointerTarget = null;
+      this.#dragAutoscroll = dragAutoscroll(
+        this.#view.dom.parentElement ?? this.#view.dom,
+        "Y",
+        () => {
+          if (this.#lastDragEvent) {
+            this.#placeDraggedHandle(this.#lastDragEvent);
+            this.#showDropIndicator(this.#lastDragEvent);
+          }
+        }
+      );
+    }
+
+    this.#lastDragEvent = event;
+    this.#placeDraggedHandle(event);
+    this.#showDropIndicator(event);
+    this.#dragAutoscroll?.update(event);
+  };
+
+  #onDragEnd = (event, info) => {
+    if (info.moved) {
+      this.#moveTo(this.#dropAt(event));
+      this.#dragEndedAt = event.timeStamp;
+    }
+    this.#finishDrag();
+  };
+
+  #onDragCancel = () => {
+    this.#finishDrag();
+  };
+
+  #onClick = async (event) => {
+    if (
+      this.#dragEndedAt !== null &&
+      event.timeStamp - this.#dragEndedAt < 500
+    ) {
+      this.#dragEndedAt = null;
+      return;
+    }
+
+    this.#dragEndedAt = null;
+    await this.openMenu();
+  };
+
+  constructor(view, pluginParams) {
+    this.#view = view;
+    this.#pluginParams = pluginParams;
+    this.#NodeSelection = pluginParams.pmState.NodeSelection;
+    this.#touchFirst = this.#pluginParams.getContext().capabilities.touchFirst;
+    this.#previousAriaKeyShortcuts = view.dom.getAttribute("aria-keyshortcuts");
+
+    const editorShortcuts = new Set(
+      (this.#previousAriaKeyShortcuts ?? "").split(/\s+/).filter(Boolean)
+    );
+    editorShortcuts.add("Alt+Enter");
+    editorShortcuts.add("Shift+F10");
+    view.dom.setAttribute("aria-keyshortcuts", [...editorShortcuts].join(" "));
+
+    this.handle = document.createElement("button");
+    this.handle.type = "button";
+    this.handle.className = "composer-drag-handle";
+    this.handle.tabIndex = -1;
+    this.handle.setAttribute("aria-label", i18n("composer.node.handle"));
+    this.handle.setAttribute("aria-keyshortcuts", "Alt+Enter Shift+F10");
+    this.handle.setAttribute("aria-expanded", "false");
+    this.handle.setAttribute("aria-hidden", "true");
+    this.handle.id = `${MENU_IDENTIFIER}-trigger-${++handleSequence}`;
+    this.handle.classList.toggle("--touch", this.#touchFirst);
+    this.handle.appendChild(iconElement("grip-vertical"));
+
+    this.#dropIndicator = document.createElement("div");
+    this.#dropIndicator.className = "composer-drag-handle__drop-indicator";
+    this.#dropIndicator.setAttribute("aria-hidden", "true");
+
+    this.handle.addEventListener("click", this.#onClick);
+    this.#cleanupPointerDrag = registerPointerDrag(this.handle, () => ({
+      onDragStart: this.#onDragStart,
+      onDrag: this.#onDrag,
+      onDragEnd: this.#onDragEnd,
+      onDragCancel: this.#onDragCancel,
+      threshold: DRAG_THRESHOLD,
+    }));
+
+    view.dom.parentElement?.append(this.handle, this.#dropIndicator);
+    view.dom.addEventListener("pointermove", this.#track);
+    view.dom.addEventListener("pointerleave", this.#releasePointer);
+    view.dom.addEventListener("blur", this.#releaseFocus);
+    view.dom.addEventListener("focus", this.#render);
+    this.handle.addEventListener("blur", this.#render);
+    this.handle.addEventListener("pointerenter", this.#holdPointer);
+    this.handle.addEventListener("pointerleave", this.#releasePointer);
+    window.addEventListener("scroll", this.#onViewportChange, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener("resize", this.#onViewportChange, {
+      passive: true,
+    });
+  }
+
+  async openMenu() {
+    if (this.#destroyed || !this.#view.editable || this.#openingMenu) {
+      return;
+    }
+
+    this.#openingMenu = true;
+
+    try {
+      if (!this.#target && this.#caretTarget) {
+        this.#target = this.#caretTarget;
+        this.#place(this.#target);
+      }
+
+      const target = this.#select();
+      if (!target) {
+        return;
+      }
+
+      const items = nodeActionsFor(target.node.type.name, {
+        node: target.node,
+        pos: target.pos,
+        view: this.#view,
+        pluginParams: this.#pluginParams,
+      });
+
+      if (!items.length) {
+        this.#view.focus();
+        return;
+      }
+
+      const context = this.#pluginParams.getContext();
+      let closed = false;
+      const menu = await context.menu.show(this.handle, {
+        identifier: MENU_IDENTIFIER,
+        component: NodeMenu,
+        placement: "bottom-start",
+        contentRole: "none",
+        modalForMobile: true,
+        autofocus: true,
+        trapTab: true,
+        onClose: () => {
+          closed = true;
+          if (!this.#destroyed) {
+            this.handle.setAttribute("aria-expanded", "false");
+            this.#menu = null;
+            this.#view.focus();
+          }
+        },
+        data: {
+          className: MENU_IDENTIFIER,
+          items,
+          run: (item) => {
+            this.#menu?.close();
+            item.action?.();
+            if (item.announcement) {
+              context.a11y.announce(item.announcement);
+            }
+          },
+        },
+      });
+
+      if (this.#destroyed || closed) {
+        menu?.destroy?.();
+        return;
+      }
+
+      this.#menu = menu;
+
+      this.handle.setAttribute(
+        "aria-expanded",
+        this.#menu?.expanded ? "true" : "false"
+      );
+    } finally {
+      this.#openingMenu = false;
+      if (!this.#destroyed) {
+        this.#render();
+      }
+    }
+  }
+
+  /** The current block used by touch placement and keyboard commands. */
+  syncCaret() {
+    if (this.#openingMenu || this.#menu?.expanded) {
+      return;
+    }
+
+    const { selection } = this.#view.state;
+    if (!this.#view.editable) {
+      this.#caretTarget = null;
+    } else if (selection instanceof this.#NodeSelection) {
+      this.#caretTarget = this.#resolveAt(selection.from);
+    } else {
+      this.#caretTarget =
+        selection.$from.depth !== 0
+          ? this.#resolveBlockAt(selection.$from)
+          : null;
+    }
+    this.#render();
+  }
+
+  destroy() {
+    this.#destroyed = true;
+    this.#cancelPointerRelease();
+    this.#finishDrag();
+    this.#cleanupPointerDrag();
+    this.#menu?.destroy?.();
+    this.handle.remove();
+    this.#dropIndicator.remove();
+    this.handle.removeEventListener("click", this.#onClick);
+    this.#view.dom.removeEventListener("pointermove", this.#track);
+    this.#view.dom.removeEventListener("pointerleave", this.#releasePointer);
+    this.#view.dom.removeEventListener("blur", this.#releaseFocus);
+    this.#view.dom.removeEventListener("focus", this.#render);
+    this.handle.removeEventListener("blur", this.#render);
+    this.handle.removeEventListener("pointerenter", this.#holdPointer);
+    this.handle.removeEventListener("pointerleave", this.#releasePointer);
+    window.removeEventListener("scroll", this.#onViewportChange, true);
+    window.removeEventListener("resize", this.#onViewportChange);
+    if (this.#previousAriaKeyShortcuts === null) {
+      this.#view.dom.removeAttribute("aria-keyshortcuts");
+    } else {
+      this.#view.dom.setAttribute(
+        "aria-keyshortcuts",
+        this.#previousAriaKeyShortcuts
+      );
+    }
+  }
+
+  #finishDrag() {
+    this.#dragAutoscroll?.stop();
+    this.#dragAutoscroll = null;
+    this.#lastDragEvent = null;
+    this.#dragOffsetY = null;
+    this.#dragTarget = null;
+    this.#hideDropIndicator();
+    this.#view.dom.classList.remove("is-dragging-block");
+    this.handle.classList.remove("is-dragging");
+    this.#render();
+  }
+
+  /** The root block or deepest list item under the pointer. */
+  #blockAt(event) {
+    const found = this.#view.posAtCoords({
+      left: event.clientX,
+      top: event.clientY,
+    });
+    if (found) {
+      const { doc } = this.#view.state;
+      const $pos = doc.resolve(Math.min(found.pos, doc.content.size));
+      if ($pos.depth !== 0) {
+        const target = this.#resolveBlockAt($pos);
+        if (target) {
+          return target;
+        }
+      }
+    }
+
+    return this.#nearestBlockAt(event.clientX, event.clientY);
+  }
+
+  #cancelPointerRelease() {
+    if (this.#pointerReleaseTimer !== null) {
+      window.clearTimeout(this.#pointerReleaseTimer);
+      this.#pointerReleaseTimer = null;
+    }
+  }
+
+  #dropAt(event) {
+    const source = this.#dragTarget;
+    const target = this.#blockAt(event);
+    if (!source || !target) {
+      return null;
+    }
+    if (
+      target.pos >= source.pos &&
+      target.pos < source.pos + source.node.nodeSize
+    ) {
+      return null;
+    }
+
+    const { doc } = this.#view.state;
+    const sourceParent = doc.resolve(source.pos).parent;
+    const $target = doc.resolve(target.pos);
+    const targetBounds = target.dom.getBoundingClientRect();
+    const after = event.clientY >= targetBounds.top + targetBounds.height / 2;
+    const targetIndex = $target.index() + (after ? 1 : 0);
+    if (
+      !$target.parent.canReplaceWith(
+        targetIndex,
+        targetIndex,
+        source.node.type,
+        source.node.marks
+      )
+    ) {
+      return null;
+    }
+
+    const insertPos = target.pos + (after ? target.node.nodeSize : 0);
+    let projectedInsertPos = insertPos;
+
+    if (sourceParent === $target.parent && projectedInsertPos > source.pos) {
+      projectedInsertPos -= source.node.nodeSize;
+    }
+    if (sourceParent === $target.parent && projectedInsertPos === source.pos) {
+      return null;
+    }
+
+    return {
+      insertPos,
+      left: targetBounds.left,
+      top: after ? targetBounds.bottom : targetBounds.top,
+      width: targetBounds.width,
+    };
+  }
+
+  #hideDropIndicator() {
+    this.#dropIndicator.classList.remove("--visible");
+  }
+
+  #hideHandle() {
+    this.handle.classList.remove("--visible");
+    this.handle.tabIndex = -1;
+    this.handle.setAttribute("aria-hidden", "true");
+  }
+
+  #place(target) {
+    const anchor = this.#placementAnchor(target);
+    const block = anchor.dom.getBoundingClientRect();
+    const editor = this.#view.dom.getBoundingClientRect();
+    const isRoot = this.#view.state.doc.resolve(target.pos).depth === 0;
+    const direction = getComputedStyle(this.#view.dom).direction;
+
+    // Aligned to the block's first line rather than its middle, so a tall block
+    // does not park the handle halfway down the page.
+    const style = getComputedStyle(anchor.dom);
+    const line =
+      parseFloat(style.lineHeight) ||
+      parseFloat(style.fontSize) * 1.2 ||
+      block.height;
+
+    const top = block.top + Math.max(line - this.handle.offsetHeight, 0) / 2;
+    const viewport = this.#visibleEditorBounds(editor);
+    if (
+      top < viewport.top ||
+      top + this.handle.offsetHeight > viewport.bottom
+    ) {
+      this.#hideHandle();
+      return;
+    }
+
+    this.handle.style.top = `${top}px`;
+    const left = this.#touchFirst
+      ? direction === "rtl"
+        ? Math.max(block.left, editor.left) + TOUCH_HANDLE_GAP
+        : Math.min(block.right, editor.right) -
+          this.handle.offsetWidth -
+          TOUCH_HANDLE_GAP
+      : this.#desktopHandleLeft({ anchor, block, direction, editor, isRoot });
+
+    this.handle.style.left = `${left}px`;
+    this.handle.classList.add("--visible");
+  }
+
+  #desktopHandleLeft({ anchor, block, direction, editor, isRoot }) {
+    const offset = this.#desktopHandleOffset();
+
+    if (anchor.listItem) {
+      const markerInset = this.#listMarkerInset(anchor.listItem, direction);
+
+      return direction === "rtl"
+        ? block.right + markerInset + offset
+        : block.left - markerInset - this.handle.offsetWidth - offset;
+    }
+
+    return direction === "rtl"
+      ? (isRoot ? editor.right : block.right) - this.handle.offsetWidth + offset
+      : (isRoot ? editor.left : block.left) - offset;
+  }
+
+  #listMarkerInset(listItem, direction) {
+    const list = listItem.parentElement;
+    if (!list) {
+      return 0;
+    }
+
+    const style = getComputedStyle(list);
+    const padding = parseFloat(
+      direction === "rtl" ? style.paddingRight : style.paddingLeft
+    );
+
+    return padding || parseFloat(style.fontSize) * 1.25 || 0;
+  }
+
+  #placementAnchor(target) {
+    const { schema } = this.#view.state;
+    const isList =
+      target.node.type === schema.nodes.bullet_list ||
+      target.node.type === schema.nodes.ordered_list;
+    const firstItem = isList
+      ? Array.from(target.dom.children).find((child) => child.matches("li"))
+      : null;
+    const dom = firstItem instanceof HTMLElement ? firstItem : target.dom;
+
+    return {
+      dom,
+      listItem:
+        dom.matches("li") &&
+        (isList || target.node.type === schema.nodes.list_item)
+          ? dom
+          : null,
+    };
+  }
+
+  #pointerInTargetCorridor(event) {
+    if (!this.#pointerTarget || !this.handle.matches(".--visible")) {
+      return false;
+    }
+
+    const anchor = this.#placementAnchor(this.#pointerTarget);
+    const block = anchor.dom.getBoundingClientRect();
+    const style = getComputedStyle(anchor.dom);
+    const line =
+      parseFloat(style.lineHeight) ||
+      parseFloat(style.fontSize) * 1.2 ||
+      block.height;
+    const handleLeft = parseFloat(this.handle.style.left);
+    const handleTop = parseFloat(this.handle.style.top);
+    const contentEdge =
+      getComputedStyle(this.#view.dom).direction === "rtl"
+        ? block.right
+        : block.left;
+
+    return (
+      event.clientX >= Math.min(handleLeft, contentEdge) &&
+      event.clientX <=
+        Math.max(handleLeft + this.handle.offsetWidth, contentEdge) &&
+      event.clientY >= Math.min(handleTop, block.top) &&
+      event.clientY <=
+        Math.max(handleTop + this.handle.offsetHeight, block.top + line)
+    );
+  }
+
+  #visibleEditorBounds(editor) {
+    const scrollport = this.#view.dom.parentElement;
+    if (!scrollport) {
+      return editor;
+    }
+
+    const bounds = scrollport.getBoundingClientRect();
+    const top = bounds.top + scrollport.clientTop;
+
+    return {
+      top,
+      bottom: top + (scrollport.clientHeight || bounds.height),
+    };
+  }
+
+  #placeDraggedHandle(event) {
+    const editor = this.#view.dom.getBoundingClientRect();
+    const handle = this.handle.getBoundingClientRect();
+    const top = Math.min(
+      Math.max(event.clientY - this.#dragOffsetY, editor.top),
+      Math.max(editor.top, editor.bottom - handle.height)
+    );
+
+    this.handle.style.top = `${top}px`;
+  }
+
+  #desktopHandleOffset() {
+    const rootFontSize = parseFloat(
+      getComputedStyle(document.documentElement).fontSize
+    );
+    return (rootFontSize || 16) * DESKTOP_HANDLE_OFFSET_REM;
+  }
+
+  #moveTo(dropTarget) {
+    const source = this.#dragTarget;
+    if (!source || !dropTarget) {
+      return;
+    }
+
+    const tr = this.#view.state.tr.deleteRange(
+      source.pos,
+      source.pos + source.node.nodeSize
+    );
+    if (!tr.steps.length) {
+      return;
+    }
+
+    const insertPos = tr.mapping.map(dropTarget.insertPos);
+    const $insert = tr.doc.resolve(insertPos);
+    if (
+      !$insert.parent.canReplaceWith(
+        $insert.index(),
+        $insert.index(),
+        source.node.type,
+        source.node.marks
+      )
+    ) {
+      return;
+    }
+
+    tr.insert(insertPos, source.node);
+    tr.setSelection(this.#NodeSelection.create(tr.doc, insertPos));
+    this.#view.dispatch(tr.scrollIntoView());
+    this.#view.focus();
+  }
+
+  #showDropIndicator(event) {
+    const dropTarget = this.#dropAt(event);
+    if (!dropTarget) {
+      this.#hideDropIndicator();
+      return;
+    }
+
+    this.#dropIndicator.style.left = `${dropTarget.left}px`;
+    this.#dropIndicator.style.top = `${dropTarget.top}px`;
+    this.#dropIndicator.style.width = `${dropTarget.width}px`;
+    this.#dropIndicator.classList.add("--visible");
+  }
+
+  #nearestBlockAt(x, y) {
+    const editorBounds = this.#view.dom.getBoundingClientRect();
+    if (y < editorBounds.top || y > editorBounds.bottom) {
+      return null;
+    }
+
+    let closest = null;
+    let closestDistance = Infinity;
+    let closestDepth = -1;
+    const { doc, schema } = this.#view.state;
+
+    doc.descendants((node, pos, parent) => {
+      if (parent !== doc && node.type !== schema.nodes.list_item) {
+        return;
+      }
+
+      const dom = this.#view.nodeDOM(pos);
+      if (!(dom instanceof HTMLElement)) {
+        return;
+      }
+
+      const bounds = dom.getBoundingClientRect();
+      const verticalDistance =
+        y < bounds.top
+          ? bounds.top - y
+          : y > bounds.bottom
+            ? y - bounds.bottom
+            : 0;
+      const horizontalDistance =
+        x < bounds.left
+          ? bounds.left - x
+          : x > bounds.right
+            ? x - bounds.right
+            : 0;
+      const distance = Math.hypot(horizontalDistance, verticalDistance);
+      const depth = doc.resolve(pos).depth + 1;
+      if (
+        distance < closestDistance ||
+        (distance === closestDistance && depth > closestDepth)
+      ) {
+        closest = { node, pos, dom };
+        closestDistance = distance;
+        closestDepth = depth;
+      }
+    });
+
+    return closest;
+  }
+
+  #resolveBlockAt($pos) {
+    for (let depth = $pos.depth; depth > 0; depth--) {
+      const target = this.#resolveAt($pos.before(depth));
+      if (
+        target &&
+        (target.node.type === this.#view.state.schema.nodes.list_item ||
+          depth === 1)
+      ) {
+        return target;
+      }
+    }
+
+    return null;
+  }
+
+  #resolveAt(pos) {
+    const node = this.#view.state.doc.nodeAt(pos);
+    const dom = this.#view.nodeDOM(pos);
+
+    return node && dom instanceof HTMLElement ? { node, pos, dom } : null;
+  }
+
+  #select(target = this.#target) {
+    if (!this.#view.editable || !target) {
+      return null;
+    }
+
+    const { state, dispatch } = this.#view;
+    dispatch(
+      state.tr.setSelection(this.#NodeSelection.create(state.doc, target.pos))
+    );
+    return target;
+  }
+}
+
+function sharedNodeActions(params) {
+  const { node, pos, view } = params;
+  const $pos = view.state.doc.resolve(pos);
+  const index = $pos.index();
+  const actions = [];
+
+  if (index > 0) {
+    actions.push({
+      icon: "arrow-up",
+      label: i18n("composer.node.move_up"),
+      className: "composer-node-menu__move-up",
+      announcement: i18n("composer.node.moved_up"),
+      action: () => moveBlock(params, -1),
+    });
+  }
+  if (index < $pos.parent.childCount - 1) {
+    actions.push({
+      icon: "arrow-down",
+      label: i18n("composer.node.move_down"),
+      className: "composer-node-menu__move-down",
+      announcement: i18n("composer.node.moved_down"),
+      action: () => moveBlock(params, 1),
+    });
+  }
+
+  actions.push(
+    {
+      icon: "copy",
+      label: i18n("composer.node.duplicate"),
+      className: "composer-node-menu__duplicate",
+      announcement: i18n("composer.node.duplicated"),
+      action: () => {
+        if (view.editable) {
+          view.dispatch(view.state.tr.insert(pos + node.nodeSize, node));
+          view.focus();
+        }
+      },
+    },
+    { divider: true },
+    {
+      icon: "trash-can",
+      label: i18n("composer.node.delete"),
+      className: "composer-node-menu__delete",
+      announcement: i18n("composer.node.deleted"),
+      dangerous: true,
+      action: () => {
+        if (view.editable) {
+          view.dispatch(view.state.tr.delete(pos, pos + node.nodeSize));
+          view.focus();
+        }
+      },
+    }
+  );
+
+  return actions;
+}
+
+function moveBlock({ node, pos, view }, direction) {
+  if (!view.editable) {
+    return;
+  }
+
+  const { doc } = view.state;
+  const $pos = doc.resolve(pos);
+  const index = $pos.index();
+  const sibling = $pos.parent.maybeChild(index + direction);
+  if (!sibling) {
+    return;
+  }
+
+  const nextPos =
+    direction < 0 ? pos - sibling.nodeSize : pos + sibling.nodeSize;
+  const tr = view.state.tr
+    .delete(pos, pos + node.nodeSize)
+    .insert(nextPos, node);
+  tr.setSelection(NodeSelection.create(tr.doc, nextPos));
+  view.dispatch(tr.scrollIntoView());
+  view.focus();
+}
+
+/** @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension} */
+const extension = {
+  // Actions every block gets. Node-specific ones come from the node's own
+  // extension, so a plugin can contribute to the blocks it introduces.
+  nodeActions: {
+    "*": (params) => sharedNodeActions(params),
+  },
+
+  plugins(pluginParams) {
+    const {
+      pmState: { Plugin, PluginKey },
+    } = pluginParams;
+
+    let handle = null;
+
+    return new Plugin({
+      key: new PluginKey("dragHandle"),
+
+      props: {
+        // The same gesture the platform uses for "open the menu for what is
+        // focused". This extension registers last, so a node with a menu of its
+        // own — a table cell, say — answers first and this never fires there.
+        handleKeyDown: (view, event) => {
+          if (!view.editable || !opensMenu(event) || !handle) {
+            return false;
+          }
+
+          event.preventDefault();
+          handle.openMenu();
+          return true;
+        },
+      },
+
+      view: (view) => {
+        handle = new DragHandleView(view, pluginParams);
+
+        return {
+          update: () => handle.syncCaret(),
+          destroy: () => {
+            handle.destroy();
+            handle = null;
+          },
+        };
+      },
+    });
+  },
+};
+
+export default extension;

--- a/frontend/discourse/app/static/prosemirror/extensions/drag-handle.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/drag-handle.js
@@ -260,7 +260,7 @@ class DragHandleView {
     });
   }
 
-  async openMenu() {
+  async openMenu({ fromCaret = false } = {}) {
     if (this.#destroyed || !this.#view.editable || this.#openingMenu) {
       return;
     }
@@ -268,7 +268,12 @@ class DragHandleView {
     this.#openingMenu = true;
 
     try {
-      if (!this.#target && this.#caretTarget) {
+      if (fromCaret) {
+        this.#target = this.#caretTarget;
+        if (this.#target) {
+          this.#place(this.#target);
+        }
+      } else if (!this.#target && this.#caretTarget) {
         this.#target = this.#caretTarget;
         this.#place(this.#target);
       }
@@ -278,12 +283,16 @@ class DragHandleView {
         return;
       }
 
-      const items = nodeActionsFor(target.node.type.name, {
-        node: target.node,
-        pos: target.pos,
-        view: this.#view,
-        pluginParams: this.#pluginParams,
-      });
+      const items = nodeActionsFor(
+        target.node.type.name,
+        {
+          node: target.node,
+          pos: target.pos,
+          view: this.#view,
+          pluginParams: this.#pluginParams,
+        },
+        this.#pluginParams.extensions
+      );
 
       if (!items.length) {
         this.#view.focus();
@@ -873,7 +882,7 @@ const extension = {
           }
 
           event.preventDefault();
-          handle.openMenu();
+          handle.openMenu({ fromCaret: true });
           return true;
         },
       },

--- a/frontend/discourse/app/static/prosemirror/extensions/drag-handle.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/drag-handle.js
@@ -135,7 +135,7 @@ class DragHandleView {
       return;
     }
 
-    this.handle.tabIndex = 0;
+    this.handle.tabIndex = this.#touchFirst ? 0 : -1;
     this.handle.setAttribute("aria-hidden", "false");
     this.#place(target);
   };

--- a/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
+++ b/frontend/discourse/app/static/prosemirror/extensions/register-default.ts
@@ -6,6 +6,7 @@ import {
 import bulletList from "./bullet-list";
 import code from "./code";
 import codeBlock from "./code-block";
+import dragHandle from "./drag-handle";
 import emoji from "./emoji";
 import grid from "./grid";
 import hardBreak from "./hard-break";
@@ -71,6 +72,8 @@ const defaultExtensions: RichEditorExtension[] = [
   uploadPlaceholder,
   previewSource,
   previewToolbar,
+  // Last: its context-menu gesture is a fallback for nodes without one.
+  dragHandle,
 ];
 
 defaultExtensions.forEach(registerRichEditorExtension);

--- a/frontend/discourse/app/static/prosemirror/lib/drag-autoscroll.js
+++ b/frontend/discourse/app/static/prosemirror/lib/drag-autoscroll.js
@@ -1,0 +1,87 @@
+const EDGE_SIZE = 32;
+const MAX_STEP = 18;
+
+export default function dragAutoscroll(anchor, axis, onScroll) {
+  let frame = null;
+  let point = null;
+  let stopped = false;
+
+  const tick = () => {
+    frame = null;
+    if (stopped || point === null) {
+      return;
+    }
+
+    const scroller = scrollTarget(anchor, axis, point);
+    if (!scroller) {
+      return;
+    }
+
+    const property = axis === "X" ? "scrollLeft" : "scrollTop";
+    const before = scroller.element[property];
+    scroller.element[property] += scroller.delta;
+    const change = scroller.element[property] - before;
+
+    if (change) {
+      onScroll?.(change);
+      frame = requestAnimationFrame(tick);
+    }
+  };
+
+  return {
+    update(event) {
+      point = axis === "X" ? event.clientX : event.clientY;
+      if (frame === null) {
+        frame = requestAnimationFrame(tick);
+      }
+    },
+
+    stop() {
+      stopped = true;
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+        frame = null;
+      }
+    },
+  };
+}
+
+function scrollTarget(anchor, axis, point) {
+  const overflowProperty = axis === "X" ? "overflowX" : "overflowY";
+  const scrollSize = axis === "X" ? "scrollWidth" : "scrollHeight";
+  const clientSize = axis === "X" ? "clientWidth" : "clientHeight";
+
+  for (let element = anchor; element; element = element.parentElement) {
+    const overflow = getComputedStyle(element)[overflowProperty];
+    if (
+      !/(auto|scroll)/.test(overflow) ||
+      element[scrollSize] <= element[clientSize]
+    ) {
+      continue;
+    }
+
+    const bounds = element.getBoundingClientRect();
+    const start = axis === "X" ? bounds.left : bounds.top;
+    const end = axis === "X" ? bounds.right : bounds.bottom;
+    const delta = edgeDelta(point, start, end);
+    if (delta) {
+      return { delta, element };
+    }
+  }
+
+  return null;
+}
+
+function edgeDelta(point, start, end) {
+  if (point < start + EDGE_SIZE) {
+    return -Math.ceil(
+      MAX_STEP * Math.min((start + EDGE_SIZE - point) / EDGE_SIZE, 1)
+    );
+  }
+  if (point > end - EDGE_SIZE) {
+    return Math.ceil(
+      MAX_STEP * Math.min((point - (end - EDGE_SIZE)) / EDGE_SIZE, 1)
+    );
+  }
+  return 0;
+}

--- a/frontend/discourse/tests/helpers/rich-editor-helper.gjs
+++ b/frontend/discourse/tests/helpers/rich-editor-helper.gjs
@@ -1,9 +1,16 @@
 import { tracked } from "@glimmer/tracking";
 import { click, render, settled, waitFor } from "@ember/test-helpers";
+import ModalContainer from "discourse/components/modal-container";
+import DMenus from "discourse/float-kit/components/d-menus";
 import DEditor from "discourse/ui-kit/d-editor";
 
 export async function setupRichEditor(assert, markdown, opts = {}) {
-  const { multiToggle = false, markdownOptions } = opts;
+  const {
+    disabled = false,
+    multiToggle = false,
+    markdownOptions,
+    withMenus = false,
+  } = opts;
   const self = new (class {
     @tracked value = markdown;
     @tracked view;
@@ -16,10 +23,15 @@ export async function setupRichEditor(assert, markdown, opts = {}) {
     <template>
       <DEditor
         @value={{self.value}}
+        @disabled={{disabled}}
         @processPreview={{false}}
         @onSetup={{handleSetup}}
         @markdownOptions={{markdownOptions}}
       />
+      {{#if withMenus}}
+        <DMenus />
+        <ModalContainer />
+      {{/if}}
     </template>
   );
 

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/drag-handle-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/drag-handle-test.js
@@ -573,6 +573,35 @@ module(
         .exists("the focused block's menu opens without a pointer");
     });
 
+    test("Alt+Enter follows the caret instead of the pointer", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC, { withMenus: true });
+      const { view } = editor;
+      let thirdParagraphPos;
+
+      await hoverBlock(view, 0);
+      view.state.doc.descendants((node, pos) => {
+        if (node.textContent === "Third paragraph.") {
+          thirdParagraphPos = pos;
+        }
+      });
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, thirdParagraphPos + 1)
+        )
+      );
+      view.focus();
+      await settled();
+
+      await triggerKeyEvent(view.dom, "keydown", "Enter", { altKey: true });
+      await waitFor('.fk-d-menu[data-identifier="composer-node-menu"]');
+
+      assert.strictEqual(
+        view.state.selection.node.textContent,
+        "Third paragraph.",
+        "keyboard actions target the block containing the caret"
+      );
+    });
+
     test("Alt+Enter targets the current nested list item", async function (assert) {
       const [editor] = await setupRichEditor(assert, NESTED_DOC, {
         withMenus: true,

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/drag-handle-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/drag-handle-test.js
@@ -82,7 +82,14 @@ module(
         .doesNotHaveClass("--visible", "and stays out of the way until wanted");
 
       await hoverBlock(view, 0);
-      assert.dom(".composer-drag-handle").hasClass("--visible");
+      assert
+        .dom(".composer-drag-handle")
+        .hasClass("--visible")
+        .hasAttribute(
+          "tabindex",
+          "-1",
+          "a pointer-revealed handle does not interrupt keyboard focus order"
+        );
       assert.strictEqual(
         parseFloat(handle().style.left),
         view.dom.getBoundingClientRect().left -

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/drag-handle-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/drag-handle-test.js
@@ -1,0 +1,1163 @@
+import Service from "@ember/service";
+import {
+  clearRender,
+  click,
+  find,
+  findAll,
+  settled,
+  triggerEvent,
+  triggerKeyEvent,
+  waitFor,
+  waitUntil,
+} from "@ember/test-helpers";
+import { NodeSelection, TextSelection } from "prosemirror-state";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import {
+  nodeActionsFor,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
+import { stubPointerCapture } from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
+
+const DOC = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+const NESTED_DOC =
+  "* Parent\n  * First nested\n  * Second nested\n\nLast paragraph.";
+const NESTED_LEVEL_DOC = "* Parent\n  * Nested\n* Sibling";
+
+function handle() {
+  return find(".composer-drag-handle");
+}
+
+async function hoverElement(view, element) {
+  const rect = element.getBoundingClientRect();
+
+  view.dom.dispatchEvent(
+    new PointerEvent("pointermove", {
+      bubbles: true,
+      clientX: rect.left + 20,
+      clientY: rect.top + 6,
+    })
+  );
+  await settled();
+
+  return element;
+}
+
+/** Puts the pointer over a block, which is what reveals its handle. */
+async function hoverBlock(view, index) {
+  const block = view.dom.children[index];
+
+  return hoverElement(view, block);
+}
+
+/** The first top-level block, as the handle would resolve it. */
+function firstBlock(view) {
+  const pos = 0;
+  return { node: view.state.doc.nodeAt(pos), pos, view, pluginParams: {} };
+}
+
+function classNames(items) {
+  return items.map((item) => (item.divider ? "---" : item.className));
+}
+
+module(
+  "Integration | Component | prosemirror-editor - drag handle",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.afterEach(() => resetRichEditorExtensions());
+
+    test("a handle appears for the block under the pointer", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      assert
+        .dom(".composer-drag-handle")
+        .exists("one handle serves every block");
+      assert
+        .dom(".composer-drag-handle")
+        .doesNotHaveClass("--visible", "and stays out of the way until wanted");
+
+      await hoverBlock(view, 0);
+      assert.dom(".composer-drag-handle").hasClass("--visible");
+      assert.strictEqual(
+        parseFloat(handle().style.left),
+        view.dom.getBoundingClientRect().left -
+          parseFloat(getComputedStyle(document.documentElement).fontSize) / 2,
+        "the handle floats half a rem across the editor edge"
+      );
+
+      // The placement is read off the inline style rather than the rendered
+      // rect: a rendering test loads no stylesheet, so the handle is never
+      // actually positioned.
+      const first = handle().style.top;
+      await hoverBlock(view, 2);
+
+      assert.notStrictEqual(
+        handle().style.top,
+        first,
+        "and follows the pointer from block to block"
+      );
+    });
+
+    test("a handle stays inside the visible editor viewport", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+      const block = view.dom.children[0];
+      const scrollport = view.dom.parentElement;
+      const blockBounds = sinon.stub(block, "getBoundingClientRect");
+      sinon.stub(handle(), "offsetHeight").get(() => 24);
+      sinon.stub(view, "posAtCoords").returns({ pos: 1 });
+      sinon.stub(scrollport, "clientHeight").get(() => 100);
+      sinon.stub(scrollport, "clientTop").get(() => 0);
+      sinon.stub(scrollport, "getBoundingClientRect").returns({
+        top: 0,
+        right: 200,
+        bottom: 100,
+        left: 0,
+        width: 200,
+        height: 100,
+      });
+
+      blockBounds.returns({
+        top: -1,
+        right: 200,
+        bottom: 23,
+        left: 0,
+        width: 200,
+        height: 24,
+      });
+      await hoverElement(view, block);
+
+      assert
+        .dom(".composer-drag-handle")
+        .doesNotHaveClass("--visible", "a handle above the viewport is hidden")
+        .hasAttribute("tabindex", "-1", "it cannot receive keyboard focus")
+        .hasAria(
+          "hidden",
+          "true",
+          "it is also hidden from assistive technology"
+        );
+
+      blockBounds.returns({
+        top: 80,
+        right: 200,
+        bottom: 104,
+        left: 0,
+        width: 200,
+        height: 24,
+      });
+      await hoverElement(view, block);
+
+      assert
+        .dom(".composer-drag-handle")
+        .doesNotHaveClass("--visible", "a handle below the viewport is hidden")
+        .hasAttribute("tabindex", "-1", "it remains outside the tab order")
+        .hasAria(
+          "hidden",
+          "true",
+          "it remains hidden from assistive technology"
+        );
+    });
+
+    test("nested list items have their own drag target", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_DOC);
+      const { view } = editor;
+      const nestedItems = findAll(".ProseMirror > ul > li > ul > li");
+      sinon.stub(handle(), "offsetWidth").get(() => 20);
+
+      assert.strictEqual(
+        nestedItems.length,
+        2,
+        "the fixture contains two nested siblings"
+      );
+
+      await hoverElement(view, nestedItems[1]);
+
+      const nestedBounds = nestedItems[1].getBoundingClientRect();
+      const listStyle = getComputedStyle(nestedItems[1].parentElement);
+      const markerInset =
+        parseFloat(listStyle.paddingLeft) ||
+        parseFloat(listStyle.fontSize) * 1.25;
+      const offset =
+        parseFloat(getComputedStyle(document.documentElement).fontSize) / 2;
+      assert.strictEqual(
+        parseFloat(handle().style.left) + handle().offsetWidth,
+        nestedBounds.left - markerInset - offset,
+        "the handle sits before the nested marker instead of over its text"
+      );
+
+      stubPointerCapture(handle());
+      const firstBounds = nestedItems[0].getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 80,
+      };
+      const to = {
+        pointerId: 1,
+        clientX: firstBounds.left + 5,
+        clientY: firstBounds.top + 1,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", to);
+
+      assert.strictEqual(
+        view.state.selection.node.textContent,
+        "Second nested",
+        "the nested list item itself is selected"
+      );
+      assert.strictEqual(
+        parseFloat(find(".composer-drag-handle__drop-indicator").style.left),
+        firstBounds.left,
+        "the insertion marker stays at the nested level"
+      );
+
+      await triggerEvent(handle(), "pointerup", to);
+
+      assert.true(
+        editor.value.indexOf("* Second nested") <
+          editor.value.indexOf("* First nested"),
+        "the nested siblings are reordered without flattening the list"
+      );
+    });
+
+    test("a whole list uses its first item's marker rail", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_DOC);
+      const { view } = editor;
+      const list = view.dom.children[0];
+      const firstItem = list.querySelector(":scope > li");
+      sinon.stub(handle(), "offsetWidth").get(() => 20);
+      sinon.stub(view, "posAtCoords").returns({ pos: 1 });
+
+      await hoverElement(view, list);
+
+      const itemBounds = firstItem.getBoundingClientRect();
+      const listStyle = getComputedStyle(list);
+      const markerInset =
+        parseFloat(listStyle.paddingLeft) ||
+        parseFloat(listStyle.fontSize) * 1.25;
+      const offset =
+        parseFloat(getComputedStyle(document.documentElement).fontSize) / 2;
+      const handleLeft = parseFloat(handle().style.left);
+
+      assert.strictEqual(
+        handleLeft + handle().offsetWidth,
+        itemBounds.left - markerInset - offset,
+        "the whole-list handle is beside its first marker"
+      );
+    });
+
+    test("crossing a list marker keeps the first item targeted", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_DOC);
+      const { view } = editor;
+      const firstItem = find(".ProseMirror > ul > li");
+      let firstItemPos;
+
+      view.state.doc.descendants((node, pos) => {
+        if (firstItemPos === undefined && node.type.name === "list_item") {
+          firstItemPos = pos;
+        }
+      });
+
+      sinon.stub(handle(), "offsetWidth").get(() => 20);
+      sinon.stub(handle(), "offsetHeight").get(() => 24);
+      sinon
+        .stub(view, "posAtCoords")
+        .onFirstCall()
+        .returns({ pos: firstItemPos + 2 })
+        .onSecondCall()
+        .returns({ pos: 1 });
+
+      await hoverElement(view, firstItem);
+
+      const itemBounds = firstItem.getBoundingClientRect();
+      const handleLeft = parseFloat(handle().style.left);
+      const handleTop = parseFloat(handle().style.top);
+      view.dom.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          clientX: (handleLeft + handle().offsetWidth + itemBounds.left) / 2,
+          clientY: itemBounds.top + 6,
+        })
+      );
+      await settled();
+
+      stubPointerCapture(handle());
+      await triggerEvent(handle(), "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: handleLeft + 10,
+        clientY: handleTop + 6,
+      });
+      await triggerEvent(handle(), "pointermove", {
+        pointerId: 1,
+        clientX: handleLeft + 16,
+        clientY: handleTop + 12,
+      });
+
+      assert.strictEqual(
+        view.state.selection.node.type.name,
+        "list_item",
+        "reaching for the grip does not replace the item with its parent list"
+      );
+
+      await triggerEvent(handle(), "pointercancel", {
+        pointerId: 1,
+        clientX: handleLeft + 16,
+        clientY: handleTop + 12,
+      });
+    });
+
+    test("a nested item can be moved to a compatible list level", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_LEVEL_DOC);
+      const { view } = editor;
+      const nested = find(".ProseMirror > ul > li > ul > li");
+      const sibling = findAll(".ProseMirror > ul > li")[1];
+
+      await hoverElement(view, nested);
+      stubPointerCapture(handle());
+
+      const targetBounds = sibling.getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 80,
+      };
+      const to = {
+        pointerId: 1,
+        clientX: targetBounds.left + 5,
+        clientY: targetBounds.top + 1,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", to);
+      await triggerEvent(handle(), "pointerup", to);
+
+      assert
+        .dom(".ProseMirror > ul > li")
+        .exists({ count: 3 }, "the item is inserted at the outer list level");
+      assert
+        .dom(".ProseMirror li > ul > li")
+        .doesNotExist("the emptied nested list is removed");
+      assert.strictEqual(
+        editor.value,
+        "* Parent\n* Nested\n* Sibling",
+        "the item keeps its list-item content while changing levels"
+      );
+    });
+
+    test("a list item can be moved into a compatible nested list", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_LEVEL_DOC);
+      const { view } = editor;
+      const nested = find(".ProseMirror > ul > li > ul > li");
+      const sibling = findAll(".ProseMirror > ul > li")[1];
+
+      await hoverElement(view, sibling);
+      stubPointerCapture(handle());
+
+      const targetBounds = nested.getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 80,
+      };
+      const to = {
+        pointerId: 1,
+        clientX: targetBounds.left + 5,
+        clientY: targetBounds.bottom - 1,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", to);
+      await triggerEvent(handle(), "pointerup", to);
+
+      assert
+        .dom(".ProseMirror > ul > li")
+        .exists({ count: 1 }, "the item leaves the outer list level");
+      assert
+        .dom(".ProseMirror > ul > li > ul > li")
+        .exists({ count: 2 }, "the item joins the nested list");
+      assert.strictEqual(
+        editor.value,
+        "* Parent\n  * Nested\n  * Sibling",
+        "the item keeps its content while becoming nested"
+      );
+    });
+
+    test("a list item cannot be dropped into its own descendants", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_LEVEL_DOC);
+      const { view } = editor;
+      const parent = find(".ProseMirror > ul > li");
+      const nested = find(".ProseMirror > ul > li > ul > li");
+
+      await hoverElement(view, parent);
+      stubPointerCapture(handle());
+
+      const targetBounds = nested.getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      };
+      const to = {
+        pointerId: 1,
+        clientX: targetBounds.left + 5,
+        clientY: targetBounds.top + 1,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", to);
+
+      assert
+        .dom(".composer-drag-handle__drop-indicator")
+        .doesNotHaveClass(
+          "--visible",
+          "an impossible recursive destination is not offered"
+        );
+
+      await triggerEvent(handle(), "pointerup", to);
+
+      assert.strictEqual(
+        editor.value,
+        NESTED_LEVEL_DOC,
+        "the document remains unchanged"
+      );
+    });
+
+    test("pressing and releasing the handle does not move the block", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+
+      await hoverBlock(editor.view, 0);
+      stubPointerCapture(handle());
+      await triggerEvent(handle(), "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      });
+      await triggerEvent(handle(), "pointerup", {
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      });
+
+      assert.strictEqual(editor.value, DOC, "a click is not treated as a drag");
+    });
+
+    test("an inactive handle is hidden from assistive technology", async function (assert) {
+      await setupRichEditor(assert, DOC);
+
+      assert.dom(".composer-drag-handle").hasAria("label");
+      assert.dom(".composer-drag-handle").doesNotHaveAttribute("hidden");
+      assert
+        .dom(".composer-drag-handle")
+        .hasAttribute(
+          "aria-hidden",
+          "true",
+          "it is not an action without a target"
+        );
+    });
+
+    test("the desktop handle does not follow the caret", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+
+      editor.view.focus();
+      await settled();
+
+      assert
+        .dom(".composer-drag-handle")
+        .doesNotHaveClass(
+          "--visible",
+          "focusing a block does not reveal its handle"
+        );
+      assert
+        .dom(".composer-drag-handle")
+        .hasAttribute("tabindex", "-1", "the hidden handle is not a tab stop");
+      assert
+        .dom(".ProseMirror")
+        .hasAttribute(
+          "aria-keyshortcuts",
+          "Alt+Enter Shift+F10",
+          "the focused editor advertises its action-menu shortcuts"
+        );
+    });
+
+    test("a touch-first editor keeps the current block's handle available", async function (assert) {
+      sinon
+        .stub(this.owner.lookup("service:capabilities"), "touchFirst")
+        .get(() => true);
+
+      const [editor] = await setupRichEditor(assert, DOC);
+      editor.view.focus();
+      await settled();
+
+      assert
+        .dom(".composer-drag-handle")
+        .hasClass("--touch", "the handle uses its in-editor touch placement");
+      assert
+        .dom(".composer-drag-handle")
+        .hasClass(
+          "--visible",
+          "tapping into a block reveals its action handle"
+        );
+      assert
+        .dom(".composer-drag-handle")
+        .hasAttribute("tabindex", "0", "the touch handle remains actionable");
+    });
+
+    test("a touch handle mirrors its placement in RTL", async function (assert) {
+      sinon
+        .stub(this.owner.lookup("service:capabilities"), "touchFirst")
+        .get(() => true);
+
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+      const block = view.dom.children[0];
+      view.dom.style.direction = "rtl";
+      sinon.stub(handle(), "offsetWidth").get(() => 20);
+
+      await hoverBlock(view, 0);
+
+      assert.strictEqual(
+        parseFloat(handle().style.left),
+        Math.max(
+          block.getBoundingClientRect().left,
+          view.dom.getBoundingClientRect().left
+        ) + 6,
+        "the touch handle uses the physical left edge away from RTL text"
+      );
+    });
+
+    test("clicking the handle opens its node actions", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC, { withMenus: true });
+
+      await hoverBlock(editor.view, 0);
+      await click(".composer-drag-handle");
+      await waitFor('.fk-d-menu[data-identifier="composer-node-menu"]');
+
+      assert
+        .dom(".composer-node-menu__duplicate")
+        .exists("the duplicate action is rendered");
+      assert
+        .dom(".composer-node-menu__delete")
+        .exists("the delete action is rendered");
+      assert
+        .dom(".composer-drag-handle")
+        .hasAttribute(
+          "aria-expanded",
+          "true",
+          "the disclosure state is exposed"
+        );
+      assert
+        .dom('.fk-d-menu[data-identifier="composer-node-menu"]')
+        .hasAttribute("role", "none", "the button list has no dialog wrapper");
+    });
+
+    test("Alt+Enter opens the current block's node actions", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC, { withMenus: true });
+
+      editor.view.focus();
+      await settled();
+      await triggerKeyEvent(editor.view.dom, "keydown", "Enter", {
+        altKey: true,
+      });
+      await waitFor('.fk-d-menu[data-identifier="composer-node-menu"]');
+
+      assert
+        .dom(".composer-node-menu__duplicate")
+        .exists("the focused block's menu opens without a pointer");
+    });
+
+    test("Alt+Enter targets the current nested list item", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_DOC, {
+        withMenus: true,
+      });
+      const { view } = editor;
+      let nestedPos;
+
+      view.state.doc.descendants((node, pos) => {
+        if (
+          node.type.name === "list_item" &&
+          node.textContent === "Second nested"
+        ) {
+          nestedPos = pos;
+        }
+      });
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, nestedPos + 2)
+        )
+      );
+      view.focus();
+      await settled();
+      await triggerKeyEvent(view.dom, "keydown", "Enter", { altKey: true });
+      await waitFor('.fk-d-menu[data-identifier="composer-node-menu"]');
+
+      assert
+        .dom(".composer-node-menu__move-up")
+        .exists("the nested item's previous-sibling action is available");
+      assert
+        .dom(".composer-node-menu__move-down")
+        .doesNotExist("the outer list's next-root-block action is not used");
+      assert.strictEqual(
+        view.state.selection.node.textContent,
+        "Second nested",
+        "the nested list item becomes the node selection"
+      );
+    });
+
+    test("Alt+Enter targets a top-level NodeSelection", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC, { withMenus: true });
+      const { view } = editor;
+      view.dispatch(
+        view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0))
+      );
+      await settled();
+
+      await triggerKeyEvent(view.dom, "keydown", "Enter", { altKey: true });
+      await waitFor('.fk-d-menu[data-identifier="composer-node-menu"]');
+
+      assert
+        .dom(".composer-node-menu__duplicate")
+        .exists("the selected top-level block's menu opens");
+      assert.strictEqual(view.state.selection.from, 0);
+    });
+
+    test("a menu that resolves after teardown is destroyed", async function (assert) {
+      let resolveMenu;
+      let showCalls = 0;
+      const lateMenu = { destroy: sinon.spy(), expanded: true };
+      this.owner.register(
+        "service:menu",
+        class DeferredMenuService extends Service {
+          close() {}
+
+          show() {
+            showCalls++;
+            return new Promise((resolve) => {
+              resolveMenu = resolve;
+            });
+          }
+        }
+      );
+      const [editor] = await setupRichEditor(assert, DOC);
+
+      await hoverBlock(editor.view, 0);
+      handle().click();
+      await waitUntil(() => showCalls === 1);
+      await clearRender();
+
+      resolveMenu(lateMenu);
+      await settled();
+
+      assert.true(
+        lateMenu.destroy.calledOnce,
+        "a late FloatKit instance cannot outlive the editor"
+      );
+    });
+
+    test("plugins can register node actions that appear and run", async function (assert) {
+      let runs = 0;
+
+      withPluginApi((api) => {
+        api.registerRichEditorExtension({
+          nodeActions: {
+            paragraph: () => [
+              {
+                label: "Test plugin action",
+                className: "composer-node-menu__test-plugin-action",
+                action: () => runs++,
+              },
+            ],
+          },
+        });
+      });
+
+      const [editor] = await setupRichEditor(assert, DOC, { withMenus: true });
+      await hoverBlock(editor.view, 0);
+      await click(".composer-drag-handle");
+      await waitFor(".composer-node-menu__test-plugin-action");
+      await click(".composer-node-menu__test-plugin-action");
+
+      assert.strictEqual(runs, 1, "the plugin action runs from the real menu");
+    });
+
+    test("a disabled editor exposes no actionable handle", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC, {
+        disabled: true,
+        withMenus: true,
+      });
+
+      assert.false(editor.view.editable);
+      assert
+        .dom(".composer-drag-handle")
+        .doesNotHaveClass(
+          "--visible",
+          "read-only content has no handle chrome"
+        );
+      assert.dom(".composer-drag-handle").hasAttribute("tabindex", "-1");
+
+      handle().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      nodeActionsFor("paragraph", firstBlock(editor.view))
+        .find((item) => item.className === "composer-node-menu__duplicate")
+        .action();
+      await settled();
+
+      assert
+        .dom('.fk-d-menu[data-identifier="composer-node-menu"]')
+        .doesNotExist("a synthetic click cannot open actions");
+      assert.strictEqual(editor.value, DOC);
+    });
+
+    test("dragging stays in the block rail and marks the insertion point", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 0);
+      stubPointerCapture(handle());
+
+      const beforeLeft = handle().style.left;
+      const beforeTop = handle().style.top;
+      const last = view.dom.children[2].getBoundingClientRect();
+      await triggerEvent(handle(), "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      });
+      await triggerEvent(handle(), "pointermove", {
+        pointerId: 1,
+        clientX: last.right + 100,
+        clientY: last.bottom - 2,
+      });
+
+      assert.true(
+        view.state.selection instanceof NodeSelection,
+        "the block itself is selected, not a cursor inside it"
+      );
+      assert.strictEqual(
+        view.state.selection.node.textContent,
+        "First paragraph.",
+        "and it is the block the handle belonged to"
+      );
+
+      assert.dom(".composer-drag-handle").hasClass("is-dragging");
+      assert.strictEqual(
+        handle().style.left,
+        beforeLeft,
+        "the handle remains in its horizontal rail"
+      );
+      assert.notStrictEqual(
+        handle().style.top,
+        beforeTop,
+        "the handle follows the pointer vertically"
+      );
+      assert
+        .dom(".composer-drag-handle__drop-indicator")
+        .hasClass("--visible", "a full-width insertion marker is shown");
+    });
+
+    test("canceling a drag clears the editor's drag state", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 0);
+      stubPointerCapture(handle());
+      await triggerEvent(handle(), "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      });
+      await triggerEvent(handle(), "pointermove", {
+        pointerId: 1,
+        clientX: 40,
+        clientY: 40,
+      });
+      await triggerEvent(handle(), "pointercancel", {
+        pointerId: 1,
+        clientX: 40,
+        clientY: 40,
+      });
+
+      assert
+        .dom(".ProseMirror")
+        .doesNotHaveClass("is-dragging-block", "the editor leaves drag mode");
+      assert
+        .dom(".composer-drag-handle__drop-indicator")
+        .doesNotHaveClass("--visible", "the insertion marker is cleared");
+    });
+
+    test("teardown during a drag clears the editor's drag state", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+      const editorDom = view.dom;
+
+      await hoverBlock(view, 0);
+      stubPointerCapture(handle());
+      await triggerEvent(handle(), "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      });
+      await triggerEvent(handle(), "pointermove", {
+        pointerId: 1,
+        clientX: 40,
+        clientY: 40,
+      });
+      assert.true(editorDom.classList.contains("is-dragging-block"));
+
+      await clearRender();
+
+      assert.false(
+        editorDom.classList.contains("is-dragging-block"),
+        "the detached editor does not retain external drag state"
+      );
+    });
+
+    test("dragging at an edge scrolls and drops at the new position", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+      const scrollport = view.dom.parentElement;
+      const first = view.dom.children[0];
+      const third = view.dom.children[2];
+      let thirdPos;
+      let scrollTop = 0;
+
+      view.state.doc.descendants((node, pos) => {
+        if (node.textContent === "Third paragraph.") {
+          thirdPos = pos;
+        }
+      });
+
+      scrollport.style.overflowY = "auto";
+      sinon.stub(scrollport, "scrollHeight").get(() => 300);
+      sinon.stub(scrollport, "clientHeight").get(() => 100);
+      sinon.stub(scrollport, "clientTop").get(() => 0);
+      sinon
+        .stub(scrollport, "scrollTop")
+        .get(() => scrollTop)
+        .set((value) => (scrollTop = Math.min(value, 64)));
+      sinon.stub(scrollport, "getBoundingClientRect").returns({
+        top: 0,
+        right: 200,
+        bottom: 100,
+        left: 0,
+        width: 200,
+        height: 100,
+      });
+      sinon.stub(view.dom, "getBoundingClientRect").returns({
+        top: 0,
+        right: 200,
+        bottom: 200,
+        left: 0,
+        width: 200,
+        height: 200,
+      });
+      sinon.stub(first, "getBoundingClientRect").returns({
+        top: 8,
+        right: 200,
+        bottom: 32,
+        left: 0,
+        width: 200,
+        height: 24,
+      });
+      sinon.stub(third, "getBoundingClientRect").callsFake(() => ({
+        top: 140 - scrollTop,
+        right: 200,
+        bottom: 164 - scrollTop,
+        left: 0,
+        width: 200,
+        height: 24,
+      }));
+      sinon.stub(handle(), "offsetHeight").get(() => 24);
+      sinon
+        .stub(view, "posAtCoords")
+        .onFirstCall()
+        .returns({ pos: 1 })
+        .returns({ pos: thirdPos + 1 });
+
+      await hoverBlock(view, 0);
+      stubPointerCapture(handle());
+      const point = { pointerId: 1, clientX: 20, clientY: 99 };
+      await triggerEvent(handle(), "pointerdown", {
+        ...point,
+        button: 0,
+        clientY: 80,
+      });
+      await triggerEvent(handle(), "pointermove", point);
+      await waitUntil(() => scrollTop === 64);
+
+      assert.strictEqual(
+        parseFloat(find(".composer-drag-handle__drop-indicator").style.top),
+        100,
+        "the indicator follows content while the pointer stays still"
+      );
+
+      await triggerEvent(handle(), "pointerup", point);
+
+      assert.strictEqual(
+        editor.value,
+        "Second paragraph.\n\nThird paragraph.\n\nFirst paragraph.",
+        "release uses the destination revealed by autoscroll"
+      );
+    });
+
+    test("dropping it puts the block in its new place", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 0);
+      stubPointerCapture(handle());
+
+      const last = view.dom.children[2].getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      };
+      const to = {
+        pointerId: 1,
+        clientX: last.left + 5,
+        clientY: last.bottom - 2,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", to);
+      assert
+        .dom(".composer-drag-handle__drop-indicator")
+        .hasClass("--visible", "the destination is visible before dropping");
+      await triggerEvent(handle(), "pointerup", to);
+
+      assert.false(
+        editor.value.startsWith("First paragraph."),
+        "the dragged block is no longer where it started"
+      );
+      assert.true(
+        editor.value.includes("First paragraph."),
+        "and it was moved rather than lost"
+      );
+      assert
+        .dom(".composer-drag-handle__drop-indicator")
+        .doesNotHaveClass("--visible", "the destination clears after dropping");
+    });
+
+    test("a block can be dragged upward", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 2);
+      stubPointerCapture(handle());
+
+      const first = view.dom.children[0].getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 80,
+      };
+      const to = {
+        pointerId: 1,
+        clientX: first.left + 5,
+        clientY: first.top + 1,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", to);
+      await triggerEvent(handle(), "pointerup", to);
+
+      assert.true(
+        editor.value.startsWith("Third paragraph.\n\nFirst paragraph."),
+        "the last block is moved before the first"
+      );
+    });
+
+    test("dropping outside the editor does not move the block", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 0);
+      stubPointerCapture(handle());
+
+      const editorBounds = view.dom.getBoundingClientRect();
+      const from = {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      };
+      const outside = {
+        pointerId: 1,
+        clientX: editorBounds.left + 5,
+        clientY: editorBounds.bottom + 50,
+      };
+      await triggerEvent(handle(), "pointerdown", from);
+      await triggerEvent(handle(), "pointermove", outside);
+      await triggerEvent(handle(), "pointerup", outside);
+
+      assert.strictEqual(editor.value, DOC);
+    });
+
+    // float-kit does not mount in a rendering test, so what is covered here is
+    // the registry the handle's menu is built from, and that its entries work.
+    test("the registry offers the shared actions to any block", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const target = firstBlock(editor.view);
+
+      assert.deepEqual(
+        classNames(nodeActionsFor("paragraph", target)),
+        [
+          "composer-node-menu__move-down",
+          "composer-node-menu__duplicate",
+          "---",
+          "composer-node-menu__delete",
+        ],
+        "a plain block gets keyboard-accessible movement and shared actions"
+      );
+    });
+
+    test("duplicate copies the block", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const items = nodeActionsFor("paragraph", firstBlock(editor.view));
+
+      items.find((i) => i.className.endsWith("duplicate")).action();
+      await settled();
+
+      assert.true(
+        editor.value.startsWith("First paragraph.\n\nFirst paragraph."),
+        `copied it in place, got: ${editor.value.slice(0, 40)}`
+      );
+    });
+
+    test("delete removes the block", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const items = nodeActionsFor("paragraph", firstBlock(editor.view));
+
+      items.find((i) => i.className === "composer-node-menu__delete").action();
+      await settled();
+
+      assert.false(editor.value.includes("First paragraph."));
+      assert.true(editor.value.startsWith("Second paragraph."));
+    });
+
+    test("move down reorders a block without a pointer", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const items = nodeActionsFor("paragraph", firstBlock(editor.view));
+
+      items.find((i) => i.className.endsWith("move-down")).action();
+      await settled();
+
+      assert.true(
+        editor.value.startsWith("Second paragraph.\n\nFirst paragraph.")
+      );
+      assert.true(editor.view.state.selection instanceof NodeSelection);
+      assert.strictEqual(
+        editor.view.state.selection.node.textContent,
+        "First paragraph.",
+        "the moved block remains selected"
+      );
+    });
+
+    test("nested item actions are scoped to their sibling list", async function (assert) {
+      const [editor] = await setupRichEditor(assert, NESTED_DOC);
+      const { view } = editor;
+      let target;
+
+      view.state.doc.descendants((node, pos) => {
+        if (
+          node.type.name === "list_item" &&
+          node.textContent === "First nested"
+        ) {
+          target = { node, pos, view, pluginParams: {} };
+        }
+      });
+
+      const items = nodeActionsFor("list_item", target);
+      items.find((item) => item.className.endsWith("move-down")).action();
+      await settled();
+
+      assert.true(
+        editor.value.indexOf("* Second nested") <
+          editor.value.indexOf("* First nested"),
+        "the action reorders nested siblings without moving the outer list"
+      );
+      assert.true(
+        editor.value.startsWith("* Parent"),
+        "the outer list item stays in place"
+      );
+    });
+
+    test("crossing a short gap to the handle keeps it up", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 0);
+      assert.dom(".composer-drag-handle").hasClass("--visible");
+
+      view.dom.dispatchEvent(
+        new PointerEvent("pointerleave", {
+          bubbles: false,
+          relatedTarget: null,
+        })
+      );
+      handle().dispatchEvent(
+        new PointerEvent("pointerenter", { bubbles: false })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await settled();
+
+      assert
+        .dom(".composer-drag-handle")
+        .hasClass("--visible", "a transient gap does not dismiss the handle");
+
+      handle().dispatchEvent(
+        new PointerEvent("pointerleave", {
+          bubbles: false,
+          relatedTarget: null,
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await settled();
+
+      assert
+        .dom(".composer-drag-handle")
+        .doesNotHaveClass(
+          "--visible",
+          "but leaving for anywhere else hides it"
+        );
+    });
+
+    test("a pointer gap keeps the nearest block available", async function (assert) {
+      const [editor] = await setupRichEditor(assert, DOC);
+      const { view } = editor;
+
+      await hoverBlock(view, 0);
+      const firstTop = handle().style.top;
+      const second = view.dom.children[1].getBoundingClientRect();
+      sinon.stub(view, "posAtCoords").returns(null);
+
+      view.dom.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          clientX: second.left,
+          clientY: second.top + second.height / 2,
+        })
+      );
+      await settled();
+
+      assert
+        .dom(".composer-drag-handle")
+        .hasClass("--visible", "the handle remains available in editor gaps");
+      assert.notStrictEqual(
+        handle().style.top,
+        firstTop,
+        "the handle resolves to the nearest block"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
@@ -1,6 +1,8 @@
-import { render, settled } from "@ember/test-helpers";
+import { click, find, render, settled, waitFor } from "@ember/test-helpers";
 import { cacheShortUploadUrl, resetCache } from "pretty-text/upload-short-url";
 import { module, test } from "qunit";
+import ModalContainer from "discourse/components/modal-container";
+import DMenus from "discourse/float-kit/components/d-menus";
 import {
   clearRichEditorExtensions,
   resetRichEditorExtensions,
@@ -9,6 +11,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import ProsemirrorEditor from "discourse/static/prosemirror/components/prosemirror-editor";
 import grid from "discourse/static/prosemirror/extensions/grid";
 import image from "discourse/static/prosemirror/extensions/image";
+import defaultExtensions from "discourse/static/prosemirror/extensions/register-default";
 import uploadPlaceholder from "discourse/static/prosemirror/extensions/upload-placeholder";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
@@ -139,6 +142,70 @@ module("Integration | Component | ProsemirrorEditor", function (hooks) {
     );
 
     assert.dom(".ProseMirror").exists("it renders the ProseMirror editor");
+  });
+
+  test("uses node actions from the editor's extensions", async function (assert) {
+    let globalRuns = 0;
+    let localRuns = 0;
+
+    withPluginApi((api) => {
+      api.registerRichEditorExtension({
+        nodeActions: {
+          paragraph: () => [
+            {
+              label: "Global action",
+              className: "composer-node-menu__global-action",
+              action: () => globalRuns++,
+            },
+          ],
+        },
+      });
+    });
+
+    const extensions = [
+      ...defaultExtensions,
+      {
+        nodeActions: {
+          paragraph: () => [
+            {
+              label: "Local action",
+              className: "composer-node-menu__local-action",
+              action: () => localRuns++,
+            },
+          ],
+        },
+      },
+    ];
+
+    await render(
+      <template>
+        <ProsemirrorEditor @extensions={{extensions}} @value="Paragraph" />
+        <DMenus />
+        <ModalContainer />
+      </template>
+    );
+
+    const block = find(".ProseMirror > p");
+    const bounds = block.getBoundingClientRect();
+    block.parentElement.dispatchEvent(
+      new PointerEvent("pointermove", {
+        bubbles: true,
+        clientX: bounds.left + 20,
+        clientY: bounds.top + 6,
+      })
+    );
+    await settled();
+    await click(".composer-drag-handle");
+    await waitFor(".composer-node-menu__local-action");
+
+    assert
+      .dom(".composer-node-menu__global-action")
+      .doesNotExist("globally registered actions stay out of this editor");
+
+    await click(".composer-node-menu__local-action");
+
+    assert.strictEqual(localRuns, 1, "the editor-local action runs");
+    assert.strictEqual(globalRuns, 0, "the global action does not run");
   });
 
   test("supports registered nodeSpec/parser/serializer", async function (assert) {

--- a/spec/system/composer/prosemirror_drag_handle_spec.rb
+++ b/spec/system/composer/prosemirror_drag_handle_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe "Composer - ProseMirror - Block drag handle" do
+  include_context "with prosemirror editor"
+
+  it "lets the user reorder blocks by dragging their handle" do
+    open_composer
+    composer.type_content("First paragraph\n\nSecond paragraph\n\nThird paragraph")
+
+    composer.drag_rich_editor_block(source: "Second paragraph", after: "Third paragraph") do
+      expect(composer).to have_dragging_rich_editor_block
+      expect(composer).to have_rich_editor_drop_indicator
+    end
+
+    expect(composer).to have_rich_editor_blocks(
+      "First paragraph",
+      "Third paragraph",
+      "Second paragraph",
+    )
+  end
+
+  it "lets the user reorder nested list items without flattening them" do
+    open_composer
+    composer.type_content("* Parent\nFirst nested")
+    composer.send_keys(:tab)
+    composer.type_content("\nSecond nested")
+
+    expect(composer).to have_nested_list_items("First nested", "Second nested")
+
+    composer.drag_rich_editor_block(source: "First nested", after: "Second nested")
+
+    expect(composer).to have_nested_list_items("Second nested", "First nested")
+  end
+end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -70,6 +70,63 @@ module PageObjects
         self
       end
 
+      def drag_rich_editor_block(source:, after:, &block)
+        draggable_blocks = "#{RICH_EDITOR} > *, #{RICH_EDITOR} li"
+        source_block = find(draggable_blocks, text: source, exact_text: true)
+        target_block = find(draggable_blocks, text: after, exact_text: true)
+
+        page.driver.with_playwright_page do |pw_page|
+          source_bounds = source_block.native.bounding_box
+          source_x = source_bounds["x"] + 120
+          source_y = source_bounds["y"] + 6
+          pw_page.mouse.move(source_x, source_y)
+
+          handle =
+            pw_page.wait_for_selector(
+              ".composer-drag-handle.--visible",
+              state: "visible",
+              timeout: Capybara.default_max_wait_time * 1000,
+            )
+          handle_bounds = handle.bounding_box
+          target_bounds = target_block.native.bounding_box
+
+          pw_page.mouse.move(
+            handle_bounds["x"] + handle_bounds["width"] / 2,
+            handle_bounds["y"] + handle_bounds["height"] / 2,
+            steps: 10,
+          )
+          pw_page.mouse.down
+          pw_page.mouse.move(
+            target_bounds["x"] + target_bounds["width"] / 2,
+            target_bounds["y"] + target_bounds["height"] - 1,
+            steps: 10,
+          )
+        end
+
+        begin
+          yield if block
+        ensure
+          page.driver.with_playwright_page { |pw_page| pw_page.mouse.up }
+        end
+        self
+      end
+
+      def has_dragging_rich_editor_block?
+        has_css?("#{RICH_EDITOR}.is-dragging-block")
+      end
+
+      def has_rich_editor_drop_indicator?
+        has_css?(".composer-drag-handle__drop-indicator.--visible")
+      end
+
+      def has_rich_editor_blocks?(*blocks)
+        ordered_text =
+          Regexp.new(blocks.map { |text| Regexp.escape(text) }.join(".*"), Regexp::MULTILINE)
+
+        has_css?(RICH_EDITOR, text: ordered_text) &&
+          blocks.all? { |text| has_css?("#{RICH_EDITOR} > *", text:, exact_text: true, count: 1) }
+      end
+
       # The composer's height is driven by this variable, so matching it is how the
       # resize is observed. Named for what it reads rather than for the height, which
       # would suggest measuring the box.
@@ -416,6 +473,15 @@ module PageObjects
 
       def has_nested_list_item?(text)
         has_css?("#{RICH_EDITOR} li > ul > li", text:, exact_text: true)
+      end
+
+      def has_nested_list_items?(*items)
+        selector = "#{RICH_EDITOR} li > :is(ul, ol) > li"
+        ordered_text =
+          Regexp.new(items.map { |text| Regexp.escape(text) }.join(".*"), Regexp::MULTILINE)
+
+        has_css?(selector, count: items.length) &&
+          has_css?("#{RICH_EDITOR} li > :is(ul, ol)", text: ordered_text)
       end
 
       def has_top_level_list_item?(text)


### PR DESCRIPTION
Rich-editor blocks had no shared control for reordering or accessing node actions.

This change adds a generic drag handle with pointer, touch, and keyboard interaction, including nested-list reordering and plugin-contributed actions.

<img width="731" height="264" alt="image" src="https://github.com/user-attachments/assets/432f3211-231f-47c2-b1f6-965f9932fb8a" />
