### PR TITLE
DEV: Derive the `DTextField` placeholder attribute without a computed setter

### DIFF
--- a/frontend/discourse/app/components/ember-text-field.gjs
+++ b/frontend/discourse/app/components/ember-text-field.gjs
@@ -86,7 +86,6 @@ const TextField = Component.extend({
     "form",
     "maxlength",
     "minlength",
-    "placeholder",
     "readonly",
     "required",
     "selectionDirection",

--- a/frontend/discourse/app/ui-kit/d-text-field.js
+++ b/frontend/discourse/app/ui-kit/d-text-field.js
@@ -16,7 +16,8 @@ const DEBOUNCE_MS = 500;
   "maxLength",
   "dir",
   "aria-label",
-  "aria-controls"
+  "aria-controls",
+  "resolvedPlaceholder:placeholder"
 )
 export default class DTextField extends TextField {
   _prevValue = null;
@@ -68,15 +69,17 @@ export default class DTextField extends TextField {
     cancel(this._timer);
   }
 
-  @computed("placeholderKey", "_placeholder")
-  get placeholder() {
-    if (this._placeholder) {
-      return this._placeholder;
+  /**
+   * The bound `placeholder` attribute, derived from both arguments. This is
+   * a separate computed rather than a setter on `placeholder`: Ember caches
+   * what a computed setter returns at assignment time, so the result would
+   * depend on which argument the caller passes first.
+   */
+  @computed("placeholder", "placeholderKey")
+  get resolvedPlaceholder() {
+    if (this.placeholder) {
+      return this.placeholder;
     }
     return this.placeholderKey ? i18n(this.placeholderKey) : "";
-  }
-
-  set placeholder(value) {
-    this.set("_placeholder", value);
   }
 }

--- a/frontend/discourse/tests/integration/components/text-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/text-field-test.gjs
@@ -43,6 +43,49 @@ module("Integration | Component | TextField", function (hooks) {
       .hasAttribute("placeholder", "[en.placeholder.i18n.key]");
   });
 
+  test("falls back to the placeholder key when the placeholder argument is empty", async function (assert) {
+    await render(
+      <template>
+        <DTextField
+          @placeholder={{null}}
+          @placeholderKey="placeholder.i18n.key"
+        />
+      </template>
+    );
+
+    assert
+      .dom("input[type=text]")
+      .hasAttribute("placeholder", "[en.placeholder.i18n.key]");
+  });
+
+  test("falls back to the placeholder key regardless of argument order", async function (assert) {
+    await render(
+      <template>
+        <DTextField
+          @placeholderKey="placeholder.i18n.key"
+          @placeholder={{null}}
+        />
+      </template>
+    );
+
+    assert
+      .dom("input[type=text]")
+      .hasAttribute("placeholder", "[en.placeholder.i18n.key]");
+  });
+
+  test("prefers an explicit placeholder over the placeholder key", async function (assert) {
+    await render(
+      <template>
+        <DTextField
+          @placeholder="Explicit"
+          @placeholderKey="placeholder.i18n.key"
+        />
+      </template>
+    );
+
+    assert.dom("input[type=text]").hasAttribute("placeholder", "Explicit");
+  });
+
   test("sets the dir attribute to auto when mixed text direction enabled", async function (assert) {
     this.siteSettings.support_mixed_text_direction = true;
 


### PR DESCRIPTION
`DTextField` took `@placeholder` through a computed setter, with a getter that fell back to `@placeholderKey`. Ember caches whatever a computed setter returns at assignment time and never re-links the computed's dependent keys, so the rendered placeholder depended on which of the two arguments the caller passed first. Passing `@placeholder` before `@placeholderKey` produced an empty placeholder; the composer title only worked because its invocation happened to list the key first.

The attribute now binds to a plain computed over both arguments, and the base `TextField` no longer binds `placeholder` itself so the two bindings do not compete. Behaviour for existing callers is unchanged: an explicit placeholder still wins over the key.

Rendering tests cover both argument orders and an explicit placeholder overriding the key.
