### PR TITLE
DEV: Fix asset compilation error for boards plugin

### DIFF
--- a/plugins/boards/plugin.rb
+++ b/plugins/boards/plugin.rb
@@ -51,10 +51,9 @@ after_initialize do
         .pluck(:icon)
         .each { |icon| DiscoursePluginRegistry.register_svg_icon(icon) }
     end
-  rescue ActiveRecord::NoDatabaseError,
-         ActiveRecord::StatementInvalid,
-         ActiveRecord::DatabaseConnectionError
-    # Database may not exist/may have pending migrations yet during db:create / db:migrate bootstrap.
+  rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
+    # Database may be unreachable (asset precompile) or may have pending migrations
+    # during db:create / db:migrate bootstrap.
   end
 
   # When a column's icon changes, register it and expire the sprite cache


### PR DESCRIPTION
Issue is that plugins/boards/plugin.rb:46 hits the database at
after_initialize (data_source_exists?(:discourse_kanban_columns)) to
pre-register column icons. The Publish Assets job runs rake
assets:precompile with no Postgres container, so the connection fails
and boot aborts.

The rescue there was meant to cover this but misses the actual class:
PG's failure surfaces as ActiveRecord::ConnectionNotEstablished. The
listed classes are NoDatabaseError, StatementInvalid, and
DatabaseConnectionError — and DatabaseConnectionError is a subclass of
ConnectionNotEstablished, not its parent, so it doesn't catch it.

The fix is to widen the rescue to ActiveRecord::ConnectionNotEstablished
(covers NoDatabaseError and DatabaseConnectionError) alongside
StatementInvalid
