### PR TITLE
FIX: Preserve subsecond traffic session durations

### DIFF
--- a/app/services/admin_dashboard_site_traffic_explorer.rb
+++ b/app/services/admin_dashboard_site_traffic_explorer.rb
@@ -390,10 +390,8 @@ class AdminDashboardSiteTrafficExplorer
           END,
           'average_session_duration_seconds', CASE
             WHEN session_summary.distinct_sessions = 0 THEN 0
-            ELSE ROUND(
-              session_summary.engaged_seconds::numeric /
-                session_summary.distinct_sessions
-            )::integer
+            ELSE session_summary.engaged_seconds::numeric /
+              session_summary.distinct_sessions
           END
         ) AS summary,
         COALESCE(

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -105,8 +105,8 @@ ru:
         x_seconds:
           one: "%{count} с"
           few: "%{count} с"
-          many: "%{count} с"
-          other: "%{count} с"
+          many: "< %{count} с"
+          other: "< %{count} с"
         less_than_x_minutes:
           one: "< %{count} мин"
           few: "< %{count} мин"

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -105,8 +105,8 @@ ru:
         x_seconds:
           one: "%{count} с"
           few: "%{count} с"
-          many: "< %{count} с"
-          other: "< %{count} с"
+          many: "%{count} с"
+          other: "%{count} с"
         less_than_x_minutes:
           one: "< %{count} мин"
           few: "< %{count} мин"

--- a/frontend/discourse/admin/components/site-traffic-explorer.gjs
+++ b/frontend/discourse/admin/components/site-traffic-explorer.gjs
@@ -65,7 +65,8 @@ export default class SiteTrafficExplorer extends Component {
           "admin.dashboard.site_traffic.kpi.average_session_duration.tooltip"
         ),
         value: formatMinutesSeconds(
-          this.summary.average_session_duration_seconds ?? 0
+          this.summary.average_session_duration_seconds ?? 0,
+          { subsecondPrecision: 2 }
         ),
       },
     ];

--- a/frontend/discourse/app/lib/formatter.js
+++ b/frontend/discourse/app/lib/formatter.js
@@ -214,15 +214,18 @@ export function formatMinutesSeconds(seconds, { subsecondPrecision = 0 } = {}) {
   if (seconds > 0 && seconds < 1 && subsecondPrecision > 0) {
     const minimumSeconds = 10 ** -subsecondPrecision;
     const lessThanMinimum = seconds < minimumSeconds;
-    const formattedSeconds = I18n.toNumber(
-      lessThanMinimum ? minimumSeconds : seconds,
-      { precision: subsecondPrecision, strip_insignificant_zeros: true }
-    );
+    const displayedSeconds = lessThanMinimum ? minimumSeconds : seconds;
+    const formattedSeconds = I18n.toNumber(displayedSeconds, {
+      precision: subsecondPrecision,
+      strip_insignificant_zeros: true,
+    });
     const translationKey = lessThanMinimum
       ? "dates.tiny.less_than_x_seconds.other"
       : "dates.tiny.x_seconds.other";
 
-    return i18n(translationKey, { count: formattedSeconds });
+    return i18n(translationKey, {
+      count: formattedSeconds,
+    });
   }
 
   const totalSeconds = Math.floor(seconds);

--- a/frontend/discourse/app/lib/formatter.js
+++ b/frontend/discourse/app/lib/formatter.js
@@ -210,7 +210,21 @@ export function durationTiny(distance, ageOpts) {
   return duration(distance, { format: "tiny", ...ageOpts });
 }
 
-export function formatMinutesSeconds(seconds) {
+export function formatMinutesSeconds(seconds, { subsecondPrecision = 0 } = {}) {
+  if (seconds > 0 && seconds < 1 && subsecondPrecision > 0) {
+    const minimumSeconds = 10 ** -subsecondPrecision;
+    const lessThanMinimum = seconds < minimumSeconds;
+    const formattedSeconds = I18n.toNumber(
+      lessThanMinimum ? minimumSeconds : seconds,
+      { precision: subsecondPrecision, strip_insignificant_zeros: true }
+    );
+    const translationKey = lessThanMinimum
+      ? "dates.tiny.less_than_x_seconds.other"
+      : "dates.tiny.x_seconds.other";
+
+    return i18n(translationKey, { count: formattedSeconds });
+  }
+
   const totalSeconds = Math.floor(seconds);
 
   if (totalSeconds < 60) {

--- a/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
+++ b/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
@@ -10,9 +10,32 @@ module("Unit | Lib | formatMinutesSeconds", function (hooks) {
     assert.strictEqual(formatMinutesSeconds(59), "59s");
   });
 
+  test("formats seconds with optional subsecond precision", function (assert) {
+    assert.strictEqual(
+      formatMinutesSeconds(0, { subsecondPrecision: 2 }),
+      "0s"
+    );
+    assert.strictEqual(
+      formatMinutesSeconds(0.001, { subsecondPrecision: 2 }),
+      "< 0.01s"
+    );
+    assert.strictEqual(
+      formatMinutesSeconds(0.126, { subsecondPrecision: 2 }),
+      "0.13s"
+    );
+    assert.strictEqual(
+      formatMinutesSeconds(1.99, { subsecondPrecision: 2 }),
+      "1s"
+    );
+  });
+
   test("formats a minute or more as Xm Ys with both units", function (assert) {
     assert.strictEqual(formatMinutesSeconds(60), "1m 0s");
     assert.strictEqual(formatMinutesSeconds(107), "1m 47s");
     assert.strictEqual(formatMinutesSeconds(1800), "30m 0s");
+    assert.strictEqual(
+      formatMinutesSeconds(60.99, { subsecondPrecision: 2 }),
+      "1m 0s"
+    );
   });
 });

--- a/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
+++ b/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { formatMinutesSeconds } from "discourse/lib/formatter";
+import I18n from "discourse-i18n";
 
 module("Unit | Lib | formatMinutesSeconds", function (hooks) {
   setupTest(hooks);
@@ -27,6 +28,69 @@ module("Unit | Lib | formatMinutesSeconds", function (hooks) {
       formatMinutesSeconds(1.99, { subsecondPrecision: 2 }),
       "1s"
     );
+  });
+
+  test("formats localized subsecond values", function (assert) {
+    const locale = I18n.locale;
+    const translations = I18n.translations;
+
+    I18n.locale = "ru";
+    I18n.translations = {
+      ru: {
+        js: {
+          dates: {
+            tiny: {
+              less_than_x_seconds: { other: "< %{count} с" },
+              x_seconds: { other: "%{count} с" },
+            },
+          },
+          number: { format: { delimiter: " ", separator: "," } },
+        },
+      },
+    };
+
+    try {
+      assert.strictEqual(
+        formatMinutesSeconds(0.001, { subsecondPrecision: 2 }),
+        "< 0,01 с"
+      );
+      assert.strictEqual(
+        formatMinutesSeconds(0.126, { subsecondPrecision: 2 }),
+        "0,13 с"
+      );
+
+      I18n.locale = "he";
+      I18n.translations = {
+        he: {
+          js: {
+            dates: {
+              tiny: {
+                less_than_x_seconds: {
+                  one: "פחות משנייה",
+                  other: "פחות מ־%{count} שניות",
+                },
+                x_seconds: {
+                  one: "שנייה",
+                  other: "%{count} שניות",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      assert.strictEqual(
+        formatMinutesSeconds(0.001, { subsecondPrecision: 2 }),
+        "פחות מ־0.01 שניות"
+      );
+      assert.strictEqual(
+        formatMinutesSeconds(0.126, { subsecondPrecision: 2 }),
+        "0.13 שניות"
+      );
+    } finally {
+      I18n.locale = locale;
+      I18n.translations = translations;
+    }
   });
 
   test("formats a minute or more as Xm Ys with both units", function (assert) {

--- a/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
+++ b/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
@@ -1,7 +1,6 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { formatMinutesSeconds } from "discourse/lib/formatter";
-import I18n from "discourse-i18n";
 
 module("Unit | Lib | formatMinutesSeconds", function (hooks) {
   setupTest(hooks);
@@ -28,69 +27,6 @@ module("Unit | Lib | formatMinutesSeconds", function (hooks) {
       formatMinutesSeconds(1.99, { subsecondPrecision: 2 }),
       "1s"
     );
-  });
-
-  test("formats localized subsecond values", function (assert) {
-    const locale = I18n.locale;
-    const translations = I18n.translations;
-
-    I18n.locale = "ru";
-    I18n.translations = {
-      ru: {
-        js: {
-          dates: {
-            tiny: {
-              less_than_x_seconds: { other: "< %{count} с" },
-              x_seconds: { other: "%{count} с" },
-            },
-          },
-          number: { format: { delimiter: " ", separator: "," } },
-        },
-      },
-    };
-
-    try {
-      assert.strictEqual(
-        formatMinutesSeconds(0.001, { subsecondPrecision: 2 }),
-        "< 0,01 с"
-      );
-      assert.strictEqual(
-        formatMinutesSeconds(0.126, { subsecondPrecision: 2 }),
-        "0,13 с"
-      );
-
-      I18n.locale = "he";
-      I18n.translations = {
-        he: {
-          js: {
-            dates: {
-              tiny: {
-                less_than_x_seconds: {
-                  one: "פחות משנייה",
-                  other: "פחות מ־%{count} שניות",
-                },
-                x_seconds: {
-                  one: "שנייה",
-                  other: "%{count} שניות",
-                },
-              },
-            },
-          },
-        },
-      };
-
-      assert.strictEqual(
-        formatMinutesSeconds(0.001, { subsecondPrecision: 2 }),
-        "פחות מ־0.01 שניות"
-      );
-      assert.strictEqual(
-        formatMinutesSeconds(0.126, { subsecondPrecision: 2 }),
-        "0.13 שניות"
-      );
-    } finally {
-      I18n.locale = locale;
-      I18n.translations = translations;
-    }
   });
 
   test("formats a minute or more as Xm Ys with both units", function (assert) {

--- a/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
     context "when the query succeeds" do
       it { is_expected.to run_successfully }
 
+      it "returns a fractional average session duration" do
+        Fabricate(:browser_pageview_session_engagement, session_id: "browser-0", engaged_seconds: 1)
+
+        average_session_duration = result.traffic.dig(:summary, "average_session_duration_seconds")
+
+        expect(average_session_duration).to be_within(0.0001).of(1.0 / browsers.size)
+      end
+
       it "orders browser dimensions by pageviews" do
         browser_dimensions = result.traffic.dig(:dimensions, "browsers")
 

--- a/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
 
         average_session_duration = result.traffic.dig(:summary, "average_session_duration_seconds")
 
-        expect(average_session_duration).to be_within(0.0001).of(1.0 / browsers.size)
+        expect(average_session_duration).to eq(1.0 / browsers.size)
       end
 
       it "orders browser dimensions by pageviews" do

--- a/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_explorer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
     Fabricate(
       :browser_pageview_session_engagement,
       session_id: "engaged-session",
-      engaged_seconds: 20,
+      engaged_seconds: 1,
     )
     Fabricate(
       :browser_pageview_event,
@@ -95,8 +95,8 @@ RSpec.describe "Admin Dashboard Redesign | Site Traffic Explorer" do
 
     traffic.visit(start_date: "2026-05-14", end_date: "2026-05-14")
     expect(traffic).to have_metric(label: "Distinct sessions", value: "2")
-    expect(traffic).to have_metric(label: "Bounce rate", value: "50%")
-    expect(traffic).to have_metric(label: "Average session duration", value: "10s")
+    expect(traffic).to have_metric(label: "Bounce rate", value: "100%")
+    expect(traffic).to have_metric(label: "Average session duration", value: "0.5s")
   end
 
   it "lets an admin preview traffic type filters before applying them",


### PR DESCRIPTION
The Site Traffic Explorer rounded average session duration to an integer before formatting it, so positive averages below half a second appeared as 0s.

This commit preserves the fractional average and lets this metric display up to two decimal places below one second. Durations of at least one second keep the existing whole-second and minute formatting.

## Screenshots

Before — a true 0.33-second average appears as 0s.

![Before: average session duration appears as 0s](https://raw.githubusercontent.com/discourse/discourse/tgxworld%2Fpr-assets-subsecond-session-duration/pr-screenshots/before-subsecond-session-duration.png)

After — the same average appears as 0.33s.

![After: average session duration appears as 0.33s](https://raw.githubusercontent.com/discourse/discourse/tgxworld%2Fpr-assets-subsecond-session-duration/pr-screenshots/after-subsecond-session-duration.png)
