### PR TITLE
FIX: Load boards plugin SVG icons lazily

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -150,6 +150,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :acl_target_classes
 
+  define_filtered_register :svg_icon_sources
+
   define_filtered_register :reviewable_types do |singleton|
     singleton.define_singleton_method("reviewable_types_lookup") do
       public_send(:_raw_reviewable_types)

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -764,6 +764,17 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_svg_icon(icon)
   end
 
+  # Registers a block returning icon names to include in the SVG sprite. Use this
+  # instead of `register_svg_icon` when the names are only known at runtime, such
+  # as when they are chosen by admins and stored in the database. The block is
+  # called while the sprite is built, so it must not run at boot, and its result
+  # is scoped to the current site.
+  #
+  # Call `SvgSprite.expire_cache` when the underlying data changes.
+  def register_svg_icon_source(&block)
+    DiscoursePluginRegistry.register_svg_icon_source(block, self)
+  end
+
   def extend_content_security_policy(extension)
     csp_extensions << extension
   end

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -418,6 +418,7 @@ module SvgSprite
         .new()
         .merge(settings_icons)
         .merge(plugin_icons)
+        .merge(plugin_icon_sources)
         .merge(badge_icons)
         .merge(group_icons)
         .merge(theme_icons(theme_id))
@@ -556,6 +557,10 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
 
   def self.plugin_icons
     DiscoursePluginRegistry.svg_icons
+  end
+
+  def self.plugin_icon_sources
+    DiscoursePluginRegistry.svg_icon_sources.flat_map { |source| Array(source.call) }
   end
 
   def self.badge_icons

--- a/plugins/boards/plugin.rb
+++ b/plugins/boards/plugin.rb
@@ -41,27 +41,12 @@ after_initialize do
 
   reloadable_patch { |plugin| Guardian.prepend Boards::GuardianExtensions }
 
-  # Register any column icons already in the DB so they appear in the SVG sprite
-  begin
-    if ActiveRecord::Base.connection.data_source_exists?(:discourse_kanban_columns) &&
-         ActiveRecord::Base.connection.column_exists?(:discourse_kanban_columns, :default_sort)
-      Boards::Column
-        .where.not(icon: [nil, ""])
-        .distinct
-        .pluck(:icon)
-        .each { |icon| DiscoursePluginRegistry.register_svg_icon(icon) }
-    end
-  rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
-    # Database may be unreachable (asset precompile) or may have pending migrations
-    # during db:create / db:migrate bootstrap.
-  end
+  # Column icons are picked by admins, so the sprite has to be told about whichever
+  # ones are in use.
+  register_svg_icon_source { Boards::Column.where.not(icon: [nil, ""]).distinct.pluck(:icon) }
 
-  # When a column's icon changes, register it and expire the sprite cache
   add_model_callback(Boards::Column, :after_commit) do
-    if saved_change_to_icon? && icon.present?
-      DiscoursePluginRegistry.register_svg_icon(icon)
-      SvgSprite.expire_cache
-    end
+    SvgSprite.expire_cache if saved_change_to_icon?
   end
 
   add_to_serializer(:current_user, :can_manage_boards) { scope.can_manage_boards? }

--- a/plugins/boards/spec/models/boards/column_spec.rb
+++ b/plugins/boards/spec/models/boards/column_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe Boards::Column do
     expect(column).to be_recency
   end
 
+  describe "icons" do
+    after { SvgSprite.expire_cache }
+
+    it "adds icons in use to the SVG sprite" do
+      board.columns.create!(title: "Backlog", position: 0, icon: "blender")
+
+      expect(SvgSprite.all_icons).to include("blender")
+    end
+
+    it "expires the sprite cache when an icon changes" do
+      column = board.columns.create!(title: "Backlog", position: 0, icon: "blender")
+
+      expect(SvgSprite.all_icons).to include("blender")
+
+      column.update!(icon: "guitar")
+
+      expect(SvgSprite.all_icons).to include("guitar")
+      expect(SvgSprite.all_icons).not_to include("blender")
+    end
+  end
+
   it "accepts a bare hex or no color, but rejects malformed values" do
     expect(board.columns.build(title: "A", position: 0, color: "1A2B3C")).to be_valid
     expect(board.columns.build(title: "B", position: 1, color: "f0a")).to be_valid

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -295,6 +295,55 @@ RSpec.describe SvgSprite do
     expect(SvgSprite.all_icons).to include("fab fa-bandcamp")
   end
 
+  describe "icon sources registered by plugins" do
+    let(:plugin) do
+      Class
+        .new(Plugin::Instance) do
+          attr_accessor :enabled
+          attr_accessor :name
+
+          def enabled?
+            @enabled
+          end
+        end
+        .new
+    end
+
+    after { DiscoursePluginRegistry._raw_svg_icon_sources.clear }
+
+    it "includes the icons the source returns" do
+      plugin.enabled = true
+      DiscoursePluginRegistry.register_svg_icon_source(-> { %w[blender guitar] }, plugin)
+
+      expect(SvgSprite.all_icons).to include("blender", "guitar")
+    end
+
+    it "ignores sources belonging to disabled plugins" do
+      plugin.enabled = false
+      DiscoursePluginRegistry.register_svg_icon_source(-> { ["blender"] }, plugin)
+
+      expect(SvgSprite.all_icons).not_to include("blender")
+    end
+
+    it "does not call the source until the sprite is built" do
+      plugin.enabled = true
+      called = false
+      DiscoursePluginRegistry.register_svg_icon_source(
+        -> do
+          called = true
+          ["blender"]
+        end,
+        plugin,
+      )
+
+      expect(called).to eq(false)
+
+      SvgSprite.all_icons
+
+      expect(called).to eq(true)
+    end
+  end
+
   it "includes Font Awesome icon from groups" do
     _group = Fabricate(:group, flair_icon: "far-building")
     expect(SvgSprite.bundle).to match(/far-building/)


### PR DESCRIPTION
Boards queried the database during startup to register user-selected
icons, breaking database-less tasks such as asset precompilation. It
also caused stale per-process state and could leak icons between sites.

Load plugin icon sources when building the site-scoped SVG sprite
instead.
