### PR TITLE
UX: Fix boards plugin description & learn more topic ID

### DIFF
--- a/plugins/boards/assets/javascripts/discourse/initializers/boards-admin-plugin-configuration-nav.js
+++ b/plugins/boards/assets/javascripts/discourse/initializers/boards-admin-plugin-configuration-nav.js
@@ -1,0 +1,18 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+const PLUGIN_ID = "boards";
+
+export default {
+  name: "boards-admin-plugin-configuration-nav",
+
+  initialize(container) {
+    const currentUser = container.lookup("service:current-user");
+    if (!currentUser?.admin) {
+      return;
+    }
+
+    withPluginApi((api) => {
+      api.setAdminPluginIcon(PLUGIN_ID, "boards");
+    });
+  },
+};

--- a/plugins/boards/plugin.rb
+++ b/plugins/boards/plugin.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # name: boards
-# about: Boards with optional topic backing and board-level ACLs.
-# meta_topic_id: 118164
+# about: Organize topics, and lightweight standalone "floater" cards, into configurable, drag-and-drop kanban-style boards, all with a purpose-built management UI and per-board access control
+# meta_topic_id: 411414
 # version: 0.1
 # authors: Discourse
 # url: https://github.com/discourse/discourse/tree/main/plugins/boards


### PR DESCRIPTION
Was pointing to the old TC topic on meta, also add
sidebar icon for the plugin