### PR TITLE
DEV: resolve array deprecation on the AI embeddings edit page

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/routes/admin-plugins/show/discourse-ai-embeddings/edit.js
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/routes/admin-plugins/show/discourse-ai-embeddings/edit.js
@@ -6,7 +6,7 @@ export default class AdminPluginsShowDiscourseAiEmbeddingsEdit extends Discourse
       "adminPlugins.show.discourse-ai-embeddings"
     );
     const id = parseInt(params.id, 10);
-    const record = allEmbeddings.find((item) => item.id === id);
+    const record = allEmbeddings.content.find((item) => item.id === id);
     record.provider_params = record.provider_params || {};
     return record;
   }

--- a/plugins/discourse-ai/spec/system/embeddings/ai_embedding_definition_spec.rb
+++ b/plugins/discourse-ai/spec/system/embeddings/ai_embedding_definition_spec.rb
@@ -92,4 +92,18 @@ RSpec.describe "Managing Embeddings configurations" do
     expect(embedding_def.embed_prompt).to eq(embed_prefix)
     expect(embedding_def.search_prompt).to eq(search_prefix)
   end
+
+  it "supports editing an existing configuration" do
+    embedding_def = Fabricate(:embedding_definition)
+
+    visit "/admin/plugins/discourse-ai/ai-embeddings/#{embedding_def.id}/edit"
+
+    form.field("display_name").fill_in("Updated embeddings")
+    form.submit
+
+    expect(PageObjects::Components::Toasts.new).to have_success(
+      I18n.t("js.discourse_ai.embeddings.saved"),
+    )
+    expect(embedding_def.reload.display_name).to eq("Updated embeddings")
+  end
 end


### PR DESCRIPTION
The edit route called `.find()` directly on the result of `store.findAll`, which is a LegacyArrayLikeObject. That triggered the `discourse.legacy-array-like-object.proxied-array` deprecation and its admin notice whenever an admin opened an embedding configuration. The llms and agents edit routes already go through `.content`, so this brings embeddings in line with them.

Also adds a system spec that edits an existing embedding configuration, since none covered the edit page before. It fails on the old code because the deprecation is fatal in system specs.