### PR TITLE
DEV: configure conditionNames in rolldown resolver

### DIFF
--- a/frontend/discourse/rolldown.config.mjs
+++ b/frontend/discourse/rolldown.config.mjs
@@ -80,6 +80,7 @@ export function buildConfig({ devMode } = {}) {
     tsconfig: false,
     resolve: {
       extensions,
+      conditionNames: isProduction ? ["production"] : ["development"],
     },
     experimental: {
       incrementalBuild: true,


### PR DESCRIPTION
Extracted from the Ember 7 PR (#40407). Vite injects the `development`/`production` export condition automatically, but our rolldown config did not.

This is a no-op on `main` today, but becomes relevant since Ember 7 makes use of these flags.