### PR TITLE
DEV: refactor sidebar section-link active state

### DIFF
--- a/frontend/discourse/app/components/sidebar/section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-link.gjs
@@ -10,7 +10,7 @@ import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
 import deprecated from "discourse/lib/deprecated";
-import { and, eq, not, or } from "discourse/truth-helpers";
+import { eq, or } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import SectionLinkPrefix from "./section-link-prefix";
@@ -42,6 +42,7 @@ export function isHex(input) {
 export default class SectionLink extends Component {
   @service capabilities;
   @service currentUser;
+  @service router;
 
   @tracked hovering = false;
   @tracked hoverActionActive = false;
@@ -129,6 +130,23 @@ export default class SectionLink extends Component {
     }
 
     return [];
+  }
+
+  get resolvedCurrentWhen() {
+    if (this.args.exactUrlMatch) {
+      return false;
+    }
+
+    const currentWhen = this.args.currentWhen;
+
+    // Ember 7's <LinkTo> ignores @models for a string @current-when; resolve the route list against this link's models ourselves.
+    if (typeof currentWhen === "string") {
+      return currentWhen
+        .split(" ")
+        .some((route) => this.router.isActive(route, ...this.models));
+    }
+
+    return currentWhen;
   }
 
   get prefixColor() {
@@ -279,7 +297,7 @@ export default class SectionLink extends Component {
             @route={{@route}}
             @query={{or @query (hash)}}
             @models={{this.models}}
-            @current-when={{and (not @exactUrlMatch) @currentWhen}}
+            @current-when={{this.resolvedCurrentWhen}}
             draggable={{if @suppressNativeDrag false}}
             title={{@title}}
             data-link-name={{@linkName}}

--- a/frontend/discourse/tests/helpers/component-test.js
+++ b/frontend/discourse/tests/helpers/component-test.js
@@ -18,6 +18,10 @@ class RouterStub extends Service {
 
   on() {}
   off() {}
+
+  isActive(routeName) {
+    return routeName === this.currentRouteName;
+  }
 }
 
 export function setupRenderingTest(hooks, opts = {}) {


### PR DESCRIPTION
Extracted from the Ember 7 PR (#40407). Ember 7's <LinkTo> no longer considers `@models` when `@current-when` is a string.

Sidebar category/tag links pass a static multi-route `current-when` string plus `@models` to stay highlighted across filter routes while narrowing to a single category/tag. Under Ember 7 it causes every link sharing the route list to light up at once.

This commit implements the `currentWhen` logic we want in JS. On Ember 6 this reproduces what <LinkTo> already does, so behaviour is unchanged.