### PR TITLE
DEV: drop injectTestHelpers from test setup

### DIFF
--- a/frontend/discourse/tests/setup-tests.js
+++ b/frontend/discourse/tests/setup-tests.js
@@ -63,7 +63,6 @@ let started = false;
 function createApplication(config, settings) {
   const app = Application.create(config);
 
-  app.injectTestHelpers();
   setApplication(app);
   setResolver(buildResolver("discourse").create({ namespace: app }));
 

--- a/frontend/discourse/tests/setup-tests.js
+++ b/frontend/discourse/tests/setup-tests.js
@@ -10,6 +10,7 @@ import { run } from "@ember/runloop";
 import {
   getSettledState,
   isSettled,
+  pauseTest,
   setApplication,
   setResolver,
 } from "@ember/test-helpers";
@@ -216,6 +217,9 @@ export default async function setupTests(config) {
 
   QUnit.config.hidepassed = true;
   QUnit.config.testTimeout = 60_000;
+
+  // Available in tests without an import
+  window.pauseTest = pauseTest;
 
   // Stop the message bus so we don't get ajax calls
   window.MessageBus.stop();


### PR DESCRIPTION
`Application#injectTestHelpers` sets up Ember's legacy global test helpers (`find`, `click`, `visit`, `pauseTest`, etc.). We've been linting against these globals for a long time, and the system will be finally removed in Ember 7.

Extracted from the Ember 7 PR (#40407).