### PR TITLE
DEV: import the concurrently named export in bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -5,7 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const { parseArgs } = require("util");
-const concurrently = require("concurrently");
+const { concurrently } = require("concurrently");
 
 const RAILS_ROOT = path.resolve(__dirname, "..");
 


### PR DESCRIPTION
concurrently 10 (bumped in #42829) stopped exporting the run function as the module's top-level export, so `bin/dev` crashed on startup with "concurrently is not a function". Use the named export.