### PR TITLE
DEV: Make DAG frozen array test browser-independent

### DIFF
--- a/frontend/discourse/tests/unit/lib/dag-test.ts
+++ b/frontend/discourse/tests/unit/lib/dag-test.ts
@@ -438,7 +438,6 @@ module("Unit | Lib | DAG", function (hooks) {
     assert.true(Object.isFrozen(resolved), "the resolved array is frozen");
     assert.throws(
       () => resolved.push({ key: "c", value: 3, position: {} }),
-      /extensible/,
       "mutating the resolved array throws"
     );
   });


### PR DESCRIPTION
## What does this change?

Makes the `DAG#resolve()` frozen-array test browser-independent.

The test already explicitly verifies that the returned array is frozen with `Object.isFrozen(resolved)`. It then verifies that mutating the array throws, but additionally matched the exception message against `/extensible/`.

That message is engine-specific. Chrome/V8 uses wording which matches `extensible`, while Firefox 154 throws:

> TypeError: can't define array index property past the end of an array with non-writable length

The behavior is correct in both browsers, so this removes the browser-specific message matcher while keeping the assertion that mutation throws.

## Testing

Before the change:

- Chrome 151: passes
- Firefox 154: fails only on the `/extensible/` message matcher

After the change:

- Firefox 154: **1 test, 1 pass, 0 failures**
- Chrome 151: **1 test, 1 pass, 0 failures**
- Pre-commit Prettier: pass
- Pre-commit ESLint: pass
