### PR TITLE
DEV: Show block math with the composer preview block

### DIFF
--- a/plugins/discourse-math/assets/javascripts/discourse/components/math-block-preview.gjs
+++ b/plugins/discourse-math/assets/javascripts/discourse/components/math-block-preview.gjs
@@ -10,7 +10,7 @@ export default class MathBlockPreview extends Component {
   @service siteSettings;
 
   // the renderers replace the element's content, so it is built outside of
-  // Glimmer's reach and rebuilt from scratch for each source
+  // Glimmer's reach
   renderMath = modifier((element, [source]) => {
     const math = document.createElement("div");
     math.classList.add("math");

--- a/plugins/discourse-math/assets/javascripts/discourse/components/math-block-preview.gjs
+++ b/plugins/discourse-math/assets/javascripts/discourse/components/math-block-preview.gjs
@@ -1,0 +1,28 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import { modifier } from "ember-modifier";
+import {
+  buildDiscourseMathOptions,
+  renderMathInElement,
+} from "discourse/plugins/discourse-math/lib/math-renderer";
+
+export default class MathBlockPreview extends Component {
+  @service siteSettings;
+
+  // the renderers replace the element's content, so it is built outside of
+  // Glimmer's reach and rebuilt from scratch for each source
+  renderMath = modifier((element, [source]) => {
+    const math = document.createElement("div");
+    math.classList.add("math");
+    math.textContent = source;
+    element.replaceChildren(math);
+
+    renderMathInElement(element, buildDiscourseMathOptions(this.siteSettings), {
+      force: true,
+    });
+  });
+
+  <template>
+    <div class="math-block-preview" {{this.renderMath @source}}></div>
+  </template>
+}

--- a/plugins/discourse-math/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/discourse-math/assets/javascripts/lib/rich-editor-extension.js
@@ -264,7 +264,10 @@ const extension = {
       math_block(state, node) {
         state.write("$$\n");
         state.text(escapeDelimiter(node.textContent, "$"), false);
-        state.write("\n$$");
+        // the closing fence needs its own write to pick up the block prefix,
+        // or the block loses it inside a blockquote
+        state.ensureNewLine();
+        state.write("$$");
         state.closeBlock(node);
       },
     };

--- a/plugins/discourse-math/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/discourse-math/assets/javascripts/lib/rich-editor-extension.js
@@ -1,10 +1,15 @@
+import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import { previewSourceNode } from "discourse/lib/composer/preview-block";
 import { iconHTML } from "discourse/lib/icon-library";
 import { i18n } from "discourse-i18n";
 import MathEditModal from "discourse/plugins/discourse-math/discourse/components/modal/math-edit";
+import MathBlockPreview from "../discourse/components/math-block-preview";
 import {
   buildDiscourseMathOptions,
   renderMathInElement,
 } from "./math-renderer";
+
+const LANGUAGE = "latex";
 
 const createMathNodeView =
   ({ getContext, pmState: { NodeSelection } }) =>
@@ -55,7 +60,7 @@ class MathNodeView {
     modal.show(MathEditModal, {
       model: {
         initialText: this.node.attrs.text ?? "",
-        isBlock: !this.node.isInline,
+        isBlock: false,
         mathType: this.node.attrs.mathType ?? "tex",
         onApply: (text) => this.#applyEdit(text),
       },
@@ -69,8 +74,7 @@ class MathNodeView {
     this.getContext = getContext;
     this.NodeSelection = NodeSelection;
 
-    const isInline = node.isInline;
-    this.dom = document.createElement(isInline ? "span" : "div");
+    this.dom = document.createElement("span");
     this.dom.classList.add("composer-math-node");
 
     this.editButton = document.createElement("button");
@@ -85,7 +89,7 @@ class MathNodeView {
     this.editButton.innerHTML = iconHTML("pencil");
     this.editButton.addEventListener("click", this.openEditModal);
 
-    this.content = document.createElement(isInline ? "span" : "div");
+    this.content = document.createElement("span");
     this.content.classList.add("math-node-content");
     this.content.setAttribute("contenteditable", "false");
 
@@ -133,8 +137,7 @@ class MathNodeView {
   }
 
   #syncContent() {
-    const isAscii =
-      this.node.isInline && this.node.attrs.mathType === "asciimath";
+    const isAscii = this.node.attrs.mathType === "asciimath";
 
     this.content.classList.toggle("asciimath", isAscii);
     this.content.classList.toggle("math", !isAscii);
@@ -158,7 +161,11 @@ class MathNodeView {
 const extension = {
   nodeViews: {
     math_inline: createMathNodeView,
-    math_block: createMathNodeView,
+    math_block: {
+      component: PreviewNodeView,
+      hasContent: true,
+      options: { preview: MathBlockPreview },
+    },
   },
   nodeSpec: {
     math_inline: {
@@ -195,24 +202,23 @@ const extension = {
     },
     math_block: {
       group: "block",
+      content: "preview_source",
       atom: true,
-      selectable: true,
       defining: true,
       isolating: true,
-      attrs: {
-        text: { default: "" },
-        mathType: { default: "tex" },
-      },
+      createGapCursor: true,
       parseDOM: [
         {
           tag: "div.math",
-          getAttrs: (dom) => ({
-            text: dom.textContent.trim(),
-            mathType: "tex",
-          }),
+          // cooked source is plain text the parser would otherwise collapse
+          getContent: (dom, schema) =>
+            schema.nodes.math_block.create(
+              null,
+              previewSourceNode(schema, dom.textContent, LANGUAGE)
+            ).content,
         },
       ],
-      toDOM: (node) => ["div", { class: "math" }, node.attrs.text],
+      toDOM: () => ["div", { class: "math" }, 0],
     },
   },
   parse: {
@@ -223,12 +229,18 @@ const extension = {
         mathType: token.meta?.mathType || "tex",
       }),
     },
-    math_block: {
-      node: "math_block",
-      getAttrs: (token) => ({
-        text: token.content,
-        mathType: token.meta?.mathType || "tex",
-      }),
+    math_block: (state, token) => {
+      const content = token.content.trim();
+
+      state.openNode(state.schema.nodes.math_block);
+      state.openNode(state.schema.nodes.preview_source, { params: LANGUAGE });
+      if (content) {
+        state.addText(content);
+      }
+      state.closeNode();
+      state.closeNode();
+
+      return true;
     },
   },
   serializeNode({ utils: { isBoundary } }) {
@@ -250,11 +262,10 @@ const extension = {
         }
       },
       math_block(state, node) {
-        state.ensureNewLine();
-        const content = escapeDelimiter(node.attrs.text ?? "", "$");
         state.write("$$\n");
-        state.write(content);
-        state.write("\n$$\n\n");
+        state.text(escapeDelimiter(node.textContent, "$"), false);
+        state.write("\n$$");
+        state.closeBlock(node);
       },
     };
   },

--- a/plugins/discourse-math/assets/stylesheets/common/discourse-math.scss
+++ b/plugins/discourse-math/assets/stylesheets/common/discourse-math.scss
@@ -109,13 +109,10 @@
     }
   }
 
-  div.composer-math-node {
-    display: block;
+  .math-block-preview {
     padding: var(--space-2);
-    margin: var(--space-2) 0;
 
-    .math-node-content {
-      display: block;
+    .math {
       white-space: pre-wrap;
     }
   }

--- a/plugins/discourse-math/spec/system/composer_spec.rb
+++ b/plugins/discourse-math/spec/system/composer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Discourse Math - composer" do
 
   let(:composer) { PageObjects::Components::Composer.new }
   let(:rich) { composer.rich_editor }
+  let(:toolbar) { PageObjects::Components::ComposerPreviewToolbar.new }
 
   before do
     SiteSetting.discourse_math_enabled = true
@@ -35,10 +36,29 @@ RSpec.describe "Discourse Math - composer" do
       expect(rich).to have_css(".composer-math-node .math-container mjx-container", wait: 10)
     end
 
-    it "renders block math in rich editor" do
+    it "renders block math and lets the user edit its source in place" do
       open_composer_and_type_math("Block math:\n\n$$\nx^2 + y^2 = z^2\n$$")
 
-      expect(rich).to have_css(".composer-math-node .math-container mjx-container", wait: 10)
+      expect(rich).to have_css(".composer-preview-node .math-block-preview mjx-container", wait: 10)
+      expect(rich).to have_no_css(".composer-preview-node.--source")
+
+      rich.find(".composer-preview-node .math-block-preview").click
+
+      expect(toolbar).to have_toolbar
+
+      toolbar.click_show_source
+
+      expect(rich).to have_css(".composer-preview-node.--source")
+
+      composer.type_content(" + 1")
+      toolbar.click_show_preview
+
+      expect(rich).to have_no_css(".composer-preview-node.--source")
+      expect(rich).to have_css(".composer-preview-node .math-block-preview mjx-container", wait: 10)
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("Block math:\n\n$$\nx^2 + y^2 = z^2 + 1\n$$")
     end
   end
 

--- a/plugins/discourse-math/test/javascripts/integration/prosemirror-editor/math-test.js
+++ b/plugins/discourse-math/test/javascripts/integration/prosemirror-editor/math-test.js
@@ -59,6 +59,23 @@ module(
       );
     });
 
+    test("preserves block math nested in a blockquote", async function (assert) {
+      this.siteSettings.discourse_math_enabled = true;
+
+      // the closing fence has to keep the "> " prefix, or the reparse swallows
+      // it into the math and leaves a stray empty block behind
+      const markdown = "> $$\n> E=mc^2\n> $$";
+
+      await testMarkdown(
+        assert,
+        markdown,
+        () => {
+          assert.dom("blockquote .composer-preview-node").exists();
+        },
+        markdown
+      );
+    });
+
     test("toggles block math between preview and source", async function (assert) {
       this.siteSettings.discourse_math_enabled = true;
 

--- a/plugins/discourse-math/test/javascripts/integration/prosemirror-editor/math-test.js
+++ b/plugins/discourse-math/test/javascripts/integration/prosemirror-editor/math-test.js
@@ -1,11 +1,25 @@
 import { getOwner } from "@ember/owner";
-import { click } from "@ember/test-helpers";
+import { click, settled, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { previewNodeViewFor } from "discourse/components/composer/preview-node-view";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import {
   setupRichEditor,
   testMarkdown,
 } from "discourse/tests/helpers/rich-editor-helper";
+
+const BLOCK_MARKDOWN = "$$\nE=mc^2\n$$";
+
+async function toggleSource(view) {
+  previewNodeViewFor(view.nodeDOM(0)).toggleSource();
+  await settled();
+}
+
+// exactly one of these matches the editor's Mod-z binding per platform
+async function undo() {
+  await triggerKeyEvent(".ProseMirror", "keydown", "Z", { ctrlKey: true });
+  await triggerKeyEvent(".ProseMirror", "keydown", "Z", { metaKey: true });
+}
 
 module(
   "Integration | Component | prosemirror-editor - math extension",
@@ -28,26 +42,119 @@ module(
       );
     });
 
-    test("renders block math and preserves markdown", async function (assert) {
+    test("renders block math as a preview block and preserves markdown", async function (assert) {
       this.siteSettings.discourse_math_enabled = true;
-
-      const markdown = "$$\nE=mc^2\n$$";
-      const expectedMarkdown = "$$\nE=mc^2\n$$\n\n";
 
       await testMarkdown(
         assert,
-        markdown,
+        BLOCK_MARKDOWN,
         () => {
-          assert.dom("div.composer-math-node").exists();
+          assert.dom(".composer-preview-node").exists();
           assert
-            .dom("div.composer-math-node .math-node-content")
-            .hasText("E=mc^2");
+            .dom(".composer-preview-node")
+            .doesNotHaveClass("--source", "starts on the preview face");
+          assert.dom(".math-block-preview .math").hasText("E=mc^2");
         },
-        expectedMarkdown
+        BLOCK_MARKDOWN
       );
     });
 
-    test("edits math via modal", async function (assert) {
+    test("toggles block math between preview and source", async function (assert) {
+      this.siteSettings.discourse_math_enabled = true;
+
+      const [editorClass] = await setupRichEditor(assert, BLOCK_MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+      assert.dom(".composer-preview-node").hasClass("--source");
+      assert
+        .dom(".composer-preview-node__source")
+        .hasText("E=mc^2", "the source face holds the LaTeX");
+
+      await toggleSource(view);
+      assert.dom(".composer-preview-node").doesNotHaveClass("--source");
+      assert.strictEqual(
+        view.state.selection.node?.type.name,
+        "math_block",
+        "the block is selected again"
+      );
+    });
+
+    test("puts the caret in the source when it is shown", async function (assert) {
+      this.siteSettings.discourse_math_enabled = true;
+
+      const [editorClass] = await setupRichEditor(assert, BLOCK_MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+
+      const { $head } = view.state.selection;
+      assert.strictEqual(
+        $head.parent.type.name,
+        "preview_source",
+        "the caret is inside the source"
+      );
+      assert.strictEqual(
+        $head.parentOffset,
+        "E=mc^2".length,
+        "the caret is at the end of the source"
+      );
+    });
+
+    test("edits to the source update the markdown, and undo restores it", async function (assert) {
+      this.siteSettings.discourse_math_enabled = true;
+
+      const [editorClass] = await setupRichEditor(assert, BLOCK_MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+      view.dispatch(view.state.tr.insertText("+p", view.state.selection.from));
+      await settled();
+
+      assert.strictEqual(
+        editorClass.value,
+        "$$\nE=mc^2+p\n$$",
+        "the markdown follows the source"
+      );
+
+      await undo();
+      assert.strictEqual(
+        editorClass.value,
+        BLOCK_MARKDOWN,
+        "undo restores the original markdown"
+      );
+    });
+
+    test("keeps the line breaks of pasted cooked block math", async function (assert) {
+      this.siteSettings.discourse_math_enabled = true;
+
+      const [editorClass] = await setupRichEditor(assert, "");
+      const { view } = editorClass;
+
+      view.pasteHTML("<div class='math'>\na^2\nb^2\n</div>");
+      await settled();
+
+      assert.strictEqual(
+        editorClass.value.trim(),
+        "$$\na^2\nb^2\n$$",
+        "the source survives the round trip through cooked HTML"
+      );
+    });
+
+    test("escapes bare dollar signs when serializing block math", async function (assert) {
+      this.siteSettings.discourse_math_enabled = true;
+
+      const [editorClass] = await setupRichEditor(assert, BLOCK_MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+      view.dispatch(view.state.tr.insertText("$", view.state.selection.from));
+      await settled();
+
+      assert.strictEqual(editorClass.value, "$$\nE=mc^2\\$\n$$");
+    });
+
+    test("edits inline math via modal", async function (assert) {
       this.siteSettings.discourse_math_enabled = true;
 
       const markdown = "Inline $E=mc^2$ math.";


### PR DESCRIPTION
Block math in the rich editor now uses the preview block primitive: the rendered MathJax/KaTeX output is the default face, and the toolbar flips to the raw LaTeX source for editing in place. Inline math keeps its pencil-and-modal node view; the block drops the modal entirely, since the in-place source covers it.

The LaTeX moves from a node attribute into a `preview_source` child, so parsing, pasting cooked math, and serializing back to `$$` fences are reworked around it while keeping the markdown round trip intact. That rework also closes a pre-existing serializer bug: the closing fence was written together with its newline, so it never picked up the block prefix and a `$$` block nested in a blockquote lost its `> ` on the first round trip.

The source face highlights when the site's `highlighted_languages` includes `latex`, like any code block.
