### PR TITLE
FIX: Stop float portals from leaking whitespace text nodes

### DIFF
--- a/frontend/discourse/float-kit/components/d-float-body.gts
+++ b/frontend/discourse/float-kit/components/d-float-body.gts
@@ -211,6 +211,7 @@ export default class DFloatBody extends Component<DFloatBodySignature> {
       @inline={{@inline}}
       @portalOutletElement={{@instance.portalOutletElement}}
     >
+      {{~! strip whitespace ~}}
       <div
         class={{dConcatClass
           @mainClass
@@ -253,6 +254,7 @@ export default class DFloatBody extends Component<DFloatBodySignature> {
           {{yield}}
         </div>
       </div>
+      {{~! strip whitespace ~}}
     </DFloatPortal>{{~! strip whitespace ~}}
   </template>
 }

--- a/frontend/discourse/float-kit/components/d-float-portal.gts
+++ b/frontend/discourse/float-kit/components/d-float-portal.gts
@@ -32,7 +32,9 @@ export default class DFloatPortal extends Component<DFloatPortalSignature> {
       {{yield}}
     {{else}}
       {{#in-element @portalOutletElement insertBefore=null}}
+        {{~! strip whitespace: outlets like `pre` render stray text nodes ~}}
         {{yield}}
+        {{~! strip whitespace ~}}
       {{/in-element}}
     {{/if~}}
   </template>


### PR DESCRIPTION
The float portal's template rendered its own whitespace (indentation and newlines around the yield) as text nodes inside the portal outlet. Every block-level outlet collapses them, so nothing ever showed — but an outlet with `white-space: pre` (a code block) paints them as literal blank lines, growing the block by ~67px whenever a menu mounts into it.

Trims the template-owned whitespace in `d-float-portal` and `d-float-body`. Consumer content inside the yield is untouched; only static whitespace from these two templates is affected.