### PR TITLE
DEV: Chain extension keymaps instead of clobbering

### DIFF
--- a/frontend/discourse/app/static/prosemirror/core/keymap.js
+++ b/frontend/discourse/app/static/prosemirror/core/keymap.js
@@ -144,7 +144,15 @@ function extractKeymap(extensions, params) {
 
   const combined = {};
   keymaps.forEach((keymap) => {
-    Object.assign(combined, keymap);
+    for (const [key, command] of Object.entries(keymap)) {
+      // two extensions binding the same key both run rather than the later
+      // registration silently clobbering the earlier; the later one runs
+      // first, so extensions registered after the defaults can override them
+      // by handling the key
+      combined[key] = combined[key]
+        ? chainCommands(command, combined[key])
+        : command;
+    }
   });
 
   return combined;

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/extension-keymap-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/extension-keymap-test.gjs
@@ -1,0 +1,85 @@
+import { triggerKeyEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
+
+async function pressModE() {
+  // "Mod-" resolves per platform at runtime, so send both variants
+  await triggerKeyEvent(".ProseMirror", "keydown", "E", { metaKey: true });
+  await triggerKeyEvent(".ProseMirror", "keydown", "E", { ctrlKey: true });
+}
+
+module(
+  "Integration | Component | prosemirror-editor - extension keymap",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function () {
+      await resetRichEditorExtensions();
+    });
+
+    hooks.afterEach(async function () {
+      await resetRichEditorExtensions();
+    });
+
+    test("a later registration runs first and can fall through to an earlier one", async function (assert) {
+      const calls = [];
+
+      registerRichEditorExtension({
+        keymap: () => ({
+          "Mod-e": () => {
+            calls.push("earlier");
+            return true;
+          },
+        }),
+      });
+      registerRichEditorExtension({
+        keymap: () => ({
+          "Mod-e": () => {
+            calls.push("later");
+            return false;
+          },
+        }),
+      });
+
+      await setupRichEditor(assert, "");
+      await pressModE();
+
+      assert.deepEqual(
+        calls,
+        ["later", "earlier"],
+        "the later registration ran first, then the chain fell through"
+      );
+    });
+
+    test("a later registration overrides an earlier one by handling the key", async function (assert) {
+      const calls = [];
+
+      registerRichEditorExtension({
+        keymap: () => ({
+          "Mod-e": () => {
+            calls.push("earlier");
+            return true;
+          },
+        }),
+      });
+      registerRichEditorExtension({
+        keymap: () => ({
+          "Mod-e": () => {
+            calls.push("later");
+            return true;
+          },
+        }),
+      });
+
+      await setupRichEditor(assert, "");
+      await pressModE();
+
+      assert.deepEqual(calls, ["later"], "the earlier binding never ran");
+    });
+  }
+);


### PR DESCRIPTION
Previously, when two rich editor extensions bound the same key, the later registration silently replaced the earlier one — `extractKeymap` merged with `Object.assign`. In core's own default set, `trailing-inline-space` registered after `code-block` and silently ate its Enter binding.

Bindings on the same key now chain, later registration first: a handler that handles the key overrides (preserving the old ability of later extensions to replace behavior), and one that declines falls through to the earlier binding instead of killing it. Two tests pin both halves of that precedence.

This is observable to third-party extensions: an earlier-registered binding that used to be dead now runs when the later one declines.