### PR TITLE
FEATURE: Let extensions register code block previews by language

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -211,6 +211,28 @@
 
   pre {
     position: relative;
+
+    // a previewable code block's faces share one footprint policy so flipping
+    // does not reflow the document below: both are bounded by the same knob
+    // the preview block primitive already ships, the code face holds the
+    // height the preview last rendered at, and overflow scrolls inside
+    &.--source {
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+      overflow-y: auto;
+      min-height: min(
+        var(--composer-preview-node-height, 0px),
+        var(--composer-preview-node-source-max-height, 14lh)
+      );
+      max-height: var(--composer-preview-node-source-max-height, 14lh);
+
+      // the code element paints the backdrop, so it fills the held footprint
+      // without shrinking below its own content
+      code {
+        flex: 1 0 auto;
+      }
+    }
   }
 
   .html-block {
@@ -398,6 +420,14 @@
         display: none;
       }
     }
+  }
+
+  // a code block's rendered face is bounded by the same knob as a source
+  // face, scrolling its overflow, so both faces share one footprint policy;
+  // features raise or clear the bound by overriding the token
+  .composer-code-block-preview-node .composer-preview-node__preview {
+    max-height: var(--composer-preview-node-source-max-height, 14lh);
+    overflow: auto;
   }
 
   .onebox-loading {

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -340,18 +340,6 @@
     }
   }
 
-  // the preview toolbar mounts here, out of flow and collapsing the portal's
-  // whitespace, so showing it never resizes the block (a pre would otherwise
-  // paint the portaled text nodes as blank lines)
-  .composer-preview-toolbar__outlet {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 0;
-    height: 0;
-    white-space: normal;
-  }
-
   // both faces share one grid cell, so swapping them does not move the document
   .composer-preview-node {
     position: relative;

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -340,6 +340,18 @@
     }
   }
 
+  // the preview toolbar mounts here, out of flow and collapsing the portal's
+  // whitespace, so showing it never resizes the block (a pre would otherwise
+  // paint the portaled text nodes as blank lines)
+  .composer-preview-toolbar__outlet {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0;
+    height: 0;
+    white-space: normal;
+  }
+
   // both faces share one grid cell, so swapping them does not move the document
   .composer-preview-node {
     position: relative;

--- a/frontend/discourse/app/components/composer/code-block-preview.gjs
+++ b/frontend/discourse/app/components/composer/code-block-preview.gjs
@@ -1,0 +1,64 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import {
+  registerPreviewNodeView,
+  TOOLBAR_IDENTIFIER,
+} from "discourse/components/composer/preview-node-view";
+
+/**
+ * Renders a registered preview component in place of a `code_block`'s code.
+ *
+ * Unlike `composer/preview-node-view`, the block has no separate source node:
+ * the code IS the node's content, so while the preview shows, the node view
+ * exposes no contentDOM and the block behaves as an atom. Showing the source
+ * swaps back to the regular code block node view.
+ *
+ * The preview gets `@source` and `@node`.
+ */
+export default class CodeBlockPreview extends Component {
+  constructor() {
+    super(...arguments);
+
+    this.args.dom.classList.add("composer-preview-node");
+    // without a contentDOM the browser must never place a caret inside
+    this.args.dom.contentEditable = "false";
+
+    registerPreviewNodeView(this.args.dom, this);
+    this.args.onSetup?.(this);
+  }
+
+  get showingSource() {
+    return false;
+  }
+
+  @action
+  toggleSource() {
+    this.args.options.onToggle(this.args.view, this.args.getPos());
+  }
+
+  selectNode() {
+    this.args.dom.classList.add("ProseMirror-selectednode");
+  }
+
+  deselectNode() {
+    this.args.dom.classList.remove("ProseMirror-selectednode");
+  }
+
+  // the toolbar is portaled into this node view, so its clicks are not document clicks
+  stopEvent(event) {
+    return (
+      event.target instanceof Node &&
+      !!event.target.closest?.(`[data-identifier="${TOOLBAR_IDENTIFIER}"]`)
+    );
+  }
+
+  <template>
+    {{~! strip whitespace ~}}<div class="composer-preview-node__preview">{{#let
+        @options.preview
+        as |Preview|
+      }}<Preview
+          @source={{@node.textContent}}
+          @node={{@node}}
+        />{{/let}}</div>{{~! strip whitespace ~}}
+  </template>
+}

--- a/frontend/discourse/app/components/composer/code-block-preview.gjs
+++ b/frontend/discourse/app/components/composer/code-block-preview.gjs
@@ -1,9 +1,6 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
-import {
-  registerPreviewNodeView,
-  TOOLBAR_IDENTIFIER,
-} from "discourse/components/composer/preview-node-view";
+import { registerPreviewNodeView } from "discourse/components/composer/preview-node-view";
 
 /**
  * Renders a registered preview component in place of a `code_block`'s code.
@@ -42,14 +39,6 @@ export default class CodeBlockPreview extends Component {
 
   deselectNode() {
     this.args.dom.classList.remove("ProseMirror-selectednode");
-  }
-
-  // the toolbar is portaled into this node view, so its clicks are not document clicks
-  stopEvent(event) {
-    return (
-      event.target instanceof Node &&
-      !!event.target.closest?.(`[data-identifier="${TOOLBAR_IDENTIFIER}"]`)
-    );
   }
 
   <template>

--- a/frontend/discourse/app/components/composer/code-block-preview.gjs
+++ b/frontend/discourse/app/components/composer/code-block-preview.gjs
@@ -17,6 +17,9 @@ export default class CodeBlockPreview extends Component {
     super(...arguments);
 
     this.args.dom.classList.add("composer-preview-node");
+    // every language shares this node view, so its class cannot tell them
+    // apart; features style their own preview through this
+    this.args.dom.dataset.language = this.args.options.language;
     // without a contentDOM the browser must never place a caret inside
     this.args.dom.contentEditable = "false";
 

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -7,7 +7,10 @@ export const TOOLBAR_IDENTIFIER = "composer-preview-toolbar";
 
 const nodeViews = new WeakMap();
 
-/** @returns {PreviewNodeView|undefined} the view rendering the block at `dom` */
+/**
+ * The view rendering the block at `dom`, whatever its class: the toolbar uses
+ * it only through the `toggleSource()`/`showingSource` seam.
+ */
 export function previewNodeViewFor(dom) {
   return nodeViews.get(dom);
 }

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -106,14 +106,6 @@ export default class PreviewNodeView extends Component {
     this.args.dom.classList.remove("ProseMirror-selectednode");
   }
 
-  // the toolbar is portaled into this node view, so its clicks are not document clicks
-  stopEvent(event) {
-    return (
-      event.target instanceof Node &&
-      !!event.target.closest?.(`[data-identifier="${TOOLBAR_IDENTIFIER}"]`)
-    );
-  }
-
   #syncMode() {
     this.args.dom.classList.toggle("--source", this.showingSource);
   }

--- a/frontend/discourse/app/components/composer/preview-node-view.gjs
+++ b/frontend/discourse/app/components/composer/preview-node-view.gjs
@@ -13,6 +13,14 @@ export function previewNodeViewFor(dom) {
 }
 
 /**
+ * Registers a view under its block's `dom`, so the preview toolbar can reach
+ * its `toggleSource()`/`showingSource` seam.
+ */
+export function registerPreviewNodeView(dom, nodeView) {
+  nodeViews.set(dom, nodeView);
+}
+
+/**
  * Renders a block's `preview_source` child in place of the source itself.
  *
  * The wrapper must be `atom` and `isolating`, or the editor will step into
@@ -48,7 +56,7 @@ export default class PreviewNodeView extends Component {
     this.args.contentDOM?.classList.add("composer-preview-node__source");
     this.#syncMode();
 
-    nodeViews.set(this.args.dom, this);
+    registerPreviewNodeView(this.args.dom, this);
     this.args.onSetup?.(this);
   }
 

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -309,6 +309,12 @@ export interface RichEditorExtension {
    * word of the block's info string). A `code_block` whose language has a
    * component renders it in place of the code, with a toggle back to the
    * source; the document node stays a plain `code_block`.
+   *
+   * Which preview mechanism to use: content written as a fenced code block
+   * registers here — one entry and a component. Content with its own markup
+   * (a wrapping tag, custom delimiters) defines its own node with a
+   * `preview_source` child and renders through `composer/preview-node-view`
+   * instead, since it also needs to parse and serialize that markup.
    */
   codeBlockPreviews?: Record<string, unknown>;
   /** Custom toolbar state contributed by the extension. */

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -304,6 +304,13 @@ export interface RichEditorExtension {
   keymap?: RichKeymap;
   /** Commands exposed on the editor view state. */
   commands?: (params: PluginParams) => Record<string, RichCommand>;
+  /**
+   * Preview components for fenced code blocks, keyed by language (the first
+   * word of the block's info string). A `code_block` whose language has a
+   * component renders it in place of the code, with a toggle back to the
+   * source; the document node stays a plain `code_block`.
+   */
+  codeBlockPreviews?: Record<string, unknown>;
   /** Custom toolbar state contributed by the extension. */
   state?: StateFunction;
 }

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -317,6 +317,15 @@ export interface RichEditorExtension {
 
 const registeredExtensions: RichEditorExtension[] = [];
 let defaultExtensionsRegistered = false;
+let registrationVersion = 0;
+
+/**
+ * Increments whenever the registered extension list changes, so derived
+ * lookups can be memoized against it.
+ */
+export function getRichEditorExtensionsVersion(): number {
+  return registrationVersion;
+}
 
 export function markDefaultExtensionsRegistered() {
   defaultExtensionsRegistered = true;
@@ -333,6 +342,7 @@ export function areDefaultExtensionsRegistered() {
  */
 export function registerRichEditorExtension(extension: RichEditorExtension) {
   registeredExtensions.push(extension);
+  registrationVersion++;
 }
 
 export async function clearRichEditorExtensions() {
@@ -344,6 +354,7 @@ export async function clearRichEditorExtensions() {
   );
   registeredExtensions.length = 0;
   defaultExtensionsRegistered = false;
+  registrationVersion++;
   return module;
 }
 

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.ts
@@ -306,9 +306,16 @@ export interface RichEditorExtension {
   commands?: (params: PluginParams) => Record<string, RichCommand>;
   /**
    * Preview components for fenced code blocks, keyed by language (the first
-   * word of the block's info string). A `code_block` whose language has a
-   * component renders it in place of the code, with a toggle back to the
-   * source; the document node stays a plain `code_block`.
+   * word of the block's info string, case-insensitive). A `code_block` whose
+   * language has a component renders it in place of the code, with a toggle
+   * back to the source; the document node stays a plain `code_block`.
+   *
+   * The block carries `data-language` while previewing, which is the hook for
+   * styling one language's preview — the node view's own class is shared by
+   * all of them. Toggling destroys and rebuilds the component, so a preview
+   * holding its own state (zoom, scroll) starts over on each flip.
+   *
+   * An older core ignores this field, so a consumer needs no version check.
    *
    * Which preview mechanism to use: content written as a fenced code block
    * registers here — one entry and a component. Content with its own markup

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -80,12 +80,24 @@ export function codeBlockPreviewComponent(node) {
   return previewComponentForParams(node.attrs.params);
 }
 
-function sourceModePositions(state) {
-  return sourceModeKey.getState(state) ?? [];
+// the pins are the decorations: the set maps through document changes on its
+// own, and returning it directly from the decorations prop avoids rebuilding
+// one per editor update
+function sourceModePins(state) {
+  return sourceModeKey.getState(state) ?? DecorationSet.empty;
+}
+
+function pinDecoration(pos, node) {
+  return Decoration.node(pos, pos + node.nodeSize, { class: "--source" });
+}
+
+// a neighboring pin ends where this block starts, so match on `from`
+function findPin(pins, pos) {
+  return pins.find(pos, pos).filter((decoration) => decoration.from === pos);
 }
 
 function isSourceMode(state, pos) {
-  return sourceModePositions(state).includes(pos);
+  return findPin(sourceModePins(state), pos).length > 0;
 }
 
 function showsPreview(node, state, pos) {
@@ -216,17 +228,35 @@ class CodeBlockWithLangSelectorNodeView {
 
   changeListener(e) {
     const pos = this.getPos();
+
+    // the view may already have been destroyed and replaced
+    if (pos === undefined) {
+      return;
+    }
+
+    const language = e.target.value;
+    const rest = (this.node.attrs.params ?? "").trim().split(/\s+/).slice(1);
+
+    // an info-string tail (```mermaid height=500) belongs to the preview
+    // feature, so it survives switching between two previewable languages;
+    // plain languages have no use for it, so it drops otherwise
+    const tail =
+      rest.length &&
+      previewComponentForParams(this.node.attrs.params) &&
+      previewComponentForParams(language)
+        ? ` ${rest.join(" ")}`
+        : "";
+
     const tr = this.view.state.tr.setNodeMarkup(pos, null, {
-      params: e.target.value,
+      params: language + tail,
     });
 
     // switching to a language that previews keeps the code face (and the
-    // caret) in place rather than flipping under the user
-    if (
-      previewComponentForParams(e.target.value) &&
-      !isSourceMode(this.view.state, pos)
-    ) {
-      tr.setMeta(sourceModeKey, pos);
+    // caret) in place rather than flipping under the user; pinning (not
+    // toggling) because setNodeMarkup replaces the node, which drops a node
+    // decoration already pinning it
+    if (previewComponentForParams(language)) {
+      tr.setMeta(sourceModeKey, { pins: [pos] });
     }
 
     this.view.dispatch(tr);
@@ -304,6 +334,16 @@ class CodeBlockWithLangSelectorNodeView {
   }
 }
 
+// A previewing block reimplements atom semantics for a non-atom node: this
+// view exposes no contentDOM, so prosemirror-view renders none of the block's
+// content and treats it as opaque. Everything an atom would get from its
+// schema spec is reproduced around that fact — clicks (the plugin's
+// handleClickOn), Backspace/Delete and arrows at the boundaries (the
+// extension keymap), and text-selection containment (the plugin's
+// appendTransaction). A prosemirror-view upgrade must re-verify that
+// contentDOM-less views stay opaque to the DOM observer and to selection,
+// that handleClickOn still fires for non-atom nodes, and that
+// view.endOfTextblock still resolves from neighboring textblocks.
 class CodeBlockPreviewNodeView extends GlimmerNodeView {
   constructor(node, view, getPos, pluginParams, preview) {
     super({
@@ -318,6 +358,8 @@ class CodeBlockPreviewNodeView extends GlimmerNodeView {
   }
 
   update(node) {
+    // during a redraw this.view.state is already the state being drawn:
+    // prosemirror-view assigns it before syncing node views
     if (
       node.type !== this.node.type ||
       codeBlockPreviewComponent(node) !== this.options.preview ||
@@ -506,32 +548,52 @@ function sourceModePlugin() {
     key: sourceModeKey,
 
     state: {
-      init: (_, state) => emptyPreviewablePins(state),
+      init: (_, state) =>
+        DecorationSet.create(
+          state.doc,
+          emptyPreviewablePins(state).map((pos) =>
+            pinDecoration(pos, state.doc.nodeAt(pos))
+          )
+        ),
 
-      apply(tr, positions, _oldState, newState) {
-        let next = positions;
-
-        if (tr.docChanged) {
-          next = next
-            .map((pos) => tr.mapping.mapResult(pos))
-            .filter((result) => !result.deleted)
-            .map((result) => result.pos);
-        }
+      apply(tr, pins, _oldState, newState) {
+        pins = pins.map(tr.mapping, tr.doc);
 
         const meta = tr.getMeta(sourceModeKey);
 
         if (typeof meta === "number") {
-          next = next.includes(meta)
-            ? next.filter((pos) => pos !== meta)
-            : [...next, meta];
+          // dispatchers resolve the position before adding their own steps
+          const pos = tr.mapping.map(meta);
+          const node = newState.doc.nodeAt(pos);
+          const existing = findPin(pins, pos);
+
+          if (existing.length) {
+            pins = pins.remove(existing);
+          } else if (node) {
+            pins = pins.add(newState.doc, [pinDecoration(pos, node)]);
+          }
         } else if (meta?.pins) {
-          next = [...new Set([...next, ...meta.pins])];
+          pins = pins.add(
+            newState.doc,
+            meta.pins
+              .map((pos) => tr.mapping.map(pos))
+              .filter((pos) => !findPin(pins, pos).length)
+              .map((pos) => pinDecoration(pos, newState.doc.nodeAt(pos)))
+          );
         }
 
-        // a pin is meaningless once its block is gone or stops previewing
-        return next.filter((pos) =>
-          codeBlockPreviewComponent(newState.doc.nodeAt(pos))
-        );
+        // a pin is meaningless once its block is gone, stops previewing, or
+        // no longer lines up with a block after mapping
+        const stale = pins.find().filter((decoration) => {
+          const node = newState.doc.nodeAt(decoration.from);
+
+          return (
+            !codeBlockPreviewComponent(node) ||
+            decoration.to !== decoration.from + node.nodeSize
+          );
+        });
+
+        return stale.length ? pins.remove(stale) : pins;
       },
     },
 
@@ -552,22 +614,10 @@ function sourceModePlugin() {
         return true;
       },
 
-      // the deco both marks the face for CSS and dirties the node so its view
+      // the pins double as the decorations: the `--source` class marks the
+      // face for CSS, and the node decoration dirties the block so its view
       // is recreated on toggle, without touching the document
-      decorations(state) {
-        const decorations = sourceModePositions(state)
-          .map((pos) => {
-            const node = state.doc.nodeAt(pos);
-
-            return (
-              node &&
-              Decoration.node(pos, pos + node.nodeSize, { class: "--source" })
-            );
-          })
-          .filter(Boolean);
-
-        return DecorationSet.create(state.doc, decorations);
-      },
+      decorations: sourceModePins,
     },
 
     appendTransaction(transactions, _oldState, state) {

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -101,6 +101,11 @@ function pinDecoration(pos, node, previewHeight) {
     pos + node.nodeSize,
     {
       class: "--source",
+      // the preview face carries this too, so a feature can style both faces
+      // of its own language
+      ...(paramsLanguage(node.attrs.params) && {
+        "data-language": paramsLanguage(node.attrs.params),
+      }),
       // the code face keeps (a bounded part of) the footprint of the preview
       // it replaced, so flipping does not reflow the document below the block
       ...(previewHeight && {
@@ -482,12 +487,30 @@ function containedSelection(state, pins) {
   return TextSelection.between($anchor, $head);
 }
 
-// the nearest position outside `block` in `dir`, or null when the block has no
-// textblock on that side to hold a selection endpoint
+// the nearest position outside `block` in `dir` that can hold a selection
+// endpoint, or undefined when there is none. findFrom ignores `isolating` and
+// knows nothing about previews, so it will happily land inside a table cell or
+// in another block's hidden source; neither is somewhere a selection may end.
 function outsideBlock(state, block, dir) {
   const boundary = dir === -1 ? block.pos : block.pos + block.node.nodeSize;
+  const $boundary = state.doc.resolve(boundary);
+  const $found = Selection.findFrom($boundary, dir, true)?.$head;
 
-  return Selection.findFrom(state.doc.resolve(boundary), dir, true)?.$head;
+  if (!$found || previewingAncestor($found, state)) {
+    return undefined;
+  }
+
+  for (
+    let depth = $found.depth;
+    depth > $boundary.sharedDepth($found.pos);
+    depth--
+  ) {
+    if ($found.node(depth).type.spec.isolating) {
+      return undefined;
+    }
+  }
+
+  return $found;
 }
 
 // the boundary a join would actually cut at, mirroring prosemirror-commands:
@@ -515,6 +538,32 @@ function cutBoundary($pos, dir) {
   return null;
 }
 
+// the textblock a join across `boundary` would actually reach: it descends the
+// neighbor the same way joinTextblocksAround does, so a block nested in a list
+// item or blockquote is found rather than the wrapper around it
+function joinTarget(state, boundary, dir) {
+  const $boundary = state.doc.resolve(boundary);
+  let node = dir === -1 ? $boundary.nodeBefore : $boundary.nodeAfter;
+  let pos = dir === -1 ? boundary - (node?.nodeSize ?? 0) : boundary;
+
+  while (node && !node.isTextblock) {
+    if (node.type.spec.isolating) {
+      return null;
+    }
+
+    const child = dir === -1 ? node.lastChild : node.firstChild;
+
+    if (!child) {
+      return null;
+    }
+
+    pos = dir === -1 ? pos + node.nodeSize - 1 - child.nodeSize : pos + 1;
+    node = child;
+  }
+
+  return node ? { node, pos } : null;
+}
+
 function selectNeighborPreview(state, dispatch, dir) {
   const { $cursor } = state.selection;
   const boundary = cutBoundary($cursor, dir);
@@ -523,14 +572,13 @@ function selectNeighborPreview(state, dispatch, dir) {
     return false;
   }
 
-  const $boundary = state.doc.resolve(boundary);
-  const neighbor = dir === -1 ? $boundary.nodeBefore : $boundary.nodeAfter;
+  const target = joinTarget(state, boundary, dir);
 
-  if (!neighbor) {
+  if (!target) {
     return false;
   }
 
-  const pos = dir === -1 ? boundary - neighbor.nodeSize : boundary;
+  const { node: neighbor, pos } = target;
 
   if (!showsPreview(neighbor, state, pos)) {
     return false;

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -270,6 +270,17 @@ class CodeBlockWithLangSelectorNodeView {
     );
   }
 
+  // the preview toolbar portals into this dom: reading its mount/unmount back
+  // into the document would loop redraw against re-portal until the editor
+  // hangs
+  ignoreMutation(mutation) {
+    if (mutation.type === "selection") {
+      return false;
+    }
+
+    return !this.contentDOM.contains(mutation.target);
+  }
+
   destroy() {
     this.dom.removeEventListener("change", (e) => this.changeListener(e));
   }
@@ -306,44 +317,99 @@ function codeBlockNodeView(pluginParams) {
     const preview = codeBlockPreviewComponent(node);
     const pos = getPos();
 
+    // empty blocks are pinned by the plugin before the view syncs, so the
+    // constructed face is always the settled one
     if (preview && pos !== undefined && !isSourceMode(view.state, pos)) {
-      if (node.content.size > 0) {
-        return new CodeBlockPreviewNodeView(
-          node,
-          view,
-          getPos,
-          pluginParams,
-          preview
-        );
-      }
-
-      // a block with nothing to preview starts on its code face, pinned so
-      // the first characters typed don't flip it
-      queueMicrotask(() => {
-        const currentPos = getPos();
-
-        if (currentPos !== undefined && !isSourceMode(view.state, currentPos)) {
-          view.dispatch(view.state.tr.setMeta(sourceModeKey, currentPos));
-        }
-      });
+      return new CodeBlockPreviewNodeView(
+        node,
+        view,
+        getPos,
+        pluginParams,
+        preview
+      );
     }
 
     return new CodeBlockWithLangSelectorNodeView(node, view, getPos);
   };
 }
 
-function previewingAncestor($pos, state) {
+function previewingAncestor($pos, state, pins = []) {
   for (let depth = $pos.depth; depth > 0; depth--) {
     const node = $pos.node(depth);
 
     if (node.type.name === "code_block") {
       const pos = $pos.before(depth);
 
-      return showsPreview(node, state, pos) ? { node, pos } : null;
+      return showsPreview(node, state, pos) && !pins.includes(pos)
+        ? { node, pos }
+        : null;
     }
   }
 
   return null;
+}
+
+// a text selection cannot stay in source that is not showing: there is no DOM
+// for it, and typing there would edit the document invisibly
+function containedSelection(state, pins) {
+  const { selection } = state;
+
+  if (!(selection instanceof TextSelection)) {
+    return null;
+  }
+
+  const head = previewingAncestor(selection.$head, state, pins);
+  const anchor = selection.empty
+    ? head
+    : previewingAncestor(selection.$anchor, state, pins);
+
+  if (!head && !anchor) {
+    return null;
+  }
+
+  if (head && anchor && head.pos === anchor.pos) {
+    return NodeSelection.create(state.doc, head.pos);
+  }
+
+  // an endpoint that fell inside moves just past the block instead
+  const anchorPos = anchor
+    ? selection.anchor <= selection.head
+      ? anchor.pos
+      : anchor.pos + anchor.node.nodeSize
+    : selection.anchor;
+  const headPos = head
+    ? selection.head < selection.anchor
+      ? head.pos
+      : head.pos + head.node.nodeSize
+    : selection.head;
+
+  return TextSelection.between(
+    state.doc.resolve(anchorPos),
+    state.doc.resolve(headPos)
+  );
+}
+
+function selectNeighborPreview(state, dispatch, dir) {
+  const { $cursor } = state.selection;
+  const boundary = dir === -1 ? $cursor.before() : $cursor.after();
+  const $boundary = state.doc.resolve(boundary);
+  const neighbor = dir === -1 ? $boundary.nodeBefore : $boundary.nodeAfter;
+
+  if (!neighbor) {
+    return false;
+  }
+
+  const pos = dir === -1 ? boundary - neighbor.nodeSize : boundary;
+
+  if (!showsPreview(neighbor, state, pos)) {
+    return false;
+  }
+
+  dispatch?.(
+    state.tr.setSelection(NodeSelection.create(state.doc, pos)).scrollIntoView()
+  );
+
+  return true;
 }
 
 // while a block previews, a caret next to it must select it rather than merge
@@ -364,28 +430,52 @@ function selectPreviewingNeighbor(dir) {
       return false;
     }
 
-    const boundary = dir === -1 ? $cursor.before() : $cursor.after();
-    const $boundary = state.doc.resolve(boundary);
-    const neighbor = dir === -1 ? $boundary.nodeBefore : $boundary.nodeAfter;
-
-    if (!neighbor) {
-      return false;
-    }
-
-    const pos = dir === -1 ? boundary - neighbor.nodeSize : boundary;
-
-    if (!showsPreview(neighbor, state, pos)) {
-      return false;
-    }
-
-    dispatch?.(
-      state.tr
-        .setSelection(NodeSelection.create(state.doc, pos))
-        .scrollIntoView()
-    );
-
-    return true;
+    return selectNeighborPreview(state, dispatch, dir);
   };
+}
+
+// a previewing block has no editable content the browser caret could step
+// through, so vertical arrows toward it stall without this
+function verticalArrowSelectsPreview(dir) {
+  return (state, dispatch, view) => {
+    const { $cursor } = state.selection;
+
+    if (!$cursor || $cursor.depth === 0) {
+      return false;
+    }
+
+    if (view && !view.endOfTextblock(dir === -1 ? "up" : "down", state)) {
+      return false;
+    }
+
+    return selectNeighborPreview(state, dispatch, dir);
+  };
+}
+
+// a block with nothing to preview belongs on its code face, so the author can
+// write the source in the first place
+function emptyPreviewablePins(state) {
+  const pins = [];
+
+  state.doc.descendants((node, pos) => {
+    if (node.type.name === "code_block") {
+      if (
+        node.content.size === 0 &&
+        codeBlockPreviewComponent(node) &&
+        !isSourceMode(state, pos)
+      ) {
+        pins.push(pos);
+      }
+
+      return false;
+    }
+
+    if (node.isTextblock) {
+      return false;
+    }
+  });
+
+  return pins;
 }
 
 function sourceModePlugin() {
@@ -393,7 +483,7 @@ function sourceModePlugin() {
     key: sourceModeKey,
 
     state: {
-      init: () => [],
+      init: (_, state) => emptyPreviewablePins(state),
 
       apply(tr, positions, _oldState, newState) {
         let next = positions;
@@ -405,12 +495,14 @@ function sourceModePlugin() {
             .map((result) => result.pos);
         }
 
-        const toggled = tr.getMeta(sourceModeKey);
+        const meta = tr.getMeta(sourceModeKey);
 
-        if (toggled !== undefined) {
-          next = next.includes(toggled)
-            ? next.filter((pos) => pos !== toggled)
-            : [...next, toggled];
+        if (typeof meta === "number") {
+          next = next.includes(meta)
+            ? next.filter((pos) => pos !== meta)
+            : [...next, meta];
+        } else if (meta?.pins) {
+          next = [...new Set([...next, ...meta.pins])];
         }
 
         // a pin is meaningless once its block is gone or stops previewing
@@ -439,50 +531,23 @@ function sourceModePlugin() {
       },
     },
 
-    // a text selection cannot land in source that is not showing: there is no
-    // DOM for it, and typing there would edit the document invisibly
     appendTransaction(transactions, _oldState, state) {
-      if (!transactions.some((tr) => tr.docChanged || tr.selectionSet)) {
+      const docChanged = transactions.some((tr) => tr.docChanged);
+
+      if (!docChanged && !transactions.some((tr) => tr.selectionSet)) {
         return null;
       }
 
-      const { selection } = state;
+      const pins = docChanged ? emptyPreviewablePins(state) : [];
+      let tr = pins.length ? state.tr.setMeta(sourceModeKey, { pins }) : null;
 
-      if (!(selection instanceof TextSelection)) {
-        return null;
+      const selection = containedSelection(state, pins);
+
+      if (selection) {
+        tr = (tr ?? state.tr).setSelection(selection);
       }
 
-      const head = previewingAncestor(selection.$head, state);
-      const anchor = selection.empty
-        ? head
-        : previewingAncestor(selection.$anchor, state);
-
-      if (!head && !anchor) {
-        return null;
-      }
-
-      if (head && anchor && head.pos === anchor.pos) {
-        return state.tr.setSelection(NodeSelection.create(state.doc, head.pos));
-      }
-
-      // an endpoint that fell inside moves just past the block instead
-      const anchorPos = anchor
-        ? selection.anchor <= selection.head
-          ? anchor.pos
-          : anchor.pos + anchor.node.nodeSize
-        : selection.anchor;
-      const headPos = head
-        ? selection.head < selection.anchor
-          ? head.pos
-          : head.pos + head.node.nodeSize
-        : selection.head;
-
-      return state.tr.setSelection(
-        TextSelection.between(
-          state.doc.resolve(anchorPos),
-          state.doc.resolve(headPos)
-        )
-      );
+      return tr;
     },
   });
 }
@@ -575,6 +640,10 @@ const extension = {
     "Shift-Tab": indentCodeBlock(true),
     Backspace: selectPreviewingNeighbor(-1),
     Delete: selectPreviewingNeighbor(1),
+    ArrowLeft: selectPreviewingNeighbor(-1),
+    ArrowRight: selectPreviewingNeighbor(1),
+    ArrowUp: verticalArrowSelectsPreview(-1),
+    ArrowDown: verticalArrowSelectsPreview(1),
   }),
   commands: ({ schema }) => ({
     formatCode() {

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -513,6 +513,22 @@ function sourceModePlugin() {
     },
 
     props: {
+      // the preview face is not an atom PM would select natively, and it has
+      // no contentDOM a click could place a caret in
+      handleClickOn(view, _pos, node, nodePos, _event, direct) {
+        if (!direct || !showsPreview(node, view.state, nodePos)) {
+          return false;
+        }
+
+        view.dispatch(
+          view.state.tr.setSelection(
+            NodeSelection.create(view.state.doc, nodePos)
+          )
+        );
+
+        return true;
+      },
+
       // the deco both marks the face for CSS and dirties the node so its view
       // is recreated on toggle, without touching the document
       decorations(state) {

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -10,7 +10,10 @@ import {
 import { Decoration, DecorationSet } from "prosemirror-view";
 import CodeBlockPreview from "discourse/components/composer/code-block-preview";
 import { registerPreviewNodeView } from "discourse/components/composer/preview-node-view";
-import { getExtensions } from "discourse/lib/composer/rich-editor-extensions";
+import {
+  getExtensions,
+  getRichEditorExtensionsVersion,
+} from "discourse/lib/composer/rich-editor-extensions";
 import { ensureHighlightJs } from "discourse/lib/highlight-syntax";
 import GlimmerNodeView from "../lib/glimmer-node-view";
 
@@ -22,14 +25,39 @@ let hljs;
 // positions of previewable blocks pinned to their code face
 const sourceModeKey = new PluginKey("code-block-source-mode");
 
-function registeredPreviews() {
-  const previews = {};
+let previewsCache;
+let previewsCacheVersion = -1;
 
-  for (const { codeBlockPreviews } of getExtensions()) {
-    Object.assign(previews, codeBlockPreviews);
+// consulted from per-keystroke paths, so memoized against the registration
+// version rather than rescanning the extension list
+function registeredPreviews() {
+  const version = getRichEditorExtensionsVersion();
+
+  if (previewsCacheVersion !== version) {
+    previewsCacheVersion = version;
+    previewsCache = {};
+
+    for (const { codeBlockPreviews } of getExtensions()) {
+      for (const [language, component] of Object.entries(
+        codeBlockPreviews ?? {}
+      )) {
+        if (previewsCache[language] && previewsCache[language] !== component) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Multiple code block previews registered for "${language}"; the last registration wins`
+          );
+        }
+
+        previewsCache[language] = component;
+      }
+    }
   }
 
-  return previews;
+  return previewsCache;
+}
+
+function hasRegisteredPreviews() {
+  return Object.keys(registeredPreviews()).length > 0;
 }
 
 function previewComponentForParams(params) {
@@ -445,6 +473,11 @@ function verticalArrowSelectsPreview(dir) {
 // a block with nothing to preview belongs on its code face, so the author can
 // write the source in the first place
 function emptyPreviewablePins(state) {
+  // don't walk the document on every change when no preview is registered
+  if (!hasRegisteredPreviews()) {
+    return [];
+  }
+
   const pins = [];
 
   state.doc.descendants((node, pos) => {

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -87,8 +87,15 @@ function sourceModePins(state) {
   return sourceModeKey.getState(state) ?? DecorationSet.empty;
 }
 
-function pinDecoration(pos, node) {
-  return Decoration.node(pos, pos + node.nodeSize, { class: "--source" });
+function pinDecoration(pos, node, previewHeight) {
+  return Decoration.node(pos, pos + node.nodeSize, {
+    class: "--source",
+    // the code face keeps (a bounded part of) the footprint of the preview it
+    // replaced, so flipping does not reflow the document below the block
+    ...(previewHeight && {
+      style: `--composer-preview-node-height: ${Math.round(previewHeight)}px`,
+    }),
+  });
 }
 
 // a neighboring pin ends where this block starts, so match on `from`
@@ -118,7 +125,14 @@ export function toggleCodeBlockSource(view, pos) {
   }
 
   const showingSource = isSourceMode(view.state, pos);
-  const tr = view.state.tr.setMeta(sourceModeKey, pos);
+
+  // measured before the preview face is destroyed, so the code face can hold
+  // its footprint
+  const dom = showingSource ? null : view.nodeDOM(pos);
+  const tr = view.state.tr.setMeta(sourceModeKey, {
+    toggle: pos,
+    previewHeight: dom instanceof HTMLElement ? dom.offsetHeight : undefined,
+  });
 
   tr.setSelection(
     showingSource
@@ -561,16 +575,18 @@ function sourceModePlugin() {
 
         const meta = tr.getMeta(sourceModeKey);
 
-        if (typeof meta === "number") {
+        if (meta?.toggle !== undefined) {
           // dispatchers resolve the position before adding their own steps
-          const pos = tr.mapping.map(meta);
+          const pos = tr.mapping.map(meta.toggle);
           const node = newState.doc.nodeAt(pos);
           const existing = findPin(pins, pos);
 
           if (existing.length) {
             pins = pins.remove(existing);
           } else if (node) {
-            pins = pins.add(newState.doc, [pinDecoration(pos, node)]);
+            pins = pins.add(newState.doc, [
+              pinDecoration(pos, node, meta.previewHeight),
+            ]);
           }
         } else if (meta?.pins) {
           pins = pins.add(

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -1,13 +1,97 @@
 import { setBlockType, toggleMark } from "prosemirror-commands";
 import { highlightPlugin } from "prosemirror-highlightjs";
 import { schema as markdownSchema } from "prosemirror-markdown";
-import { TextSelection } from "prosemirror-state";
+import {
+  NodeSelection,
+  Plugin,
+  PluginKey,
+  TextSelection,
+} from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+import CodeBlockPreview from "discourse/components/composer/code-block-preview";
+import {
+  registerPreviewNodeView,
+  TOOLBAR_IDENTIFIER,
+} from "discourse/components/composer/preview-node-view";
+import { getExtensions } from "discourse/lib/composer/rich-editor-extensions";
 import { ensureHighlightJs } from "discourse/lib/highlight-syntax";
+import GlimmerNodeView from "../lib/glimmer-node-view";
 
 const INDENT = "  ";
 
 // cached hljs instance with custom plugins/languages
 let hljs;
+
+// positions of previewable blocks pinned to their code face
+const sourceModeKey = new PluginKey("code-block-source-mode");
+
+function registeredPreviews() {
+  const previews = {};
+
+  for (const { codeBlockPreviews } of getExtensions()) {
+    Object.assign(previews, codeBlockPreviews);
+  }
+
+  return previews;
+}
+
+function previewComponentForParams(params) {
+  const language = params?.trim().split(/\s+/)[0];
+
+  return language ? registeredPreviews()[language] : undefined;
+}
+
+/**
+ * The preview component registered for a `code_block`'s language, keyed on the
+ * first word of its info string.
+ *
+ * @returns {unknown|undefined}
+ */
+export function codeBlockPreviewComponent(node) {
+  if (node?.type?.name !== "code_block") {
+    return undefined;
+  }
+
+  return previewComponentForParams(node.attrs.params);
+}
+
+function sourceModePositions(state) {
+  return sourceModeKey.getState(state) ?? [];
+}
+
+function isSourceMode(state, pos) {
+  return sourceModePositions(state).includes(pos);
+}
+
+function showsPreview(node, state, pos) {
+  return !!codeBlockPreviewComponent(node) && !isSourceMode(state, pos);
+}
+
+/**
+ * Swaps a previewable `code_block` between its rendered and code faces.
+ *
+ * @param {import("prosemirror-view").EditorView} view
+ * @param {number} pos the block's position
+ */
+export function toggleCodeBlockSource(view, pos) {
+  const node = view.state.doc.nodeAt(pos);
+
+  if (node?.type?.name !== "code_block") {
+    return;
+  }
+
+  const showingSource = isSourceMode(view.state, pos);
+  const tr = view.state.tr.setMeta(sourceModeKey, pos);
+
+  tr.setSelection(
+    showingSource
+      ? NodeSelection.create(tr.doc, pos)
+      : TextSelection.create(tr.doc, pos + 1 + node.content.size)
+  );
+
+  view.dispatch(tr);
+  view.focus();
+}
 
 function selectedCodeLines(state) {
   const { selection } = state;
@@ -92,14 +176,35 @@ class CodeBlockWithLangSelectorNodeView {
     this.contentDOM = code;
 
     this.appendSelect();
+
+    registerPreviewNodeView(pre, this);
+  }
+
+  // the block's code face IS this regular code block view
+  get showingSource() {
+    return true;
+  }
+
+  toggleSource() {
+    toggleCodeBlockSource(this.view, this.getPos());
   }
 
   changeListener(e) {
-    this.view.dispatch(
-      this.view.state.tr.setNodeMarkup(this.getPos(), null, {
-        params: e.target.value,
-      })
-    );
+    const pos = this.getPos();
+    const tr = this.view.state.tr.setNodeMarkup(pos, null, {
+      params: e.target.value,
+    });
+
+    // switching to a language that previews keeps the code face (and the
+    // caret) in place rather than flipping under the user
+    if (
+      previewComponentForParams(e.target.value) &&
+      !isSourceMode(this.view.state, pos)
+    ) {
+      tr.setMeta(sourceModeKey, pos);
+    }
+
+    this.view.dispatch(tr);
 
     if (e.target.firstChild.textContent) {
       e.target.firstChild.textContent = "";
@@ -118,7 +223,12 @@ class CodeBlockWithLangSelectorNodeView {
     select.addEventListener("change", (e) => this.changeListener(e));
     select.classList.add("code-language-select");
 
-    const languages = hljs.listLanguages().sort((a, b) => a.localeCompare(b));
+    const languages = [
+      ...new Set([
+        ...hljs.listLanguages(),
+        ...Object.keys(registeredPreviews()),
+      ]),
+    ].sort((a, b) => a.localeCompare(b));
 
     const empty = document.createElement("option");
     empty.textContent = languages.includes(this.node.attrs.params)
@@ -139,12 +249,242 @@ class CodeBlockWithLangSelectorNodeView {
   update(node) {
     this.appendSelect();
 
-    return node.type === this.node.type;
+    if (node.type !== this.node.type) {
+      return false;
+    }
+
+    // recreate as the preview view when the rendered face should be shown
+    if (showsPreview(node, this.view.state, this.getPos())) {
+      return false;
+    }
+
+    this.node = node;
+
+    return true;
+  }
+
+  stopEvent(event) {
+    return (
+      event.target instanceof Node &&
+      !!event.target.closest?.(`[data-identifier="${TOOLBAR_IDENTIFIER}"]`)
+    );
   }
 
   destroy() {
     this.dom.removeEventListener("change", (e) => this.changeListener(e));
   }
+}
+
+class CodeBlockPreviewNodeView extends GlimmerNodeView {
+  constructor(node, view, getPos, pluginParams, preview) {
+    super({
+      node,
+      view,
+      getPos,
+      pluginParams,
+      component: CodeBlockPreview,
+      name: "code-block-preview",
+      options: { preview, onToggle: toggleCodeBlockSource },
+    });
+  }
+
+  update(node) {
+    if (
+      node.type !== this.node.type ||
+      codeBlockPreviewComponent(node) !== this.options.preview ||
+      isSourceMode(this.view.state, this.getPos())
+    ) {
+      return false;
+    }
+
+    return super.update(node);
+  }
+}
+
+function codeBlockNodeView(pluginParams) {
+  return (node, view, getPos) => {
+    const preview = codeBlockPreviewComponent(node);
+    const pos = getPos();
+
+    if (preview && pos !== undefined && !isSourceMode(view.state, pos)) {
+      if (node.content.size > 0) {
+        return new CodeBlockPreviewNodeView(
+          node,
+          view,
+          getPos,
+          pluginParams,
+          preview
+        );
+      }
+
+      // a block with nothing to preview starts on its code face, pinned so
+      // the first characters typed don't flip it
+      queueMicrotask(() => {
+        const currentPos = getPos();
+
+        if (currentPos !== undefined && !isSourceMode(view.state, currentPos)) {
+          view.dispatch(view.state.tr.setMeta(sourceModeKey, currentPos));
+        }
+      });
+    }
+
+    return new CodeBlockWithLangSelectorNodeView(node, view, getPos);
+  };
+}
+
+function previewingAncestor($pos, state) {
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+
+    if (node.type.name === "code_block") {
+      const pos = $pos.before(depth);
+
+      return showsPreview(node, state, pos) ? { node, pos } : null;
+    }
+  }
+
+  return null;
+}
+
+// while a block previews, a caret next to it must select it rather than merge
+// text into source that is not showing
+function selectPreviewingNeighbor(dir) {
+  return (state, dispatch) => {
+    const { $cursor } = state.selection;
+
+    if (!$cursor || $cursor.depth === 0) {
+      return false;
+    }
+
+    if (dir === -1 && $cursor.parentOffset !== 0) {
+      return false;
+    }
+
+    if (dir === 1 && $cursor.parentOffset !== $cursor.parent.content.size) {
+      return false;
+    }
+
+    const boundary = dir === -1 ? $cursor.before() : $cursor.after();
+    const $boundary = state.doc.resolve(boundary);
+    const neighbor = dir === -1 ? $boundary.nodeBefore : $boundary.nodeAfter;
+
+    if (!neighbor) {
+      return false;
+    }
+
+    const pos = dir === -1 ? boundary - neighbor.nodeSize : boundary;
+
+    if (!showsPreview(neighbor, state, pos)) {
+      return false;
+    }
+
+    dispatch?.(
+      state.tr
+        .setSelection(NodeSelection.create(state.doc, pos))
+        .scrollIntoView()
+    );
+
+    return true;
+  };
+}
+
+function sourceModePlugin() {
+  return new Plugin({
+    key: sourceModeKey,
+
+    state: {
+      init: () => [],
+
+      apply(tr, positions, _oldState, newState) {
+        let next = positions;
+
+        if (tr.docChanged) {
+          next = next
+            .map((pos) => tr.mapping.mapResult(pos))
+            .filter((result) => !result.deleted)
+            .map((result) => result.pos);
+        }
+
+        const toggled = tr.getMeta(sourceModeKey);
+
+        if (toggled !== undefined) {
+          next = next.includes(toggled)
+            ? next.filter((pos) => pos !== toggled)
+            : [...next, toggled];
+        }
+
+        // a pin is meaningless once its block is gone or stops previewing
+        return next.filter((pos) =>
+          codeBlockPreviewComponent(newState.doc.nodeAt(pos))
+        );
+      },
+    },
+
+    props: {
+      // the deco both marks the face for CSS and dirties the node so its view
+      // is recreated on toggle, without touching the document
+      decorations(state) {
+        const decorations = sourceModePositions(state)
+          .map((pos) => {
+            const node = state.doc.nodeAt(pos);
+
+            return (
+              node &&
+              Decoration.node(pos, pos + node.nodeSize, { class: "--source" })
+            );
+          })
+          .filter(Boolean);
+
+        return DecorationSet.create(state.doc, decorations);
+      },
+    },
+
+    // a text selection cannot land in source that is not showing: there is no
+    // DOM for it, and typing there would edit the document invisibly
+    appendTransaction(transactions, _oldState, state) {
+      if (!transactions.some((tr) => tr.docChanged || tr.selectionSet)) {
+        return null;
+      }
+
+      const { selection } = state;
+
+      if (!(selection instanceof TextSelection)) {
+        return null;
+      }
+
+      const head = previewingAncestor(selection.$head, state);
+      const anchor = selection.empty
+        ? head
+        : previewingAncestor(selection.$anchor, state);
+
+      if (!head && !anchor) {
+        return null;
+      }
+
+      if (head && anchor && head.pos === anchor.pos) {
+        return state.tr.setSelection(NodeSelection.create(state.doc, head.pos));
+      }
+
+      // an endpoint that fell inside moves just past the block instead
+      const anchorPos = anchor
+        ? selection.anchor <= selection.head
+          ? anchor.pos
+          : anchor.pos + anchor.node.nodeSize
+        : selection.anchor;
+      const headPos = head
+        ? selection.head < selection.anchor
+          ? head.pos
+          : head.pos + head.node.nodeSize
+        : selection.head;
+
+      return state.tr.setSelection(
+        TextSelection.between(
+          state.doc.resolve(anchorPos),
+          state.doc.resolve(headPos)
+        )
+      );
+    },
+  });
 }
 
 function convertCodeBlockToParagraphs(schema) {
@@ -229,10 +569,12 @@ const extension = {
       ...markdownSchema.nodes.code_block.spec,
     },
   },
-  nodeViews: { code_block: CodeBlockWithLangSelectorNodeView },
+  nodeViews: { code_block: codeBlockNodeView },
   keymap: () => ({
     Tab: indentCodeBlock(),
     "Shift-Tab": indentCodeBlock(true),
+    Backspace: selectPreviewingNeighbor(-1),
+    Delete: selectPreviewingNeighbor(1),
   }),
   commands: ({ schema }) => ({
     formatCode() {
@@ -263,22 +605,24 @@ const extension = {
       };
     },
   }),
-  async plugins({ getContext }) {
-    return highlightPlugin(
-      (hljs = await ensureHighlightJs(getContext().session.highlightJsPath)),
-      ["code_block", "html_block", "preview_source"],
+  plugins: [
+    sourceModePlugin(),
+    async ({ getContext }) =>
+      highlightPlugin(
+        (hljs = await ensureHighlightJs(getContext().session.highlightJsPath)),
+        ["code_block", "html_block", "preview_source"],
 
-      // NOTE: If the language has not been set with the code block, we default to plain
-      // text rather than autodetecting. This is to work around an infinite loop issue
-      // in prosemirror-highlightjs when autodetecting which hangs the browser sometimes
-      // for > 10 seconds, for example:
-      //
-      // https://github.com/b-kelly/prosemirror-highlightjs/issues/21
-      //
-      // We can remove this if we find some other workaround.
-      (node) => node.attrs.params || "text"
-    );
-  },
+        // NOTE: If the language has not been set with the code block, we default to plain
+        // text rather than autodetecting. This is to work around an infinite loop issue
+        // in prosemirror-highlightjs when autodetecting which hangs the browser sometimes
+        // for > 10 seconds, for example:
+        //
+        // https://github.com/b-kelly/prosemirror-highlightjs/issues/21
+        //
+        // We can remove this if we find some other workaround.
+        (node) => node.attrs.params || "text"
+      ),
+  ],
 };
 
 export default extension;

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -5,6 +5,7 @@ import {
   NodeSelection,
   Plugin,
   PluginKey,
+  Selection,
   TextSelection,
 } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
@@ -38,9 +39,11 @@ function registeredPreviews() {
     previewsCache = {};
 
     for (const { codeBlockPreviews } of getExtensions()) {
-      for (const [language, component] of Object.entries(
-        codeBlockPreviews ?? {}
-      )) {
+      for (const [name, component] of Object.entries(codeBlockPreviews ?? {})) {
+        // hljs treats language names case-insensitively, so ```Mermaid must
+        // find the same preview as ```mermaid
+        const language = name.toLowerCase();
+
         if (previewsCache[language] && previewsCache[language] !== component) {
           // eslint-disable-next-line no-console
           console.warn(
@@ -60,8 +63,13 @@ function hasRegisteredPreviews() {
   return Object.keys(registeredPreviews()).length > 0;
 }
 
+// the language a block's info string declares: its first word, lowercased
+function paramsLanguage(params) {
+  return params?.trim().split(/\s+/)[0]?.toLowerCase();
+}
+
 function previewComponentForParams(params) {
-  const language = params?.trim().split(/\s+/)[0];
+  const language = paramsLanguage(params);
 
   return language ? registeredPreviews()[language] : undefined;
 }
@@ -88,14 +96,20 @@ function sourceModePins(state) {
 }
 
 function pinDecoration(pos, node, previewHeight) {
-  return Decoration.node(pos, pos + node.nodeSize, {
-    class: "--source",
-    // the code face keeps (a bounded part of) the footprint of the preview it
-    // replaced, so flipping does not reflow the document below the block
-    ...(previewHeight && {
-      style: `--composer-preview-node-height: ${Math.round(previewHeight)}px`,
-    }),
-  });
+  return Decoration.node(
+    pos,
+    pos + node.nodeSize,
+    {
+      class: "--source",
+      // the code face keeps (a bounded part of) the footprint of the preview
+      // it replaced, so flipping does not reflow the document below the block
+      ...(previewHeight && {
+        style: `--composer-preview-node-height: ${Math.round(previewHeight)}px`,
+      }),
+    },
+    // readable back off a pin that is about to be replaced
+    { previewHeight }
+  );
 }
 
 // a neighboring pin ends where this block starts, so match on `from`
@@ -237,7 +251,14 @@ class CodeBlockWithLangSelectorNodeView {
   }
 
   toggleSource() {
-    toggleCodeBlockSource(this.view, this.getPos());
+    const pos = this.getPos();
+
+    // the view may already have been destroyed and replaced
+    if (pos === undefined) {
+      return;
+    }
+
+    toggleCodeBlockSource(this.view, pos);
   }
 
   changeListener(e) {
@@ -299,8 +320,11 @@ class CodeBlockWithLangSelectorNodeView {
       ]),
     ].sort((a, b) => a.localeCompare(b));
 
+    // an info-string tail (```mermaid height=500) is not part of the language
+    const language = paramsLanguage(this.node.attrs.params);
+
     const empty = document.createElement("option");
-    empty.textContent = languages.includes(this.node.attrs.params)
+    empty.textContent = languages.includes(language)
       ? ""
       : this.node.attrs.params;
     select.appendChild(empty);
@@ -308,7 +332,7 @@ class CodeBlockWithLangSelectorNodeView {
     languages.forEach((lang) => {
       const option = document.createElement("option");
       option.textContent = lang;
-      option.selected = lang === this.node.attrs.params;
+      option.selected = lang === language;
       select.appendChild(option);
     });
 
@@ -342,22 +366,12 @@ class CodeBlockWithLangSelectorNodeView {
 
     return !this.contentDOM.contains(mutation.target);
   }
-
-  destroy() {
-    this.dom.removeEventListener("change", (e) => this.changeListener(e));
-  }
 }
 
 // A previewing block reimplements atom semantics for a non-atom node: this
 // view exposes no contentDOM, so prosemirror-view renders none of the block's
-// content and treats it as opaque. Everything an atom would get from its
-// schema spec is reproduced around that fact — clicks (the plugin's
-// handleClickOn), Backspace/Delete and arrows at the boundaries (the
-// extension keymap), and text-selection containment (the plugin's
-// appendTransaction). A prosemirror-view upgrade must re-verify that
-// contentDOM-less views stay opaque to the DOM observer and to selection,
-// that handleClickOn still fires for non-atom nodes, and that
-// view.endOfTextblock still resolves from neighboring textblocks.
+// content and treats it as opaque. Clicks, the Backspace/Delete and arrow
+// boundaries, and text-selection containment are all rebuilt around that.
 class CodeBlockPreviewNodeView extends GlimmerNodeView {
   constructor(node, view, getPos, pluginParams, preview) {
     super({
@@ -367,7 +381,11 @@ class CodeBlockPreviewNodeView extends GlimmerNodeView {
       pluginParams,
       component: CodeBlockPreview,
       name: "code-block-preview",
-      options: { preview, onToggle: toggleCodeBlockSource },
+      options: {
+        preview,
+        language: paramsLanguage(node.attrs.params),
+        onToggle: toggleCodeBlockSource,
+      },
     });
   }
 
@@ -377,6 +395,7 @@ class CodeBlockPreviewNodeView extends GlimmerNodeView {
     if (
       node.type !== this.node.type ||
       codeBlockPreviewComponent(node) !== this.options.preview ||
+      paramsLanguage(node.attrs.params) !== this.options.language ||
       isSourceMode(this.view.state, this.getPos())
     ) {
       return false;
@@ -445,27 +464,65 @@ function containedSelection(state, pins) {
     return NodeSelection.create(state.doc, head.pos);
   }
 
-  // an endpoint that fell inside moves just past the block instead
-  const anchorPos = anchor
-    ? selection.anchor <= selection.head
-      ? anchor.pos
-      : anchor.pos + anchor.node.nodeSize
-    : selection.anchor;
-  const headPos = head
-    ? selection.head < selection.anchor
-      ? head.pos
-      : head.pos + head.node.nodeSize
-    : selection.head;
+  // an endpoint that fell inside moves out to the neighboring textblock. A
+  // boundary position resolves to the document, and TextSelection.between
+  // would send such an endpoint back into the block it just left, so each one
+  // is stepped away from the block explicitly.
+  const $anchor = anchor
+    ? outsideBlock(state, anchor, selection.anchor <= selection.head ? -1 : 1)
+    : state.doc.resolve(selection.anchor);
+  const $head = head
+    ? outsideBlock(state, head, selection.head < selection.anchor ? -1 : 1)
+    : state.doc.resolve(selection.head);
 
-  return TextSelection.between(
-    state.doc.resolve(anchorPos),
-    state.doc.resolve(headPos)
-  );
+  if (!$anchor || !$head) {
+    return NodeSelection.create(state.doc, (head ?? anchor).pos);
+  }
+
+  return TextSelection.between($anchor, $head);
+}
+
+// the nearest position outside `block` in `dir`, or null when the block has no
+// textblock on that side to hold a selection endpoint
+function outsideBlock(state, block, dir) {
+  const boundary = dir === -1 ? block.pos : block.pos + block.node.nodeSize;
+
+  return Selection.findFrom(state.doc.resolve(boundary), dir, true)?.$head;
+}
+
+// the boundary a join would actually cut at, mirroring prosemirror-commands:
+// walk out of every wrapper the caret sits at the edge of, so a neighbor
+// nested in a list item or blockquote is still seen
+function cutBoundary($pos, dir) {
+  if ($pos.parent.type.spec.isolating) {
+    return null;
+  }
+
+  for (let depth = $pos.depth - 1; depth >= 0; depth--) {
+    if (dir === -1) {
+      if ($pos.index(depth) > 0) {
+        return $pos.before(depth + 1);
+      }
+    } else if ($pos.index(depth) + 1 < $pos.node(depth).childCount) {
+      return $pos.after(depth + 1);
+    }
+
+    if ($pos.node(depth).type.spec.isolating) {
+      break;
+    }
+  }
+
+  return null;
 }
 
 function selectNeighborPreview(state, dispatch, dir) {
   const { $cursor } = state.selection;
-  const boundary = dir === -1 ? $cursor.before() : $cursor.after();
+  const boundary = cutBoundary($cursor, dir);
+
+  if (boundary === null) {
+    return false;
+  }
+
   const $boundary = state.doc.resolve(boundary);
   const neighbor = dir === -1 ? $boundary.nodeBefore : $boundary.nodeAfter;
 
@@ -571,6 +628,7 @@ function sourceModePlugin() {
         ),
 
       apply(tr, pins, _oldState, newState) {
+        const before = pins;
         pins = pins.map(tr.mapping, tr.doc);
 
         const meta = tr.getMeta(sourceModeKey);
@@ -592,9 +650,18 @@ function sourceModePlugin() {
           pins = pins.add(
             newState.doc,
             meta.pins
-              .map((pos) => tr.mapping.map(pos))
-              .filter((pos) => !findPin(pins, pos).length)
-              .map((pos) => pinDecoration(pos, newState.doc.nodeAt(pos)))
+              .map((pos) => ({
+                pos: tr.mapping.map(pos),
+                // setNodeMarkup replaces the node, which kills its node
+                // decoration, so a re-pin has to carry the footprint the
+                // dying pin was holding
+                previewHeight: findPin(before, pos)[0]?.spec.previewHeight,
+                node: newState.doc.nodeAt(tr.mapping.map(pos)),
+              }))
+              .filter(({ pos, node }) => node && !findPin(pins, pos).length)
+              .map(({ pos, node, previewHeight }) =>
+                pinDecoration(pos, node, previewHeight)
+              )
           );
         }
 

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -720,6 +720,9 @@ const extension = {
   nodeSpec: {
     code_block: {
       createGapCursor: true,
+      // the preview toolbar targets blocks that declare themselves preview
+      // blocks, so the generic primitive needs no knowledge of this feature
+      isPreviewBlock: (node) => !!codeBlockPreviewComponent(node),
       ...markdownSchema.nodes.code_block.spec,
     },
   },

--- a/frontend/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/code-block.js
@@ -9,10 +9,7 @@ import {
 } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import CodeBlockPreview from "discourse/components/composer/code-block-preview";
-import {
-  registerPreviewNodeView,
-  TOOLBAR_IDENTIFIER,
-} from "discourse/components/composer/preview-node-view";
+import { registerPreviewNodeView } from "discourse/components/composer/preview-node-view";
 import { getExtensions } from "discourse/lib/composer/rich-editor-extensions";
 import { ensureHighlightJs } from "discourse/lib/highlight-syntax";
 import GlimmerNodeView from "../lib/glimmer-node-view";
@@ -263,16 +260,9 @@ class CodeBlockWithLangSelectorNodeView {
     return true;
   }
 
-  stopEvent(event) {
-    return (
-      event.target instanceof Node &&
-      !!event.target.closest?.(`[data-identifier="${TOOLBAR_IDENTIFIER}"]`)
-    );
-  }
-
-  // the preview toolbar portals into this dom: reading its mount/unmount back
-  // into the document would loop redraw against re-portal until the editor
-  // hangs
+  // anything mounted into this dom from outside (the language select today;
+  // any portaled UI tomorrow) must not be read back into the document — the
+  // editor would loop redraw against remount until it hangs
   ignoreMutation(mutation) {
     if (mutation.type === "selection") {
       return false;

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -185,25 +185,6 @@ class PreviewToolbarPluginView {
     }
   }
 
-  // the portaled template renders whitespace text nodes next to the menu, and
-  // a code block's `pre` would paint them as blank lines, growing the block
-  // whenever the toolbar mounts; a zero-sized out-of-flow outlet keeps the
-  // mount from ever affecting the block's layout
-  #portalOutlet(trigger) {
-    let outlet = trigger.querySelector(
-      ":scope > .composer-preview-toolbar__outlet"
-    );
-
-    if (!outlet) {
-      outlet = document.createElement("div");
-      outlet.className = "composer-preview-toolbar__outlet";
-      outlet.contentEditable = "false";
-      trigger.appendChild(outlet);
-    }
-
-    return outlet;
-  }
-
   async #showFloatingToolbar() {
     const trigger = this.#view.nodeDOM(this.#pos);
 
@@ -226,7 +207,9 @@ class PreviewToolbarPluginView {
       fallbackPlacements: ["top-end"],
       padding: MENU_PADDING,
       data: this.#toolbar,
-      portalOutletElement: this.#portalOutlet(trigger),
+      // outside the editor DOM, so mounting it can never affect the block's
+      // layout or be read back by the editor as a document change
+      portalOutletElement: this.#view.dom.parentElement,
       closeOnClickOutside: false,
       closeOnEscape: false,
       closeOnScroll: false,

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -6,7 +6,6 @@ import {
 import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
 import { ToolbarBase } from "discourse/lib/composer/toolbar";
 import { rovingButtonBar } from "discourse/lib/roving-button-bar";
-import { codeBlockPreviewComponent } from "./code-block";
 
 const MENU_PADDING = 8;
 
@@ -15,7 +14,7 @@ function isPreviewBlock(node, schema) {
 
   return (
     (!!previewSource && node.firstChild?.type === previewSource) ||
-    !!codeBlockPreviewComponent(node)
+    !!node.type.spec.isPreviewBlock?.(node)
   );
 }
 

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -6,8 +6,18 @@ import {
 import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
 import { ToolbarBase } from "discourse/lib/composer/toolbar";
 import { rovingButtonBar } from "discourse/lib/roving-button-bar";
+import { codeBlockPreviewComponent } from "./code-block";
 
 const MENU_PADDING = 8;
+
+function isPreviewBlock(node, schema) {
+  const previewSource = schema.nodes.preview_source;
+
+  return (
+    (!!previewSource && node.firstChild?.type === previewSource) ||
+    !!codeBlockPreviewComponent(node)
+  );
+}
 
 /**
  * Finds the preview block a selection acts on: one selected as a node, or the
@@ -16,15 +26,9 @@ const MENU_PADDING = 8;
  * @returns {{ node: import("prosemirror-model").Node, pos: number }|null}
  */
 export function activePreviewBlock({ selection, schema }) {
-  const previewSource = schema.nodes.preview_source;
-
-  if (!previewSource) {
-    return null;
-  }
-
   if (
     selection instanceof NodeSelection &&
-    selection.node.firstChild?.type === previewSource
+    isPreviewBlock(selection.node, schema)
   ) {
     return { node: selection.node, pos: selection.from };
   }
@@ -34,7 +38,7 @@ export function activePreviewBlock({ selection, schema }) {
   for (let depth = $head.depth; depth > 0; depth--) {
     const node = $head.node(depth);
 
-    if (node.firstChild?.type === previewSource) {
+    if (isPreviewBlock(node, schema)) {
       return { node, pos: $head.before(depth) };
     }
   }
@@ -265,13 +269,11 @@ const extension = {
           }
 
           const { selection, schema } = view.state;
-          const previewSource = schema.nodes.preview_source;
 
           // only from the selected block: inside the source, Tab is typing
           if (
-            !previewSource ||
             !(selection instanceof NodeSelection) ||
-            selection.node.firstChild?.type !== previewSource
+            !isPreviewBlock(selection.node, schema)
           ) {
             return false;
           }

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -78,6 +78,7 @@ class PreviewToolbar extends ToolbarBase {
 }
 
 class PreviewToolbarPluginView {
+  #destroyed = false;
   #menuInstance;
   #menuTrigger;
   #replacedToolbar;
@@ -230,6 +231,13 @@ class PreviewToolbarPluginView {
       },
     });
 
+    // destroyed while the instance was being created
+    if (this.#destroyed) {
+      this.#menuInstance?.destroy();
+      this.#menuInstance = null;
+      return;
+    }
+
     await this.#menuInstance.show();
   }
 
@@ -248,6 +256,7 @@ class PreviewToolbarPluginView {
   }
 
   destroy() {
+    this.#destroyed = true;
     this.#resetToolbar();
     this.#toolbars.clear();
     this.#toolbar = null;

--- a/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/preview-toolbar.js
@@ -185,6 +185,25 @@ class PreviewToolbarPluginView {
     }
   }
 
+  // the portaled template renders whitespace text nodes next to the menu, and
+  // a code block's `pre` would paint them as blank lines, growing the block
+  // whenever the toolbar mounts; a zero-sized out-of-flow outlet keeps the
+  // mount from ever affecting the block's layout
+  #portalOutlet(trigger) {
+    let outlet = trigger.querySelector(
+      ":scope > .composer-preview-toolbar__outlet"
+    );
+
+    if (!outlet) {
+      outlet = document.createElement("div");
+      outlet.className = "composer-preview-toolbar__outlet";
+      outlet.contentEditable = "false";
+      trigger.appendChild(outlet);
+    }
+
+    return outlet;
+  }
+
   async #showFloatingToolbar() {
     const trigger = this.#view.nodeDOM(this.#pos);
 
@@ -207,7 +226,7 @@ class PreviewToolbarPluginView {
       fallbackPlacements: ["top-end"],
       padding: MENU_PADDING,
       data: this.#toolbar,
-      portalOutletElement: trigger,
+      portalOutletElement: this.#portalOutlet(trigger),
       closeOnClickOutside: false,
       closeOnEscape: false,
       closeOnScroll: false,

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -25,7 +25,7 @@ class PreviewStub extends Component {
 }
 
 const extension = {
-  codeBlockPreviews: { mermaid: PreviewStub },
+  codeBlockPreviews: { mermaid: PreviewStub, chart: PreviewStub },
 };
 
 const MARKDOWN = "before\n\n```mermaid height=500\nflowchart\n```\n\nafter";
@@ -259,6 +259,30 @@ module(
       assert.strictEqual(editorClass.value, MARKDOWN);
     });
 
+    test("undoing a deleted source-pinned block restores it on the preview face", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+      assert.dom("pre.--source").exists();
+
+      view.dispatch(
+        view.state.tr.setSelection(new AllSelection(view.state.doc))
+      );
+      view.dispatch(view.state.tr.deleteSelection());
+      await settled();
+
+      undo(view.state, view.dispatch);
+      await settled();
+
+      // intentional: the pin is UI state keyed by position, deleted with the
+      // block; undo restores the document, and the block comes back on its
+      // default rendered face
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+      assert.dom("pre.--source").doesNotExist();
+      assert.strictEqual(editorClass.value, MARKDOWN);
+    });
+
     test("switching the language away drops the preview, and back picks it up", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, MARKDOWN);
       const { view } = editorClass;
@@ -285,6 +309,32 @@ module(
       assert.strictEqual(
         editorClass.value,
         "before\n\n```mermaid\nflowchart\n```\n\nafter"
+      );
+    });
+
+    test("the selector keeps the info-string tail between previewable languages", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+
+      const select = document.querySelector(".code-language-select");
+      select.value = "chart";
+      await triggerEvent(select, "change");
+
+      assert.strictEqual(
+        editorClass.value,
+        "before\n\n```chart height=500\nflowchart\n```\n\nafter",
+        "the tail belongs to the preview feature and survives"
+      );
+
+      select.value = "ruby";
+      await triggerEvent(select, "change");
+
+      assert.strictEqual(
+        editorClass.value,
+        "before\n\n```ruby\nflowchart\n```\n\nafter",
+        "a plain language has no use for the tail, so it drops"
       );
     });
 

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -50,6 +50,21 @@ async function toggleSource(view) {
   await settled();
 }
 
+// PM resolves clicks through posAtCoords, so the synthetic events must carry
+// the element's real coordinates
+async function clickAt(element) {
+  const rect = element.getBoundingClientRect();
+  const coords = {
+    button: 0,
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+  };
+
+  await triggerEvent(element, "mousedown", coords);
+  await triggerEvent(element, "mouseup", coords);
+  await triggerEvent(element, "click", coords);
+}
+
 module(
   "Integration | Component | prosemirror-editor - code block preview",
   function (hooks) {
@@ -293,6 +308,34 @@ module(
       await toggleSource(view);
 
       assert.dom(".cb-preview-stub").hasText("flowchart");
+    });
+
+    test("clicking the preview face selects the block, clicking the code face places the caret", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { node, pos } = findCodeBlock(view);
+
+      await clickAt(document.querySelector(".composer-preview-node__preview"));
+
+      assert.true(
+        view.state.selection instanceof NodeSelection,
+        "the block is node-selected, so its toolbar can show"
+      );
+      assert.strictEqual(view.state.selection.from, pos);
+
+      await toggleSource(view);
+      await clickAt(document.querySelector("pre.--source code"));
+
+      assert.true(
+        view.state.selection instanceof TextSelection,
+        "the code face takes a caret"
+      );
+      assert.strictEqual(
+        view.state.selection.$head.parent,
+        view.state.doc.nodeAt(pos),
+        "inside the block"
+      );
+      assert.strictEqual(node.attrs.params, "mermaid height=500");
     });
 
     test("foreign DOM mounted into the code face is left alone", async function (assert) {

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -243,6 +243,78 @@ module(
       assert.strictEqual(editorClass.value, MARKDOWN, "nothing merged");
     });
 
+    test("backspace from a nested neighbor selects the block instead of merging", async function (assert) {
+      const markdown = "```mermaid\nflowchart\n```\n\n* item";
+      const [editorClass] = await setupRichEditor(assert, markdown);
+      const { view } = editorClass;
+      const { node, pos } = findCodeBlock(view);
+
+      // start of the list item's paragraph: the boundary at the caret's own
+      // depth has no node before it, so the guard has to look further out
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos + node.nodeSize + 3)
+        )
+      );
+      await settled();
+
+      await triggerKeyEvent(".ProseMirror", "keydown", "Backspace");
+
+      assert.true(view.state.selection instanceof NodeSelection);
+      assert.strictEqual(view.state.selection.from, pos);
+      assert.strictEqual(editorClass.value, markdown, "nothing merged");
+    });
+
+    test("delete from a nested neighbor selects the block instead of merging", async function (assert) {
+      const markdown = "> quote\n\n```mermaid\nflowchart\n```";
+      const [editorClass] = await setupRichEditor(assert, markdown);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      // end of the blockquote's paragraph
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos - 2)
+        )
+      );
+      await settled();
+
+      await triggerKeyEvent(".ProseMirror", "keydown", "Delete");
+
+      assert.true(view.state.selection instanceof NodeSelection);
+      assert.strictEqual(view.state.selection.from, pos);
+      assert.strictEqual(editorClass.value, markdown, "nothing merged");
+    });
+
+    test("a selection sweeping backwards out of the block keeps its head outside", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { node, pos } = findCodeBlock(view);
+
+      // a drag starting in "after" and moving up into the diagram
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos + node.nodeSize + 3, pos + 2)
+        )
+      );
+      await settled();
+
+      assert.notStrictEqual(
+        view.state.selection.$head.parent.type.name,
+        "code_block",
+        "the head is not left inside the hidden source"
+      );
+
+      view.dispatch(view.state.tr.insertText("X"));
+      await settled();
+
+      assert.strictEqual(
+        findCodeBlock(view),
+        undefined,
+        "typing replaced the whole block rather than editing hidden source"
+      );
+    });
+
     test("select-all removes the block, and undo brings the preview back", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, MARKDOWN);
       const { view } = editorClass;
@@ -444,8 +516,10 @@ module(
       portal.textContent = "portaled toolbar";
       pre.appendChild(portal);
 
-      await settled();
+      // the DOM observer flushes on its own timeout, which settled() does not
+      // wait for, so a redraw has to be given a real chance to happen
       await new Promise((resolve) => setTimeout(resolve, 50));
+      await settled();
 
       assert
         .dom("pre.--source .fake-toolbar")

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -501,6 +501,47 @@ module(
         .doesNotExist("flipping back settles to the preview's own height");
     });
 
+    test("a language change carries the pinned footprint", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      const previewHeight = view.nodeDOM(pos).offsetHeight;
+      await toggleSource(view);
+
+      const held = getComputedStyle(document.querySelector("pre.--source"))
+        .getPropertyValue("--composer-preview-node-height")
+        .trim();
+      assert.strictEqual(held, `${Math.round(previewHeight)}px`);
+
+      // setNodeMarkup replaces the node, so its pin dies and is rebuilt
+      const select = document.querySelector(".code-language-select");
+      select.value = "chart";
+      await triggerEvent(select, "change");
+
+      assert.strictEqual(
+        getComputedStyle(document.querySelector("pre.--source"))
+          .getPropertyValue("--composer-preview-node-height")
+          .trim(),
+        held,
+        "the rebuilt pin still holds the footprint"
+      );
+    });
+
+    test("a previewing block exposes its language to CSS", async function (assert) {
+      await setupRichEditor(assert, MARKDOWN);
+
+      assert
+        .dom(".composer-code-block-preview-node")
+        .hasAttribute("data-language", "mermaid");
+    });
+
+    test("a language matches its preview regardless of case", async function (assert) {
+      await setupRichEditor(assert, "```MerMaid\nflowchart\n```");
+
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+    });
+
     test("foreign DOM mounted into the code face is left alone", async function (assert) {
       // the preview toolbar portals into the block's dom; reading that
       // mutation back into the document looped redraw against re-portal

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -286,6 +286,35 @@ module(
       assert.strictEqual(editorClass.value, markdown, "nothing merged");
     });
 
+    test("backspace into a nested previewing block selects it instead of merging", async function (assert) {
+      const markdown = "> ```mermaid\n> flowchart\n> ```\n\nafter";
+      const [editorClass] = await setupRichEditor(assert, markdown);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      // the block is nested, so the boundary's own neighbour is the
+      // blockquote, not the textblock a join would descend into
+      let afterPos;
+      view.state.doc.descendants((node, at) => {
+        if (node.type.name === "paragraph" && node.textContent === "after") {
+          afterPos = at + 1;
+        }
+      });
+
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, afterPos)
+        )
+      );
+      await settled();
+
+      await triggerKeyEvent(".ProseMirror", "keydown", "Backspace");
+
+      assert.true(view.state.selection instanceof NodeSelection);
+      assert.strictEqual(view.state.selection.from, pos);
+      assert.strictEqual(editorClass.value, markdown, "nothing merged");
+    });
+
     test("a selection sweeping backwards out of the block keeps its head outside", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, MARKDOWN);
       const { view } = editorClass;
@@ -499,6 +528,30 @@ module(
       assert
         .dom("pre.--source")
         .doesNotExist("flipping back settles to the preview's own height");
+    });
+
+    test("the selector shows the language, not the info-string tail", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+
+      const select = document.querySelector(".code-language-select");
+
+      assert.strictEqual(select.value, "mermaid", "the language is selected");
+      assert.strictEqual(
+        select.options[0].textContent,
+        "",
+        "a known language needs no placeholder option"
+      );
+    });
+
+    test("the code face exposes its language to CSS too", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+
+      await toggleSource(editorClass.view);
+
+      assert.dom("pre.--source").hasAttribute("data-language", "mermaid");
     });
 
     test("a language change carries the pinned footprint", async function (assert) {

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -20,7 +20,11 @@ class PreviewStub extends Component {
   }
 
   <template>
-    <span class="cb-preview-stub">{{@source}}</span>
+    {{! taller than the code face, like a rendered diagram }}
+    <span
+      class="cb-preview-stub"
+      style="display: block; height: 150px"
+    >{{@source}}</span>
   </template>
 }
 
@@ -386,6 +390,43 @@ module(
         "inside the block"
       );
       assert.strictEqual(node.attrs.params, "mermaid height=500");
+    });
+
+    test("the code face keeps the preview's footprint", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      const face = document.querySelector(".composer-preview-node__preview");
+      assert.strictEqual(
+        getComputedStyle(face).overflowY,
+        "auto",
+        "the rendered face scrolls overflow within the shared bound"
+      );
+
+      const previewHeight = view.nodeDOM(pos).offsetHeight;
+      assert.true(previewHeight >= 150, "the preview face is tall");
+
+      await toggleSource(view);
+
+      const pre = document.querySelector("pre.--source");
+      assert.strictEqual(
+        getComputedStyle(pre)
+          .getPropertyValue("--composer-preview-node-height")
+          .trim(),
+        `${Math.round(previewHeight)}px`,
+        "the pin carries the measured height"
+      );
+      assert.true(
+        pre.offsetHeight >= Math.round(previewHeight) - 1,
+        "a few lines of code hold the diagram's footprint"
+      );
+
+      await toggleSource(view);
+
+      assert
+        .dom("pre.--source")
+        .doesNotExist("flipping back settles to the preview's own height");
     });
 
     test("foreign DOM mounted into the code face is left alone", async function (assert) {

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -1,0 +1,326 @@
+import Component from "@glimmer/component";
+import { settled, triggerEvent, triggerKeyEvent } from "@ember/test-helpers";
+import { undo } from "prosemirror-history";
+import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
+import { module, test } from "qunit";
+import { previewNodeViewFor } from "discourse/components/composer/preview-node-view";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { setupRichEditor } from "discourse/tests/helpers/rich-editor-helper";
+
+let previewRenders = 0;
+
+class PreviewStub extends Component {
+  constructor() {
+    super(...arguments);
+    previewRenders++;
+  }
+
+  <template>
+    <span class="cb-preview-stub">{{@source}}</span>
+  </template>
+}
+
+const extension = {
+  codeBlockPreviews: { mermaid: PreviewStub },
+};
+
+const MARKDOWN = "before\n\n```mermaid height=500\nflowchart\n```\n\nafter";
+
+function findCodeBlock(view) {
+  let found;
+
+  view.state.doc.descendants((node, pos) => {
+    if (node.type.name === "code_block") {
+      found = { node, pos };
+      return false;
+    }
+  });
+
+  return found;
+}
+
+async function toggleSource(view) {
+  const { pos } = findCodeBlock(view);
+
+  previewNodeViewFor(view.nodeDOM(pos)).toggleSource();
+  await settled();
+}
+
+module(
+  "Integration | Component | prosemirror-editor - code block preview",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function () {
+      previewRenders = 0;
+      await resetRichEditorExtensions();
+      registerRichEditorExtension(extension);
+    });
+
+    hooks.afterEach(async function () {
+      // the registration is global: leaking it would add the language to
+      // other modules' selectors
+      await resetRichEditorExtensions();
+    });
+
+    test("renders the registered preview in place of the code", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+
+      assert
+        .dom(".composer-code-block-preview-node .cb-preview-stub")
+        .hasText("flowchart");
+      assert
+        .dom(".composer-code-block-preview-node")
+        .hasClass("composer-preview-node", "reuses the preview block frame");
+      assert
+        .dom(".composer-code-block-preview-node pre")
+        .doesNotExist("the code face is not in the DOM while previewing");
+
+      const { pos } = findCodeBlock(editorClass.view);
+      assert.strictEqual(
+        editorClass.view.nodeDOM(pos).contentEditable,
+        "false",
+        "the block is not editable while previewing"
+      );
+
+      assert.strictEqual(
+        editorClass.value,
+        MARKDOWN,
+        "the info string round-trips byte-identically"
+      );
+    });
+
+    test("leaves unregistered languages untouched", async function (assert) {
+      const [editorClass] = await setupRichEditor(
+        assert,
+        "```ruby\nputs 1\n```"
+      );
+
+      assert.dom(".composer-code-block-preview-node").doesNotExist();
+      assert.dom(".cb-preview-stub").doesNotExist();
+      assert.dom("pre code").hasText("puts 1");
+      assert.dom("pre .code-language-select").exists();
+      assert.strictEqual(editorClass.value, "```ruby\nputs 1\n```");
+    });
+
+    test("flips to the code face and back without re-rendering per keystroke", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+
+      const initialRenders = previewRenders;
+
+      await toggleSource(view);
+
+      assert.dom(".cb-preview-stub").doesNotExist("the preview is put away");
+      assert.dom("pre.--source code").hasText("flowchart");
+
+      const { node, pos } = findCodeBlock(view);
+      assert.true(
+        view.state.selection instanceof TextSelection,
+        "the caret is a text selection"
+      );
+      assert.strictEqual(
+        view.state.selection.$head.parent,
+        node,
+        "inside the code"
+      );
+      assert.strictEqual(
+        view.state.selection.$head.parentOffset,
+        node.content.size,
+        "at its end"
+      );
+
+      // type into the code face
+      view.dispatch(
+        view.state.tr.insertText(" xy", pos + 1 + node.content.size)
+      );
+      await settled();
+
+      assert.strictEqual(
+        previewRenders,
+        initialRenders,
+        "typing does not render the preview"
+      );
+
+      await toggleSource(view);
+
+      assert.dom(".cb-preview-stub").hasText("flowchart xy");
+      assert.strictEqual(
+        previewRenders,
+        initialRenders + 1,
+        "showing the preview again renders it once"
+      );
+      assert.true(
+        view.state.selection instanceof NodeSelection,
+        "the block is selected, so its toolbar stays up"
+      );
+      assert.strictEqual(
+        editorClass.value,
+        "before\n\n```mermaid height=500\nflowchart xy\n```\n\nafter"
+      );
+    });
+
+    test("a text selection cannot stay inside a previewing block", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos + 3)
+        )
+      );
+      await settled();
+
+      const { selection } = view.state;
+      assert.true(
+        selection instanceof NodeSelection,
+        "becomes a node selection"
+      );
+      assert.strictEqual(selection.from, pos, "of the block itself");
+    });
+
+    test("backspace after the block selects it instead of merging", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { node, pos } = findCodeBlock(view);
+
+      // start of the "after" paragraph
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos + node.nodeSize + 1)
+        )
+      );
+      await settled();
+
+      await triggerKeyEvent(".ProseMirror", "keydown", "Backspace");
+
+      assert.true(view.state.selection instanceof NodeSelection);
+      assert.strictEqual(view.state.selection.from, pos);
+      assert.strictEqual(editorClass.value, MARKDOWN, "nothing merged");
+    });
+
+    test("delete before the block selects it instead of merging", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      // end of the "before" paragraph
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos - 1)
+        )
+      );
+      await settled();
+
+      await triggerKeyEvent(".ProseMirror", "keydown", "Delete");
+
+      assert.true(view.state.selection instanceof NodeSelection);
+      assert.strictEqual(view.state.selection.from, pos);
+      assert.strictEqual(editorClass.value, MARKDOWN, "nothing merged");
+    });
+
+    test("select-all removes the block, and undo brings the preview back", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+
+      view.dispatch(
+        view.state.tr.setSelection(new AllSelection(view.state.doc))
+      );
+      view.dispatch(view.state.tr.deleteSelection());
+      await settled();
+
+      assert.dom(".cb-preview-stub").doesNotExist();
+      assert.strictEqual(findCodeBlock(view), undefined);
+
+      undo(view.state, view.dispatch);
+      await settled();
+
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+      assert.strictEqual(editorClass.value, MARKDOWN);
+    });
+
+    test("switching the language away drops the preview, and back picks it up", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      view.dispatch(
+        view.state.tr.setNodeMarkup(pos, null, { params: "javascript" })
+      );
+      await settled();
+
+      assert.dom(".cb-preview-stub").doesNotExist();
+      assert.dom("pre code").hasText("flowchart", "a plain code block again");
+      assert.strictEqual(
+        editorClass.value,
+        "before\n\n```javascript\nflowchart\n```\n\nafter"
+      );
+
+      view.dispatch(
+        view.state.tr.setNodeMarkup(pos, null, { params: "mermaid" })
+      );
+      await settled();
+
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+      assert.strictEqual(
+        editorClass.value,
+        "before\n\n```mermaid\nflowchart\n```\n\nafter"
+      );
+    });
+
+    test("picking a previewed language in the selector keeps the code face", async function (assert) {
+      const [editorClass] = await setupRichEditor(
+        assert,
+        "```ruby\nflowchart\n```"
+      );
+      const { view } = editorClass;
+
+      const select = document.querySelector(".code-language-select");
+      select.value = "mermaid";
+      await triggerEvent(select, "change");
+
+      assert
+        .dom("pre.--source code")
+        .hasText("flowchart", "still on the code face");
+      assert.dom(".cb-preview-stub").doesNotExist();
+      assert.strictEqual(editorClass.value, "```mermaid\nflowchart\n```");
+
+      await toggleSource(view);
+
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+    });
+
+    test("an empty block starts on its code face and stays while typing", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      const { view } = editorClass;
+      const { schema } = view.state;
+
+      const block = schema.nodes.code_block.create({ params: "mermaid" });
+      view.dispatch(
+        view.state.tr.replaceWith(0, view.state.doc.content.size, block)
+      );
+      await settled();
+
+      assert.dom(".cb-preview-stub").doesNotExist();
+      assert.dom("pre code").exists("the code face is shown");
+
+      const { pos } = findCodeBlock(view);
+      view.dispatch(view.state.tr.insertText("flowchart", pos + 1));
+      await settled();
+
+      assert
+        .dom("pre code")
+        .hasText("flowchart", "typing does not flip the block");
+      assert.dom(".cb-preview-stub").doesNotExist();
+
+      await toggleSource(view);
+
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/code-block-preview-test.gjs
@@ -295,6 +295,138 @@ module(
       assert.dom(".cb-preview-stub").hasText("flowchart");
     });
 
+    test("foreign DOM mounted into the code face is left alone", async function (assert) {
+      // the preview toolbar portals into the block's dom; reading that
+      // mutation back into the document looped redraw against re-portal
+      // until the editor hung
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+
+      await toggleSource(view);
+
+      const pre = document.querySelector("pre.--source");
+      const portal = document.createElement("div");
+      portal.className = "fake-toolbar";
+      portal.textContent = "portaled toolbar";
+      pre.appendChild(portal);
+
+      await settled();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      assert
+        .dom("pre.--source .fake-toolbar")
+        .exists("the mounted element is not torn down by a redraw");
+      assert.strictEqual(
+        editorClass.value,
+        MARKDOWN,
+        "and nothing leaks into the document"
+      );
+
+      portal.remove();
+      await settled();
+    });
+
+    test("switching an empty block to a previewed language keeps a working code face", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "```ruby\nx\n```");
+      const { view } = editorClass;
+      const { node, pos } = findCodeBlock(view);
+
+      // empty the block with the caret inside, like a user clearing it
+      const emptying = view.state.tr.delete(
+        pos + 1,
+        pos + 1 + node.content.size
+      );
+      emptying.setSelection(TextSelection.create(emptying.doc, pos + 1));
+      view.dispatch(emptying);
+      await settled();
+
+      const select = document.querySelector(".code-language-select");
+      select.value = "mermaid";
+      await triggerEvent(select, "change");
+
+      assert.dom("pre code").exists("still on the code face");
+      assert.dom(".cb-preview-stub").doesNotExist();
+
+      view.dispatch(view.state.tr.insertText("flowchart", pos + 1));
+      await settled();
+
+      assert
+        .dom("pre code")
+        .hasText("flowchart", "typing lands in the block and does not flip it");
+      assert.strictEqual(editorClass.value, "```mermaid\nflowchart\n```");
+
+      await toggleSource(view);
+      assert.dom(".cb-preview-stub").hasText("flowchart");
+    });
+
+    test("arrow keys select a previewing block instead of stalling at it", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, MARKDOWN);
+      const { view } = editorClass;
+      const { pos } = findCodeBlock(view);
+
+      const isBlockSelected = () =>
+        view.state.selection instanceof NodeSelection &&
+        view.state.selection.from === pos;
+
+      // ArrowDown from anywhere on the last line of the paragraph above
+      view.dispatch(
+        view.state.tr.setSelection(TextSelection.create(view.state.doc, 2))
+      );
+      await triggerKeyEvent(".ProseMirror", "keydown", "ArrowDown");
+      assert.true(isBlockSelected(), "ArrowDown selects the block");
+
+      // ArrowUp from the paragraph below
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(
+            view.state.doc,
+            pos + view.state.doc.nodeAt(pos).nodeSize + 2
+          )
+        )
+      );
+      await triggerKeyEvent(".ProseMirror", "keydown", "ArrowUp");
+      assert.true(isBlockSelected(), "ArrowUp selects the block");
+
+      // ArrowRight from the end of the paragraph above
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, pos - 1)
+        )
+      );
+      await triggerKeyEvent(".ProseMirror", "keydown", "ArrowRight");
+      assert.true(isBlockSelected(), "ArrowRight selects the block");
+
+      // ArrowLeft from the start of the paragraph below
+      view.dispatch(
+        view.state.tr.setSelection(
+          TextSelection.create(
+            view.state.doc,
+            pos + view.state.doc.nodeAt(pos).nodeSize + 1
+          )
+        )
+      );
+      await triggerKeyEvent(".ProseMirror", "keydown", "ArrowLeft");
+      assert.true(isBlockSelected(), "ArrowLeft selects the block");
+    });
+
+    test("arrow keys are untouched next to a plain code block", async function (assert) {
+      const [editorClass] = await setupRichEditor(
+        assert,
+        "before\n\n```ruby\nx\n```"
+      );
+      const { view } = editorClass;
+
+      view.dispatch(
+        view.state.tr.setSelection(TextSelection.create(view.state.doc, 2))
+      );
+      await triggerKeyEvent(".ProseMirror", "keydown", "ArrowDown");
+
+      assert.false(
+        view.state.selection instanceof NodeSelection,
+        "no node selection is forced"
+      );
+    });
+
     test("an empty block starts on its code face and stays while typing", async function (assert) {
       const [editorClass] = await setupRichEditor(assert, "");
       const { view } = editorClass;

--- a/spec/system/composer/prosemirror_code_block_preview_spec.rb
+++ b/spec/system/composer/prosemirror_code_block_preview_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+describe "Composer - ProseMirror - code block previews" do
+  include_context "with prosemirror editor"
+
+  fab!(:theme)
+
+  let(:toolbar) { PageObjects::Components::ComposerPreviewToolbar.new }
+
+  before do
+    theme.set_field(
+      target: :extra_js,
+      type: :js,
+      name: "discourse/api-initializers/register-code-block-preview.gjs",
+      value: <<~JS,
+        import { apiInitializer } from "discourse/lib/api";
+
+        const Preview = <template>
+          <div class="test-code-block-preview">rendered {{@source}}</div>
+        </template>;
+
+        export default apiInitializer((api) => {
+          api.registerRichEditorExtension({
+            codeBlockPreviews: { mermaid: Preview },
+          });
+        });
+      JS
+    )
+    theme.save!
+    SiteSetting.default_theme_id = theme.id
+  end
+
+  def compose_preview_between_paragraphs
+    open_composer
+    composer.type_content("before\n\n")
+    composer.type_content("```hidden source")
+
+    expect(rich).to have_css("pre code", text: "hidden source")
+
+    # a registered preview's language is offered by the selector even though
+    # highlight.js does not know it
+    rich.find("pre .code-language-select").find("option", text: "mermaid").select_option
+
+    toolbar.click_show_preview
+
+    expect(rich).to have_css(".test-code-block-preview", text: "hidden source")
+    expect(rich).to have_no_css("pre")
+
+    composer.send_keys(:down)
+    composer.type_content("after")
+    rich.find("p", text: "after") # settle before measuring drag targets
+  end
+
+  def center_of(selector, text: nil)
+    rich.find(selector, text: text).evaluate_script(
+      "(({ x, y, width, height }) => [x + width / 2, y + height / 2])(this.getBoundingClientRect())",
+    )
+  end
+
+  # while the block previews, its source has no DOM a selection could enter:
+  # a selection swept across it must take the block whole, never place text
+  # inside the hidden source
+  it "keeps a mouse-drag selection out of the hidden source" do
+    compose_preview_between_paragraphs
+
+    from_x, from_y = center_of("p", text: "before")
+    over_x, over_y = center_of(".test-code-block-preview")
+    to_x, to_y = center_of("p", text: "after")
+
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.mouse.move(from_x, from_y)
+      pw_page.mouse.down
+      pw_page.mouse.move(over_x, over_y, steps: 5)
+      pw_page.mouse.move(to_x, to_y, steps: 5)
+      pw_page.mouse.up
+    end
+
+    composer.type_content("REPLACED")
+    composer.toggle_rich_editor
+
+    value = composer.composer_input.value
+    expect(value).to include("REPLACED")
+    expect(value).not_to include("hidden source")
+    expect(value).not_to include("```")
+    expect(value).not_to include("\n")
+  end
+
+  it "keeps a shift-click range selection out of the hidden source" do
+    compose_preview_between_paragraphs
+
+    rich.find("p", text: "before").click
+    rich.find("p", text: "after").click(:shift)
+
+    composer.send_keys(:backspace)
+    composer.toggle_rich_editor
+
+    value = composer.composer_input.value
+    expect(value).not_to include("hidden source")
+    expect(value).not_to include("```")
+    expect(value).not_to include("\n")
+  end
+
+  it "replaces the whole block within a select-all" do
+    compose_preview_between_paragraphs
+
+    composer.select_all
+    composer.type_content("REPLACED")
+    composer.toggle_rich_editor
+
+    expect(composer).to have_value("REPLACED")
+  end
+end


### PR DESCRIPTION
A fenced code block whose language has a registered preview component now renders in the rich editor with the same flip as preview blocks: the rendered result is the default face, and the toolbar switches to the ordinary code editor. A language with no registered preview renders exactly as before. The document node stays `code_block` throughout — no schema, parse, or serialize changes, so markdown fidelity and fallback (markdown editor, old cores, plain sites) are untouched.

Since `code_block` is not an atom, the preview face exposes no contentDOM and the extension reimplements the leaf semantics ProseMirror gives atoms for free: click and arrow selection, backspace/delete boundary guards, and selection normalization.

Registration is an optional `codeBlockPreviews` field on the rich editor extension interface, ignored by older cores, so out-of-repo consumers (theme components included) can feature-detect it for free. A registered language is offered by the block's language selector alongside the highlight.js ones and matched case-insensitively, and a previewing block carries `data-language` so a feature can style its own preview. The first consumer is the mermaid theme component.
