### PR TITLE
FEATURE: Add video playback to the rich editor

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -564,6 +564,77 @@
   }
 }
 
+.composer-video-node {
+  aspect-ratio: 16 / 9;
+  background-color: rgb(var(--always-black-rgb));
+  border-radius: var(--d-border-radius);
+  display: grid;
+  overflow: hidden;
+  place-items: center;
+  position: relative;
+  width: 100%;
+
+  &__error {
+    inset-block-start: 0;
+    inset-inline: 0;
+    position: absolute;
+    z-index: 1;
+  }
+
+  &__play.btn-flat {
+    --d-button-flat-bg-color: color-mix(
+      in srgb,
+      var(--primary) 75%,
+      transparent
+    );
+    --d-button-flat-bg-color--focus: color-mix(
+      in srgb,
+      var(--primary) 85%,
+      transparent
+    );
+    --d-button-flat-bg-color--hover: color-mix(
+      in srgb,
+      var(--primary) 85%,
+      transparent
+    );
+    --d-button-flat-icon-color: var(--secondary);
+    --d-button-flat-icon-color--hover: var(--secondary);
+    padding: 1rem;
+    z-index: 2;
+
+    .d-icon {
+      filter: drop-shadow(3px 3px 2px rgb(var(--always-black-rgb), 0.25));
+      height: 2.3rem;
+      transition: transform 0.15s;
+      width: 2.3rem;
+
+      @media (prefers-reduced-motion) {
+        transition: transform 0s;
+      }
+    }
+
+    @include hover {
+      .d-icon {
+        transform: scale(1.2);
+      }
+    }
+  }
+
+  &__video {
+    display: block;
+    height: 100%;
+    border-radius: var(--d-border-radius);
+    inset: 0;
+    object-fit: contain;
+    position: absolute;
+    width: 100%;
+
+    &.is-inactive {
+      pointer-events: none;
+    }
+  }
+}
+
 .image-alt-text-input {
   min-width: 100%;
   display: flex;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5884,6 +5884,7 @@ en:
 
     cannot_render_video: This video cannot be rendered because your browser does not support the codec.
     invalid_video_url: This video cannot be played because the URL is invalid or unavailable.
+    play_video: Play video
 
     keyboard_shortcuts_help:
       search_label: "Search shortcuts"

--- a/frontend/discourse/app/static/prosemirror/components/media-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/media-node-view.gjs
@@ -1,0 +1,29 @@
+import { eq } from "discourse/truth-helpers";
+import ImageNodeView from "./image-node-view";
+import VideoNodeView from "./video-node-view";
+
+export default <template>
+  {{#if (eq @node.attrs.extras "video")}}
+    <VideoNodeView
+      @contentDOM={{@contentDOM}}
+      @dom={{@dom}}
+      @getPos={{@getPos}}
+      @node={{@node}}
+      @onSetup={{@onSetup}}
+      @options={{@options}}
+      @pluginParams={{@pluginParams}}
+      @view={{@view}}
+    />
+  {{else}}
+    <ImageNodeView
+      @contentDOM={{@contentDOM}}
+      @dom={{@dom}}
+      @getPos={{@getPos}}
+      @node={{@node}}
+      @onSetup={{@onSetup}}
+      @options={{@options}}
+      @pluginParams={{@pluginParams}}
+      @view={{@view}}
+    />
+  {{/if}}
+</template>

--- a/frontend/discourse/app/static/prosemirror/components/video-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/video-node-view.gjs
@@ -1,0 +1,264 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { schedule } from "@ember/runloop";
+import { service } from "@ember/service";
+import { waitForPromise } from "@ember/test-waiters";
+import {
+  lookupCachedUploadUrl,
+  lookupUncachedUploadUrls,
+  MISSING,
+} from "pretty-text/upload-short-url";
+import { NodeSelection } from "prosemirror-state";
+import { ajax } from "discourse/lib/ajax";
+import DButton from "discourse/ui-kit/d-button";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+const UNRESOLVED_MEDIA_PATHS = ["/404", "/images/transparent.png"];
+
+function resolvedUrl(url) {
+  return url &&
+    url !== MISSING &&
+    !UNRESOLVED_MEDIA_PATHS.some((path) => url.endsWith(path))
+    ? url
+    : null;
+}
+
+function videoThumbnailShortUrl(url) {
+  return url?.match(/^(upload:\/\/[a-zA-Z0-9]+)(?:\.[a-z0-9]+)?$/i)?.[1];
+}
+
+export default class VideoNodeView extends Component {
+  @service a11y;
+
+  @tracked error;
+  @tracked isActivated = false;
+  @tracked isPlaybackRequested = false;
+  @tracked poster;
+  @tracked source;
+
+  #loadId = 0;
+  #originalSrc;
+  #playId = 0;
+  #playPending = false;
+  #video;
+
+  constructor() {
+    super(...arguments);
+
+    this.args.dom.classList.remove("composer-image-node");
+    this.args.dom.classList.add("composer-video-node");
+    this.#originalSrc = this.args.node.attrs.originalSrc;
+    this.args.onSetup?.(this);
+    this.#load(this.args.node);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.#loadId++;
+    this.#playId++;
+    this.#playPending = false;
+    this.args.dom.classList.remove(
+      "composer-video-node",
+      "ProseMirror-selectednode"
+    );
+    this.args.dom.classList.add("composer-image-node");
+  }
+
+  @action
+  activateVideo() {
+    this.error = null;
+    this.isActivated = true;
+  }
+
+  deselectNode() {
+    this.args.dom.classList.remove("ProseMirror-selectednode");
+  }
+
+  @action
+  handlePlaybackError() {
+    if (this.source) {
+      this.#setError(
+        "cannot_render_video",
+        this.#playPending ? "assertive" : "polite"
+      );
+    }
+  }
+
+  @action
+  async playVideo() {
+    const playId = ++this.#playId;
+
+    if (!this.source) {
+      const loaded = await this.#load(this.args.node, { retryMissing: true });
+      if (!loaded || playId !== this.#playId) {
+        return;
+      }
+    }
+
+    this.error = null;
+    this.isPlaybackRequested = true;
+    await new Promise((resolve) => schedule("afterRender", resolve));
+    if (playId !== this.#playId) {
+      return;
+    }
+
+    this.#playPending = true;
+
+    try {
+      await this.#video.play();
+    } catch {
+      if (playId === this.#playId) {
+        this.#setError("cannot_render_video", "assertive");
+      }
+    } finally {
+      if (playId === this.#playId) {
+        this.#playPending = false;
+      }
+    }
+  }
+
+  @action
+  selectVideo() {
+    const pos = this.args.getPos();
+    const tr = this.args.view.state.tr.setSelection(
+      NodeSelection.create(this.args.view.state.doc, pos)
+    );
+
+    this.args.view.dispatch(tr);
+    this.args.view.focus();
+  }
+
+  selectNode() {
+    this.args.dom.classList.add("ProseMirror-selectednode");
+  }
+
+  @action
+  setupVideo(video) {
+    this.#video = video;
+  }
+
+  stopEvent(event) {
+    if (
+      ["dragstart", "dragover", "dragend", "drop", "dragleave"].includes(
+        event.type
+      )
+    ) {
+      return false;
+    }
+
+    return (
+      event.target instanceof HTMLVideoElement ||
+      event.target.closest?.(".composer-video-node__play")
+    );
+  }
+
+  update(node) {
+    if (node.attrs.originalSrc !== this.#originalSrc) {
+      this.isActivated = false;
+      this.isPlaybackRequested = false;
+      this.#playId++;
+      this.#playPending = false;
+      this.#originalSrc = node.attrs.originalSrc;
+    }
+
+    this.#load(node);
+  }
+
+  async #load(node, { retryMissing = false } = {}) {
+    const loadId = ++this.#loadId;
+    this.error = null;
+    this.source = resolvedUrl(node.attrs.src);
+    this.poster = null;
+
+    const sourceShortUrl = node.attrs.originalSrc;
+    const posterShortUrl = videoThumbnailShortUrl(sourceShortUrl);
+    const shortUrls = [
+      ...new Set(
+        [sourceShortUrl, posterShortUrl].filter((url) => {
+          const cachedUrl = lookupCachedUploadUrl(url).url;
+          return url && (!cachedUrl || (retryMissing && cachedUrl === MISSING));
+        })
+      ),
+    ];
+
+    const promise =
+      shortUrls.length > 0
+        ? lookupUncachedUploadUrls(shortUrls, ajax)
+        : Promise.resolve();
+
+    try {
+      await waitForPromise(promise);
+    } catch {
+      if (loadId === this.#loadId) {
+        this.#setError("invalid_video_url", "polite");
+      }
+      return false;
+    }
+
+    if (loadId !== this.#loadId) {
+      return false;
+    }
+
+    this.source =
+      resolvedUrl(lookupCachedUploadUrl(sourceShortUrl).url) ?? this.source;
+    this.poster =
+      resolvedUrl(lookupCachedUploadUrl(posterShortUrl).url) ?? this.poster;
+
+    if (!this.source) {
+      this.#setError("invalid_video_url", "polite");
+      return false;
+    }
+
+    return true;
+  }
+
+  #setError(key, announcementLevel) {
+    if (this.error === key) {
+      return;
+    }
+
+    this.error = key;
+    if (announcementLevel) {
+      this.a11y.announce(i18n(key), announcementLevel);
+    }
+  }
+
+  <template>
+    <video
+      class={{dConcatClass
+        "composer-video-node__video"
+        (unless this.isActivated "is-inactive")
+      }}
+      aria-label={{@node.attrs.alt}}
+      src={{if this.isPlaybackRequested this.source}}
+      poster={{this.poster}}
+      controls
+      playsinline
+      preload="metadata"
+      contenteditable="false"
+      {{didInsert this.setupVideo}}
+      {{on "click" this.selectVideo}}
+      {{on "error" this.handlePlaybackError}}
+      {{on "playing" this.activateVideo}}
+    ></video>
+    {{#if this.error}}
+      <div class="notice error composer-video-node__error">
+        {{dIcon "triangle-exclamation"}}
+        {{i18n this.error}}
+      </div>
+    {{/if}}
+    {{#unless this.isActivated}}
+      <DButton
+        class="btn-flat composer-video-node__play"
+        @action={{this.playVideo}}
+        @icon="play"
+        @title="play_video"
+      />
+    {{/unless}}
+  </template>
+}

--- a/frontend/discourse/app/static/prosemirror/extensions/image.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/image.js
@@ -8,7 +8,7 @@ import discourseDebounce from "discourse/lib/debounce";
 import { authorizesOneOrMoreImageExtensions } from "discourse/lib/uploads";
 import { isNumeric } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
-import ImageNodeView from "../components/image-node-view";
+import MediaNodeView from "../components/media-node-view";
 import { getChangedRanges } from "../lib/plugin-utils";
 
 const PLACEHOLDER_IMG = "/images/transparent.png";
@@ -31,9 +31,8 @@ const UPLOAD_TIMEOUT = 30_000;
 const extension = {
   nodeViews: {
     image: {
-      component: ImageNodeView,
-      shouldRender: ({ node }) =>
-        node.attrs.extras !== "audio" && node.attrs.extras !== "video",
+      component: MediaNodeView,
+      shouldRender: ({ node }) => node.attrs.extras !== "audio",
     },
   },
 
@@ -119,6 +118,18 @@ const extension = {
             };
           },
         },
+        {
+          tag: "div.onebox-placeholder-container[data-orig-src]",
+          getAttrs(dom) {
+            return {
+              src: "/404",
+              alt: dom.dataset.alt || null,
+              originalSrc: dom.dataset.origSrc,
+              title: dom.dataset.title || null,
+              extras: "video",
+            };
+          },
+        },
       ],
       toDOM(node) {
         if (node.attrs.extras === "audio") {
@@ -134,7 +145,9 @@ const extension = {
             "div",
             {
               class: "onebox-placeholder-container",
+              "data-alt": node.attrs.alt,
               "data-orig-src": node.attrs.originalSrc,
+              "data-title": node.attrs.title,
             },
             ["span", { class: "placeholder-icon video" }],
           ];

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/image-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/image-test.js
@@ -1,10 +1,14 @@
+import { click, find, settled } from "@ember/test-helpers";
+import { NodeSelection, TextSelection } from "prosemirror-state";
 import { module, test } from "qunit";
+import sinon from "sinon";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import {
   setupRichEditor,
   testRenderedMarkdown,
 } from "discourse/tests/helpers/rich-editor-helper";
+import { i18n } from "discourse-i18n";
 
 // Dragging an image exposes it as a file, as the browser does.
 function dragEvent(type, target) {
@@ -13,6 +17,26 @@ function dragEvent(type, target) {
   target.dispatchEvent(
     new DragEvent(type, { dataTransfer, bubbles: true, cancelable: true })
   );
+}
+
+function requestedShortUrls(request) {
+  return new URLSearchParams(request.requestBody).getAll("short_urls[]");
+}
+
+function videoLookupResponse(request, base62Sha1, extension = "mp4") {
+  const urls = requestedShortUrls(request);
+  const uploads = [
+    {
+      short_url: `upload://${base62Sha1}.${extension}`,
+      url: `/uploads/video.${extension}`,
+    },
+    {
+      short_url: `upload://${base62Sha1}`,
+      url: "/uploads/video-thumbnail.png",
+    },
+  ];
+
+  return response(uploads.filter((upload) => urls.includes(upload.short_url)));
 }
 
 module(
@@ -131,20 +155,393 @@ module(
       )
     );
 
-    test(
-      "video placeholder",
-      testRenderedMarkdown("![alt text|video](upload://hash)", (assert) => {
-        assert
-          .dom(".onebox-placeholder-container")
-          .exists("Video placeholder should exist");
-        assert
-          .dom(".onebox-placeholder-container")
-          .hasAttribute("data-orig-src", "upload://hash");
-        assert
-          .dom(".placeholder-icon.video")
-          .exists("Video placeholder icon should exist");
-      })
-    );
+    test("video player resolves its video and poster", async function (assert) {
+      const markdown = "![Screen Recording|video](upload://videoHash.MOV)";
+      let shortUrls;
+      pretender.post("/uploads/lookup-urls", (request) => {
+        shortUrls = requestedShortUrls(request);
+        return videoLookupResponse(request, "videoHash", "MOV");
+      });
+
+      const [editor] = await setupRichEditor(assert, markdown);
+
+      assert
+        .dom(".composer-video-node video")
+        .doesNotHaveAttribute(
+          "src",
+          "the video source is not loaded before playback is requested"
+        );
+      assert
+        .dom(".composer-video-node video")
+        .hasAttribute(
+          "poster",
+          "/uploads/video-thumbnail.png",
+          "the generated thumbnail is shown"
+        );
+      assert
+        .dom(".composer-video-node video")
+        .hasAttribute("controls", "", "native playback controls are available");
+      assert
+        .dom(".composer-video-node video")
+        .hasAttribute(
+          "aria-label",
+          "Screen Recording",
+          "the video keeps its label"
+        );
+      assert
+        .dom(".composer-video-node__play")
+        .exists("a prominent play control is available");
+      assert.deepEqual(
+        shortUrls,
+        ["upload://videoHash.MOV", "upload://videoHash"],
+        "the video and extensionless thumbnail URLs are requested"
+      );
+      assert.strictEqual(
+        editor.value,
+        markdown,
+        "rendering the player preserves the markdown"
+      );
+    });
+
+    test("video player can be selected before and after playback", async function (assert) {
+      pretender.post("/uploads/lookup-urls", (request) =>
+        videoLookupResponse(request, "selectableVideoHash")
+      );
+      const [editor] = await setupRichEditor(
+        assert,
+        "![alt text|video](upload://selectableVideoHash.mp4)"
+      );
+      const video = find(".composer-video-node video");
+      let videoClicks = 0;
+      let played = false;
+      video.addEventListener("click", () => videoClicks++);
+      video.play = () => {
+        played = true;
+        video.dispatchEvent(new Event("playing"));
+        return Promise.resolve();
+      };
+
+      editor.view.dispatch(
+        editor.view.state.tr.setSelection(
+          TextSelection.create(editor.view.state.doc, 2)
+        )
+      );
+      await click(".composer-video-node");
+
+      assert.true(
+        editor.view.state.selection instanceof NodeSelection,
+        "clicking the player selects the video node"
+      );
+      assert.false(played, "selecting the video does not start playback");
+      assert.strictEqual(
+        getComputedStyle(video).pointerEvents,
+        "none",
+        "the paused video leaves pointer handling to the editor"
+      );
+
+      editor.view.dispatch(
+        editor.view.state.tr.setSelection(
+          TextSelection.create(editor.view.state.doc, 2)
+        )
+      );
+      await click(".composer-video-node__play");
+      editor.view.dispatch(
+        editor.view.state.tr.setSelection(
+          TextSelection.create(editor.view.state.doc, 2)
+        )
+      );
+      await click(".composer-video-node video");
+
+      assert.true(
+        editor.view.state.selection instanceof NodeSelection,
+        "clicking the video selects it after playback"
+      );
+      assert.strictEqual(
+        videoClicks,
+        1,
+        "selection does not consume the video's click behavior"
+      );
+    });
+
+    test("video play control tracks playback", async function (assert) {
+      pretender.post("/uploads/lookup-urls", (request) =>
+        videoLookupResponse(request, "playableVideoHash")
+      );
+      const [editor] = await setupRichEditor(
+        assert,
+        "![alt text|video](upload://playableVideoHash.mp4)"
+      );
+
+      let played = false;
+      const video = find(".composer-video-node video");
+
+      video.play = () => {
+        assert.strictEqual(
+          video.getAttribute("src"),
+          "/uploads/video.mp4",
+          "the source is rendered only when playback is requested"
+        );
+        played = true;
+        video.dispatchEvent(new Event("play"));
+        return Promise.resolve();
+      };
+
+      editor.view.dispatch(
+        editor.view.state.tr.setSelection(
+          TextSelection.create(editor.view.state.doc, 2)
+        )
+      );
+
+      await click(".composer-video-node__play");
+
+      assert.true(played, "the prominent play control starts playback");
+      assert.false(
+        editor.view.state.selection instanceof NodeSelection,
+        "playing the video does not select it"
+      );
+      assert
+        .dom(".composer-video-node__play")
+        .exists("the prominent play control remains until playback begins");
+
+      video.dispatchEvent(new Event("playing"));
+      await settled();
+
+      assert
+        .dom(".composer-video-node__play")
+        .doesNotExist("the prominent play control is hidden during playback");
+      assert.strictEqual(
+        getComputedStyle(video).pointerEvents,
+        "auto",
+        "native controls are interactive during playback"
+      );
+
+      video.dispatchEvent(new Event("pause"));
+      await settled();
+
+      assert
+        .dom(".composer-video-node__play")
+        .doesNotExist("pausing does not replace the native controls");
+      assert.strictEqual(
+        getComputedStyle(video).pointerEvents,
+        "auto",
+        "native controls remain interactive while paused"
+      );
+    });
+
+    test("video player keeps stable 16:9 geometry", async function (assert) {
+      pretender.post("/uploads/lookup-urls", (request) =>
+        videoLookupResponse(request, "geometryVideoHash")
+      );
+      await setupRichEditor(
+        assert,
+        "![alt text|video](upload://geometryVideoHash.mp4)"
+      );
+
+      const player = find(".composer-video-node");
+      const video = find(".composer-video-node video");
+      const initialPlayerRect = player.getBoundingClientRect();
+      const videoRect = video.getBoundingClientRect();
+
+      assert.true(initialPlayerRect.width > 0, "the player has positive width");
+      assert.true(
+        initialPlayerRect.height > 0,
+        "the player has positive height"
+      );
+      assert.true(
+        Math.abs(initialPlayerRect.width / initialPlayerRect.height - 16 / 9) <
+          0.01,
+        "the player uses a 16:9 aspect ratio"
+      );
+      assert.propEqual(
+        {
+          bottom: videoRect.bottom,
+          left: videoRect.left,
+          right: videoRect.right,
+          top: videoRect.top,
+        },
+        {
+          bottom: initialPlayerRect.bottom,
+          left: initialPlayerRect.left,
+          right: initialPlayerRect.right,
+          top: initialPlayerRect.top,
+        },
+        "the video fills the player"
+      );
+
+      video.dispatchEvent(new Event("playing"));
+      await settled();
+
+      const playingPlayerRect = player.getBoundingClientRect();
+      assert.strictEqual(
+        playingPlayerRect.width,
+        initialPlayerRect.width,
+        "playback does not change the player width"
+      );
+      assert.strictEqual(
+        playingPlayerRect.height,
+        initialPlayerRect.height,
+        "playback does not change the player height"
+      );
+    });
+
+    test("video URL lookup failures can be retried", async function (assert) {
+      const announce = sinon.spy(this.owner.lookup("service:a11y"), "announce");
+      let lookupCount = 0;
+      pretender.post("/uploads/lookup-urls", (request) => {
+        lookupCount++;
+        return lookupCount === 1
+          ? response([])
+          : videoLookupResponse(request, "retryVideoHash");
+      });
+      await setupRichEditor(
+        assert,
+        "![alt text|video](upload://retryVideoHash.mp4)"
+      );
+      const video = find(".composer-video-node video");
+      let played = false;
+      video.play = () => {
+        assert.strictEqual(
+          video.getAttribute("src"),
+          "/uploads/video.mp4",
+          "the resolved source is rendered before playback starts"
+        );
+        played = true;
+        video.dispatchEvent(new Event("playing"));
+        return Promise.resolve();
+      };
+
+      assert
+        .dom(".composer-video-node__error")
+        .hasText(i18n("invalid_video_url"), "the lookup error is displayed");
+      assert.true(
+        announce.calledWith(i18n("invalid_video_url"), "polite"),
+        "the background lookup failure is announced politely"
+      );
+
+      await click(".composer-video-node__play");
+
+      assert.strictEqual(lookupCount, 2, "the play control retries the lookup");
+      assert.true(played, "the same click plays the resolved video");
+      assert
+        .dom(".composer-video-node__error")
+        .doesNotExist("the lookup error is cleared after retrying");
+      assert
+        .dom(".composer-video-node video")
+        .hasAttribute(
+          "src",
+          "/uploads/video.mp4",
+          "the retry resolves the video"
+        );
+    });
+
+    test("video playback failures are displayed", async function (assert) {
+      const announce = sinon.spy(this.owner.lookup("service:a11y"), "announce");
+      pretender.post("/uploads/lookup-urls", (request) =>
+        videoLookupResponse(request, "brokenVideoHash")
+      );
+      await setupRichEditor(
+        assert,
+        "![alt text|video](upload://brokenVideoHash.mp4)"
+      );
+      const video = find(".composer-video-node video");
+      video.play = () => Promise.reject();
+
+      await click(".composer-video-node__play");
+
+      assert
+        .dom(".composer-video-node__error")
+        .hasText(
+          i18n("cannot_render_video"),
+          "the playback error is displayed"
+        );
+      assert.true(
+        announce.calledWith(i18n("cannot_render_video"), "assertive"),
+        "the user-triggered playback failure is announced assertively"
+      );
+
+      video.dispatchEvent(new Event("error"));
+      await settled();
+
+      assert.strictEqual(
+        announce.callCount,
+        1,
+        "the same playback failure is not announced twice"
+      );
+    });
+
+    test("pending playback failures are ignored after teardown", async function (assert) {
+      const announce = sinon.spy(this.owner.lookup("service:a11y"), "announce");
+      pretender.post("/uploads/lookup-urls", (request) =>
+        videoLookupResponse(request, "removedVideoHash")
+      );
+      const [editor] = await setupRichEditor(
+        assert,
+        "![alt text|video](upload://removedVideoHash.mp4)"
+      );
+      const video = find(".composer-video-node video");
+      let markPlaybackStarted;
+      let rejectPlayback;
+      const playbackStarted = new Promise((resolve) => {
+        markPlaybackStarted = resolve;
+      });
+      video.play = () =>
+        new Promise((_resolve, reject) => {
+          markPlaybackStarted();
+          rejectPlayback = reject;
+        });
+
+      const interaction = click(".composer-video-node__play");
+      await playbackStarted;
+      editor.view.dispatch(editor.view.state.tr.delete(1, 2));
+      await settled();
+      rejectPlayback();
+      await interaction;
+      await settled();
+
+      assert.strictEqual(
+        announce.callCount,
+        0,
+        "a removed player does not announce a late playback failure"
+      );
+    });
+
+    test("round-trips a video through the clipboard", async function (assert) {
+      const markdown =
+        '![alt text|video](upload://clipboardHash.mp4 "video title")';
+      pretender.post("/uploads/lookup-urls", (request) =>
+        videoLookupResponse(request, "clipboardHash")
+      );
+      const [editor] = await setupRichEditor(assert, markdown);
+      const { view } = editor;
+      const clipboardData = new DataTransfer();
+
+      view.dispatch(
+        view.state.tr.setSelection(NodeSelection.create(view.state.doc, 1))
+      );
+      const { dom, text } = view.serializeForClipboard(
+        view.state.selection.content()
+      );
+      clipboardData.setData("text/html", dom.innerHTML);
+      clipboardData.setData("text/plain", text);
+      view.dispatch(view.state.tr.deleteSelection());
+      view.dom.dispatchEvent(
+        new ClipboardEvent("paste", {
+          bubbles: true,
+          cancelable: true,
+          clipboardData,
+        })
+      );
+      await settled();
+
+      assert
+        .dom(".composer-video-node video")
+        .exists("the pasted video remains in the editor");
+      assert.strictEqual(
+        editor.value,
+        markdown,
+        "the pasted video preserves its upload URL"
+      );
+    });
 
     test(
       "audio element",


### PR DESCRIPTION
Previously, videos pasted into the rich editor were rendered as static placeholders, so their thumbnails and contents could not be verified without switching to preview.

This change renders uploaded videos with their generated poster and native playback controls while preserving editor selection and clipboard behavior.