### PR TITLE
FIX: Keep image grid controls visible in rich editor

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/composer-image-gallery.scss
+++ b/app/assets/stylesheets/common/rich-editor/composer-image-gallery.scss
@@ -2,11 +2,7 @@
 
 .composer-image-gallery {
   &__mode-buttons {
-    position: absolute;
-    right: var(--space-2);
-    top: var(--space-2);
     display: flex;
-    z-index: 1;
 
     @include viewport.until(sm) {
       flex-direction: column;
@@ -18,11 +14,13 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    border: 1px solid var(--primary-low);
+    border: 0;
+    border-radius: var(--d-border-radius);
     background: var(--secondary);
     color: var(--primary-medium);
     font-size: var(--font-down-1-rem);
     padding: var(--space-1) var(--space-2);
+    cursor: pointer;
 
     @include viewport.until(sm) {
       padding: var(--space-2) var(--space-4);
@@ -30,33 +28,36 @@
 
     @include viewport.from(sm) {
       &:first-child {
-        border-top-left-radius: var(--d-border-radius);
-        border-bottom-left-radius: var(--d-border-radius);
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
       }
 
       &:last-child {
-        border-top-right-radius: var(--d-border-radius);
-        border-bottom-right-radius: var(--d-border-radius);
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
       }
 
       &:not(:first-child) {
-        border-left: none;
+        border-inline-start: 1px solid var(--content-border-color);
       }
+    }
 
-      &:hover {
-        color: var(--primary);
-        background-color: var(--d-hover);
-      }
+    html.discourse-no-touch &:hover:not(:disabled, .is-active) {
+      color: var(--primary);
+      background-color: var(--d-hover);
+    }
+
+    &:active:not(:disabled) {
+      background: var(--secondary);
     }
 
     &.is-active {
       background-color: var(--tertiary-low);
       color: var(--tertiary);
-      border-color: var(--tertiary-low);
     }
 
     &:focus-visible {
-      outline: 1px auto var(--tertiary);
+      @include default-focus;
     }
   }
 }

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -239,12 +239,17 @@
 
   .composer-image-grid {
     position: relative;
+
+    // Portal whitespace should not create anonymous line boxes in the grid.
+    display: flex;
+    flex-direction: column;
+    min-block-size: var(--composer-image-grid-controls-min-block-size, 0);
     border: 2px dashed var(--primary-low-mid);
     border-radius: var(--d-border-radius);
     padding: var(--space-half) var(--space-2) 0 var(--space-2);
     margin-block: var(--space-4);
 
-    > div:not(.composer-image-gallery__mode-buttons) {
+    &__content {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-2);
@@ -256,25 +261,33 @@
     }
 
     &__remove-btn {
-      position: absolute;
-      bottom: var(--space-2);
-      right: var(--space-2);
       color: var(--primary-medium);
       padding: var(--space-1) var(--space-2);
       background: var(--secondary);
-      border: 1px solid var(--primary-low);
+      border: 0;
+      border-radius: var(--d-border-radius);
       font-size: var(--font-down-1-rem);
+      white-space: nowrap;
       display: flex;
       align-items: center;
       gap: var(--space-1);
+      cursor: pointer;
 
       @include viewport.until(sm) {
         padding: var(--space-2) var(--space-4);
       }
 
-      &:hover {
+      html.discourse-no-touch &:hover:not(:disabled) {
         color: var(--primary);
-        background: var(--primary-low);
+        background: var(--d-hover);
+      }
+
+      &:active:not(:disabled) {
+        background: var(--secondary);
+      }
+
+      &:focus-visible {
+        @include default-focus;
       }
     }
 
@@ -427,6 +440,8 @@
 .fk-d-menu[data-identifier="composer-link-toolbar"],
 .fk-d-menu[data-identifier="composer-image-toolbar"],
 .fk-d-menu[data-identifier="composer-image-alt-text"],
+.fk-d-menu[data-identifier^="composer-image-grid-mode-"],
+.fk-d-menu[data-identifier^="composer-image-grid-remove-"],
 .fk-d-menu[data-identifier="composer-preview-toolbar"],
 .fk-d-menu[data-identifier="composer-onebox-toolbar"] {
   user-select: none;

--- a/frontend/discourse/app/static/prosemirror/components/grid-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/grid-node-view.gjs
@@ -2,19 +2,91 @@ import Component from "@glimmer/component";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { guidFor } from "@ember/object/internals";
+import { service } from "@ember/service";
 import { eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+const MENU_PADDING = 8;
+const MODE_MENU_IDENTIFIER = "composer-image-grid-mode";
+const REMOVE_MENU_IDENTIFIER = "composer-image-grid-remove";
+
+const GridModeButtons = <template>
+  <div
+    class="composer-image-gallery__mode-buttons"
+    role="group"
+    contenteditable="false"
+  >
+    <button
+      type="button"
+      class={{dConcatClass
+        "composer-image-gallery__mode-btn"
+        (if (eq @data.currentMode "grid") "is-active")
+      }}
+      data-mode="grid"
+      aria-label={{i18n "composer.grid_mode_grid"}}
+      title={{i18n
+        "composer.grid_mode_title"
+        mode=(i18n "composer.grid_mode_grid")
+      }}
+      aria-pressed={{if (eq @data.currentMode "grid") "true" "false"}}
+      {{on "click" (fn @data.setMode "grid")}}
+    >{{dIcon "table-cells"}}<span>{{i18n
+          "composer.grid_mode_grid"
+        }}</span></button>
+    <button
+      type="button"
+      class={{dConcatClass
+        "composer-image-gallery__mode-btn"
+        (if (eq @data.currentMode "carousel") "is-active")
+      }}
+      data-mode="carousel"
+      aria-label={{i18n "composer.grid_mode_carousel"}}
+      title={{i18n
+        "composer.grid_mode_title"
+        mode=(i18n "composer.grid_mode_carousel")
+      }}
+      aria-pressed={{if (eq @data.currentMode "carousel") "true" "false"}}
+      {{on "click" (fn @data.setMode "carousel")}}
+    >{{dIcon "image"}}<span>{{i18n
+          "composer.grid_mode_carousel"
+        }}</span></button>
+  </div>
+</template>;
+
+const RemoveGridButton = <template>
+  <button
+    type="button"
+    class="composer-image-grid__remove-btn"
+    title={{i18n "composer.remove_grid"}}
+    contenteditable="false"
+    {{on "click" @data.removeGrid}}
+  ><span>{{i18n "composer.remove_grid"}}</span></button>
+</template>;
+
 export default class GridNodeView extends Component {
+  @service menu;
+
+  #modeMenuInstance;
+  #removeMenuInstance;
+
   // Note: contentDOM is appended to dom in GlimmerNodeView constructor
   // and is a sibling of the Glimmer-rendered content
 
   constructor() {
     super(...arguments);
     this.args.dom?.classList.add("composer-image-grid");
+    this.args.contentDOM?.classList.add("composer-image-grid__content");
     this.args.onSetup?.(this);
+    this.#showMenus(guidFor(this));
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.#modeMenuInstance?.destroy();
+    this.#removeMenuInstance?.destroy();
   }
 
   get currentMode() {
@@ -44,6 +116,13 @@ export default class GridNodeView extends Component {
     this.args.view.dispatch(tr);
   }
 
+  stopEvent(event) {
+    return !!(
+      this.#modeMenuInstance?.content?.contains(event.target) ||
+      this.#removeMenuInstance?.content?.contains(event.target)
+    );
+  }
+
   selectNode() {
     this.args.dom.classList.add("ProseMirror-selectednode");
   }
@@ -52,54 +131,105 @@ export default class GridNodeView extends Component {
     this.args.dom.classList.remove("ProseMirror-selectednode");
   }
 
-  <template>
-    {{~! strip whitespace ~}}<div
-      class="composer-image-gallery__mode-buttons"
-      role="group"
-      contenteditable="false"
-    >
-      <button
-        type="button"
-        class={{dConcatClass
-          "composer-image-gallery__mode-btn"
-          (if (eq this.currentMode "grid") "is-active")
-        }}
-        data-mode="grid"
-        aria-label={{i18n "composer.grid_mode_grid"}}
-        title={{i18n
-          "composer.grid_mode_title"
-          mode=(i18n "composer.grid_mode_grid")
-        }}
-        aria-pressed={{if (eq this.currentMode "grid") "true" "false"}}
-        {{on "click" (fn this.setMode "grid")}}
-      >{{dIcon "table-cells"}}<span>{{i18n
-            "composer.grid_mode_grid"
-          }}</span></button>
-      <button
-        type="button"
-        class={{dConcatClass
-          "composer-image-gallery__mode-btn"
-          (if (eq this.currentMode "carousel") "is-active")
-        }}
-        data-mode="carousel"
-        aria-label={{i18n "composer.grid_mode_carousel"}}
-        title={{i18n
-          "composer.grid_mode_title"
-          mode=(i18n "composer.grid_mode_carousel")
-        }}
-        aria-pressed={{if (eq this.currentMode "carousel") "true" "false"}}
-        {{on "click" (fn this.setMode "carousel")}}
-      >{{dIcon "image"}}<span>{{i18n
-            "composer.grid_mode_carousel"
-          }}</span></button>
-    </div><button
-      type="button"
-      class="composer-image-grid__remove-btn"
-      title={{i18n "composer.remove_grid"}}
-      contenteditable="false"
-      {{on "click" this.removeGrid}}
-    ><span>{{i18n
-          "composer.remove_grid"
-        }}</span></button>{{~! strip whitespace ~}}
-  </template>
+  async #showMenus(menuId) {
+    this.#modeMenuInstance = this.menu.newInstance(this.args.dom, {
+      identifier: `${MODE_MENU_IDENTIFIER}-${menuId}`,
+      component: GridModeButtons,
+      contentRole: "none",
+      placement: "top-end",
+      fallbackPlacements: ["top-end"],
+      padding: MENU_PADDING,
+      data: this,
+      portalOutletElement: this.args.dom,
+      closeOnClickOutside: false,
+      closeOnEscape: false,
+      closeOnScroll: false,
+      trapTab: false,
+      offset({ rects }) {
+        return {
+          mainAxis: -MENU_PADDING - rects.floating.height,
+          crossAxis: -MENU_PADDING,
+        };
+      },
+      onPositioned: () => this.#updateControlsMinBlockSize(),
+      limitShift: {
+        offset: ({ rects }) => {
+          const removeButtonHeight =
+            this.#removeMenuInstance?.content?.offsetHeight || 0;
+
+          return {
+            crossAxis: Math.min(
+              rects.floating.height + 2 * MENU_PADDING + removeButtonHeight,
+              rects.reference.height - MENU_PADDING
+            ),
+          };
+        },
+      },
+    });
+
+    this.#removeMenuInstance = this.menu.newInstance(this.args.dom, {
+      identifier: `${REMOVE_MENU_IDENTIFIER}-${menuId}`,
+      component: RemoveGridButton,
+      contentRole: "none",
+      placement: "bottom-end",
+      fallbackPlacements: ["bottom-end"],
+      padding: MENU_PADDING,
+      data: this,
+      portalOutletElement: this.args.dom,
+      closeOnClickOutside: false,
+      closeOnEscape: false,
+      closeOnScroll: false,
+      trapTab: false,
+      offset({ rects }) {
+        return {
+          mainAxis: -MENU_PADDING - rects.floating.height,
+          crossAxis: -MENU_PADDING,
+        };
+      },
+      onPositioned: () => this.#updateControlsMinBlockSize(),
+      limitShift: {
+        offset: ({ rects }) => {
+          const modeButtonsHeight =
+            this.#modeMenuInstance?.content?.offsetHeight || 0;
+
+          return {
+            crossAxis:
+              modeButtonsHeight + 2 * MENU_PADDING + rects.floating.height,
+          };
+        },
+      },
+    });
+
+    await Promise.all([
+      this.#modeMenuInstance.show(),
+      this.#removeMenuInstance.show(),
+    ]);
+    this.#updateControlsMinBlockSize();
+  }
+
+  #updateControlsMinBlockSize() {
+    const modeButtonsHeight =
+      this.#modeMenuInstance?.content?.offsetHeight || 0;
+    const removeButtonHeight =
+      this.#removeMenuInstance?.content?.offsetHeight || 0;
+
+    if (!modeButtonsHeight || !removeButtonHeight) {
+      return;
+    }
+
+    const controlsHeight =
+      modeButtonsHeight + removeButtonHeight + 3 * MENU_PADDING;
+    const minBlockSize = `${controlsHeight}px`;
+
+    if (
+      this.args.dom.style.getPropertyValue(
+        "--composer-image-grid-controls-min-block-size"
+      ) !== minBlockSize
+    ) {
+      this.args.dom.style.setProperty(
+        "--composer-image-grid-controls-min-block-size",
+        minBlockSize
+      );
+    }
+  }
 }

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
@@ -1,6 +1,7 @@
-import { render, settled } from "@ember/test-helpers";
+import { findAll, render, settled, waitUntil } from "@ember/test-helpers";
 import { cacheShortUploadUrl, resetCache } from "pretty-text/upload-short-url";
 import { module, test } from "qunit";
+import DMenus from "discourse/float-kit/components/d-menus";
 import {
   clearRichEditorExtensions,
   resetRichEditorExtensions,
@@ -62,7 +63,10 @@ module("Integration | Component | ProsemirrorEditor", function (hooks) {
     };
 
     await render(
-      <template><ProsemirrorEditor @onSetup={{handleSetup}} /></template>
+      <template>
+        <DMenus />
+        <ProsemirrorEditor @onSetup={{handleSetup}} />
+      </template>
     );
 
     const files = [1, 2, 3].map((number) => ({
@@ -86,7 +90,6 @@ module("Integration | Component | ProsemirrorEditor", function (hooks) {
         { count: 3 },
         "all pending images use generic placeholders inside the grid"
       );
-
     const shortUrls = files.map((file, index) => {
       const shortUrl = `upload://heic-grid-${index}.jpeg`;
       const resolvedUrl = `/images/heic-grid-${index}.jpeg`;
@@ -122,6 +125,84 @@ module("Integration | Component | ProsemirrorEditor", function (hooks) {
     assert
       .dom(".composer-image-grid .composer-image-node")
       .exists({ count: 3 }, "all completed images are in the grid");
+  });
+
+  test("keeps controls available for multiple short grids", async function (assert) {
+    withPluginApi((api) => {
+      api.registerRichEditorExtension(grid);
+      api.registerRichEditorExtension(image);
+    });
+
+    let textManipulation;
+    const handleSetup = (value) => {
+      textManipulation = value;
+    };
+
+    await render(
+      <template>
+        <DMenus />
+        <ProsemirrorEditor @onSetup={{handleSetup}} />
+      </template>
+    );
+
+    const { schema } = textManipulation.view.state;
+    const emptyGrid = () => schema.nodes.grid.createAndFill();
+    const separator = schema.nodes.paragraph.create(
+      null,
+      schema.text("Between grids")
+    );
+    textManipulation.view.dispatch(
+      textManipulation.view.state.tr.replaceWith(
+        0,
+        textManipulation.view.state.doc.content.size,
+        [emptyGrid(), separator, emptyGrid()]
+      )
+    );
+    await settled();
+
+    assert
+      .dom(".composer-image-grid")
+      .exists({ count: 2 }, "both short grids are rendered");
+    assert
+      .dom('[data-identifier^="composer-image-grid-mode-"]')
+      .exists({ count: 2 }, "each grid keeps its mode toolbar");
+    assert
+      .dom('[data-identifier^="composer-image-grid-remove-"]')
+      .exists({ count: 2 }, "each grid keeps its remove toolbar");
+    assert
+      .dom('[data-identifier^="composer-image-grid-"][role="none"]')
+      .exists({ count: 4 }, "the persistent toolbars are not dialogs");
+
+    const modeMenus = findAll('[data-identifier^="composer-image-grid-mode-"]');
+    const removeMenus = findAll(
+      '[data-identifier^="composer-image-grid-remove-"]'
+    );
+    const controlsDoNotOverlap = (modeMenu) => {
+      const menuId = modeMenu.dataset.identifier.replace(
+        "composer-image-grid-mode-",
+        ""
+      );
+      const removeMenu = removeMenus.find(
+        (menu) =>
+          menu.dataset.identifier === `composer-image-grid-remove-${menuId}`
+      );
+
+      return (
+        modeMenu.getBoundingClientRect().bottom <
+        removeMenu.getBoundingClientRect().top
+      );
+    };
+
+    await waitUntil(() => modeMenus.every(controlsDoNotOverlap), {
+      timeout: 3000,
+    });
+
+    modeMenus.forEach((modeMenu) => {
+      assert.true(
+        controlsDoNotOverlap(modeMenu),
+        "the controls do not overlap in a short grid"
+      );
+    });
   });
 
   test("renders the editor with minimum extensions", async function (assert) {

--- a/spec/system/image_grid_carousel_spec.rb
+++ b/spec/system/image_grid_carousel_spec.rb
@@ -85,7 +85,7 @@ describe "Image Carousel" do
 
   it "allows changing modes in the rich text editor", js: true do
     SiteSetting.post_menu_hidden_items = ""
-    current_user.user_option.update!(composition_mode: 1)
+    current_user.user_option.update!(composition_mode: UserOption.composition_mode_types[:rich])
 
     post = create_post(raw: <<~MD)
       [grid mode=carousel]
@@ -106,5 +106,41 @@ describe "Image Carousel" do
 
     composer.toggle_rich_editor
     expect(composer.composer_input.value).to include("[grid]")
+  end
+
+  it "keeps controls usable for short, tall, and multiple grids", js: true do
+    SiteSetting.post_menu_hidden_items = ""
+    current_user.user_option.update!(composition_mode: UserOption.composition_mode_types[:rich])
+    blocks = Array.new(60, "<br>").join("\n\n")
+    post = create_post(raw: "[grid]\n<br>\n[/grid]\n\n[grid]\n#{blocks}\n[/grid]")
+
+    topic_page.visit_topic(post.topic, post_number: post.post_number)
+    topic_page.click_post_action_button(post, :edit)
+
+    expect(composer).to be_opened
+    expect(composer).to have_rich_editor_active
+    expect(composer.image_grid).to have_grids(count: 2)
+    expect(composer.image_grid).to have_mode_selects(count: 2)
+
+    wait_for do
+      empty_grid_positions = composer.image_grid.control_positions(index: 0)
+      empty_grid_positions["modeBottom"] < empty_grid_positions["removeTop"] &&
+        empty_grid_positions["removeLabelLineCount"] == 1 &&
+        empty_grid_positions["gridBottom"] - empty_grid_positions["gridTop"] < 150
+    end
+
+    positions = nil
+    wait_for(timeout: 5) do
+      composer.image_grid.scroll_grid_to_editor_middle(index: 1)
+      positions = composer.image_grid.control_positions(index: 1)
+
+      positions["gridTop"] < positions["editorTop"] &&
+        positions["gridBottom"] > positions["editorBottom"] &&
+        positions["modeTop"] >= positions["editorTop"] &&
+        positions["modeTop"] <= positions["editorTop"] + 20 &&
+        positions["removeBottom"] <= positions["editorBottom"] &&
+        positions["removeBottom"] >= positions["editorBottom"] - 20 &&
+        positions["modeBottom"] < positions["removeTop"]
+    end
   end
 end

--- a/spec/system/page_objects/components/composer_image_grid.rb
+++ b/spec/system/page_objects/components/composer_image_grid.rb
@@ -17,6 +17,50 @@ module PageObjects
         self
       end
 
+      def scroll_grid_to_editor_middle(index:)
+        grid = @rich_editor.all(".composer-image-grid")[index]
+
+        grid.execute_script(<<~JS)
+          const editor = this.closest(".ProseMirror");
+          const editorRect = editor.getBoundingClientRect();
+          const gridRect = this.getBoundingClientRect();
+          editor.scrollTop +=
+            gridRect.top -
+            editorRect.top +
+            (gridRect.height - editor.clientHeight) / 2;
+        JS
+
+        self
+      end
+
+      def control_positions(index:)
+        grid = @rich_editor.all(".composer-image-grid")[index]
+
+        grid.evaluate_script(<<~JS)
+          (() => {
+            const editor = this.closest(".ProseMirror").getBoundingClientRect();
+            const grid = this.getBoundingClientRect();
+            const mode = this.querySelector(".composer-image-gallery__mode-buttons").getBoundingClientRect();
+            const removeButton = this.querySelector(".composer-image-grid__remove-btn");
+            const remove = removeButton.getBoundingClientRect();
+            const removeLabelRange = document.createRange();
+            removeLabelRange.selectNodeContents(removeButton.querySelector("span"));
+
+            return {
+              editorTop: editor.top,
+              editorBottom: editor.bottom,
+              gridTop: grid.top,
+              gridBottom: grid.bottom,
+              modeTop: mode.top,
+              modeBottom: mode.bottom,
+              removeTop: remove.top,
+              removeBottom: remove.bottom,
+              removeLabelLineCount: removeLabelRange.getClientRects().length,
+            };
+          })()
+        JS
+      end
+
       def select_first_grid_image
         @rich_editor.all(".composer-image-grid .composer-image-node img").first.click
         self
@@ -42,6 +86,10 @@ module PageObjects
         @rich_editor.has_css?(".composer-image-grid .composer-image-node img", count: count)
       end
 
+      def has_grids?(count:)
+        @rich_editor.has_css?(".composer-image-grid", count: count)
+      end
+
       def has_no_grid_images?
         @rich_editor.has_no_css?(".composer-image-grid .composer-image-node img")
       end
@@ -54,6 +102,10 @@ module PageObjects
 
       def has_mode_select?
         @rich_editor.has_css?(".composer-image-gallery__mode-buttons")
+      end
+
+      def has_mode_selects?(count:)
+        @rich_editor.has_css?(".composer-image-gallery__mode-buttons", count: count)
       end
 
       def select_mode(mode)


### PR DESCRIPTION
Previously, image grid controls used absolute positioning, so they scrolled out of view for tall grids and empty grids could retain excess height.

This change uses persistent floating menus to keep the controls aligned to the editor viewport while preserving a compact short-grid layout.