### PR TITLE
DEV: Move Discourse Workflows to beta

### DIFF
--- a/plugins/discourse-workflows/config/settings.yml
+++ b/plugins/discourse-workflows/config/settings.yml
@@ -4,7 +4,7 @@ plugins:
     client: true
     hidden: true
     upcoming_change:
-      status: "experimental"
+      status: "beta"
       impact: "feature,admins"
       learn_more_url: "https://meta.discourse.org/t/-/407100"
       allow_enabled_for:


### PR DESCRIPTION
Update the Discourse Workflows upcoming change status from experimental to beta.