### PR TITLE
FIX: Always allow stop impersonation

### DIFF
--- a/app/controllers/admin/impersonate_controller.rb
+++ b/app/controllers/admin/impersonate_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::ImpersonateController < Admin::AdminController
   skip_before_action :ensure_admin, only: :destroy
+  skip_before_action :redirect_to_login_if_required, only: :destroy
 
   def create
     params.require(:username_or_email)

--- a/spec/requests/admin/impersonate_controller_spec.rb
+++ b/spec/requests/admin/impersonate_controller_spec.rb
@@ -124,24 +124,40 @@ RSpec.describe Admin::ImpersonateController do
     it "succeeds and logs the impersonation" do
       post "/admin/impersonate.json", params: { username_or_email: user.username }
 
-      delete "/admin/impersonate.json"
+      delete "/admin/impersonate"
 
       expect(response.status).to eq(200)
       expect(session[:current_user_id]).to eq(admin.id)
     end
 
     it "does nothing and returns success if not impersonating" do
-      delete "/admin/impersonate.json"
+      delete "/admin/impersonate"
 
       expect(response.status).to eq(200)
     end
 
     it "stops impersonating" do
       post "/admin/impersonate.json", params: { username_or_email: user.username }
-      delete "/admin/impersonate.json"
+      delete "/admin/impersonate"
 
       expect(response.status).to eq(200)
       expect(session[:current_user_id]).to eq(admin.id)
+    end
+
+    context "when enforce_second_factor is enabled and impersonated user has no 2FA" do
+      before do
+        SiteSetting.enforce_second_factor = "all"
+        Fabricate(:user_second_factor_totp, user: admin)
+      end
+
+      it "stops impersonating despite 2FA enforcement on the impersonated user" do
+        post "/admin/impersonate.json", params: { username_or_email: user.username }
+
+        delete "/admin/impersonate"
+
+        expect(response.status).to eq(200)
+        expect(session[:current_user_id]).to eq(admin.id)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes an edge case where an user can get stuck impersonating another user without 2FA, when 2FA enforcement is enabled. The impersonation correctly shows the user can only interact with UI elements for adding 2FA. But this restriction extends to the closing the impersonation session.

This commit fixes this by ensuring the DELETE /admin/impersonate endpoint is always accessible.