### PR TITLE
DEV: Add `create-topic-button-click` behavior transformer

### DIFF
--- a/frontend/discourse/app/components/d-navigation.gjs
+++ b/frontend/discourse/app/components/d-navigation.gjs
@@ -17,7 +17,10 @@ import TopicDismissButtons from "discourse/components/topic-dismiss-buttons";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
 import { NotificationLevels } from "discourse/lib/notification-levels";
-import { applyValueTransformer } from "discourse/lib/transformer";
+import {
+  applyBehaviorTransformer,
+  applyValueTransformer,
+} from "discourse/lib/transformer";
 import NavItem from "discourse/models/nav-item";
 import CategoriesAdminDropdown from "discourse/select-kit/components/categories-admin-dropdown";
 import TagCategoryAdminDropdown from "discourse/select-kit/components/tag-category-admin-dropdown";
@@ -272,7 +275,11 @@ export default class DNavigation extends Component {
 
   @action
   clickCreateTopicButton() {
-    this.createTopic();
+    applyBehaviorTransformer(
+      "create-topic-button-click",
+      () => this.createTopic(),
+      { category: this.category, tag: this.tag }
+    );
   }
 
   @action

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -19,6 +19,7 @@ export const BEHAVIOR_TRANSFORMERS = Object.freeze([
   "composer-position:correct-scroll-position",
   "composer-position:editor-touch-move",
   "create-account",
+  "create-topic-button-click",
   "custom-homepage-model",
   "discovery-topic-list-load-more",
   "full-page-search-load-more",

--- a/frontend/discourse/tests/acceptance/create-topic-button-click-test.js
+++ b/frontend/discourse/tests/acceptance/create-topic-button-click-test.js
@@ -1,0 +1,43 @@
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Create topic button click transformer", function (needs) {
+  needs.user();
+
+  test("a behavior transformer can take over the click", async function (assert) {
+    withPluginApi((api) => {
+      api.registerBehaviorTransformer(
+        "create-topic-button-click",
+        ({ context }) => {
+          assert.step(`intercepted:${context.category?.slug}`);
+        }
+      );
+    });
+
+    await visit("/c/bug/1");
+    await click("#create-topic");
+
+    assert.verifySteps(["intercepted:bug"]);
+    assert.dom("#reply-control.open").doesNotExist("the composer stays closed");
+  });
+
+  test("calling next keeps the default composer behaviour", async function (assert) {
+    withPluginApi((api) => {
+      api.registerBehaviorTransformer(
+        "create-topic-button-click",
+        ({ next }) => {
+          assert.step("passed through");
+          next();
+        }
+      );
+    });
+
+    await visit("/c/bug/1");
+    await click("#create-topic");
+
+    assert.verifySteps(["passed through"]);
+    assert.dom("#reply-control.open").exists("the composer opens");
+  });
+});


### PR DESCRIPTION
Previously, the create-topic button's click always opened the composer, so a plugin that needs its own creation flow (for example, an event form in event categories) had to hide the core button with a CSS hack and render a second button next to it, losing the drafts menu along the way.

This change wraps the click in a `create-topic-button-click` behavior transformer with the current category and tag as context, so a plugin can take over the click (or call `next()` to keep the default) while core's button, its label and icon transformers, and the drafts menu stay in place.
