### PR TITLE
DEV: Unencode the brackets of a JSON:API link

### DIFF
--- a/lib/json_api_kit/document/error_object.rb
+++ b/lib/json_api_kit/document/error_object.rb
@@ -15,7 +15,7 @@ module JsonApiKit
 
       attr_reader :error
 
-      def links = error.type&.then { { type: it } }
+      def links = error.type.try { { type: it } }
     end
   end
 end

--- a/lib/json_api_kit/linkage/to_one.rb
+++ b/lib/json_api_kit/linkage/to_one.rb
@@ -3,7 +3,7 @@
 module JsonApiKit
   class Linkage
     class ToOne < Linkage
-      def collapse(&) = records.first&.then(&)
+      def collapse(&) = records.first.try(&)
     end
   end
 end

--- a/lib/json_api_kit/pagination/order/segment.rb
+++ b/lib/json_api_kit/pagination/order/segment.rb
@@ -35,8 +35,9 @@ module JsonApiKit
 
         def reverse = self.class.new(id:, keyset: keyset.reverse, digest:, condition:)
 
-        def narrowed_by(other) =
+        def narrowed_by(other)
           self.class.new(id:, keyset:, digest:, condition: condition_after(other))
+        end
 
         private
 

--- a/lib/json_api_kit/url.rb
+++ b/lib/json_api_kit/url.rb
@@ -35,6 +35,6 @@ module JsonApiKit
 
     def member_names(page) = page.transform_keys { KIT.member_name(it) }
 
-    def query_string = parameters.to_query.presence&.then { "?#{it}" }
+    def query_string = Rack::Utils.build_nested_query(parameters).presence.try { "?#{it}" }
   end
 end

--- a/spec/integration/json_api_kit/documents_spec.rb
+++ b/spec/integration/json_api_kit/documents_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "a rendered document" do
       expect(document).to eq(
         data: [topic_object(oldest)],
         included: [],
-        links: links_of(next: page_url(after: cursor_of_record(oldest), size: 1)),
+        links: links_of(next: page_url(size: 1, after: cursor_of_record(oldest))),
       )
     end
 
@@ -49,7 +49,7 @@ RSpec.describe "a rendered document" do
             ),
           ],
           included: [user_object(oldest.user)],
-          links: links_of(next: page_url(after: cursor_of_record(oldest), size: 1)),
+          links: links_of(next: page_url(size: 1, after: cursor_of_record(oldest))),
         )
       end
     end
@@ -79,8 +79,8 @@ RSpec.describe "a rendered document" do
           included: [],
           links:
             links_of(
-              prev: page_url(before: cursor_of_record(middle), size: 1),
-              next: page_url(after: cursor_of_record(middle), size: 1),
+              prev: page_url(size: 1, before: cursor_of_record(middle)),
+              next: page_url(size: 1, after: cursor_of_record(middle)),
             ),
         )
       end

--- a/spec/integration/json_api_kit/endpoint_spec.rb
+++ b/spec/integration/json_api_kit/endpoint_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "a JSON:API endpoint", type: :request do
         {
           data: [topic_object(newest, fields:), topic_object(middle, fields:)],
           included: [],
-          links: links_of(next: page_url(after: cursor_of_record(middle), size: 2)),
+          links: links_of(next: page_url(size: 2, after: cursor_of_record(middle))),
         }.deep_stringify_keys,
       )
     end

--- a/spec/integration/json_api_kit/pagination_spec.rb
+++ b/spec/integration/json_api_kit/pagination_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "a page of a listing" do
       included: [],
       links:
         links_of(
-          next: page_url(after: cursor_of_record(middle, sort: { created_at: :asc }), size: 2),
+          next: page_url(size: 2, after: cursor_of_record(middle, sort: { created_at: :asc })),
         ),
     )
   end
@@ -60,8 +60,8 @@ RSpec.describe "a page of a listing" do
         included: [],
         links:
           links_of(
-            prev: page_url(before: cursor_of_record(middle, sort: { created_at: :asc }), size: 1),
-            next: page_url(after: cursor_of_record(middle, sort: { created_at: :asc }), size: 1),
+            prev: page_url(size: 1, before: cursor_of_record(middle, sort: { created_at: :asc })),
+            next: page_url(size: 1, after: cursor_of_record(middle, sort: { created_at: :asc })),
           ),
       )
     end

--- a/spec/integration/json_api_kit/relationships_spec.rb
+++ b/spec/integration/json_api_kit/relationships_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe "a document with related records" do
 
     def next_page_of(row, post)
       "#{base}/topics/#{row.id}/relationships/posts?" +
-        { page: { after: cursor_of_record(post, of: JsonApiKitSpec::PostResource) } }.to_query
+        query_of(page: { after: cursor_of_record(post, of: JsonApiKitSpec::PostResource) })
     end
 
     it "renders one page of them and links to the next" do

--- a/spec/integration/json_api_kit/support.rb
+++ b/spec/integration/json_api_kit/support.rb
@@ -205,13 +205,17 @@ RSpec.shared_context "with a listing of topics" do
   def profile_link(name) = "https://jsonapi.org/profiles/ethanresnick/cursor-pagination/#{name}"
 
   def self_link
-    href = query.blank? ? current : "#{current}?#{query.to_query}"
+    href = query.blank? ? current : "#{current}?#{query_of(query)}"
     { href:, type: JsonApiKit::Pagination::Profile::MEDIA_TYPE }
   end
 
+  def query_of(hash) = Rack::Utils.build_nested_query(hash)
+
   def links_of(**pages) = { self: self_link, **{ prev: nil, next: nil }.merge(pages) }
 
-  def page_url(**page) = "#{current}?#{query.except("page").merge(page:).to_query}"
+  def page_url(**page)
+    "#{current}?#{query_of(query.merge("page" => page))}"
+  end
 
   def cursor_at(index, rendered = document) = cursor_of(rendered[:data][index])
 
@@ -223,7 +227,7 @@ RSpec.shared_context "with a listing of topics" do
   end
 
   def relationship_page_url(type, row, name, **page)
-    "#{base}/#{type}/#{row.id}/#{name}?#{{ page: page }.to_query}"
+    "#{base}/#{type}/#{row.id}/#{name}?#{query_of(page: page)}"
   end
 
   def listed_ids(rendered = document) = rendered[:data].map { it[:id] }

--- a/spec/lib/json_api_kit/document/collection_spec.rb
+++ b/spec/lib/json_api_kit/document/collection_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe JsonApiKit::Document::Collection do
       it "renders a link to the page at each end" do
         expect(document.to_h[:links]).to eq(
           self: self_link,
-          prev: "https://example.com/api/topics?page%5Bbefore%5D=#{page_cursor}",
-          next: "https://example.com/api/topics?page%5Bafter%5D=#{page_cursor}",
+          prev: "https://example.com/api/topics?page[before]=#{page_cursor}",
+          next: "https://example.com/api/topics?page[after]=#{page_cursor}",
         )
       end
     end

--- a/spec/lib/json_api_kit/document/page_links_spec.rb
+++ b/spec/lib/json_api_kit/document/page_links_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe JsonApiKit::Document::PageLinks do
 
     it "returns a link to the page at each end" do
       expect(links).to eq(
-        prev: "https://example.com/api/topics?page%5Bbefore%5D=read-back-here",
-        next: "https://example.com/api/topics?page%5Bafter%5D=read-on-here",
+        prev: "https://example.com/api/topics?page[before]=read-back-here",
+        next: "https://example.com/api/topics?page[after]=read-on-here",
       )
     end
 
@@ -30,7 +30,7 @@ RSpec.describe JsonApiKit::Document::PageLinks do
       it "returns a next link only" do
         expect(links).to eq(
           prev: nil,
-          next: "https://example.com/api/topics?page%5Bafter%5D=read-on-here",
+          next: "https://example.com/api/topics?page[after]=read-on-here",
         )
       end
     end

--- a/spec/lib/json_api_kit/document/relationship_object_spec.rb
+++ b/spec/lib/json_api_kit/document/relationship_object_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe JsonApiKit::Document::RelationshipObject do
         expect(relationship_object.to_h[:links]).to eq(
           self: relationship_url,
           related: related_url,
-          prev: "#{relationship_url}?page%5Bbefore%5D=read-back-here",
-          next: "#{relationship_url}?page%5Bafter%5D=read-on-here",
+          prev: "#{relationship_url}?page[before]=read-back-here",
+          next: "#{relationship_url}?page[after]=read-on-here",
         )
       end
     end

--- a/spec/lib/json_api_kit/url_spec.rb
+++ b/spec/lib/json_api_kit/url_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe JsonApiKit::Url do
 
   describe "#to_s" do
     it "returns the address with the parameters it carries" do
-      expect(url.to_s).to eq("https://example.com/api/topics?page%5Bsize%5D=2&sort=createdAt")
+      expect(url.to_s).to eq("https://example.com/api/topics?page[size]=2&sort=createdAt")
     end
 
     context "when it carries no parameter" do
@@ -26,14 +26,14 @@ RSpec.describe JsonApiKit::Url do
 
       it "writes it in camel case" do
         expect(url.at(before_size: 2).to_s).to eq(
-          "https://example.com/api/topics?page%5BbeforeSize%5D=2",
+          "https://example.com/api/topics?page[beforeSize]=2",
         )
       end
     end
 
     it "adds the cursor to the parameters it carries" do
       expect(url.at(after: "a-cursor").to_s).to eq(
-        "https://example.com/api/topics?page%5Bafter%5D=a-cursor&page%5Bsize%5D=2&sort=createdAt",
+        "https://example.com/api/topics?page[size]=2&page[after]=a-cursor&sort=createdAt",
       )
     end
 
@@ -46,7 +46,7 @@ RSpec.describe JsonApiKit::Url do
 
       it "drops the other end" do
         expect(url.at(before: "a-cursor").to_s).to eq(
-          "https://example.com/api/topics?page%5Bbefore%5D=a-cursor&page%5Bsize%5D=2",
+          "https://example.com/api/topics?page[size]=2&page[before]=a-cursor",
         )
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe JsonApiKit::Url do
 
       it "drops the anchor and the window, and keeps the page size" do
         expect(url.at(after: "a-cursor").to_s).to eq(
-          "https://example.com/api/topics?page%5Bafter%5D=a-cursor&page%5Bsize%5D=2",
+          "https://example.com/api/topics?page[size]=2&page[after]=a-cursor",
         )
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe JsonApiKit::Url do
 
       it "carries only that cursor" do
         expect(url.at(after: "a-cursor").to_s).to eq(
-          "https://example.com/api/topics?page%5Bafter%5D=a-cursor",
+          "https://example.com/api/topics?page[after]=a-cursor",
         )
       end
     end

--- a/spec/lib/json_api_kit/urls_spec.rb
+++ b/spec/lib/json_api_kit/urls_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe JsonApiKit::Urls do
 
   describe "#current" do
     it "returns the URL a caller read with the parameters they sent" do
-      expect(urls.current.to_s).to eq(
-        "https://example.com/api/topics?page%5Bsize%5D=2&sort=createdAt",
-      )
+      expect(urls.current.to_s).to eq("https://example.com/api/topics?page[size]=2&sort=createdAt")
     end
   end
 


### PR DESCRIPTION
`to_query` percent-encodes the brackets of a nested parameter, so links are like this: `page%5Bafter%5D=...`. Using `Rack::Utils.build_nested_query` will give `page[after]=...` and it still escapes the values and round-trips through the parser Rails uses for the query string.