### PR TITLE
DEV: Let a signup flow prefill the code-signup user fields

### DIFF
--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -22,6 +22,7 @@ import discourseDebounce from "discourse/lib/debounce";
 import escape from "discourse/lib/escape";
 import getURL from "discourse/lib/get-url";
 import discourseLater from "discourse/lib/later";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import UserFieldsValidationHelper from "discourse/lib/user-fields-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
@@ -241,6 +242,44 @@ export default class CodeLoginForm extends Component {
     this.codeError = null;
   }
 
+  // A signup flow can gather the required signup fields before the code is
+  // verified — a themed landing page that asks for them up front, say. Taking
+  // those answers here lets the extra step be skipped entirely.
+  //
+  // Returns whether they can be submitted along with the code. The server
+  // reads any `user_fields` it receives as the complete answer, so a partial
+  // set would fail the signup outright rather than prompting for the rest:
+  // hold them back unless every required field ends up answered.
+  #prefillUserFields() {
+    const values = applyValueTransformer(
+      "code-login-user-field-values",
+      {},
+      { signup: this.isSignup }
+    );
+
+    if (!values || Object.keys(values).length === 0) {
+      return false;
+    }
+
+    let prefilled = false;
+
+    this.userFields.forEach((f) => {
+      const value = values[f.field.id];
+
+      if (value !== undefined) {
+        f.value = value;
+        prefilled = true;
+      }
+    });
+
+    return (
+      prefilled &&
+      this.userFields.every(
+        (f) => !f.field.required || (f.value && f.value !== "false")
+      )
+    );
+  }
+
   @action
   async verifyCode(code) {
     if (typeof code === "string") {
@@ -267,7 +306,7 @@ export default class CodeLoginForm extends Component {
       data.second_factor_method = this.secondFactorMethod;
     }
 
-    if (this.isUserFieldsStep) {
+    if (this.isUserFieldsStep || this.#prefillUserFields()) {
       data.user_fields = {};
       this.userFields.forEach((f) => (data.user_fields[f.field.id] = f.value));
       if (this.nameRequired) {

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -60,6 +60,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "category-subcategories",
   "category-text-color",
   "category-visibility-private-locked",
+  "code-login-user-field-values",
   "composer-actions-content",
   "composer-editing-post",
   "composer-editor-quoted-post-avatar-template",

--- a/frontend/discourse/tests/integration/components/code-login-form-test.gjs
+++ b/frontend/discourse/tests/integration/components/code-login-form-test.gjs
@@ -1,6 +1,7 @@
 import { click, fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import CodeLoginForm from "discourse/components/code-login-form";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import formKit from "discourse/tests/helpers/form-kit-helper";
@@ -158,6 +159,76 @@ module("Integration | Component | CodeLoginForm", function (hooks) {
 
     assert.dom(".code-login-form__second-factor-step").exists();
     assert.dom("#second-factor").exists();
+  });
+
+  test("sends prefilled user fields with the code, skipping the extra step", async function (assert) {
+    stubCodeRequest();
+    this.owner
+      .lookup("service:site")
+      .set("user_fields", [
+        { id: 7, position: 1, required: true, show_on_signup: true },
+      ]);
+    withPluginApi((api) =>
+      api.registerValueTransformer("code-login-user-field-values", () => ({
+        7: "true",
+      }))
+    );
+
+    let verifyParams;
+    pretender.post("/session/login-code/verify", (request) => {
+      verifyParams = new URLSearchParams(request.requestBody);
+
+      return response({
+        account_created: true,
+        user: { id: 1, username: "jane", avatar_template: "/letter/j.png" },
+        can_edit_username: true,
+        prefill_username: true,
+      });
+    });
+
+    await goToCodeStep();
+    await fillIn(".d-otp-input", "123456");
+
+    assert.strictEqual(
+      verifyParams.get("user_fields[7]"),
+      "true",
+      "the prefilled answer rides along with the code"
+    );
+    assert
+      .dom(".code-login-form__user-fields-step")
+      .doesNotExist("the fields are already answered, so the step is skipped");
+  });
+
+  test("withholds prefilled user fields while a required one is unanswered", async function (assert) {
+    stubCodeRequest();
+    this.owner.lookup("service:site").set("user_fields", [
+      { id: 7, position: 1, required: true, show_on_signup: true },
+      { id: 8, position: 2, required: true, show_on_signup: true },
+    ]);
+    withPluginApi((api) =>
+      api.registerValueTransformer("code-login-user-field-values", () => ({
+        7: "true",
+      }))
+    );
+
+    let verifyParams;
+    pretender.post("/session/login-code/verify", (request) => {
+      verifyParams = new URLSearchParams(request.requestBody);
+
+      return response({ user_fields_required: true });
+    });
+
+    await goToCodeStep();
+    await fillIn(".d-otp-input", "123456");
+
+    assert.strictEqual(
+      verifyParams.get("user_fields[7]"),
+      null,
+      "a partial set is not sent, which the server would read as complete"
+    );
+    assert
+      .dom(".code-login-form__user-fields-step")
+      .exists("the remaining field is still collected");
   });
 
   test("collects a required full name before completing signup", async function (assert) {


### PR DESCRIPTION
**Previously**, code signup always collected required signup user fields in a step of its own, even when the flow around it had already asked for them.

**In this update**, a `code-login-user-field-values` value transformer can supply those answers alongside the code, so the step is skipped. They are withheld unless every required field ends up answered, since the server reads any `user_fields` it receives as the complete set and would fail the signup rather than prompt for the rest.
