### PR TITLE
MT: Stop stamping last_emailed_at on bulk-imported users

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -1463,7 +1463,6 @@ class BulkImport::Base
     user[:staged] = false if user[:staged].nil?
     user[:admin] ||= false
     user[:moderator] ||= false
-    user[:last_emailed_at] ||= NOW
     user[:created_at] ||= NOW
     user[:updated_at] ||= user[:created_at]
 


### PR DESCRIPTION
Previously, the bulk importer set `last_emailed_at` to the import time on every migrated user to keep digest emails from going out, and that timestamp then showed customers a "last emailed" date that never happened.

This change drops the stamp, since the digest job now gates on `last_seen_at` and no sending path reads `last_emailed_at`, so migrated users show no email history until they are actually emailed.