### PR TITLE
FIX: Refresh browse-more counts when topic tracking state changes

### DIFF
--- a/frontend/discourse/app/components/more-topics/browse-more.gjs
+++ b/frontend/discourse/app/components/more-topics/browse-more.gjs
@@ -68,6 +68,8 @@ export default class BrowseMore extends Component {
   }
 
   get topicBrowseMoreMessage() {
+    this.topicTrackingState.get("messageCount");
+
     let category = this.args.topic.get("category");
 
     if (category && category.id === this.site.uncategorized_category_id) {

--- a/frontend/discourse/tests/integration/components/more-topics/browse-more-test.gjs
+++ b/frontend/discourse/tests/integration/components/more-topics/browse-more-test.gjs
@@ -1,0 +1,45 @@
+import EmberObject from "@ember/object";
+import { render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import BrowseMore from "discourse/components/more-topics/browse-more";
+import { NotificationLevels } from "discourse/lib/notification-levels";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | MoreTopics | BrowseMore", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("updates counts when the topic tracking state changes", async function (assert) {
+    this.currentUser.unified_new_enabled = true;
+    this.siteSettings.enable_unified_new = true;
+
+    const topicTrackingState = this.owner.lookup(
+      "service:topic-tracking-state"
+    );
+    topicTrackingState.loadStates([
+      {
+        topic_id: 123,
+        last_read_post_number: 1,
+        highest_post_number: 2,
+        notification_level: NotificationLevels.TRACKING,
+      },
+    ]);
+
+    const topic = EmberObject.create({
+      category: null,
+      isPrivateMessage: false,
+    });
+
+    await render(<template><BrowseMore @topic={{topic}} /></template>);
+
+    assert
+      .dom(".more-topics__browse-more a[href='/new?subset=replies']")
+      .hasText("1 unread", "the unread count is rendered");
+
+    topicTrackingState.updateSeen(123, 2);
+    await settled();
+
+    assert
+      .dom(".more-topics__browse-more a[href='/new?subset=replies']")
+      .doesNotExist("the unread count is removed after reading the topic");
+  });
+});


### PR DESCRIPTION
The browse-more message was not consuming the tracking state’s invalidation
token, so its new and unread counts remained stale after reading a topic.
Recompute the message whenever the topic tracking state changes.
