### PR TITLE
FIX: Create group staff action logging hole

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -174,6 +174,7 @@ class UserHistory < ActiveRecord::Base
         admin_onboarding_completed: 129,
         admin_onboarding_dismissed: 130,
         removed_avatar: 131,
+        create_group: 132,
       )
   end
 
@@ -309,6 +310,7 @@ class UserHistory < ActiveRecord::Base
       admin_onboarding_completed
       admin_onboarding_dismissed
       removed_avatar
+      create_group
     ]
   end
 

--- a/app/services/group_action_logger.rb
+++ b/app/services/group_action_logger.rb
@@ -63,6 +63,8 @@ class GroupActionLogger
       log_make_user_group_owner(group_user.user) if group_user.owner?
       log_add_user_to_group(group_user.user)
     end
+
+    StaffActionLogger.new(@acting_user).log_group_creation(@group)
   end
 
   private

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -1169,6 +1169,18 @@ class StaffActionLogger
     )
   end
 
+  def log_group_creation(group)
+    raise Discourse::InvalidParameters.new(:group) if group.nil?
+
+    details = ["name: #{group.name}", "full_name: #{group.full_name}", "id: #{group.id}"]
+
+    UserHistory.create!(
+      acting_user_id: @admin.id,
+      action: UserHistory.actions[:create_group],
+      details: details.join(", "),
+    )
+  end
+
   def log_permanently_delete_post_revisions(post)
     raise Discourse::InvalidParameters.new(:post) if post.nil?
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9340,6 +9340,7 @@ en:
             admin_onboarding_step_completed: "complete admin onboarding step"
             admin_onboarding_completed: "complete admin onboarding"
             admin_onboarding_dismissed: "dismiss admin onboarding"
+            create_group: "create group"
         screened_emails:
           title: "Screened emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/spec/services/groups/create_spec.rb
+++ b/spec/services/groups/create_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe Groups::Create do
       {
         name: "builders",
         title: "Builders",
+        full_name: "Builders",
         usernames: [member_1.username, member_2.username].join(","),
         owner_usernames: [admin.username].join(","),
       }
@@ -171,6 +172,20 @@ RSpec.describe Groups::Create do
 
       it "logs group history" do
         expect { result }.to change { GroupHistory.count }.by(4)
+      end
+
+      it "logs group creation in staff action log" do
+        result
+        expect(
+          UserHistory.where(action: UserHistory.actions[:create_group]).find_by(
+            acting_user_id: admin.id,
+          ),
+        ).to have_attributes(
+          acting_user_id: admin.id,
+          details: ["name: #{group.name}", "full_name: #{group.full_name}", "id: #{group.id}"].join(
+            ", ",
+          ),
+        )
       end
 
       context "when guardian can associate groups" do


### PR DESCRIPTION
Add a staff action log for group creation, we don't have
that right now, only delete.
