### PR TITLE
SECURITY: Redact password-reset tokens from Site Traffic Explorer URL dimensions

### DIFF
--- a/app/services/admin_dashboard_site_traffic_explorer.rb
+++ b/app/services/admin_dashboard_site_traffic_explorer.rb
@@ -643,12 +643,17 @@ class AdminDashboardSiteTrafficExplorer
 
   def decorate_dimension_row(dimension, row)
     value = row.fetch("value")
+    value = redact_password_reset_token(value) if %w[top_urls entry_urls].include?(dimension)
     value = BrowserPageviewEvent.browsers.key(value.to_i) || "unknown" if dimension == "browsers"
     {
       value: value,
       label: dimension_label(dimension, value, row["representative_ip"]),
       pageviews: row.fetch("pageviews"),
     }
+  end
+
+  def redact_password_reset_token(value)
+    value.sub(%r{\A(/(?:u|users)/password-reset)/[^/]+\z}, "\\1/<redacted>")
   end
 
   def dimension_label(dimension, value, representative_ip)

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -1580,49 +1580,6 @@ RSpec.describe Admin::DashboardController do
         )
       end
 
-      it "does not expose password reset tokens that can reset another admin's password" do
-        victim = Fabricate(:admin, password: "original-password")
-        email_token =
-          Fabricate(:email_token, user: victim, scope: EmailToken.scopes[:password_reset])
-        reset_path = "/u/password-reset/#{email_token.token}"
-        alternate_reset_path = "/users/password-reset/#{email_token.token}"
-        [reset_path, alternate_reset_path].each_with_index do |path, index|
-          Fabricate(
-            :browser_pageview_event,
-            url: path,
-            normalized_url: path,
-            user_id: victim.id,
-            session_id: "victim-password-reset-#{index}",
-            source: BrowserPageviewEvent::SOURCE_BEACON,
-            created_at: "2026-05-10 10:02:00",
-          )
-        end
-
-        get "/admin/dashboard/site-traffic-explorer.json", params: request_params
-
-        expect(response.status).to eq(200)
-        expect(response.body).not_to include(reset_path, alternate_reset_path)
-        expect(response.parsed_body.dig("dimensions", "top_urls")).to include(
-          {
-            "value" => "/u/password-reset/<redacted>",
-            "label" => "/u/password-reset/<redacted>",
-            "pageviews" => 1,
-          },
-          {
-            "value" => "/users/password-reset/<redacted>",
-            "label" => "/users/password-reset/<redacted>",
-            "pageviews" => 1,
-          },
-        )
-
-        sign_out
-        put "/u/password-reset/#{email_token.token}.json", params: { password: "attacker-password" }
-
-        expect(response.status).to eq(200)
-        expect(response.parsed_body).to include("success" => true)
-        expect(victim.reload.confirm_password?("attacker-password")).to be(true)
-      end
-
       it "matches any selected value within a dimension and every selected dimension" do
         referrers = ["search.example/results?q=discourse", ""]
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -1580,6 +1580,49 @@ RSpec.describe Admin::DashboardController do
         )
       end
 
+      it "does not expose password reset tokens that can reset another admin's password" do
+        victim = Fabricate(:admin, password: "original-password")
+        email_token =
+          Fabricate(:email_token, user: victim, scope: EmailToken.scopes[:password_reset])
+        reset_path = "/u/password-reset/#{email_token.token}"
+        alternate_reset_path = "/users/password-reset/#{email_token.token}"
+        [reset_path, alternate_reset_path].each_with_index do |path, index|
+          Fabricate(
+            :browser_pageview_event,
+            url: path,
+            normalized_url: path,
+            user_id: victim.id,
+            session_id: "victim-password-reset-#{index}",
+            source: BrowserPageviewEvent::SOURCE_BEACON,
+            created_at: "2026-05-10 10:02:00",
+          )
+        end
+
+        get "/admin/dashboard/site-traffic-explorer.json", params: request_params
+
+        expect(response.status).to eq(200)
+        expect(response.body).not_to include(reset_path, alternate_reset_path)
+        expect(response.parsed_body.dig("dimensions", "top_urls")).to include(
+          {
+            "value" => "/u/password-reset/<redacted>",
+            "label" => "/u/password-reset/<redacted>",
+            "pageviews" => 1,
+          },
+          {
+            "value" => "/users/password-reset/<redacted>",
+            "label" => "/users/password-reset/<redacted>",
+            "pageviews" => 1,
+          },
+        )
+
+        sign_out
+        put "/u/password-reset/#{email_token.token}.json", params: { password: "attacker-password" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to include("success" => true)
+        expect(victim.reload.confirm_password?("attacker-password")).to be(true)
+      end
+
       it "matches any selected value within a dimension and every selected dimension" do
         referrers = ["search.example/results?q=discourse", ""]
 

--- a/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_explorer_spec.rb
@@ -88,6 +88,62 @@ RSpec.describe AdminDashboardSiteTrafficExplorer do
       end
     end
 
+    context "when traffic contains password reset URLs" do
+      let(:browsers) { [] }
+
+      it "redacts password reset tokens from URL dimensions" do
+        password_reset_token = "secret-token"
+        reset_paths = %W[
+          /u/password-reset/#{password_reset_token}
+          /users/password-reset/#{password_reset_token}
+        ]
+        reset_paths.each_with_index do |path, index|
+          Fabricate(
+            :browser_pageview_event,
+            url: path,
+            normalized_url: path,
+            ip_address: "192.0.2.1",
+            session_id: "password-reset-#{index}",
+            source: BrowserPageviewEvent::SOURCE_BEACON,
+            browser: :chrome,
+            created_at: Time.zone.local(2026, 5, 10, 11, index),
+          )
+        end
+
+        expect(result.traffic.fetch(:dimensions)).to eq(
+          "top_urls" => [
+            {
+              value: "/u/password-reset/<redacted>",
+              label: "/u/password-reset/<redacted>",
+              pageviews: 1,
+            },
+            {
+              value: "/users/password-reset/<redacted>",
+              label: "/users/password-reset/<redacted>",
+              pageviews: 1,
+            },
+          ],
+          "entry_urls" => [
+            {
+              value: "/u/password-reset/<redacted>",
+              label: "/u/password-reset/<redacted>",
+              pageviews: 1,
+            },
+            {
+              value: "/users/password-reset/<redacted>",
+              label: "/users/password-reset/<redacted>",
+              pageviews: 1,
+            },
+          ],
+          "referrers" => [{ value: "", label: "Direct / unknown", pageviews: 2 }],
+          "countries" => [],
+          "networks" => [],
+          "browsers" => [{ value: "chrome", label: "Google Chrome", pageviews: 2 }],
+          "ip_addresses" => [{ value: "192.0.2.1", label: "192.0.2.1", pageviews: 2 }],
+        )
+      end
+    end
+
     context "when the query succeeds" do
       it { is_expected.to run_successfully }
 


### PR DESCRIPTION
## Summary

Site Traffic Explorer previously returned credential-bearing password-reset paths verbatim, allowing one administrator to recover another administrator's still-valid reset token through URL analytics. The Explorer query now strips the token segment from both `/u/password-reset/:token` and `/users/password-reset/:token` routes at fetch time, so reset-token rows are grouped and returned under safe token-free paths.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/2522

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>