### PR TITLE
SECURITY: Enforce access-control-post checks on upload endpoints

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -94,11 +94,22 @@ class UploadsController < ApplicationController
     uploads = []
 
     if params[:short_urls] && params[:short_urls].length > 0
-      PrettyText::Helpers
-        .lookup_upload_urls(params[:short_urls])
-        .each do |short_url, paths|
-          uploads << { short_url: short_url, url: paths[:url], short_path: paths[:short_path] }
+      upload_urls = PrettyText::Helpers.lookup_upload_urls(params[:short_urls])
+      uploads_by_sha1 =
+        Upload.where(
+          sha1:
+            upload_urls.values.map { |paths| Upload.sha1_from_base62_encoded(paths[:base62_sha1]) },
+        ).index_by(&:sha1)
+
+      upload_urls.each do |short_url, paths|
+        upload = uploads_by_sha1[Upload.sha1_from_base62_encoded(paths[:base62_sha1])]
+        if upload.nil? ||
+             (upload.access_control_post_id.present? && !guardian.can_see_upload?(upload))
+          next
         end
+
+        uploads << { short_url: short_url, url: paths[:url], short_path: paths[:short_path] }
+      end
     end
 
     render json: uploads.to_json
@@ -125,6 +136,8 @@ class UploadsController < ApplicationController
             Upload.find_by(id: params[:id], url: request.env["PATH_INFO"])
 
         if upload.present?
+          check_secure_upload_permission(upload) if upload.secure? && SiteSetting.secure_uploads?
+
           if !Discourse.store.internal?
             local_store = FileStore::LocalStore.new
             return render_404 unless local_store.has_been_uploaded?(upload.url)
@@ -230,6 +243,8 @@ class UploadsController < ApplicationController
     params.require(:url)
     upload = Upload.get_from_url(params[:url])
     raise Discourse::NotFound unless upload
+
+    check_secure_upload_permission(upload)
 
     render json: {
              original_filename: upload.original_filename,

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -383,6 +383,24 @@ RSpec.describe UploadsController do
 
         expect(response.status).to eq(200)
       end
+
+      it "does not disclose a retained secure upload to a user without access to its post" do
+        SiteSetting.authorized_extensions = "*"
+        SiteSetting.secure_uploads = true
+        private_post = Fabricate(:post)
+        private_post.topic.change_category_to_id(
+          Fabricate(:private_category, group: Fabricate(:group)).id,
+        )
+        upload.update!(secure: true, access_control_post: private_post)
+        attacker = Fabricate(:user)
+        upload_contents = File.binread(Discourse.store.path_for(upload))
+
+        sign_in(attacker)
+        get "/uploads/#{site}/#{upload.sha1}.#{upload.extension}"
+
+        expect(response.status).to eq(403)
+        expect(response.body).not_to include(upload_contents)
+      end
     end
 
     it "returns 404 when the upload doesn't exist" do
@@ -853,6 +871,44 @@ RSpec.describe UploadsController do
       )
     end
 
+    it "does not disclose uploads whose access-control post the user cannot see" do
+      setup_s3
+      SiteSetting.authorized_extensions = "pdf"
+      SiteSetting.secure_uploads = true
+
+      owner = Fabricate(:user)
+      private_post = Fabricate(:post, user: owner)
+      private_post.topic.change_category_to_id(
+        Fabricate(:private_category, group: Fabricate(:group)).id,
+      )
+      private_upload =
+        Fabricate(
+          :upload_s3,
+          user: owner,
+          original_filename: "confidential-attachment.pdf",
+          extension: "pdf",
+          secure: true,
+          access_control_post: private_post,
+        )
+
+      sign_in(user)
+
+      aggregate_failures do
+        post "/uploads/lookup-metadata.json", params: { url: private_upload.url }
+
+        expect(response.status).to eq(403)
+        expect(response.body).not_to include(private_upload.original_filename)
+
+        post "/uploads/lookup-urls.json", params: { short_urls: [private_upload.short_url] }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq([])
+        expect(response.body).not_to include(
+          Upload.secure_uploads_url_from_upload_url(private_upload.url),
+        )
+      end
+    end
+
     it "can look up long urls" do
       sign_in(user)
       upload = Fabricate(:upload)
@@ -920,6 +976,30 @@ RSpec.describe UploadsController do
 
     describe "when signed in" do
       before { sign_in(user) }
+
+      it "does not disclose metadata for access-controlled uploads" do
+        owner = Fabricate(:user)
+        private_post = Fabricate(:private_message_post, user: owner)
+        private_upload =
+          Fabricate(
+            :secure_upload,
+            user: owner,
+            access_control_post: private_post,
+            original_filename: "payroll-2026.png",
+            extension: "png",
+          )
+
+        post "/uploads/lookup-metadata.json", params: { url: private_upload.url }
+
+        expect(response).to be_forbidden
+        expect(response.body).not_to include(private_upload.original_filename)
+
+        sign_in(owner)
+        post "/uploads/lookup-metadata.json", params: { url: private_upload.url }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["original_filename"]).to eq(private_upload.original_filename)
+      end
 
       describe "when url is invalid" do
         it "should return the right response" do


### PR DESCRIPTION
## Summary

All three patches apply secure-upload Guardian authorization to upload routes that exposed protected files or metadata without checking the access-control post. They share app/controllers/uploads_controller.rb and spec/requests/uploads_controller_spec.rb.

## Automated conflict resolutions

- `app/controllers/uploads_controller.rb` — patch #2524's changes were merged by an LLM because they overlapped another grouped fix. **Review this file closely.**

## Patches

- **Legacy /uploads/:site/:sha route serves secure uploads without access-control...** ([patch #2510](https://patch.discourse.org/patch-triage/2510))
  Prevent unauthorized disclosure of secure uploads by adding the access-control-post permission check to the legacy long upload route. The `show` action now calls `check_secure_upload_permission` before serving any upload marked secure while secure uploads are enabled, mirroring the existing protection on the short and secure-upload routes.
- **Gate upload lookup endpoints on access-control-post visibility** ([patch #2512](https://patch.discourse.org/patch-triage/2512))
  Authenticated upload lookup endpoints returned protected upload metadata and resolved short URLs without applying the access-control-post visibility rule. Add the same Guardian-based authorization used by secure download handling: metadata requests for protected uploads now return 403, and short-URL lookups omit entries the requester cannot see.
- **Enforce access-control-post authorization on upload metadata endpoint** ([patch #2524](https://patch.discourse.org/patch-triage/2524))
  `POST /uploads/lookup-metadata` returned the original filename, dimensions, and size of any known upload without checking whether the current user may view the upload's access-control post. An authenticated user outside a private message or restricted category could therefore learn a protected file's metadata. The metadata action now calls `check_secure_upload_permission`, applying the same Guardian boundary used by secure download paths so only authorized viewers receive the response.

## Source

- Patch group: https://patch.discourse.org/patch-triage/groups/17

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>