### PR TITLE
DEV: Make AI usage time series tests timezone-independent

### DIFF
--- a/plugins/discourse-ai/test/javascripts/unit/lib/ai-usage-time-series-test.js
+++ b/plugins/discourse-ai/test/javascripts/unit/lib/ai-usage-time-series-test.js
@@ -28,7 +28,7 @@ module("Unit | Lib | ai-usage-time-series", function () {
     });
 
     assert.strictEqual(
-      moment(normalized[0].period).format("HH:00"),
+      moment.utc(normalized[0].period).format("HH:00"),
       "10:00",
       "starts at the earliest server row, even when it is before the selected range"
     );
@@ -38,7 +38,7 @@ module("Unit | Lib | ai-usage-time-series", function () {
       "keeps the server row that would otherwise be clamped"
     );
     assert.strictEqual(
-      moment(normalized[normalized.length - 1].period).format("HH:00"),
+      moment.utc(normalized[normalized.length - 1].period).format("HH:00"),
       "14:00",
       "extends through the server-provided date range"
     );
@@ -64,7 +64,7 @@ module("Unit | Lib | ai-usage-time-series", function () {
     );
 
     assert.deepEqual(
-      normalized.map((row) => moment(row.period).format("HH:00")),
+      normalized.map((row) => moment.utc(row.period).format("HH:00")),
       ["12:00", "13:00", "14:00"],
       "uses the server date range to avoid a one-point chart"
     );
@@ -95,7 +95,7 @@ module("Unit | Lib | ai-usage-time-series", function () {
     );
 
     assert.deepEqual(
-      normalized.map((row) => moment(row.period).format("HH:00")),
+      normalized.map((row) => moment.utc(row.period).format("HH:00")),
       ["12:00", "13:00", "14:00"],
       "extends around a single returned bucket"
     );


### PR DESCRIPTION
## What does this change?

Makes the `ai-usage-time-series` QUnit tests independent of the developer machine's local timezone.

The test data uses explicit UTC timestamps (`...Z`) and the expected clock values are also UTC values, but the assertions formatted the normalized timestamps with `moment(...)`. That converts them to the browser's local timezone before comparison.

On a machine in `Europe/London` during BST (`UTC+1`), all three tests therefore failed with values exactly one hour ahead. Using `moment.utc(...)` in the assertion-side formatting makes the expectations explicit and stable across local timezones without changing production behavior.

## Testing

Chrome 151 on the same machine/source/build:

| Environment | Before | After |
| --- | --- | --- |
| `TZ=UTC` | 3 pass, 0 fail | 3 pass, 0 fail |
| `Europe/London` / BST (`UTC+1`) | 0 pass, 3 fail | 3 pass, 0 fail |

Before the change under BST, the failures were all exactly +1 hour, for example `13:00,14:00,15:00` instead of `12:00,13:00,14:00`.

Pre-commit checks:

- Prettier: pass
- ESLint: pass
- `git diff --check`: clean
