### PR TITLE
DEV: Add `admin-above-plugins-index` plugin outlet

### DIFF
--- a/frontend/discourse/admin/templates/admin-plugins/index.gjs
+++ b/frontend/discourse/admin/templates/admin-plugins/index.gjs
@@ -32,6 +32,12 @@ export default <template>
       </:breadcrumbs>
     </DPageHeader>
 
+    <PluginOutlet
+      @name="admin-above-plugins-index"
+      @connectorTagName="div"
+      @outletArgs={{lazyHash model=@controller.model}}
+    />
+
     {{#if @controller.model.length}}
       <DFilterControls
         @array={{@controller.model}}


### PR DESCRIPTION
Previously, the admin plugins page only exposed an outlet below the list, so a plugin had nowhere to put a notice admins see before scrolling through every installed plugin.

This change adds a matching `admin-above-plugins-index` outlet between the page header and the filter controls, with the same `model` outlet argument.