### PR TITLE
DEV: Correct supportEndDate for 2026.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -66,7 +66,7 @@
   "2026.1": {
     "developmentStartDate": "2025-12-30",
     "releaseDate": "2026-01-28",
-    "supportEndDate": "2026-09-29",
+    "supportEndDate": "2026-09-22",
     "released": true,
     "esr": true,
     "supported": true


### PR DESCRIPTION
This was always supposed to align with the release of 2026.9