### PR TITLE
FIX: Cast per_page before computing private message list offset

### DIFF
--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -269,6 +269,7 @@ class TopicQuery
     def private_messages_default_scope(user)
       options = @options
       options.reverse_merge!(per_page: per_page_setting)
+      options[:per_page] = options[:per_page].to_i
 
       result =
         Topic

--- a/spec/lib/topic_query/private_message_lists_spec.rb
+++ b/spec/lib/topic_query/private_message_lists_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe TopicQuery::PrivateMessageLists do
 
       expect(TopicQuery.new(user_4).list_private_messages(user_4).topics).to contain_exactly(pm)
     end
+
+    it "accepts page and per_page as strings" do
+      topics =
+        TopicQuery.new(user_2, page: "0", per_page: "5").list_private_messages(user_2).topics
+
+      expect(topics).to contain_exactly(private_message)
+    end
   end
 
   describe "private_messages_personal_inbox_query modifier" do


### PR DESCRIPTION
`GET /topics/private-messages/:username.json?page=1&per_page=5` returns a 500:

    TypeError (String can't be coerced into Integer)
    lib/topic_query/private_message_lists.rb:288:in 'Integer#*'

`private_messages_default_scope` multiplies `options[:page].to_i` by `options[:per_page]`, but when `per_page` comes from the query string it is still a String. Either param on its own works; only the combination fails. The regular topic list path already casts with `&.to_i` in `TopicQuery#default_results`.

Casts `per_page` the same way and adds a spec.