### PR TITLE
DEV: Add optional state param support to oidc logout endpoint url

### DIFF
--- a/plugins/discourse-openid-connect/config/locales/server.en.yml
+++ b/plugins/discourse-openid-connect/config/locales/server.en.yml
@@ -8,6 +8,7 @@ en:
     openid_connect_rp_initiated_logout: "Redirect the user to end_session_endpoint after logout. Must be supported by your identity provider and included in the discovery document."
     openid_connect_rp_initiated_logout_redirect: "(optional) The post_logout_redirect_uri which will be passed to the logout endpoint. If provided, it must be registered with the identity provider."
     openid_connect_rp_initiated_logout_include_client_id: "(optional) Append the client_id (openid_connect_client_id setting) as a query parameter to the logout endpoint"
+    openid_connect_rp_initiated_logout_include_state: "(optional) Append a randomly generated state parameter to the logout endpoint. Some identity providers require this parameter to be present, even though Discourse does not validate it on return."
     openid_connect_token_scope: "The scopes sent when requesting the token endpoint. The official specification does not require this."
     openid_connect_error_redirects: "If the callback error_reason contains the first parameter, the user will be redirected to the URL in the second parameter"
     openid_connect_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the OpenID Connect provider"

--- a/plugins/discourse-openid-connect/config/settings.yml
+++ b/plugins/discourse-openid-connect/config/settings.yml
@@ -21,6 +21,9 @@ discourse_openid_connect:
   openid_connect_rp_initiated_logout_include_client_id:
     default: false
     area: "oidc"
+  openid_connect_rp_initiated_logout_include_state:
+    default: false
+    area: "oidc"
   openid_connect_allow_association_change:
     default: false
     area: "oidc"

--- a/plugins/discourse-openid-connect/plugin.rb
+++ b/plugins/discourse-openid-connect/plugin.rb
@@ -67,6 +67,10 @@ on(:before_session_destroy) do |data|
   post_logout_redirect = SiteSetting.openid_connect_rp_initiated_logout_redirect.presence
   params << ["post_logout_redirect_uri", post_logout_redirect] if post_logout_redirect
 
+  if SiteSetting.openid_connect_rp_initiated_logout_include_state
+    params << ["state", SecureRandom.hex(16)]
+  end
+
   uri.query = URI.encode_www_form(params)
   data[:redirect_url] = uri.to_s
 end

--- a/plugins/discourse-openid-connect/spec/requests/rp_initiated_logout_spec.rb
+++ b/plugins/discourse-openid-connect/spec/requests/rp_initiated_logout_spec.rb
@@ -123,5 +123,17 @@ describe "OIDC RP-Initiated Logout" do
         )
       end
     end
+
+    context "with state included in logout endpoint" do
+      before { SiteSetting.openid_connect_rp_initiated_logout_include_state = true }
+
+      it "appends a random state param to the logout endpoint url" do
+        delete "/session/#{user.username}", xhr: true
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["redirect_url"]).to match(
+          %r{\Ahttps://id\.example\.com/endsession\?id_token_hint=myoidctoken&state=[0-9a-f]{32}\z},
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds support for including an opaque `state` value as a query parameter on the RP-Initiated Logout request sent to the OIDC provider's end_session_endpoint.

Per the RP-Initiated Logout 1.0 spec, the OP echoes `state` back to the RP via the `post_logout_redirect_uri` callback, letting the RP carry context across the logout round-trip. This mirrors the existing optional `client_id` param support (#37818): it's off by default and only appended when `openid_connect_rp_initiated_logout_include_state` is configured, so it won't affect existing sites.