### PR TITLE
DEV: Add a skip_rate_limits option to PostCreator

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -35,6 +35,7 @@ class PostCreator
   #                             call `enqueue_jobs` after the transaction is committed.
   #   hidden_reason_id        - Reason for hiding the post (optional)
   #   skip_validations        - Do not validate any of the content in the post
+  #   skip_rate_limits        - Do not apply the author's post rate limits
   #   skip_staff_author_pm_membership_sync - Do not add the post author to private message allowed users when a staff guardian authorizes the post
   #   draft_key               - the key of the draft we are creating (will be deleted on success)
   #   advance_draft           - Destroy draft after creating post or topic
@@ -607,7 +608,7 @@ class PostCreator
   end
 
   def save_post
-    @post.disable_rate_limits! if skip_validations?
+    @post.disable_rate_limits! if skip_validations? || @opts[:skip_rate_limits]
     @post.skip_validation = skip_validations?
     saved = @post.save
     rollback_from_errors!(@post) unless saved

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -286,7 +286,7 @@ class TopicCreator
   end
 
   def save_topic(topic)
-    topic.disable_rate_limits! if @opts[:skip_validations]
+    topic.disable_rate_limits! if @opts[:skip_validations] || @opts[:skip_rate_limits]
 
     rollback_from_errors!(topic) unless topic.save(validate: !@opts[:skip_validations])
   end

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -1852,6 +1852,43 @@ RSpec.describe PostCreator do
     end
   end
 
+  describe "skip_rate_limits" do
+    fab!(:author) { Fabricate(:user, refresh_auto_groups: true, trust_level: TrustLevel[4]) }
+    fab!(:topic)
+
+    before do
+      RateLimiter.enable
+      SiteSetting.rate_limit_create_post = 5
+    end
+
+    it "rate limits a non-staff author by default" do
+      PostCreator.create!(author, topic_id: topic.id, raw: "the first post from this author")
+
+      expect {
+        PostCreator.create!(author, topic_id: topic.id, raw: "a second post moments later")
+      }.to raise_error(RateLimiter::LimitExceeded)
+    end
+
+    it "does not rate limit when skip_rate_limits is set" do
+      PostCreator.create!(author, topic_id: topic.id, raw: "the first post from this author")
+
+      expect {
+        PostCreator.create!(
+          author,
+          topic_id: topic.id,
+          raw: "a second post moments later",
+          skip_rate_limits: true,
+        )
+      }.not_to raise_error
+    end
+
+    it "still validates content when only rate limits are skipped" do
+      expect {
+        PostCreator.create!(author, topic_id: topic.id, raw: "", skip_rate_limits: true)
+      }.to raise_error(ActiveRecord::RecordNotSaved)
+    end
+  end
+
   describe "private message to a user that has disabled private messages" do
     fab!(:another_user) { Fabricate(:user, username: "HelloWorld") }
 


### PR DESCRIPTION
Posts created on behalf of a user by automation — a plugin, a scheduled job, or a workflow acting as the person who triggered it — are subject to the same per-user rate limits as someone typing in the composer. When the automation runs in response to that user's own post, it reliably trips `rate_limit_create_post` and the post is silently dropped.

Only staff are exempt (`RateLimiter#rate_unlimited?` checks `staff?`), so trust level 4 members hit this too.

Until now the only way out was `skip_validations`, which is far broader: it also skips content validation, the host spam check, the suspended user check and the review queue. Callers that only need the rate limit lifted had to give up all of that.

`skip_rate_limits` lifts exactly the rate limit and nothing else, for both post and topic creation. The spec covers all three cases, including that content is still validated when only the rate limit is skipped.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>