### PR TITLE
DEV: Share the topic type, tag and group inbox matchers between workflow nodes

### DIFF
--- a/plugins/discourse-topic-voting/lib/discourse_workflows/nodes/topic_received_vote/v1.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_workflows/nodes/topic_received_vote/v1.rb
@@ -79,7 +79,8 @@ if defined?(DiscourseWorkflows)
               topic.category_id,
               category_ids_parameter(trigger_ctx),
               include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
-            ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
+            ) &&
+              matches_tags?(topic, normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
           end
 
           private
@@ -90,10 +91,6 @@ if defined?(DiscourseWorkflows)
 
           def voter
             @voter ||= @vote&.user
-          end
-
-          def matches_tags?(tag_names)
-            tag_names.empty? || (topic.tags.pluck(:name) & tag_names).any?
           end
         end
       end

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -5,6 +5,8 @@ module DiscourseWorkflows
     include NodeErrorHandling
     extend NodeTypeDescriptor
 
+    TOPIC_TYPE_OPTIONS = %w[all topics personal_messages].freeze
+
     DESCRIPTION_DEFAULTS = {
       version: "1.0",
       defaults: {
@@ -372,6 +374,35 @@ module DiscourseWorkflows
 
     def matches_category_ids?(topic_category_id, category_ids, include_subcategories: true)
       self.class.matches_category_ids?(topic_category_id, category_ids, include_subcategories:)
+    end
+
+    def matches_topic_type?(topic, topic_type)
+      case topic_type.presence || "topics"
+      when "all"
+        true
+      when "topics"
+        !topic.private_message?
+      when "personal_messages"
+        topic.private_message?
+      else
+        false
+      end
+    end
+
+    def matches_group_inbox?(topic, group_id)
+      return true if group_id.blank?
+      return false if !topic.private_message?
+
+      topic.allowed_groups.exists?(id: group_id.to_i)
+    end
+
+    def matches_tags?(topic, tag_names)
+      tag_names.empty? || (topic_tag_names(topic) & tag_names).any?
+    end
+
+    def topic_tag_names(topic)
+      @topic_tag_names ||= {}
+      @topic_tag_names[topic.id] ||= topic.tags.pluck(:name)
     end
 
     def resolve_timezone(exec_ctx, item_index)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
@@ -4,8 +4,6 @@ module DiscourseWorkflows
   module Nodes
     module PostCreated
       class V1 < NodeType
-        TOPIC_TYPE_OPTIONS = %w[all topics personal_messages].freeze
-
         description(
           name: "trigger:post_created",
           version: "1.0",
@@ -131,34 +129,6 @@ module DiscourseWorkflows
 
         def user_data(user)
           serialize_user(user)
-        end
-
-        def matches_topic_type?(topic, topic_type)
-          case topic_type.presence || "topics"
-          when "all"
-            true
-          when "topics"
-            !topic.private_message?
-          when "personal_messages"
-            topic.private_message?
-          else
-            false
-          end
-        end
-
-        def matches_group_inbox?(topic, group_id)
-          return true if group_id.blank?
-          return false if !topic.private_message?
-
-          topic.allowed_groups.exists?(id: group_id.to_i)
-        end
-
-        def matches_tags?(topic, tag_names)
-          tag_names.empty? || (topic_tag_names(topic) & tag_names).any?
-        end
-
-        def topic_tag_names(topic)
-          @topic_tag_names ||= topic.tags.pluck(:name)
         end
       end
     end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
@@ -94,8 +94,11 @@ module DiscourseWorkflows
               @post.topic.category_id,
               category_ids_parameter(trigger_ctx),
               include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
-            ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names"))) &&
-            matches_trust_level?(trigger_ctx.get_node_parameter("trust_levels"))
+            ) &&
+            matches_tags?(
+              @post.topic,
+              normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")),
+            ) && matches_trust_level?(trigger_ctx.get_node_parameter("trust_levels"))
         end
 
         private
@@ -113,14 +116,6 @@ module DiscourseWorkflows
           else
             @post.post_number == 1
           end
-        end
-
-        def matches_tags?(tag_names)
-          tag_names.empty? || (topic_tag_names & tag_names).any?
-        end
-
-        def topic_tag_names
-          @topic_tag_names ||= @post.topic.tags.pluck(:name)
         end
 
         def matches_trust_level?(trust_levels)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
@@ -84,7 +84,11 @@ module DiscourseWorkflows
             destination_topic.category_id,
             category_ids_parameter(trigger_ctx),
             include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
-          ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
+          ) &&
+            matches_tags?(
+              destination_topic,
+              normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")),
+            )
         end
 
         private
@@ -99,14 +103,6 @@ module DiscourseWorkflows
 
         def original_topic
           @original_topic ||= ::Topic.find_by(id: @original_topic_id)
-        end
-
-        def matches_tags?(tag_names)
-          tag_names.empty? || (destination_topic_tag_names & tag_names).any?
-        end
-
-        def destination_topic_tag_names
-          @destination_topic_tag_names ||= destination_topic.tags.pluck(:name)
         end
       end
     end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
@@ -66,17 +66,8 @@ module DiscourseWorkflows
             @topic.category_id,
             category_ids_parameter(trigger_ctx),
             include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
-          ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
-        end
-
-        private
-
-        def matches_tags?(tag_names)
-          tag_names.empty? || (topic_tag_names & tag_names).any?
-        end
-
-        def topic_tag_names
-          @topic_tag_names ||= @topic.tags.pluck(:name)
+          ) &&
+            matches_tags?(@topic, normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
         end
       end
     end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
@@ -4,8 +4,6 @@ module DiscourseWorkflows
   module Nodes
     module TopicCreated
       class V1 < NodeType
-        TOPIC_TYPE_OPTIONS = %w[all topics personal_messages].freeze
-
         description(
           name: "trigger:topic_created",
           version: "1.0",
@@ -103,47 +101,20 @@ module DiscourseWorkflows
         end
 
         def matches?(trigger_ctx)
-          matches_topic_type?(trigger_ctx.get_node_parameter("topic_type", "topics")) &&
-            matches_group_inbox?(trigger_ctx.get_node_parameter("group_inbox_id")) &&
+          matches_topic_type?(@topic, trigger_ctx.get_node_parameter("topic_type", "topics")) &&
+            matches_group_inbox?(@topic, trigger_ctx.get_node_parameter("group_inbox_id")) &&
             matches_category_ids?(
               @topic.category_id,
               category_ids_parameter(trigger_ctx),
               include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
-            ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
+            ) &&
+            matches_tags?(@topic, normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
         end
 
         private
 
         def post_data(post)
           serialize_post(post)
-        end
-
-        def matches_topic_type?(topic_type)
-          case topic_type.presence || "topics"
-          when "all"
-            true
-          when "topics"
-            !@topic.private_message?
-          when "personal_messages"
-            @topic.private_message?
-          else
-            false
-          end
-        end
-
-        def matches_group_inbox?(group_id)
-          return true if group_id.blank?
-          return false if !@topic.private_message?
-
-          @topic.allowed_groups.exists?(id: group_id.to_i)
-        end
-
-        def matches_tags?(tag_names)
-          tag_names.empty? || (topic_tag_names & tag_names).any?
-        end
-
-        def topic_tag_names
-          @topic_tag_names ||= @topic.tags.pluck(:name)
         end
       end
     end


### PR DESCRIPTION
Every workflow trigger that filters on a topic carried its own copy of the same matching logic. `matches_tags?` and `topic_tag_names` existed seven times, `matches_topic_type?` three times and `matches_group_inbox?` twice — once per node, plus another copy in discourse-topic-voting. They only differed in whether the topic arrived as an argument or was read from an ivar.

`NodeType` already hosts `matches_category_ids?`, `matches_user_groups?` and `normalize_tag_names` for exactly this reason, so these belong beside them.

Nodes now pass their topic explicitly, which is what the majority of the copies already did, and is unambiguous for `post_moved` where two topics are in play. `topic_tag_names` memoises per topic id rather than in a single ivar, so a node that inspects more than one topic cannot silently read another topic's tags.

---

Every trigger that filters on a topic carried its own copy of the same
matching logic. `matches_tags?` and `topic_tag_names` existed seven times,
`matches_topic_type?` three times and `matches_group_inbox?` twice - once
per node, plus another copy in discourse-topic-voting. They only differed
in whether the topic arrived as an argument or was read from an ivar.

`NodeType` already hosts `matches_category_ids?`, `matches_user_groups?`
and `normalize_tag_names` for exactly this reason, so these belong beside
them. Nodes now pass their topic explicitly, which is what the majority of
the copies already did, and is unambiguous for `post_moved` where two
topics are in play.

`topic_tag_names` memoises per topic id rather than in a single ivar, so a
node that inspects more than one topic cannot silently read another
topic's tags.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>