### PR TITLE
DEV: Share the category and tag filter properties between workflow nodes

### DIFF
--- a/plugins/discourse-topic-voting/lib/discourse_workflows/nodes/topic_received_vote/v1.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_workflows/nodes/topic_received_vote/v1.rb
@@ -22,34 +22,8 @@ if defined?(DiscourseWorkflows)
               },
             ],
             properties: {
-              category_ids: {
-                type: :array,
-                required: false,
-                ui: {
-                  control: :category,
-                  multiple: true,
-                },
-              },
-              include_subcategories: {
-                type: :boolean,
-                required: false,
-                default: true,
-                ui: {
-                  control: :checkbox,
-                },
-                display_options: {
-                  show: {
-                    category_ids: [{ condition: { exists: true } }],
-                  },
-                },
-              },
-              tag_names: {
-                type: :string,
-                required: false,
-                ui: {
-                  control: :tags,
-                },
-              },
+              **CATEGORY_FILTER_PROPERTIES,
+              **TAG_FILTER_PROPERTIES,
             },
           )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -7,6 +7,49 @@ module DiscourseWorkflows
 
     TOPIC_TYPE_OPTIONS = %w[all topics personal_messages].freeze
 
+    TOPIC_TYPE_FILTER_PROPERTIES = {
+      topic_type: {
+        type: :options,
+        required: true,
+        default: "topics",
+        options: TOPIC_TYPE_OPTIONS,
+      },
+    }.freeze
+
+    CATEGORY_FILTER_PROPERTIES = {
+      category_ids: {
+        type: :array,
+        required: false,
+        ui: {
+          control: :category,
+          multiple: true,
+        },
+      },
+      include_subcategories: {
+        type: :boolean,
+        required: false,
+        default: true,
+        ui: {
+          control: :checkbox,
+        },
+        display_options: {
+          show: {
+            category_ids: [{ condition: { exists: true } }],
+          },
+        },
+      },
+    }.freeze
+
+    TAG_FILTER_PROPERTIES = {
+      tag_names: {
+        type: :string,
+        required: false,
+        ui: {
+          control: :tags,
+        },
+      },
+    }.freeze
+
     DESCRIPTION_DEFAULTS = {
       version: "1.0",
       defaults: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
@@ -24,12 +24,7 @@ module DiscourseWorkflows
             },
           ],
           properties: {
-            topic_type: {
-              type: :options,
-              required: true,
-              default: "topics",
-              options: TOPIC_TYPE_OPTIONS,
-            },
+            **TOPIC_TYPE_FILTER_PROPERTIES,
             group_inbox_id: {
               type: :integer,
               required: false,
@@ -51,34 +46,8 @@ module DiscourseWorkflows
                 none: "discourse_workflows.post_created.group_inbox_id_placeholder",
               },
             },
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
-            tag_names: {
-              type: :string,
-              required: false,
-              ui: {
-                control: :tags,
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
+            **TAG_FILTER_PROPERTIES,
           },
         )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
@@ -32,34 +32,8 @@ module DiscourseWorkflows
               default: "first_post",
               options: POST_SCOPE_OPTIONS,
             },
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
-            tag_names: {
-              type: :string,
-              required: false,
-              ui: {
-                control: :tags,
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
+            **TAG_FILTER_PROPERTIES,
             trust_levels: {
               type: :multi_options,
               required: false,

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_lifecycle.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_lifecycle.rb
@@ -5,40 +5,9 @@ module DiscourseWorkflows
     module PostLifecycle
       I18N_SCOPE = "post_lifecycle"
       PROPERTIES = {
-        topic_type: {
-          type: :options,
-          required: true,
-          default: "topics",
-          options: NodeType::TOPIC_TYPE_OPTIONS,
-        },
-        category_ids: {
-          type: :array,
-          required: false,
-          ui: {
-            control: :category,
-            multiple: true,
-          },
-        },
-        include_subcategories: {
-          type: :boolean,
-          required: false,
-          default: true,
-          ui: {
-            control: :checkbox,
-          },
-          display_options: {
-            show: {
-              category_ids: [{ condition: { exists: true } }],
-            },
-          },
-        },
-        tag_names: {
-          type: :string,
-          required: false,
-          ui: {
-            control: :tags,
-          },
-        },
+        **NodeType::TOPIC_TYPE_FILTER_PROPERTIES,
+        **NodeType::CATEGORY_FILTER_PROPERTIES,
+        **NodeType::TAG_FILTER_PROPERTIES,
       }.freeze
 
       OUTPUT_CONTRACTS = [

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
@@ -29,34 +29,8 @@ module DiscourseWorkflows
           event: :post_moved,
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
           properties: {
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
-            tag_names: {
-              type: :string,
-              required: false,
-              ui: {
-                control: :tags,
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
+            **TAG_FILTER_PROPERTIES,
           },
         )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
@@ -20,34 +20,8 @@ module DiscourseWorkflows
               default: 24,
               min: 1,
             },
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
-            tag_names: {
-              type: :string,
-              required: false,
-              ui: {
-                control: :tags,
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
+            **TAG_FILTER_PROPERTIES,
           },
           capabilities: {
             manually_triggerable: true,

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
@@ -15,34 +15,8 @@ module DiscourseWorkflows
           event: :topic_status_updated,
           output_contracts: [{ schema: Schema::TOPIC_LIST_ITEM_SCHEMA }],
           properties: {
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
-            tag_names: {
-              type: :string,
-              required: false,
-              ui: {
-                control: :tags,
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
+            **TAG_FILTER_PROPERTIES,
           },
         )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
@@ -17,12 +17,7 @@ module DiscourseWorkflows
             { schema: Schema.merge(Schema::TOPIC_LIST_ITEM_SCHEMA, Schema::POST_SCHEMA) },
           ],
           properties: {
-            topic_type: {
-              type: :options,
-              required: true,
-              default: "topics",
-              options: TOPIC_TYPE_OPTIONS,
-            },
+            **TOPIC_TYPE_FILTER_PROPERTIES,
             group_inbox_id: {
               type: :integer,
               required: false,
@@ -44,34 +39,8 @@ module DiscourseWorkflows
                 none: "discourse_workflows.topic_created.group_inbox_id_placeholder",
               },
             },
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
-            tag_names: {
-              type: :string,
-              required: false,
-              ui: {
-                control: :tags,
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
+            **TAG_FILTER_PROPERTIES,
           },
         )
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
@@ -27,27 +27,7 @@ module DiscourseWorkflows
           event: :topic_tags_changed,
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
           properties: {
-            category_ids: {
-              type: :array,
-              required: false,
-              ui: {
-                control: :category,
-                multiple: true,
-              },
-            },
-            include_subcategories: {
-              type: :boolean,
-              required: false,
-              default: true,
-              ui: {
-                control: :checkbox,
-              },
-              display_options: {
-                show: {
-                  category_ids: [{ condition: { exists: true } }],
-                },
-              },
-            },
+            **CATEGORY_FILTER_PROPERTIES,
           },
         )
 


### PR DESCRIPTION
Nine trigger nodes declared the same `category_ids`, `include_subcategories` and `tag_names` properties, byte for byte, across two plugins. Adding a UI control, changing a default or introducing a new filter meant nine edits and a good chance of drift.

The behaviour behind these properties already lives on `NodeType`, so the declarations belong there too. Nodes splat in the sets they need, which keeps each node's own property order — and therefore the order of the fields in the editor — unchanged.

The per-node translations are untouched: they key off each node's i18n scope rather than the property hash, so nodes keep describing their own filters in their own words.

The identically named property on the topic and tag group actions is a different thing — a list of tags to apply, not to filter by — and is left alone.

---

Nine trigger nodes declared the same `category_ids`, `include_subcategories`
and `tag_names` properties, byte for byte, across two plugins. Adding a UI
control, changing a default or introducing a new filter meant nine edits and
a good chance of drift.

The behaviour behind these properties already lives on `NodeType`, so the
declarations belong there too. Nodes splat in the sets they need, which
keeps each node's own property order - and therefore the order of the fields
in the editor - unchanged.

The per-node translations are untouched: they key off each node's i18n
scope rather than the property hash, so nodes keep describing their own
filters in their own words.

The identically named property on the topic and tag group actions is a
different thing - a list of tags to apply, not to filter by - and is left
alone.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>