### PR TITLE
DEV: Stop re-asserting the node type schema at the HTTP layer

### DIFF
--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
@@ -17,140 +17,13 @@ RSpec.describe DiscourseWorkflows::NodeTypesController do
   end
 
   describe "GET /admin/plugins/discourse-workflows/node-types" do
-    it "returns all registered node types" do
+    it "renders the registered node types", :aggregate_failures do
       get "/admin/plugins/discourse-workflows/node-types.json"
 
       expect(response).to have_http_status(:ok)
-      json = response.parsed_body
-      identifiers = json["node_types"].map { |nt| nt["identifier"] }
-
-      expect(identifiers).to include("trigger:topic_closed")
-      expect(identifiers).to include("action:topic_tags")
-      expect(identifiers).to include("action:tag_group")
-      expect(identifiers).to include("action:post")
-      expect(identifiers).to include("action:topic")
-      expect(identifiers).to include("action:group")
-      expect(identifiers).to include("condition:if")
-      expect(identifiers).to include("action:send_personal_message")
+      identifiers = response.parsed_body["node_types"].map { |nt| nt["identifier"] }
+      expect(identifiers).to include("trigger:topic_closed", "action:post", "condition:if")
       expect(identifiers).not_to include("condition:user_in_group")
-    end
-
-    it "returns Post operation and List posts query control metadata" do
-      get "/admin/plugins/discourse-workflows/node-types.json"
-
-      post_node =
-        response.parsed_body["node_types"].find do |node_type|
-          node_type["identifier"] == "action:post"
-        end
-      properties = post_node["properties"]
-
-      expect(properties["operation"]).to include(
-        "type" => "options",
-        "default" => "create",
-        "options" => %w[create edit get list delete recover],
-      )
-      expect(properties["query"]).to include(
-        "type" => "string",
-        "ui" => include("control" => "filter_query", "filter" => "posts"),
-      )
-      expect(properties["editor_username"]).to include(
-        "type" => "string",
-        "default" => "system",
-        "ui" => include("control" => "actor"),
-      )
-      expect(properties["whisper"]).to include(
-        "type" => "boolean",
-        "default" => false,
-        "ui" => include("control" => "boolean", "expression" => true),
-        "display_options" => include("show" => include("operation" => ["create"])),
-      )
-      expect(properties["categories"]["ui"]).to include("hidden" => true)
-      expect(properties["advanced_filter"]["ui"]).to include("hidden" => true)
-    end
-
-    it "returns Send personal message recipient control metadata" do
-      get "/admin/plugins/discourse-workflows/node-types.json"
-
-      personal_message_node =
-        response.parsed_body["node_types"].find do |node_type|
-          node_type["identifier"] == "action:send_personal_message"
-        end
-      properties = personal_message_node["properties"]
-
-      expect(properties["recipient_usernames"]).to include(
-        "type" => "array",
-        "ui" => include("control" => "user", "expression" => true, "multiple" => true),
-      )
-      expect(properties["recipient_group_names"]).to include(
-        "type" => "array",
-        "type_options" => include("load_options_method" => "groups"),
-        "ui" => include("control" => "group_select", "expression" => true, "multiple" => true),
-        "control_options" =>
-          include("value_property" => "name", "name_property" => "name", "filterable" => true),
-      )
-      expect(properties["sender_username"]).to include(
-        "type" => "string",
-        "default" => "system",
-        "ui" => include("control" => "actor"),
-      )
-      expect(personal_message_node.dig("metadata", "groups")).to include(
-        include("id" => Group::AUTO_GROUPS[:everyone], "name" => "everyone"),
-      )
-    end
-
-    it "returns Tag group action metadata" do
-      tag_group = Fabricate(:tag_group, name: "Workflow tags")
-
-      get "/admin/plugins/discourse-workflows/node-types.json"
-
-      tag_group_node =
-        response.parsed_body["node_types"].find do |node_type|
-          node_type["identifier"] == "action:tag_group"
-        end
-      properties = tag_group_node["properties"]
-
-      expect(properties["operation"]).to include(
-        "type" => "options",
-        "default" => "add",
-        "options" => %w[add remove],
-      )
-      expect(properties["tag_group_id"]).to include(
-        "type" => "integer",
-        "required" => true,
-        "type_options" => include("load_options_method" => "tag_groups"),
-        "ui" => include("control" => "combo_box", "dynamic_value" => "tag_group_id"),
-      )
-      expect(properties["tag_names"]).to include(
-        "type" => "string",
-        "required" => true,
-        "ui" => include("control" => "tags"),
-      )
-      expect(tag_group_node.dig("metadata", "tag_groups")).to include(
-        "id" => tag_group.id,
-        "name" => tag_group.name,
-      )
-      expect(tag_group_node.dig("output_contracts", 0, "schema", "properties")).to include(
-        "tag_group_id" => include("type" => "integer"),
-        "tag_group_name" => include("type" => "string"),
-        "tag_names" => include("type" => "array"),
-      )
-    end
-
-    it "includes load options metadata in node type response" do
-      get "/admin/plugins/discourse-workflows/node-types.json"
-
-      badge_node =
-        response.parsed_body["node_types"].find { |nt| nt["identifier"] == "action:badge" }
-      expect(badge_node.dig("metadata", "badges")).to all(include("id", "name"))
-
-      group_node =
-        response.parsed_body["node_types"].find { |nt| nt["identifier"] == "action:group" }
-      expect(group_node.dig("metadata", "groups")).to include(
-        include("id" => Group::AUTO_GROUPS[:everyone], "name" => "everyone"),
-      )
-      expect(group_node.dig("properties", "group_id", "type_options")).not_to include(
-        "load_options_depends_on",
-      )
     end
 
     it "does not preload load options metadata that depends on node parameters" do
@@ -166,30 +39,6 @@ RSpec.describe DiscourseWorkflows::NodeTypesController do
         "load_options_depends_on",
       )
       expect(topic_node.fetch("metadata", {})).not_to have_key("topic_custom_fields")
-    end
-
-    it "returns descriptor fields used by the admin client" do
-      get "/admin/plugins/discourse-workflows/node-types.json"
-
-      condition =
-        response.parsed_body["node_types"].find do |node_type|
-          node_type["identifier"] == "condition:if"
-        end
-
-      expect(condition["ui"]["palette_group"]).to include("id" => "flow")
-      expect(condition["capabilities"]).to include(
-        "branching" => true,
-        "manually_triggerable" => false,
-        "result_mode" => "ports",
-      )
-      expect(condition["ports"]).to include(
-        a_hash_including(
-          "key" => "true",
-          "label_key" => "discourse_workflows.branch.true",
-          "primary" => true,
-        ),
-      )
-      expect(condition["inputs"]).to include(a_hash_including("key" => "main", "required" => true))
     end
   end
 end

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/node_type/list_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/node_type/list_spec.rb
@@ -70,12 +70,6 @@ RSpec.describe DiscourseWorkflows::NodeType::List do
         )
       end
 
-      it "returns UI hints for schema-driven configurators" do
-        node_type = result[:node_types].find { |nt| nt[:identifier] == "action:post" }
-
-        expect(node_type.dig(:properties, :raw, :ui)).to eq(control: :textarea)
-      end
-
       it "includes specialized property-engine controls in node schemas" do
         award_badge = result[:node_types].find { |nt| nt[:identifier] == "action:badge" }
         code = result[:node_types].find { |nt| nt[:identifier] == "action:code" }
@@ -120,11 +114,6 @@ RSpec.describe DiscourseWorkflows::NodeType::List do
             name: membership_group.name,
           )
         end
-      end
-
-      it "includes branching for condition nodes" do
-        condition = result[:node_types].find { |nt| nt[:identifier] == "condition:if" }
-        expect(condition[:branching]).to be(true)
       end
 
       it "serializes ui palette group for action nodes" do
@@ -196,12 +185,6 @@ RSpec.describe DiscourseWorkflows::NodeType::List do
 
         expect(loop_node[:palette_visible]).to eq(false)
         expect(loop_node[:output_contracts].pluck(:mode)).to eq(%i[passthrough passthrough])
-      end
-
-      it "serializes ui palette group for trigger nodes" do
-        topic_closed = result[:node_types].find { |nt| nt[:identifier] == "trigger:topic_closed" }
-
-        expect(topic_closed.dig(:ui, :palette_group, :id)).to eq("discourse_triggers")
       end
 
       it "includes manually_triggerable for triggers that support it" do


### PR DESCRIPTION
The node types controller renders what the list service returns, with no transformation of its own, so its request spec had grown into a second copy of the service spec expressed in JSON: the same property schemas, the same UI controls, the same operation lists, asserted twice. Touching a node schema meant updating both.

The request spec now covers what only it can — the admin constraint, and that the endpoint renders — plus the one case that genuinely belongs at this layer, where metadata must not be preloaded for options that depend on node parameters.

A few examples in the service spec asserted facts that neighbouring examples in the same file already covered, and are gone too.

---

The node types controller renders what the list service returns, with no
transformation of its own, so its request spec had grown into a second copy
of the service spec expressed in JSON: the same property schemas, the same
UI controls, the same operation lists, asserted twice. Touching a node
schema meant updating both.

The request spec now covers what only it can - the admin constraint, and
that the endpoint renders - plus the one case that genuinely belongs at
this layer, where metadata must not be preloaded for options that depend on
node parameters.

A few examples in the service spec asserted facts that neighbouring
examples in the same file already covered, and are gone too.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>