### PR TITLE
DEV: Make the workflow node matchers plain instance methods

### DIFF
--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -329,30 +329,6 @@ module DiscourseWorkflows
       category_ids.flat_map { |id| ::Category.subcategory_ids(id) }.uniq
     end
 
-    def self.matches_category_ids?(topic_category_id, category_ids, include_subcategories: true)
-      return true if category_ids.empty?
-
-      category_ids = expand_subcategory_ids(category_ids) if include_subcategories != false
-      category_ids.include?(topic_category_id)
-    end
-
-    def self.matches_user_groups?(user, group_ids)
-      raw_group_ids = Array.wrap(group_ids).reject(&:blank?)
-      return true if raw_group_ids.empty?
-
-      group_ids =
-        raw_group_ids.filter_map do |group_id|
-          value = group_id.to_s
-          value.to_i if value.match?(/\A\d+\z/)
-        end
-      group_ids.present? && !!user&.in_any_groups?(group_ids)
-    end
-
-    def self.matches_reviewable_types?(reviewable, reviewable_types)
-      reviewable_types = Array.wrap(reviewable_types).compact_blank
-      reviewable_types.empty? || reviewable_types.include?(reviewable.class.sti_name)
-    end
-
     def self.reviewable_type_options
       Reviewable
         .types
@@ -416,7 +392,11 @@ module DiscourseWorkflows
     end
 
     def matches_category_ids?(topic_category_id, category_ids, include_subcategories: true)
-      self.class.matches_category_ids?(topic_category_id, category_ids, include_subcategories:)
+      return true if category_ids.empty?
+
+      category_ids = self.class.expand_subcategory_ids(category_ids) if include_subcategories !=
+        false
+      category_ids.include?(topic_category_id)
     end
 
     def matches_topic_type?(topic, topic_type)
@@ -463,11 +443,20 @@ module DiscourseWorkflows
     end
 
     def matches_user_groups?(user, group_ids)
-      self.class.matches_user_groups?(user, group_ids)
+      raw_group_ids = Array.wrap(group_ids).reject(&:blank?)
+      return true if raw_group_ids.empty?
+
+      group_ids =
+        raw_group_ids.filter_map do |group_id|
+          value = group_id.to_s
+          value.to_i if value.match?(/\A\d+\z/)
+        end
+      group_ids.present? && !!user&.in_any_groups?(group_ids)
     end
 
     def matches_reviewable_types?(reviewable, reviewable_types)
-      self.class.matches_reviewable_types?(reviewable, reviewable_types)
+      reviewable_types = Array.wrap(reviewable_types).compact_blank
+      reviewable_types.empty? || reviewable_types.include?(reviewable.class.sti_name)
     end
 
     def reviewable_data(reviewable)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
@@ -332,35 +332,33 @@ RSpec.describe DiscourseWorkflows::NodeType do
     end
   end
 
-  describe ".matches_category_ids?" do
+  describe "#matches_category_ids?" do
+    subject(:node) { Class.new(described_class) { public :matches_category_ids? }.new }
+
     fab!(:parent_category, :category)
     fab!(:subcategory) { Fabricate(:category, parent_category: parent_category) }
     fab!(:other_category, :category)
 
-    it "matches everything when no categories are configured" do
-      expect(described_class.matches_category_ids?(subcategory.id, [])).to eq(true)
-      expect(described_class.matches_category_ids?(nil, [])).to eq(true)
+    it "matches everything when no categories are configured", :aggregate_failures do
+      expect(node.matches_category_ids?(subcategory.id, [])).to eq(true)
+      expect(node.matches_category_ids?(nil, [])).to eq(true)
     end
 
-    it "expands subcategories by default" do
-      expect(described_class.matches_category_ids?(subcategory.id, [parent_category.id])).to eq(
-        true,
-      )
-      expect(described_class.matches_category_ids?(subcategory.id, [other_category.id])).to eq(
-        false,
-      )
+    it "expands subcategories by default", :aggregate_failures do
+      expect(node.matches_category_ids?(subcategory.id, [parent_category.id])).to eq(true)
+      expect(node.matches_category_ids?(subcategory.id, [other_category.id])).to eq(false)
     end
 
-    it "matches exactly when include_subcategories is false" do
+    it "matches exactly when include_subcategories is false", :aggregate_failures do
       expect(
-        described_class.matches_category_ids?(
+        node.matches_category_ids?(
           subcategory.id,
           [parent_category.id],
           include_subcategories: false,
         ),
       ).to eq(false)
       expect(
-        described_class.matches_category_ids?(
+        node.matches_category_ids?(
           parent_category.id,
           [parent_category.id],
           include_subcategories: false,
@@ -370,7 +368,7 @@ RSpec.describe DiscourseWorkflows::NodeType do
 
     it "expands subcategories when include_subcategories is nil" do
       expect(
-        described_class.matches_category_ids?(
+        node.matches_category_ids?(
           subcategory.id,
           [parent_category.id],
           include_subcategories: nil,
@@ -380,10 +378,7 @@ RSpec.describe DiscourseWorkflows::NodeType do
 
     it "matches against the union of all configured categories" do
       expect(
-        described_class.matches_category_ids?(
-          subcategory.id,
-          [other_category.id, parent_category.id],
-        ),
+        node.matches_category_ids?(subcategory.id, [other_category.id, parent_category.id]),
       ).to eq(true)
     end
   end


### PR DESCRIPTION
`NodeType` exposed six of its filter helpers twice: a class method holding the implementation, and a private instance method whose entire body forwarded to it. Three of those pairs existed for no reason — nothing in either plugin called `matches_category_ids?`, `matches_user_groups?` or `matches_reviewable_types?` at class level.

The pairs are not pointless in general. `stale_topic` filters from `self.trigger_data_for` rather than from an instance, so `category_ids_parameter`, `normalize_tag_names`, `normalize_category_ids` and `expand_subcategory_ids` genuinely need a class form and keep it. The rule is "a class method when a class method needs it", and these three were the exceptions to it.

Their spec reached for the class form because that was the only public way in; it now exercises them through a node, which is how nodes use them.

---

`NodeType` exposed six of its filter helpers twice: a class method holding
the implementation, and a private instance method whose entire body
forwarded to it. Three of those pairs existed for no reason - nothing in
either plugin called `matches_category_ids?`, `matches_user_groups?` or
`matches_reviewable_types?` at class level.

The pairs are not pointless in general. `stale_topic` filters from
`self.trigger_data_for` rather than from an instance, so
`category_ids_parameter`, `normalize_tag_names`, `normalize_category_ids`
and `expand_subcategory_ids` genuinely need a class form and keep it. The
rule is "a class method when a class method needs it", and these three were
the exceptions to it.

Their spec reached for the class form because that was the only public way
in; it now exercises them through a node, which is how nodes use them.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>