### PR TITLE
FEATURE: Add recurring event successor topic mode

### DIFF
--- a/plugins/discourse-events/app/services/discourse_events/events/event/create_successor_topic.rb
+++ b/plugins/discourse-events/app/services/discourse_events/events/event/create_successor_topic.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+module DiscourseEvents
+  module Events
+    class Event::CreateSuccessorTopic
+      QUOTATION_MARKS = [
+        %w[" "],
+        %w[' '],
+        %w[« »],
+        %w[“ ”],
+        %w[” ”],
+        %w[‘ ’],
+        %w[„ “],
+        %w[‚ ’],
+        %w[‹ ›],
+      ].freeze
+
+      EVENT_OPEN_TAG =
+        /
+        \[event(?=\s|\])
+        (?:
+          [^"'«“”‘„‚‹\]]+
+          | "[^"]*"
+          | '[^']*'
+          | «[^»]*»
+          | “[^”]*”
+          | ”[^”]*”
+          | ‘[^’]*’
+          | „[^“]*“
+          | ‚[^’]*’
+          | ‹[^›]*›
+        )*
+        \]
+      /ix
+
+      ATTRIBUTE_VALUE =
+        /
+        (?:
+          "[^"]*"
+          | '[^']*'
+          | «[^»]*»
+          | “[^”]*”
+          | ”[^”]*”
+          | ‘[^’]*’
+          | „[^“]*“
+          | ‚[^’]*’
+          | ‹[^›]*›
+          | [^\s\]]+
+        )
+      /x
+
+      def self.call(event_date)
+        new(event_date).call
+      end
+
+      def initialize(event_date)
+        @event_date = event_date
+        @event = event_date.event
+      end
+
+      def call
+        original_raw = post.raw
+        original_title = topic.title
+        event_open_tag_match = rendered_event_open_tag_match(original_raw)
+        raise Discourse::InvalidParameters.new(:event) unless event_open_tag_match
+
+        invitees = snapshot_invitees
+
+        next_occurrence = event.calculate_next_occurrence_from(event_date.starts_at + 1.second)
+
+        successor_post = nil
+
+        Event.transaction do
+          topic.acting_user = Discourse.system_user
+
+          archived_raw =
+            rewrite_event_attributes(
+              original_raw,
+              event_open_tag_match,
+              "start" => format_date(event_date.starts_at),
+              "end" => formatted_end(event_date.ends_at),
+              "recurrence" => nil,
+              "recurrence-until" => nil,
+              "recurrenceUntil" => nil,
+            )
+
+          revisor = PostRevisor.new(post)
+          revised =
+            revisor.revise!(
+              Discourse.system_user,
+              { raw: archived_raw, title: archived_title(original_title) },
+              bypass_bump: true,
+            )
+
+          unless revised
+            errors = (topic.errors.full_messages + post.errors.full_messages).uniq
+            raise ActiveRecord::RecordNotSaved.new(errors.to_sentence)
+          end
+
+          if next_occurrence
+            successor_raw =
+              rewrite_event_attributes(
+                original_raw,
+                event_open_tag_match,
+                "start" => format_date(next_occurrence[:starts_at]),
+                "end" => formatted_end(next_occurrence[:ends_at]),
+              )
+
+            successor_post = create_successor_post(successor_raw, original_title)
+            copy_recurring_invitees(invitees, successor_post)
+          end
+        end
+
+        successor_post&.topic
+      end
+
+      private
+
+      attr_reader :event_date, :event
+
+      def post
+        event.post
+      end
+
+      def topic
+        post.topic
+      end
+
+      def create_successor_post(raw, title)
+        PostCreator.create!(
+          post.user || Discourse.system_user,
+          guardian: Discourse.system_user.guardian,
+          title:,
+          raw:,
+          category: topic.category_id,
+          tags: topic.tags.pluck(:name),
+        ).reload
+      end
+
+      def snapshot_invitees
+        Invitee
+          .unscoped
+          .where(post_id: event.id)
+          .pluck(:user_id, :status, :recurring, :notified)
+          .map do |user_id, status, recurring, notified|
+            { user_id:, status:, recurring:, notified: }
+          end
+      end
+
+      def copy_recurring_invitees(invitees, successor_post)
+        successor_event = successor_post.event
+        going = Invitee.statuses[:going]
+
+        invitees
+          .select { |invitee| invitee[:status] == going && invitee[:recurring] }
+          .each do |invitee|
+            successor_invitee =
+              Invitee.create!(
+                post_id: successor_event.id,
+                user_id: invitee[:user_id],
+                status: going,
+                recurring: true,
+                notified: invitee[:notified],
+              )
+
+            successor_invitee.update_topic_tracking!
+          end
+      end
+
+      def archived_title(original_title)
+        date =
+          if event.all_day
+            event_date.starts_at.utc.strftime("%Y-%m-%d")
+          else
+            event_date.starts_at.in_time_zone(event.rrule_timezone).strftime("%Y-%m-%d")
+          end
+
+        suffix = " — #{date}"
+        candidate = title_with_suffix(original_title, suffix)
+        return candidate unless archived_title_taken?(candidate)
+
+        suffix = " — #{date} ##{topic.id}"
+        candidate = title_with_suffix(original_title, suffix)
+        return candidate unless archived_title_taken?(candidate)
+
+        counter = 2
+
+        loop do
+          suffix = " — #{date} ##{topic.id}-#{counter}"
+          candidate = title_with_suffix(original_title, suffix)
+          return candidate unless archived_title_taken?(candidate)
+
+          counter += 1
+        end
+      end
+
+      def title_with_suffix(original_title, suffix)
+        max_length = SiteSetting.max_topic_title_length
+        return suffix[-max_length, max_length] if suffix.length >= max_length
+
+        title_length = max_length - suffix.length
+        "#{original_title.truncate(title_length, omission: "").rstrip}#{suffix}"
+      end
+
+      def archived_title_taken?(candidate)
+        return false if SiteSetting.duplicate_topic_titles.allowed?
+
+        topic
+          .duplicate_title_candidates
+          .where.not(id: topic.id)
+          .where("lower(title) = ?", candidate.downcase)
+          .exists?
+      end
+
+      def formatted_end(value)
+        return nil if event.original_ends_at.nil?
+        return nil if value.nil?
+
+        format_date(value)
+      end
+
+      def format_date(value)
+        if event.all_day
+          value.utc.strftime("%Y-%m-%d")
+        else
+          value.in_time_zone(event.rrule_timezone).strftime("%Y-%m-%d %H:%M")
+        end
+      end
+
+      def rewrite_event_attributes(raw, match, attributes)
+        opening_tag = match[0]
+
+        attributes.each { |name, value| opening_tag = rewrite_attribute(opening_tag, name, value) }
+
+        raw[0...match.begin(0)] + opening_tag + raw[match.end(0)..]
+      end
+
+      def rendered_event_open_tag_match(raw)
+        matches = raw.to_enum(:scan, EVENT_OPEN_TAG).map { Regexp.last_match.dup }
+        return if matches.empty?
+        return matches.first if matches.one?
+
+        marked_raw =
+          raw
+            .gsub(EVENT_OPEN_TAG)
+            .with_index do |opening_tag, index|
+              opening_tag.sub(/\]\z/, %( rolloverMarker="candidate-#{index}"]))
+            end
+
+        cooked = PrettyText.cook(marked_raw, topic_id: post.topic_id, user_id: post.user_id)
+
+        marker =
+          Nokogiri::HTML5
+            .fragment(cooked)
+            .at_css("div.discourse-post-event[data-rollover-marker]")
+            &.[]("data-rollover-marker")
+
+        return if !marker&.match?(/\Acandidate-\d+\z/)
+
+        matches[marker.delete_prefix("candidate-").to_i]
+      end
+
+      def rewrite_attribute(opening_tag, name, value)
+        pattern =
+          /
+            \s+#{Regexp.escape(name)}
+            (?:=#{ATTRIBUTE_VALUE})?
+            (?=\s|\])
+          /ix
+
+        opening_tag = opening_tag.gsub(pattern, "")
+        return opening_tag if value.nil?
+
+        serialized = serialize_attribute(name, value)
+        opening_tag.sub(/\]\z/, " #{serialized}]")
+      end
+
+      def serialize_attribute(name, value)
+        string_value = value.to_s
+
+        return "#{name}=#{string_value}" unless string_value.match?(/[\s\]]/)
+
+        QUOTATION_MARKS.each do |open_quote, close_quote|
+          if string_value.exclude?(open_quote) && string_value.exclude?(close_quote)
+            return "#{name}=#{open_quote}#{string_value}#{close_quote}"
+          end
+        end
+
+        %(#{name}="#{string_value.delete('"')}")
+      end
+    end
+  end
+end

--- a/plugins/discourse-events/config/locales/server.en.yml
+++ b/plugins/discourse-events/config/locales/server.en.yml
@@ -46,6 +46,7 @@ en:
     discourse_post_event_enabled: "Enables the Event features. Note: also needs {{setting:discourse_events_enabled}} to be enabled."
     displayed_invitees_limit: "Limits the numbers of invitees displayed on an event."
     display_post_event_date_on_topic_title: "Displays the date of the event after the topic title."
+    discourse_post_event_recurring_topic_mode: "Controls how recurring Events use Topics. 'reuse_topic' keeps the current Topic for each occurrence. 'create_next_topic' preserves the completed occurrence Topic and creates a new Topic for the next occurrence."
     use_local_event_date: "Use local date after topic title instead of relative time."
     discourse_post_event_allowed_on_groups: "Groups that are allowed to create events."
     discourse_post_event_allowed_custom_fields: "Allows to let each event to set the value of custom fields."

--- a/plugins/discourse-events/config/settings.yml
+++ b/plugins/discourse-events/config/settings.yml
@@ -87,6 +87,12 @@ discourse_events:
   display_post_event_date_on_topic_title:
     default: true
     client: true
+  discourse_post_event_recurring_topic_mode:
+    type: enum
+    default: reuse_topic
+    choices:
+      - reuse_topic
+      - create_next_topic
   use_local_event_date:
     default: false
     client: true

--- a/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
+++ b/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
@@ -39,20 +39,35 @@ module Jobs
 
       def finish(event_date)
         return if !event_date.ended?
-        event_date.update!(finished_at: Time.current)
 
-        # The occurrence goes along with the event: `set_next_date` below moves
-        # the event on to the next one, so it can no longer name the one that ended.
-        DiscourseEvent.trigger(:discourse_post_event_event_ended, event_date.event, event_date)
+        event = event_date.event
+        recurring = event.recurrence.present?
+        create_successor_topic =
+          recurring && SiteSetting.discourse_post_event_recurring_topic_mode == "create_next_topic"
+
+        if create_successor_topic
+          DiscourseEvents::Events::Event.transaction do
+            event_date.update!(finished_at: Time.current)
+            DiscourseEvents::Events::Event::CreateSuccessorTopic.call(event_date)
+          end
+        else
+          event_date.update!(finished_at: Time.current)
+        end
+
+        # Use the Event instance captured before rollover. In create-next-topic
+        # mode the persisted Event is rewritten as one-off, while event-ended
+        # should retain the series metadata for the occurrence that just ended.
+        DiscourseEvent.trigger(:discourse_post_event_event_ended, event, event_date)
         MessageBus.publish(
-          "/topic/#{event_date.event.post.topic_id}",
+          "/topic/#{event.post.topic_id}",
           reload_topic: true,
           refresh_stream: true,
         )
 
-        return if event_date.event.recurrence.blank?
-        event_date.event.set_next_date
-        event_date.event.set_topic_bump
+        return if !recurring || create_successor_topic
+
+        event.set_next_date
+        event.set_topic_bump
       end
 
       def due_reminders(event_date)

--- a/plugins/discourse-events/spec/integration/workflows_event_triggers_spec.rb
+++ b/plugins/discourse-events/spec/integration/workflows_event_triggers_spec.rb
@@ -100,5 +100,52 @@ RSpec.describe "Post event workflow triggers" do
         enqueued_workflow_ids("trigger-all", "trigger-topic", "trigger-other"),
       ).to contain_exactly(all_events.id, this_topic.id)
     end
+    it "preserves recurring metadata in the workflow payload when creating a successor topic" do
+      SiteSetting.discourse_post_event_recurring_topic_mode = "create_next_topic"
+
+      starts_at = 7.days.from_now.change(sec: 0)
+      ends_at = starts_at + 1.hour
+      category = Fabricate(:category)
+
+      post =
+        PostCreator.create!(
+          admin,
+          title: "Recurring workflow metadata",
+          category: category.id,
+          raw: <<~RAW,
+            [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+            Meeting notes.
+            [/event]
+          RAW
+        )
+
+      original_event = post.reload.event
+
+      publish_workflow(
+        "trigger-recurring",
+        "trigger:event_ended",
+        { "topic_id" => post.topic_id.to_s },
+      )
+
+      freeze_time(ends_at + 1.hour)
+      Jobs::DiscourseCalendar::MonitorEventDates.new.execute({})
+
+      completed_event = DiscourseEvents::Events::Event.find(original_event.id)
+
+      expect(completed_event.recurring?).to eq(false)
+      expect(completed_event.recurrence).to be_nil
+
+      job_args =
+        Jobs::DiscourseWorkflows::ExecuteWorkflow
+          .jobs
+          .map { |job| job["args"].first }
+          .find { |args| args["trigger_node_id"] == "trigger-recurring" }
+
+      expect(job_args).to be_present
+      expect(job_args["trigger_data"]["event"]).to include(
+        "recurring" => true,
+        "recurrence" => "every_week",
+      )
+    end
   end
 end

--- a/plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb
+++ b/plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb
@@ -174,6 +174,436 @@ describe Jobs::DiscourseCalendar::MonitorEventDates do
       )
     end
 
+    context "when recurring topic mode is create_next_topic" do
+      fab!(:event_author) { Fabricate(:user, admin: true, refresh_auto_groups: true) }
+      fab!(:event_category, :category)
+      fab!(:event_tag, :tag)
+      fab!(:going_once_user, :user)
+      fab!(:going_recurring_user, :user)
+
+      before do
+        SiteSetting.discourse_events_enabled = true
+        SiteSetting.discourse_post_event_enabled = true
+        SiteSetting.discourse_post_event_recurring_topic_mode = "create_next_topic"
+      end
+
+      it "truncates the archived title while preserving the occurrence date" do
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title =
+          ("Weekly planning meeting discussion notes agenda " * 10)[
+            0,
+            SiteSetting.max_topic_title_length
+          ]
+
+        post = PostCreator.create!(event_author, title:, category: event_category.id, raw: <<~RAW)
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+
+        suffix = " — #{starts_at.utc.strftime("%Y-%m-%d")}"
+
+        expect(original_topic.title.length).to eq(SiteSetting.max_topic_title_length)
+        expect(original_topic.title).to end_with(suffix)
+
+        successor_topic = Topic.where(title:).where.not(id: original_topic.id).sole
+
+        expect(successor_topic.title).to eq(title)
+      end
+
+      it "archives the final occurrence without creating a successor topic" do
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title = "Finite weekly planning meeting"
+
+        post = PostCreator.create!(event_author, title:, category: event_category.id, raw: <<~RAW)
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week" recurrenceUntil="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}"]
+              Final meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+        original_event = post.reload.event
+
+        DiscourseEvents::Events::Invitee.create_attendance!(
+          going_once_user.id,
+          original_event.id,
+          :going,
+        )
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.not_to change(Topic, :count)
+
+        original_topic.reload
+        original_event.reload
+        post.reload
+
+        expect(original_topic.title).to eq("#{title} — #{starts_at.utc.strftime("%Y-%m-%d")}")
+        expect(original_event.recurrence).to be_blank
+        expect(original_event.recurrence_until).to be_nil
+        expect(original_event.event_dates.pending).to be_empty
+
+        invitee = original_event.invitees.find_by(user_id: going_once_user.id)
+        expect(invitee.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+
+        expect(post.raw).not_to include("recurrenceUntil")
+        expect(post.raw).not_to include("recurrence-until")
+        expect(post.raw).not_to match(/\srecurrence=/)
+      end
+
+      it "preserves all-day dates without timezone drift" do
+        starts_on = 7.days.after.to_date
+        title = "Weekly all-day planning meeting"
+
+        post = PostCreator.create!(event_author, title:, category: event_category.id, raw: <<~RAW)
+              [event start="#{starts_on}" end="#{starts_on}" all-day="true" status="public" timezone="America/Los_Angeles" recurrence="every_week"]
+              All-day meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+        original_event = post.reload.event
+        original_date = original_event.event_dates.pending.first
+
+        freeze_time(original_date.ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+        original_event.reload
+
+        expect(original_topic.title).to eq("#{title} — #{starts_on}")
+        expect(original_event.original_starts_at).to eq_time(starts_on.to_time(:utc))
+        expect(original_event.recurrence).to be_blank
+
+        successor_topic = Topic.where(title:).where.not(id: original_topic.id).sole
+        successor_event = successor_topic.first_post.event
+
+        expect(successor_event.all_day).to eq(true)
+        expect(successor_event.original_starts_at.to_date).to eq(starts_on + 7.days)
+        expect(successor_topic.first_post.raw).to include("start=#{starts_on + 7.days}")
+      end
+
+      it "ignores event markup in code blocks when creating a successor" do
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title = "Weekly planning with event example"
+        fence = "`" * 3
+
+        post = PostCreator.create!(event_author, title:, category: event_category.id, raw: <<~RAW)
+              Example Event markup:
+
+              #{fence}
+              [event start="2000-01-01 10:00" recurrence="every_week"]
+              [/event]
+              #{fence}
+
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Actual meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+        original_event = post.reload.event
+        original_date = original_event.event_dates.pending.first
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+        original_event.reload
+        post.reload
+
+        expect(post.raw).to include(%[event start="2000-01-01 10:00" recurrence="every_week"])
+        expect(original_event.recurrence).to be_blank
+
+        successor_topic = Topic.where(title:).where.not(id: original_topic.id).sole
+        successor_post = successor_topic.first_post
+        successor_event = successor_post.event
+
+        expect(successor_post.raw).to include(
+          %[event start="2000-01-01 10:00" recurrence="every_week"],
+        )
+        expect(successor_event.original_starts_at).to eq_time(original_date.starts_at + 7.days)
+      end
+
+      it "disambiguates archived titles that collide after truncation" do
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+
+        prefix =
+          ("Weekly planning meeting discussion notes agenda " * 10)[
+            0,
+            SiteSetting.max_topic_title_length - 1
+          ]
+        first_title = "#{prefix}A"
+        second_title = "#{prefix}B"
+
+        first_post =
+          PostCreator.create!(
+            event_author,
+            title: first_title,
+            category: event_category.id,
+            raw: <<~RAW,
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              First meeting.
+              [/event]
+            RAW
+          )
+
+        second_post =
+          PostCreator.create!(
+            event_author,
+            title: second_title,
+            category: event_category.id,
+            raw: <<~RAW,
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Second meeting.
+              [/event]
+            RAW
+          )
+
+        first_topic = first_post.topic
+        second_topic = second_post.topic
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(2)
+
+        first_topic.reload
+        second_topic.reload
+
+        expect(first_topic.title).not_to eq(second_topic.title)
+        expect(first_topic.title).to end_with(starts_at.utc.strftime("%Y-%m-%d"))
+        expect(second_topic.title).to include(starts_at.utc.strftime("%Y-%m-%d"))
+        expect(first_topic.title.length).to be <= SiteSetting.max_topic_title_length
+        expect(second_topic.title.length).to be <= SiteSetting.max_topic_title_length
+
+        expect(Topic.where(title: first_title).where.not(id: first_topic.id)).to exist
+        expect(Topic.where(title: second_title).where.not(id: second_topic.id)).to exist
+      end
+
+      it "creates a successor when the maximum topic title length is shorter than the archive suffix" do
+        SiteSetting.min_topic_title_length = 1
+        SiteSetting.max_topic_title_length = 5
+
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title = "Meet"
+
+        post = PostCreator.create!(event_author, title:, category: event_category.id, raw: <<~RAW)
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+
+        expect(original_topic.title.length).to be <= SiteSetting.max_topic_title_length
+        expect(Topic.where(title:).where.not(id: original_topic.id)).to exist
+      end
+
+      it "avoids archive title collisions hidden from the original author" do
+        original_author = Fabricate(:user, refresh_auto_groups: true)
+        SiteSetting.discourse_post_event_allowed_on_groups = Group::AUTO_GROUPS[:trust_level_0].to_s
+
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title = "Weekly planning with hidden collision"
+
+        post =
+          PostCreator.create!(original_author, title:, category: event_category.id, raw: <<~RAW)
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+        archive_title = "#{title} — #{starts_at.utc.strftime("%Y-%m-%d")}"
+
+        private_group = Fabricate(:group)
+        hidden_category =
+          Fabricate(:category).tap do |category|
+            category.set_permissions(private_group => :full)
+            category.save!
+          end
+
+        Fabricate(:topic, title: archive_title, category: hidden_category, user: event_author)
+
+        expect(original_author.guardian.can_see_category?(hidden_category)).to eq(false)
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+
+        expect(original_topic.title).to eq("#{archive_title} ##{original_topic.id}")
+        expect(Topic.where(title:).where.not(id: original_topic.id)).to exist
+      end
+
+      it "creates a successor when the original author can no longer create topics in the category" do
+        restricted_author = Fabricate(:user, refresh_auto_groups: true)
+        SiteSetting.discourse_post_event_allowed_on_groups = Group::AUTO_GROUPS[:trust_level_0].to_s
+
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title = "Weekly planning after permission change"
+
+        post =
+          PostCreator.create!(restricted_author, title:, category: event_category.id, raw: <<~RAW)
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Meeting notes.
+              [/event]
+            RAW
+
+        original_topic = post.topic
+
+        event_category.set_permissions(everyone: :readonly, staff: :full)
+        event_category.save!
+
+        expect(restricted_author.guardian.can_create_topic_on_category?(event_category)).to eq(
+          false,
+        )
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+
+        successor_topic = Topic.where(title:).where.not(id: original_topic.id).sole
+
+        expect(successor_topic.user_id).to eq(restricted_author.id)
+        expect(successor_topic.first_post.user_id).to eq(restricted_author.id)
+        expect(successor_topic.category_id).to eq(event_category.id)
+      end
+
+      it "keeps the occurrence pending when successor creation fails" do
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+
+        post =
+          PostCreator.create!(
+            event_author,
+            title: "Weekly planning retry",
+            category: event_category.id,
+            raw: <<~RAW,
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Meeting notes.
+              [/event]
+            RAW
+          )
+
+        event_date = post.reload.event.event_dates.pending.first
+
+        freeze_time(ends_at + 1.hour)
+
+        DiscourseEvents::Events::Event::CreateSuccessorTopic.stubs(:call).raises(
+          StandardError,
+          "successor creation failed",
+        )
+
+        expect { job.execute({}) }.to raise_error(StandardError, "successor creation failed")
+
+        expect(event_date.reload.finished_at).to be_nil
+        expect(DiscourseEvents::Events::EventDate.pending.where(id: event_date.id)).to exist
+      end
+
+      it "preserves the completed topic and creates a successor for the next occurrence" do
+        starts_at = 7.days.after.change(sec: 0)
+        ends_at = starts_at + 1.hour
+        title = "Weekly planning meeting"
+
+        post =
+          PostCreator.create!(
+            event_author,
+            title:,
+            category: event_category.id,
+            tags: [event_tag.name],
+            raw: <<~RAW,
+              [event start="#{starts_at.utc.strftime("%Y-%m-%d %H:%M")}" end="#{ends_at.utc.strftime("%Y-%m-%d %H:%M")}" status="public" timezone="UTC" recurrence="every_week"]
+              Meeting notes and files go here.
+              [/event]
+            RAW
+          )
+
+        original_topic = post.topic
+        original_event = post.reload.event
+        original_date = original_event.event_dates.pending.first
+
+        DiscourseEvents::Events::Invitee.create_attendance!(
+          going_once_user.id,
+          original_event.id,
+          :going,
+        )
+        DiscourseEvents::Events::Invitee.create_attendance!(
+          going_recurring_user.id,
+          original_event.id,
+          :going,
+          recurring: true,
+        )
+
+        freeze_time(ends_at + 1.hour)
+
+        expect { job.execute({}) }.to change(Topic, :count).by(1)
+
+        original_topic.reload
+        original_event.reload
+
+        expect(original_topic.id).to eq(post.topic_id)
+        expect(original_topic.title).to eq(
+          "#{title} — #{original_date.starts_at.utc.strftime("%Y-%m-%d")}",
+        )
+        expect(original_event.recurrence).to be_blank
+        expect(original_event.event_dates.pending).to be_empty
+
+        original_once = original_event.invitees.find_by(user_id: going_once_user.id)
+        original_recurring = original_event.invitees.find_by(user_id: going_recurring_user.id)
+
+        expect(original_once.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+        expect(original_once.recurring).to eq(false)
+        expect(original_recurring.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+        expect(original_recurring.recurring).to eq(true)
+
+        successor_topic = Topic.where(title:).where.not(id: original_topic.id).sole
+        successor_post = successor_topic.first_post
+        successor_event = successor_post.event
+
+        expect(successor_topic.user_id).to eq(event_author.id)
+        expect(successor_topic.category_id).to eq(event_category.id)
+        expect(successor_topic.tags.pluck(:name)).to contain_exactly(event_tag.name)
+        expect(successor_post.raw).to include("Meeting notes and files go here.")
+
+        expect(successor_event.recurrence).to eq("every_week")
+        expect(successor_event.original_starts_at).to eq_time(original_date.starts_at + 7.days)
+        expect(successor_event.original_ends_at).to eq_time(original_date.ends_at + 7.days)
+
+        expect(successor_event.invitees.find_by(user_id: going_once_user.id)).to be_nil
+
+        successor_recurring = successor_event.invitees.find_by(user_id: going_recurring_user.id)
+        expect(successor_recurring.status).to eq(DiscourseEvents::Events::Invitee.statuses[:going])
+        expect(successor_recurring.recurring).to eq(true)
+      end
+    end
+
     it "does not process closed events" do
       past_event.update!(recurrence: "every_week", closed: true)
       initial_event_date = past_event.event_dates.first


### PR DESCRIPTION
## Summary

Adds an opt-in mode for recurring Events where each completed occurrence is preserved in its own Topic and the next occurrence is created in a successor Topic.

The new `discourse_post_event_recurring_topic_mode` enum site setting has two values:

- `reuse_topic` — existing behavior and the default
- `create_next_topic` — archive the completed occurrence Topic and create a successor Topic for the next occurrence

## Details

When `create_next_topic` is enabled, the scheduled event-date monitor:

- preserves the completed Topic by converting its Event to a one-off occurrence
- appends the occurrence date to the archived Topic title, handling title-length and duplicate-title constraints
- creates the successor Topic from the original post content while advancing only the Event start/end dates
- preserves category, tags, original author and recurring Event metadata
- carries forward only recurring `going` invitees; one-off attendance remains on the completed occurrence
- performs the rollover transactionally so a failed successor creation leaves the occurrence pending for retry
- still emits the event-ended workflow trigger with the completed occurrence's recurring-series metadata

If the recurrence has no next occurrence, the completed Topic is preserved as a one-off Event and no successor Topic is created.

The existing `reuse_topic` path is unchanged.

## UI smoke test

With `discourse_post_event_recurring_topic_mode` set to `create_next_topic`:

**Site setting**

<img width="678" height="142" alt="01-admin-setting-create-next-topic" src="https://github.com/user-attachments/assets/78dc6698-6886-4c10-81d4-22d991f0f452" />

**Before rollover — recurring occurrence on September 3**

<img width="1512" height="958" alt="02-before-rollover-sep-3-every-thursday" src="https://github.com/user-attachments/assets/3150b843-1264-4990-8dd8-2e931e28b9dc" />

**Completed occurrence preserved in the dated Topic**

<img width="2048" height="1076" alt="03-archived-topic-2026-09-03" src="https://github.com/user-attachments/assets/d6d28341-f684-4ba8-9b54-2fec0c537bb7" />

**Successor Topic created for the next weekly occurrence**

<img width="2048" height="1073" alt="04-successor-topic-sep-10-every-thursday" src="https://github.com/user-attachments/assets/0ff611b4-f316-4130-bb75-7948d36e61e9" />

## Tests

Focused specs after rebasing onto current `main`:

> 22 examples, 0 failures

Coverage includes the existing reuse-topic behavior, normal successor rollover, final recurrence, all-day timezone handling, fenced-code Event markup, title collisions/truncation, restricted original authors, transactional retry behavior, recurring RSVP inheritance, and workflow event-ended payloads.

The UI and scheduled-job smoke tests confirmed that the completed Topic was preserved with a dated title and that a successor Topic was created for the following weekly occurrence, including through the normal supervised Sidekiq scheduler.