### PR TITLE
FIX: Let chat moderators lift a silence the flag owns

### DIFF
--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -39,11 +39,7 @@ module Chat
     def silenced_for_this_message?
       return false if !chat_message_creator&.silenced?
 
-      UserHistory.exists?(
-        action: UserHistory.actions[:silence_user],
-        target_user_id: chat_message_creator.id,
-        reviewable_id: id,
-      )
+      chat_message_creator.silenced_record&.reviewable_id == id
     end
 
     def post
@@ -105,6 +101,31 @@ module Chat
       unless chat_message.deleted_at?
         build_action(actions, :delete_and_agree, icon: "trash-can", bundle: disagree_bundle)
       end
+
+      build_unsilence_action(actions, guardian)
+    end
+
+    def build_unsilence_action(actions, guardian)
+      return if !chat_message_creator&.silenced?
+      return if !guardian.can_unsilence_user?(chat_message_creator)
+
+      build_action(actions, :unsilence_user, icon: "microphone-slash")
+    end
+
+    def penalty_effect_for(action_id)
+      return if author_penalties.empty?
+
+      lifts_silence =
+        case action_id
+        when :disagree, :disagree_and_restore
+          silenced_for_this_message?
+        when :unsilence_user
+          true
+        else
+          false
+        end
+
+      lifts_silence ? :lifts_penalty : :retains_penalty
     end
 
     def perform_agree_and_keep_message(performed_by, args)
@@ -129,6 +150,12 @@ module Chat
 
     def perform_ignore(performed_by, args)
       ignore
+    end
+
+    def perform_unsilence_user(performed_by, _args)
+      UserSilencer.unsilence(chat_message_creator, performed_by, reviewable_id: id)
+
+      create_result(:success) { |result| result.remove_reviewable_ids = [] }
     end
 
     def perform_delete_and_ignore(performed_by, args)

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -154,6 +154,10 @@ en:
         ignore:
           title: "Ignore flag"
           description: "Remove it from the queue without taking action."
+        unsilence_user:
+          title: "Unsilence author"
+          description: "Lift the silence on the author. This flag stays in the queue."
+          complete: "Author unsilenced."
       direct_messages:
         transcript_title: "Transcript of previous messages in %{channel_name}"
         transcript_body: "To give you more context, we included a transcript of the previous messages in this conversation (up to ten):\n\n%{transcript}"

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -176,6 +176,7 @@ Fabricator(:chat_reviewable_message, class_name: "Chat::ReviewableMessage") do
   type "ReviewableChatMessage"
   created_by { Fabricate(:user) }
   target { Fabricate(:chat_message) }
+  target_created_by { |attrs| attrs[:target].user }
   reviewable_scores { |p| [Fabricate.build(:reviewable_score, reviewable_id: p[:id])] }
 end
 

--- a/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
@@ -114,4 +114,80 @@ RSpec.describe Chat::ReviewableMessage, type: :model do
       expect(user.reload.silenced?).to eq(true)
     end
   end
+
+  context "when a silence from this flag was already lifted and a new one replaced it" do
+    before do
+      UserSilencer.silence(
+        user,
+        Discourse.system_user,
+        silenced_till: 10.minutes.from_now,
+        reason: I18n.t("chat.errors.auto_silence_from_flags"),
+        reviewable_id: reviewable.id,
+      )
+      UserSilencer.unsilence(user, moderator)
+
+      UserSilencer.silence(
+        user,
+        Discourse.system_user,
+        silenced_till: 10.minutes.from_now,
+        reason: "unrelated reason",
+      )
+    end
+
+    it "perform_disagree leaves the later, unrelated silence in place" do
+      reviewable.perform(moderator, :disagree)
+
+      expect(user.reload.silenced?).to eq(true)
+    end
+  end
+
+  describe "#perform_unsilence_user" do
+    def unsilence_action(guardian = moderator.guardian)
+      reviewable.actions_for(guardian).to_a.find { |a| a.server_action == "unsilence_user" }
+    end
+
+    it "is not offered when the author is not silenced" do
+      expect(unsilence_action).to eq(nil)
+    end
+
+    context "when the author is silenced" do
+      before do
+        UserSilencer.silence(
+          user,
+          Discourse.system_user,
+          silenced_till: 10.minutes.from_now,
+          reason: I18n.t("chat.errors.auto_silence_from_flags"),
+        )
+      end
+
+      it "is offered with a translated label" do
+        action = unsilence_action
+
+        expect(action).to be_present
+        expect(I18n.t(action.label)).to eq("Unsilence author")
+        expect(I18n.t(action.completed_message)).to eq("Author unsilenced.")
+      end
+
+      it "is not offered to a user who cannot unsilence the author" do
+        expect(unsilence_action(Fabricate(:user).guardian)).to eq(nil)
+      end
+
+      it "lifts the silence without resolving the flag" do
+        reviewable.perform(moderator, :unsilence_user)
+
+        expect(user.reload.silenced?).to eq(false)
+        expect(reviewable.reload).to be_pending
+      end
+
+      it "attributes the unsilence to the moderator and the reviewable" do
+        reviewable.perform(moderator, :unsilence_user)
+
+        history =
+          UserHistory.find_by(action: UserHistory.actions[:unsilence_user], target_user_id: user.id)
+
+        expect(history.acting_user_id).to eq(moderator.id)
+        expect(history.reviewable_id).to eq(reviewable.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The review queue gained an "Unsilence author" action, but only for flagged posts. A chat flag showed the author's silence and said an action would leave it in place, while offering nothing to lift it — so the one queue that silences authors automatically was the one with no way back.

Chat now builds the same action, gated on the same permission, and reports the same penalty effect on its actions.

`silenced_for_this_message?` also asked whether this flag had *ever* silenced the author, rather than whether it caused the silence they are serving now. An author silenced by this flag, released, then silenced again for something unrelated had that second, unrelated silence lifted by disagreeing with the first flag. It now reads the current silence record.

This also closes the upgrade gap: silences recorded before the parent stack shipped carry no `reviewable_id`, so disagreeing no longer lifts them. Rather than backfill a link that cannot be reconstructed reliably, moderators get an explicit control that works regardless of how the silence was recorded.

The chat reviewable fabricator now sets `target_created_by`, which `Chat::ReviewQueue` has always set in production. Without it `author_penalties` is empty and every penalty assertion passes vacuously.