### PR TITLE
PERF: Batch the acting user behind each author penalty

### DIFF
--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -56,6 +56,7 @@ class ReviewablesController < ApplicationController
       Reviewable.list_for(current_user, **filters.merge(limit: PER_PAGE, offset: offset)).to_a
 
     claimed_topics = ReviewableClaimedTopic.claimed_hash(reviewables.map { |r| r.topic_id }.uniq)
+    Reviewable.preload_author_penalties(reviewables)
 
     # This is a bit awkward, but ActiveModel serializers doesn't seem to serialize STI. Note `hash`
     # is mutated by the serializer and contains the side loaded records which must be merged in the end.

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -342,6 +342,13 @@ class Reviewable < ActiveRecord::Base
     )
   end
 
+  def self.preload_author_penalties(reviewables)
+    histories = reviewables.flat_map(&:author_penalties).filter_map(&:history)
+    return if histories.empty?
+
+    ActiveRecord::Associations::Preloader.new(records: histories, associations: :acting_user).call
+  end
+
   def author_penalties
     @author_penalties ||= AuthorPenalty.all_for(target_created_by, target_post:, reviewable_id: id)
   end

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -50,6 +50,27 @@ RSpec.describe ReviewablesController do
         expect(json["reviewables"]).to eq([])
       end
 
+      it "loads the acting user behind every author penalty in one query" do
+        silencers =
+          3.times.map do
+            author = Fabricate(:user, refresh_auto_groups: true)
+            flagged_post = Fabricate(:post, user: author)
+            silencer = Fabricate(:moderator)
+            UserSilencer.silence(author, silencer, post_id: flagged_post.id)
+            PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), flagged_post)
+            silencer
+          end
+
+        queries = track_sql_queries { get "/review.json" }
+
+        loaded_one_by_one =
+          silencers.select do |silencer|
+            queries.any? { |sql| sql.include?(%Q("users"."id" = #{silencer.id} LIMIT 1)) }
+          end
+
+        expect(loaded_one_by_one).to eq([])
+      end
+
       it "returns JSON with reviewable content" do
         reviewable = Fabricate(:reviewable_flagged_post)
 


### PR DESCRIPTION
Every penalty shown on the review queue names the staff member who applied it, and each one was fetched on its own. A page of flagged posts by penalized authors issued one extra user lookup per penalty, on a staff endpoint that already runs a long query for every row.

The penalty histories are loaded by the time the list is built, so their acting users can be preloaded onto them in a single query.

Measured on `GET /review.json` with flagged posts by silenced authors, counting uncached `sql.active_record` events: single-row `users` lookups went from one per penalized author to none — the acting users now arrive in one `IN (...)`.

The preload deliberately warms `author_penalties` itself, so it cannot race the memoisation that `bundled_actions` also depends on. It reuses whichever history row `silenced_record`/`suspend_record` already chose, so the serialized output is unchanged by construction.