### PR TITLE
FIX: Replace the penalty toast instead of stacking one per flag

### DIFF
--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -49,6 +49,8 @@ import dFormatDate from "discourse/ui-kit/helpers/d-format-date";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+const PENALTY_TOAST_KEY = "reviewable-author-penalty";
+
 const fieldComponents = {
   category: ReviewableFieldCategory,
   editor: ReviewableFieldEditor,
@@ -441,6 +443,7 @@ export default class ReviewableItem extends Component {
 
     this.toasts.success({
       autoClose: false,
+      key: `${PENALTY_TOAST_KEY}-${author.id}`,
       data: {
         title: performableAction.completed_message,
         message: i18n("review.author_penalty.toast.still_silenced", {

--- a/frontend/discourse/float-kit/lib/constants.ts
+++ b/frontend/discourse/float-kit/lib/constants.ts
@@ -357,6 +357,9 @@ export interface ToastOptions {
 
   /** A class added to the toast element. */
   class?: string;
+
+  /** Replaces any showing toast with the same key, so only the newest is kept. */
+  key?: string;
 }
 
 export const TOOLTIP: { options: TooltipOptions; portalOutletId: string } = {

--- a/frontend/discourse/float-kit/services/toasts.ts
+++ b/frontend/discourse/float-kit/services/toasts.ts
@@ -28,7 +28,8 @@ export default class Toasts extends Service {
    *
    * @param options - options passed to the toast component as its `@toast` argument;
    *   each field is documented on {@link ToastOptions}. When no `component` is given,
-   *   `DDefaultToast` is used.
+   *   `DDefaultToast` is used. Passing a `key` closes any toast already showing with
+   *   that key, so a repeated notification replaces itself instead of stacking.
    *
    * @returns the created toast instance.
    */
@@ -39,11 +40,27 @@ export default class Toasts extends Service {
       ...options,
     });
 
-    if (instance.isValidForView) {
-      this.activeToasts.push(instance);
+    if (!instance.isValidForView) {
+      return instance;
     }
 
+    if (instance.options.key) {
+      this.closeByKey(instance.options.key);
+    }
+
+    this.activeToasts.push(instance);
+
     return instance;
+  }
+
+  /**
+   * Close every showing toast that was created with `key`.
+   */
+  @action
+  closeByKey(key: string) {
+    this.activeToasts = trackedArray(
+      this.activeToasts.filter((activeToast) => activeToast.options.key !== key)
+    );
   }
 
   /**

--- a/frontend/discourse/tests/unit/services/toasts-test.js
+++ b/frontend/discourse/tests/unit/services/toasts-test.js
@@ -18,4 +18,22 @@ module("Unit | Service | Toasts", function (hooks) {
 
     assert.true(this.toasts.activeToasts.length < 2);
   });
+
+  test("key option replaces the toast sharing that key", function (assert) {
+    this.toasts.show({ key: "penalty", data: { text: "first" } });
+    this.toasts.show({ key: "other", data: { text: "untouched" } });
+    this.toasts.show({ key: "penalty", data: { text: "second" } });
+
+    assert.deepEqual(
+      this.toasts.activeToasts.map((toast) => toast.options.data.text),
+      ["untouched", "second"]
+    );
+  });
+
+  test("toasts without a key stack", function (assert) {
+    this.toasts.show({ data: { text: "first" } });
+    this.toasts.show({ data: { text: "second" } });
+
+    assert.strictEqual(this.toasts.activeToasts.length, 2);
+  });
 });

--- a/spec/system/review_author_penalty_spec.rb
+++ b/spec/system/review_author_penalty_spec.rb
@@ -79,6 +79,26 @@ describe "Review queue | author penalty" do
       expect(author.reload).to be_silenced
     end
 
+    it "keeps only the newest undo toast when several flags share an author" do
+      other_post = Fabricate(:post, user: author, topic: flagged_post.topic)
+      other_reviewable = PostActionCreator.spam(flagger, other_post).reviewable
+      other_post.update!(hidden: true, hidden_at: Time.zone.now)
+
+      page.visit("/review")
+
+      review_page.select_bundled_action(reviewable, "post-delete_and_agree", bundle_index: 1)
+      expect(page).to have_css(".fk-d-default-toast__title", text: "Post deleted.")
+
+      review_page.select_bundled_action(
+        other_reviewable,
+        "post-agree_and_keep_hidden",
+        bundle_index: 1,
+      )
+      expect(page).to have_css(".fk-d-default-toast__title", text: "Post kept hidden.")
+
+      expect(page).to have_css(".reviewable-undo-penalty", count: 1)
+    end
+
     it "offers an undo on that toast" do
       review_page.visit_reviewable(reviewable)
 


### PR DESCRIPTION
The toast naming a penalty an action left behind never closes on its own, because a moderation decision should not expire while it is being read. Working a run of flags raised against the same author therefore buried the screen under identical toasts, each still offering an undo — and every one after the first acted on a user who had already been reinstated.

Toasts can now carry a `key`. Showing one closes whatever is already showing under that key, so the review queue keeps a single toast per author, titled with the most recent decision. Toasts without a key stack as before.

A system spec acts on two flags against the same silenced author and asserts one undo survives; it finds two without the fix.