### PR TITLE
DEV: Let a signup flow add fields to the code-signup email step

### DIFF
--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -724,6 +724,14 @@ export default class CodeLoginForm extends Component {
             <field.Control autofocus="autofocus" autocomplete="username" />
           </form.Field>
 
+          {{! Lets a signup flow add its own fields to this form — an agreement
+          it needs accepted before the account exists, say — so they are
+          validated and submitted together with the email. }}
+          <PluginOutlet
+            @name="code-login-email-step-fields"
+            @outletArgs={{lazyHash form=form context=@context}}
+          />
+
           {{#if this.codeError}}
             <div class="code-login-form__error" aria-live="polite" role="alert">
               {{this.codeError}}


### PR DESCRIPTION
**Previously**, a signup flow could supply answers for the required signup user fields (#43145) but had nowhere to ask for them: the only extension point on the email step is the heading outlet, which sits outside the form, so a field added there could not be `required` — the Continue button belongs to core's form and never validated it.

**In this update**, a `code-login-email-step-fields` outlet inside that form yields the form-kit `form`, so a connector can add its own fields and have them validated and submitted along with the email. Core reads only `email` off the submitted data, so extra keys go no further.
