### PR TITLE
FIX: Preserve push subscription when DND is active on page load

### DIFF
--- a/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/frontend/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -86,7 +86,7 @@ class SubscribeUserNotificationsInit {
           this.router,
           this.appEvents
         );
-      } else {
+      } else if (!this.currentUser.isInDoNotDisturb()) {
         unsubscribePushNotifications(this.currentUser);
       }
     }


### PR DESCRIPTION
Previously, loading the site while Do Not Disturb was active would permanently destroy the user's push subscription, because `unsubscribePushNotifications` was called unconditionally whenever `isPushNotificationsEnabled` returned false.

This change skips the unsubscription when DND is the reason, since the server already suppresses push delivery during DND via `PostAlerter` — the client-side subscription never needed to be torn down.