### PR TITLE
DEV: Enforce blank lines between definitions

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -129,5 +129,5 @@ jobs:
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
+            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec spec --tag rails)
           done

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -129,5 +129,5 @@ jobs:
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec spec --tag rails)
+            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec "$GITHUB_WORKSPACE/migrations/$gem/spec" --tag rails)
           done

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -129,5 +129,5 @@ jobs:
         run: |
           for gem in core tooling converters importer; do
             echo "== migrations-$gem (Rails integration) =="
-            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec "$GITHUB_WORKSPACE/migrations/$gem/spec" --tag rails)
+            (cd "migrations/$gem" && LD_PRELOAD="$RUBY_ALLOCATOR" BUNDLE_GEMFILE="$GITHUB_WORKSPACE/Gemfile" bundle exec rspec --tag rails)
           done

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ inherit_mode:
   merge:
     - Exclude
 
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+
 # Still work to do in ensuring we don't link old files
 Discourse/NoAddReferenceOrAliasesActiveRecordMigration:
   Enabled: false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -320,6 +320,7 @@ module ApplicationHelper
   def is_crawler_homepage?
     request.path == "/" && use_crawler_layout?
   end
+
   # Creates open graph and twitter card meta data
   def crawlable_meta_data(opts = nil)
     opts ||= {}

--- a/app/serializers/email_log_serializer.rb
+++ b/app/serializers/email_log_serializer.rb
@@ -16,6 +16,7 @@ class EmailLogSerializer < ApplicationSerializer
     return if object.cc_addresses.blank?
     object.cc_addresses_split
   end
+
   def include_reply_key?
     reply_keys = @options[:reply_keys]
     reply_keys.present? && reply_keys[[object.post_id, object.user_id]]

--- a/db/migrate/20251107123438_add_index_to_tag_groups.rb
+++ b/db/migrate/20251107123438_add_index_to_tag_groups.rb
@@ -10,6 +10,7 @@ class AddIndexToTagGroups < ActiveRecord::Migration[8.0]
 
     add_index :tag_groups, "lower(name)", unique: true
   end
+
   def down
     raise ActiveRecord::IrreversibleMigration
   end

--- a/lib/schema_settings_object_validator.rb
+++ b/lib/schema_settings_object_validator.rb
@@ -128,6 +128,7 @@ class SchemaSettingsObjectValidator
       @errors.map(&:error_message)
     end
   end
+
   class SchemaSettingsObjectError
     def initialize(error, i18n_opts = {})
       @error = error

--- a/migrations/core/lib/migrations/settings_parser.rb
+++ b/migrations/core/lib/migrations/settings_parser.rb
@@ -4,6 +4,7 @@ module Migrations
   class SettingsParser
     class InvalidYaml < StandardError
     end
+
     class ValidationError < StandardError
     end
 

--- a/migrations/core/spec/lib/common/reporting/factory_spec.rb
+++ b/migrations/core/spec/lib/common/reporting/factory_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Migrations::Reporting::Factory do
       def io.tty?
         true
       end
+
       def io.winsize
         [24, 80]
       end

--- a/migrations/core/spec/spec_setup.rb
+++ b/migrations/core/spec/spec_setup.rb
@@ -50,6 +50,7 @@ module MigrationsSpecSetup
   # `disco` binary does before loading the Rails environment.
   def self.boot_rails(spec_dir)
     rails_root = File.expand_path("../../..", spec_dir)
+    RSpec.configuration.files_to_run
     Dir.chdir(rails_root) { require File.join(rails_root, "spec", "rails_helper") }
   end
 

--- a/migrations/importer/lib/migrations/importer/uploads/site_settings.rb
+++ b/migrations/importer/lib/migrations/importer/uploads/site_settings.rb
@@ -37,6 +37,7 @@ module Migrations
             def self.current_db_override=(value)
               @current_db_override = value
             end
+
             def self.current_db
               @current_db_override
             end

--- a/migrations/tooling/scripts/benchmarks/ipc_serialization.rb
+++ b/migrations/tooling/scripts/benchmarks/ipc_serialization.rb
@@ -75,6 +75,7 @@ module Codecs
     def dump(data)
       Oj.dump(data, OJ_OBJECT_SETTINGS)
     end
+
     def load(string)
       Oj.load(string, OJ_OBJECT_SETTINGS)
     end
@@ -82,6 +83,7 @@ module Codecs
     def write(io, data)
       Oj.to_stream(io, data, OJ_OBJECT_SETTINGS)
     end
+
     def each(io, &)
       Oj.load(io, OJ_OBJECT_SETTINGS, &)
     end
@@ -95,6 +97,7 @@ module Codecs
     def dump(data)
       Oj.dump(data, OJ_COMPAT_DUMP_SETTINGS)
     end
+
     def load(string)
       Oj.load(string, OJ_COMPAT_LOAD_SETTINGS)
     end
@@ -102,6 +105,7 @@ module Codecs
     def write(io, data)
       Oj.to_stream(io, data, OJ_COMPAT_DUMP_SETTINGS)
     end
+
     def each(io, &)
       Oj.load(io, OJ_COMPAT_LOAD_SETTINGS, &)
     end
@@ -117,6 +121,7 @@ module Codecs
     def dump(data)
       Oj.dump(data, OJ_STRICT_DUMP_SETTINGS)
     end
+
     def load(string)
       Oj.load(string, OJ_STRICT_LOAD_SETTINGS)
     end
@@ -124,6 +129,7 @@ module Codecs
     def write(io, data)
       Oj.to_stream(io, data, OJ_STRICT_DUMP_SETTINGS)
     end
+
     def each(io, &)
       Oj.load(io, OJ_STRICT_LOAD_SETTINGS, &)
     end
@@ -137,6 +143,7 @@ module Codecs
     def dump(data)
       JSON.generate(data)
     end
+
     def load(string)
       JSON.parse(string, symbolize_names: true)
     end
@@ -160,6 +167,7 @@ module Codecs
     def dump(data)
       ::Marshal.dump(data)
     end
+
     def load(string)
       ::Marshal.load(string)
     end
@@ -184,6 +192,7 @@ module Codecs
     def dump(data)
       MessagePack.pack(data)
     end
+
     def load(string)
       MessagePack.unpack(string, symbolize_keys: true)
     end

--- a/plugins/automation/db/migrate/20250307031538_migrate_category_to_categories_post_created.rb
+++ b/plugins/automation/db/migrate/20250307031538_migrate_category_to_categories_post_created.rb
@@ -33,6 +33,7 @@ class MigrateCategoryToCategoriesPostCreated < ActiveRecord::Migration[7.2]
       AND a.trigger = 'post_created_edited'
     SQL
   end
+
   def down
     raise ActiveRecord::IrreversibleMigration
   end

--- a/plugins/discourse-ai/lib/agents/artifact_update_strategies/base.rb
+++ b/plugins/discourse-ai/lib/agents/artifact_update_strategies/base.rb
@@ -4,6 +4,7 @@ module DiscourseAi
     module ArtifactUpdateStrategies
       class InvalidFormatError < StandardError
       end
+
       class Base
         attr_reader :post,
                     :user,

--- a/plugins/discourse-ai/lib/utils/diff_utils/simple_diff.rb
+++ b/plugins/discourse-ai/lib/utils/diff_utils/simple_diff.rb
@@ -8,6 +8,7 @@ module DiscourseAi
 
         class Error < StandardError
         end
+
         class NoMatchError < Error
         end
 

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/slack/slack_transcript.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/slack/slack_transcript.rb
@@ -75,6 +75,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
     def first_message_number
       @first_message_index < 0 ? @messages.length + @first_message_index : @first_message_index
     end
+
     def last_message_number
       @last_message_index < 0 ? @messages.length + @last_message_index : @last_message_index
     end

--- a/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
+++ b/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
@@ -12,6 +12,7 @@ module OmniAuth
     class OpenIDConnect < OmniAuth::Strategies::OAuth2
       class NonceVerifyError < StandardError
       end
+
       class SubVerifyError < StandardError
       end
 

--- a/script/bulk_import/uploads_importer.rb
+++ b/script/bulk_import/uploads_importer.rb
@@ -27,6 +27,7 @@ module BulkImport
   class UploadsImporter
     class DownloadFailedError < StandardError
     end
+
     class UploadSizeExceededError < DownloadFailedError
     end
 
@@ -777,6 +778,7 @@ module BulkImport
           def self.current_db_override=(value)
             @current_db_override = value
           end
+
           def self.current_db
             @current_db_override
           end

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -1255,6 +1255,7 @@ RSpec.describe Admin::DashboardController do
     let(:fake_provider) do
       Class.new(AdminDashboard::Reports::SourceProvider) do
         def self.source_name = "fake_source"
+
         def self.fetch_many(identifiers, guardian:, filters: {})
           identifiers.each_with_object({}) do |id, h|
             h[id.to_s] = { id: id.to_s, filters: filters }
@@ -1266,6 +1267,7 @@ RSpec.describe Admin::DashboardController do
     let(:raising_provider) do
       Class.new(AdminDashboard::Reports::SourceProvider) do
         def self.source_name = "raising_source"
+
         def self.fetch_many(identifiers, guardian:, filters: {})
           identifiers.each_with_object({}) do |id, h|
             raise "boom" if id == "broken"
@@ -2329,6 +2331,7 @@ RSpec.describe Admin::DashboardController do
       Class.new(AdminDashboard::Reports::SourceProvider) do
         def self.source_name = "fake_source"
         def self.label = "Fake"
+
         def self.accessible_ids(identifiers, guardian:)
           identifiers.map(&:to_s).reject { |id| id == "forbidden" }.to_set
         end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -5,6 +5,7 @@ module Helpers
 
   class NotAThemeError < StandardError
   end
+
   class NotAComponentThemeError < StandardError
   end
 

--- a/spec/system/page_objects/components/private_message_map.rb
+++ b/spec/system/page_objects/components/private_message_map.rb
@@ -32,6 +32,7 @@ module PageObjects
       def has_no_add_participants_button?
         controls.has_no_button?(class: "add-participant-btn")
       end
+
       def click_add_participants_button
         controls.click_button(class: "add-participant-btn")
       end


### PR DESCRIPTION
This PR enables the `Layout/EmptyLineBetweenDefs` RuboCop rule.