### PR TITLE
UX: Change min scale for composer image resize to 25%

### DIFF
--- a/frontend/discourse/app/static/prosemirror/components/image-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/image-node-view.gjs
@@ -17,7 +17,7 @@ import ImageAltTextInput from "./image-alt-text-input";
 
 const PLACEHOLDER_CLASSES = ["upload-placeholder", "--image"];
 
-const MIN_SCALE = 50;
+const MIN_SCALE = 25;
 const MAX_SCALE = 100;
 const SCALE_STEP = 25;
 


### PR DESCRIPTION
Some images are still quite big at 50%, so this adds an extra
step down in size
