### PR TITLE
FIX: Render recurring event labels after expiry

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/lib/event-recurrence.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/lib/event-recurrence.js
@@ -2,11 +2,32 @@ import { i18n } from "discourse-i18n";
 
 const ORDINALS = ["first", "second", "third", "fourth"];
 
+function recurrenceStartFromRrule(rrule) {
+  return rrule?.match(/^DTSTART(?:;[^:]*)?:(\d{8}(?:T\d{6}Z?)?)$/m)?.[1];
+}
+
 export function recurrenceRef(event) {
-  if (event.allDay) {
-    return moment(event.startsAt, "YYYY-MM-DD");
+  if (event.startsAt) {
+    if (event.allDay) {
+      return moment(event.startsAt, "YYYY-MM-DD");
+    }
+
+    return moment(event.startsAt).tz(event.timezone || "UTC");
   }
-  return moment(event.startsAt).tz(event.timezone || "UTC");
+
+  const recurrenceStart = recurrenceStartFromRrule(event.rrule);
+
+  if (event.allDay) {
+    return moment(recurrenceStart?.slice(0, 8), "YYYYMMDD");
+  }
+
+  if (recurrenceStart?.endsWith("Z")) {
+    return moment
+      .utc(recurrenceStart, "YYYYMMDDTHHmmss[Z]")
+      .tz(event.timezone || "UTC");
+  }
+
+  return moment.tz(recurrenceStart, "YYYYMMDDTHHmmss", event.timezone || "UTC");
 }
 
 export function recurrenceContext(ref) {

--- a/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -173,6 +173,50 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
       .hasText("Every Thursday", "uses the date's weekday, not the prior day");
   });
 
+  test("renders the recurrence weekday for an expired recurring event with no current date", async function (assert) {
+    const event = buildEvent({
+      recurrence: "every_week",
+      all_day: true,
+      is_expired: true,
+      starts_at: null,
+      ends_at: null,
+      rrule:
+        "DTSTART:20260820T000000Z\nRRULE:FREQ=WEEKLY;BYDAY=TH;UNTIL=20260827T235900;INTERVAL=1;WKST=MO",
+    });
+
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "Every Thursday",
+        "uses the original recurrence date instead of rendering an invalid weekday"
+      );
+  });
+
+  test("renders the monthly recurrence label for an expired timed event with no current date", async function (assert) {
+    const event = buildEvent({
+      recurrence: "every_month",
+      is_expired: true,
+      starts_at: null,
+      ends_at: null,
+      timezone: "Europe/London",
+      show_local_time: true,
+      rrule: "DTSTART:20260226T180000\nRRULE:FREQ=MONTHLY;INTERVAL=1;WKST=MO",
+    });
+
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "The fourth Thursday of every month",
+        "uses the original timed recurrence date for the monthly label"
+      );
+  });
+
   test("labels a fourth weekday as fourth even when the month has no fifth", async function (assert) {
     // 2026-02-26 is both the fourth and the final Thursday of February
     stubApi.call(


### PR DESCRIPTION
## Summary

Fixes recurring Event labels rendering `Every Invalid date` after a bounded recurrence has expired.

When the final occurrence of a recurring Event has passed, `starts_at` can be `nil` while the Event still retains its recurrence and serialized RRULE. The recurrence label was deriving its weekday from the missing `starts_at`, resulting in an invalid Moment date.

This change falls back to the original `DTSTART` contained in the serialized RRULE when there is no current `startsAt`.

Existing behavior is unchanged while a current occurrence is available.

## Tests

Added coverage for:

- an expired all-day weekly Event with no current occurrence
- an expired timed monthly Event using the fourth weekday of the month

Manual smoke testing also covered:

- the original all-day weekly reproduction
- a timed weekly Event in `Europe/London`
- a timed fourth-Thursday monthly Event

The broader discourse-events JavaScript run completed with:

> 274 tests, 273 passed, 1 skipped, 0 failed

The focused expired-event tests pass with no deprecation warnings.

Also verified with Prettier, ESLint, and `git diff --check`.
