### PR TITLE
DEV: Preserve leading trivia when dts-generator replaces a node

### DIFF
--- a/frontend/discourse-types/dts-generator.ts
+++ b/frontend/discourse-types/dts-generator.ts
@@ -104,6 +104,8 @@ function processTree(
     const replacement = replacer(node);
 
     if (replacement != null) {
+      const start = node.getStart(sourceFile);
+      code += sourceFile.text.slice(cursorPosition, start);
       code += replacement;
       skip(node);
     } else {


### PR DESCRIPTION
processTree() in dts-generator (used to bundle each vendored package's .d.ts into @discourse/types) replaces certain nodes, like the `declare` keyword, with an empty string. TypeScript scans a node's `pos` to include its leading trivia (blank lines, comments), but skip() jumps straight to `node.end` on replacement, so that trivia got silently deleted along with the token being replaced.

This surfaced concretely in @floating-ui/dom's type declarations, where `export { Axis }` was immediately followed by a blank line and `declare type BivariantCallback = ...`. Removing `declare` also removed the blank line, merging the two statements onto a single line and producing invalid TypeScript in the generated external-types/floating-ui__dom/index.d.ts (confirmed by PR #43280, which bumped to a build containing this and failed `pnpm lint:types` with `TS1005: ';' expected`).

The fix emits the node's leading trivia before applying the replacement, so only the token itself is swallowed.