### PR TITLE
DEV: Group @warp-drive/* dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,6 +108,9 @@ updates:
       uppy:
         patterns:
           - "@uppy*"
+      warp-drive:
+        patterns:
+          - "@warp-drive/*"
       fullcalendar:
         patterns:
           - "@fullcalendar/*"


### PR DESCRIPTION
Adds a dependabot group for @warp-drive/* npm packages, following the same pattern as the existing embroider, codemirror, and uppy groups, so their version bumps land in a single PR instead of one per package.