### PR TITLE
FIX: Refresh event dates in topic lists

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/components/event-date.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/event-date.gjs
@@ -4,6 +4,7 @@ import { i18n } from "discourse-i18n";
 import guessDateFormat from "../lib/guess-best-date-format";
 
 export default class EventDate extends Component {
+  @service a11y;
   @service siteSettings;
 
   <template>
@@ -66,11 +67,16 @@ export default class EventDate extends Component {
     return this._formattedDate(this.eventStartedAt);
   }
 
+  get now() {
+    this.a11y.autoUpdatingRelativeDateRef;
+    return Date.now();
+  }
+
   get relativeDateType() {
     if (this.isWithinDateRange) {
       return "current";
     }
-    if (this.eventStartedAt.isAfter(moment())) {
+    if (this.eventStartedAt.isAfter(this.now)) {
       return "future";
     }
     return "past";
@@ -78,23 +84,23 @@ export default class EventDate extends Component {
 
   get isWithinDateRange() {
     return (
-      this.eventStartedAt.isBefore(moment()) &&
-      this.eventEndedAt.isAfter(moment())
+      this.eventStartedAt.isBefore(this.now) &&
+      this.eventEndedAt.isAfter(this.now)
     );
   }
 
   get relativeDateContent() {
     // dateType "current" uses a different implementation
     const relativeDates = {
-      future: this.eventStartedAt.from(moment()),
-      past: this.eventEndedAt.from(moment()),
+      future: this.eventStartedAt.from(this.now),
+      past: this.eventEndedAt.from(this.now),
     };
     return relativeDates[this.relativeDateType];
   }
 
   get timeRemainingContent() {
     return i18n("discourse_post_event.topic_title.ends_in_duration", {
-      duration: this.eventEndedAt.from(moment()),
+      duration: this.eventEndedAt.from(this.now),
     });
   }
 

--- a/plugins/discourse-events/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
@@ -198,8 +198,19 @@ export default {
 
   initialize(container) {
     const siteSettings = container.lookup("service:site-settings");
-    if (siteSettings.discourse_post_event_enabled) {
-      withPluginApi(initializeDiscoursePostEventDecorator);
-    }
+
+    withPluginApi((api) => {
+      api.addTrackedTopicProperties(
+        "event_starts_at",
+        "event_ends_at",
+        "event_all_day",
+        "event_timezone",
+        "event_show_local_time"
+      );
+
+      if (siteSettings.discourse_post_event_enabled) {
+        initializeDiscoursePostEventDecorator(api);
+      }
+    });
   },
 };

--- a/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
+++ b/plugins/discourse-events/jobs/scheduled/monitor_event_dates.rb
@@ -52,6 +52,7 @@ module Jobs
 
         return if event_date.event.recurrence.blank?
         event_date.event.set_next_date
+        TopicTrackingState.publish_latest(event_date.event.post.topic)
         event_date.event.set_topic_bump
       end
 

--- a/plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb
+++ b/plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb
@@ -174,6 +174,18 @@ describe Jobs::DiscourseCalendar::MonitorEventDates do
       )
     end
 
+    it "publishes a latest update when a recurring event advances" do
+      past_event.update!(recurrence: "every_week")
+
+      freeze_time 8.days.after
+
+      allow(TopicTrackingState).to receive(:publish_latest)
+
+      job.execute({})
+
+      expect(TopicTrackingState).to have_received(:publish_latest).with(past_event.post.topic)
+    end
+
     it "does not process closed events" do
       past_event.update!(recurrence: "every_week", closed: true)
       initial_event_date = past_event.event_dates.first

--- a/plugins/discourse-events/test/javascripts/integration/components/event-date-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/event-date-test.gjs
@@ -1,4 +1,5 @@
-import { render } from "@ember/test-helpers";
+import { getOwner } from "@ember/owner";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
@@ -85,6 +86,71 @@ module("Integration | Component | EventDate", function (hooks) {
         "title",
         /February 2, 2026.*5:00 PM/,
         "displays date in browser timezone (Harare) when no event timezone"
+      );
+  });
+
+  test("updates as time passes without topic changes", async function (assert) {
+    this.siteSettings.use_local_event_date = false;
+    moment.tz.guess = () => "UTC";
+    this.clock = fakeTime("2026-09-04T13:12:00Z", "UTC", true);
+
+    const topic = {
+      event_starts_at: "2026-09-04T13:11:00.000Z",
+      event_ends_at: "2026-09-04T13:13:00.000Z",
+    };
+
+    await render(<template><EventDate @topic={{topic}} /></template>);
+
+    assert
+      .dom(".event-relative-date.current")
+      .exists("shows the event as current before it ends");
+
+    this.clock.tick(2 * 60 * 1000);
+    getOwner(this).lookup("service:a11y").autoUpdatingRelativeDateRef =
+      new Date();
+
+    await settled();
+
+    assert
+      .dom(".event-relative-date.past")
+      .exists("updates to past after the event ends");
+  });
+
+  test("updates when topic event dates are rehydrated", async function (assert) {
+    moment.tz.guess = () => "UTC";
+    this.clock = fakeTime("2026-09-04T12:28:00Z", "UTC", true);
+
+    const store = getOwner(this).lookup("service:store");
+    const topic = store.createRecord("topic", {
+      id: 1234,
+      event_starts_at: "2026-09-04T11:25:00.000Z",
+      event_ends_at: "2026-09-04T11:27:00.000Z",
+    });
+
+    await render(<template><EventDate @topic={{topic}} /></template>);
+
+    assert
+      .dom(".event-date")
+      .hasAttribute(
+        "title",
+        /September 4, 2026/,
+        "shows the initial event date"
+      );
+
+    store.createRecord("topic", {
+      id: 1234,
+      event_starts_at: "2026-09-11T11:25:00.000Z",
+      event_ends_at: "2026-09-11T11:27:00.000Z",
+    });
+
+    await settled();
+
+    assert
+      .dom(".event-date")
+      .hasAttribute(
+        "title",
+        /September 11, 2026/,
+        "rerenders when the existing topic is rehydrated"
       );
   });
 


### PR DESCRIPTION
## What changed

Event date badges in topic lists could become stale in two ways:

- relative labels such as `in a minute`, `Ends in a minute`, or `a minute ago` did not rerender as time passed unless something else caused the component to update;
- when a recurring event advanced to its next occurrence, `/latest` did not publish an update for the topic, and the existing Topic model did not track the event date fields needed to rerender after rehydration.

This change:

- makes `EventDate` consume Discourse's existing once-per-minute `a11y.autoUpdatingRelativeDateRef`, so future/current/past relative labels update as time passes without adding another timer;
- registers the event date/topic fields as tracked Topic properties so rehydrating an existing topic updates the badge;
- publishes a latest-topic update after a recurring event advances to its next date, while leaving non-recurring event completion unchanged.

## Tests

Automated:

- `bin/qunit --standalone plugins/discourse-events/test/javascripts/integration/components/event-date-test.gjs` — 274 tests, 273 passed, 1 skipped, 0 failed
- `bin/rspec plugins/discourse-events/spec/jobs/scheduled/monitor_event_dates_spec.rb` — 9 examples, 0 failures
- Prettier, ESLint, RuboCop, Syntax Tree and `git diff --check` pass

Manual GUI smoke tests:

- a non-recurring event updated automatically from pre-event relative time to the active `Ends in …` state, then to past relative time, and continued updating each minute without a page refresh;

- a recurring event advanced through the same future/current/past states, then showed Discourse's normal `See 1 new or updated topic` notice after rollover; loading that update changed the badge to the next weekly occurrence (`in 7 days`) without a full page refresh.
