### PR TITLE
DEV: Update pnpm minimumReleaseAge settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,6 +76,7 @@ updates:
       default-days: 7
       exclude:
         - "@discourse/*"
+        - "discourse" # npm alias for @discourse/types in plugins
     open-pull-requests-limit: 40
     versioning-strategy: increase
     ignore:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,10 @@ ignoredBuiltDependencies:
 - "@zoom/meetingsdk"
 - core-js
 - rete
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+- "@discourse/*"
+- discourse
 packages:
 - "docs/developer-guides"
 - "frontend/deprecation-silencer"


### PR DESCRIPTION
- Match pnpm setting to dependabot, so we get the same behavior regardless of update mechanism
- Add exception for `discourse`, which is the internal alias for `@discourse/types`

This should get dependabot working again since we bumped `@discourse/types`