### PR TITLE
DEV: Remove the post event format filter

### DIFF
--- a/plugins/discourse-events/app/controllers/discourse_events/events_controller.rb
+++ b/plugins/discourse-events/app/controllers/discourse_events/events_controller.rb
@@ -200,7 +200,6 @@ module DiscourseEvents
         :tags,
         :search,
         :status,
-        :event_format,
         tags: [],
       )
     end

--- a/plugins/discourse-events/lib/discourse_events/events/finder.rb
+++ b/plugins/discourse-events/lib/discourse_events/events/finder.rb
@@ -15,7 +15,6 @@ module DiscourseEvents
           .then { |query| filter_by_tags(query, params, guardian) }
           .then { |query| filter_by_search(query, params) }
           .then { |query| filter_by_status(query, params) }
-          .then { |query| filter_by_format(query, params) }
           .then { |query| apply_ordering(query, params) }
           .then { |query| apply_limit(query, params) }
       end
@@ -252,21 +251,6 @@ module DiscourseEvents
         return events.none if statuses.empty?
 
         events.where(status: statuses)
-      end
-
-      def self.filter_by_format(events, params)
-        case params[:event_format]
-        when nil, ""
-          events
-        when "virtual"
-          events.where.not(url: nil).where(location: [nil, ""])
-        when "in_person"
-          events.where(url: [nil, ""]).where.not(location: nil).where.not(location: "")
-        when "hybrid"
-          events.where.not(url: [nil, ""]).where.not(location: [nil, ""])
-        else
-          events.none
-        end
       end
 
       def self.apply_ordering(events, params)

--- a/plugins/discourse-events/spec/requests/api/events_spec.rb
+++ b/plugins/discourse-events/spec/requests/api/events_spec.rb
@@ -132,15 +132,6 @@ RSpec.describe "events" do
                 },
                 description: "Filter by event attendance status"
 
-      parameter name: :event_format,
-                in: :query,
-                required: false,
-                schema: {
-                  type: :string,
-                  enum: %w[virtual in_person hybrid],
-                },
-                description: "Filter by whether the event has a URL, location, or both"
-
       produces "application/json"
 
       response "200", "success response (basic)" do

--- a/plugins/discourse-events/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-events/spec/requests/events_controller_spec.rb
@@ -132,7 +132,7 @@ module DiscourseEvents::Events
         expect(response.parsed_body["events"]).not_to be_empty
       end
 
-      it "filters by tags, text, status, and format" do
+      it "filters by tags, text, and status" do
         tag = Fabricate(:tag, name: "launch")
         tagged_event =
           Fabricate(
@@ -149,13 +149,6 @@ module DiscourseEvents::Events
             status: DiscourseEvents::Events::Event.statuses[:private],
             url: "https://example.com/meeting",
           )
-        hybrid_event =
-          Fabricate(
-            :event,
-            original_starts_at: 3.days.from_now,
-            url: "https://example.com/meeting",
-            location: "Room 6",
-          )
 
         get "/discourse-post-event/events.json", params: { tags: [tag.name] }
         expect(response.parsed_body["events"].pluck("id")).to contain_exactly(tagged_event.id)
@@ -165,9 +158,6 @@ module DiscourseEvents::Events
 
         get "/discourse-post-event/events.json", params: { status: "private" }
         expect(response.parsed_body["events"].pluck("id")).to contain_exactly(private_event.id)
-
-        get "/discourse-post-event/events.json", params: { event_format: "hybrid" }
-        expect(response.parsed_body["events"].pluck("id")).to contain_exactly(hybrid_event.id)
       end
 
       it "should return events in ics format" do


### PR DESCRIPTION
Previously, the events finder could filter events by whether they had a URL, a location, or both, exposed as the `event_format` parameter added in #43131.

We are still figuring how should we define the event_format