### PR TITLE
DEV: Restore the playwright browser install step in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -298,6 +298,10 @@ jobs:
           name: ember-exam-execution-${{ matrix.target }}-${{ matrix.browser }}-frontend-${{ hashFiles('./frontend/discourse/test-execution-*.json') }}
           path: ./frontend/discourse/test-execution-*.json
 
+      - name: Install playwright
+        if: matrix.build_type == 'system'
+        run: pnpm playwright-install
+
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:


### PR DESCRIPTION
PR #40214 dropped this step to avoid re-downloading Chromium on every system test job, since the discourse_test image already bakes in a matching browser. That assumption breaks whenever package.json bumps the playwright version ahead of the image: the pinned npm package then expects a browser revision the image doesn't have, and every system test fails with "Executable doesn't exist".

`playwright install` already skips browsers it finds already present for the current version, so restoring the step costs nothing when the image is in sync and downloads the right browser when it isn't.