### PR TITLE
DEV: Add value helpers to `ContentLocalization`

### DIFF
--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -34,12 +34,8 @@ class BasicPostSerializer < ApplicationSerializer
         I18n.t("flagging.user_must_edit")
       end
     else
-      cooked = object.filter_quotes(@parent_post)
-
-      translated_cooked =
-        object.get_localization&.cooked if ContentLocalization.show_translated_post?(object, scope)
-
-      translated_cooked || cooked
+      ContentLocalization.translated_post_cooked(object, scope) ||
+        object.filter_quotes(@parent_post)
     end
   end
 

--- a/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
+++ b/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
@@ -45,7 +45,6 @@ module LocalizedFancyTopicTitleMixin
   end
 
   def translated_title
-    ContentLocalization.show_translated_topic?(_topic, scope) &&
-      _topic.get_localization&.fancy_title.presence
+    ContentLocalization.translated_topic_fancy_title(_topic, scope)
   end
 end

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -11,10 +11,6 @@ class ContentLocalization
     automatically_translate_anonymously?(scope&.request&.cookies)
   end
 
-  def self.show_original?(scope)
-    !automatically_translate?(scope)
-  end
-
   # @param cookies [ActionDispatch::Cookies::CookieJar, Hash]
   # @return [Boolean]
   def self.automatically_translate_anonymously?(cookies)
@@ -39,8 +35,14 @@ class ContentLocalization
   # @param post [Post] The post object
   # @return [Boolean]
   def self.show_translated_post?(post, scope)
-    SiteSetting.content_localization_enabled && post.raw.present? && post.locale.present? &&
+    SiteSetting.content_localization_enabled && post&.raw.present? && post.locale.present? &&
       !post.in_user_locale? && automatically_translate?(scope) && !understands?(post.locale, scope)
+  end
+
+  def self.translated_post_cooked(post, scope)
+    return if !show_translated_post?(post, scope)
+
+    post.get_localization&.cooked.presence
   end
 
   # This method returns true when we should try to show the translated topic.
@@ -48,8 +50,20 @@ class ContentLocalization
   # @param topic [Topic] The topic record
   # @return [Boolean]
   def self.show_translated_topic?(topic, scope)
-    SiteSetting.content_localization_enabled && topic.locale.present? && !topic.in_user_locale? &&
+    SiteSetting.content_localization_enabled && topic&.locale.present? && !topic.in_user_locale? &&
       automatically_translate?(scope) && !understands?(topic.locale, scope)
+  end
+
+  def self.translated_topic_title(topic, scope)
+    return if !show_translated_topic?(topic, scope)
+
+    topic.get_localization&.title.presence
+  end
+
+  def self.translated_topic_fancy_title(topic, scope)
+    return if !show_translated_topic?(topic, scope)
+
+    topic.get_localization&.fancy_title.presence
   end
 
   # This method returns true when we should try to show the translated category.

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -170,6 +170,42 @@ describe ContentLocalization do
     end
   end
 
+  describe "translated value helpers" do
+    fab!(:post)
+
+    before do
+      SiteSetting.content_localization_enabled = true
+      post.topic.update!(locale: "ja")
+      post.update!(locale: "ja")
+      I18n.locale = "de"
+    end
+
+    it "returns the localization, or nil when there is none or no record" do
+      scope = create_scope
+
+      expect(ContentLocalization.translated_post_cooked(post, scope)).to be_nil
+      expect(ContentLocalization.translated_topic_title(post.topic, scope)).to be_nil
+      expect(ContentLocalization.translated_post_cooked(nil, scope)).to be_nil
+      expect(ContentLocalization.translated_topic_title(nil, scope)).to be_nil
+
+      Fabricate(:post_localization, post: post, locale: "de", cooked: "<p>uebersetzt</p>")
+      Fabricate(
+        :topic_localization,
+        topic: post.topic,
+        locale: "de",
+        title: "Titel",
+        fancy_title: "Fancy Titel",
+      )
+      post.reload.topic.reload
+
+      expect(ContentLocalization.translated_post_cooked(post, scope)).to eq("<p>uebersetzt</p>")
+      expect(ContentLocalization.translated_topic_title(post.topic, scope)).to eq("Titel")
+      expect(ContentLocalization.translated_topic_fancy_title(post.topic, scope)).to eq(
+        "Fancy Titel",
+      )
+    end
+  end
+
   describe ".show_translated_category?" do
     fab!(:category)
 


### PR DESCRIPTION
First of a stack fixing content localization on the surfaces that summarise a post or a topic outside its own page.

`ContentLocalization` only answered "should this viewer see a translation?". Every caller then had to remember the second half — fetch the localization, guard against a blank field, fall back to the original — and that half was open-coded at each site, so it drifted. Adding a localized surface meant reproducing four lines correctly rather than making one call.

This pairs each gate with a helper returning the translated value, or `nil` when the original should be shown, and moves the two existing hand-rolled copies onto them.

The `nil`-returning shape is deliberate rather than returning the display value directly: callers fall back to things the helper cannot know (a quote-filtered `cooked`, a raw SQL column), and `fancy_title_localized` needs to tell "translated" apart from "same string".

Also makes both gates nil-tolerant, since several callers hold a nullable topic, and drops `show_original?`, which lost its last caller when category description localization moved into the serializer.

No behaviour change.