### PR TITLE
FIX: Localize post excerpts wherever `PostItemExcerpt` renders them

### DIFF
--- a/app/serializers/post_item_excerpt.rb
+++ b/app/serializers/post_item_excerpt.rb
@@ -6,7 +6,9 @@ module PostItemExcerpt
   end
 
   def cooked
-    @cooked ||= object.cooked || PrettyText.cook(object.raw)
+    @cooked ||=
+      ContentLocalization.translated_post_cooked(excerpt_source_post, scope) ||
+        excerpt_source_post&.cooked || object.cooked || PrettyText.cook(object.raw)
   end
 
   def excerpt
@@ -33,8 +35,16 @@ module PostItemExcerpt
 
   private
 
+  def post_item_excerpt_post
+    nil
+  end
+
+  def excerpt_source_post
+    post_item_excerpt_post || (object if object.is_a?(Post))
+  end
+
   def can_see_post_item_excerpt?
-    return true if !respond_to?(:post_item_excerpt_post) || post_item_excerpt_post.blank?
+    return true if post_item_excerpt_post.blank?
     scope&.can_see_post?(post_item_excerpt_post)
   end
 end

--- a/app/serializers/user_bookmark_base_serializer.rb
+++ b/app/serializers/user_bookmark_base_serializer.rb
@@ -24,10 +24,6 @@ class UserBookmarkBaseSerializer < ApplicationSerializer
     raise NotImplementedError
   end
 
-  def cooked
-    raise NotImplementedError
-  end
-
   def bookmarkable_url
     raise NotImplementedError
   end

--- a/app/serializers/user_post_bookmark_serializer.rb
+++ b/app/serializers/user_post_bookmark_serializer.rb
@@ -21,10 +21,6 @@ class UserPostBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
     post.raw
   end
 
-  def cooked
-    post.cooked
-  end
-
   def post_item_excerpt_post
     post
   end

--- a/app/serializers/user_topic_bookmark_serializer.rb
+++ b/app/serializers/user_topic_bookmark_serializer.rb
@@ -26,10 +26,6 @@ class UserTopicBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
     first_post.raw
   end
 
-  def cooked
-    first_post.cooked
-  end
-
   def post_item_excerpt_post
     first_post
   end

--- a/plugins/discourse-solved/app/serializers/discourse_solved/solved_post_serializer.rb
+++ b/plugins/discourse-solved/app/serializers/discourse_solved/solved_post_serializer.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class DiscourseSolved::SolvedPostSerializer < ApplicationSerializer
+  include PostItemExcerpt
+
   attributes :created_at,
              :archived,
              :avatar_template,
              :category_id,
              :closed,
              :cooked,
-             :excerpt,
              :name,
              :post_id,
              :post_number,
@@ -16,7 +17,6 @@ class DiscourseSolved::SolvedPostSerializer < ApplicationSerializer
              :slug,
              :topic_id,
              :topic_title,
-             :truncated,
              :url,
              :user_id,
              :username
@@ -35,10 +35,6 @@ class DiscourseSolved::SolvedPostSerializer < ApplicationSerializer
 
   def closed
     object.topic.closed
-  end
-
-  def excerpt
-    @excerpt ||= PrettyText.excerpt(cooked, 300, keep_emoji_images: true)
   end
 
   def name
@@ -63,14 +59,6 @@ class DiscourseSolved::SolvedPostSerializer < ApplicationSerializer
 
   def topic_title
     object.topic.fancy_title
-  end
-
-  def truncated
-    true
-  end
-
-  def include_truncated?
-    cooked.length > 300
   end
 
   def url

--- a/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
@@ -24,6 +24,19 @@ describe DiscourseSolved::SolvedTopicsController do
         expect(result["user_solved_posts"][0]["post_id"]).to eq(answer_post.id)
       end
 
+      it "returns the translated excerpt" do
+        viewer = Fabricate(:user, locale: "ja")
+        SiteSetting.content_localization_enabled = true
+        answer_post.update!(raw: "Original answer body", locale: "en")
+        Fabricate(:post_localization, post: answer_post, locale: "ja", cooked: "<p>翻訳された回答</p>")
+
+        sign_in(viewer)
+        get "/solution/by_user.json", params: { username: user.username }
+
+        solved_post = response.parsed_body["user_solved_posts"][0]
+        expect(solved_post["excerpt"]).to eq("翻訳された回答")
+      end
+
       it "returns escaped topic_title" do
         topic.update_columns(title: "<script>alert('xss')</script> test", fancy_title: nil)
         sign_in(user)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -804,6 +804,19 @@ RSpec.describe GroupsController do
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
+    it "returns the translated excerpt" do
+      viewer = Fabricate(:user, locale: "ja")
+      SiteSetting.content_localization_enabled = true
+      post = Fabricate(:post, user: user, raw: "Original group post body", locale: "en")
+      Fabricate(:post_localization, post: post, locale: "ja", cooked: "<p>翻訳された本文</p>")
+
+      sign_in(viewer)
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].first["excerpt"]).to eq("翻訳された本文")
+    end
+
     it "omits hidden posts from other users", :aggregate_failures do
       visible_post = Fabricate(:post, user: user, raw: "visible group post")
       hidden_post = Fabricate(:post, user: user, raw: "private hidden group post", hidden: true)

--- a/spec/serializers/user_post_bookmark_serializer_spec.rb
+++ b/spec/serializers/user_post_bookmark_serializer_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe UserPostBookmarkSerializer do
       expect(serializer.highest_post_number).to eq(4)
     end
   end
+
+  describe "#excerpt" do
+    let(:viewer) { Fabricate(:user, locale: "ja") }
+
+    before do
+      SiteSetting.content_localization_enabled = true
+      post.update!(raw: "Original post body", locale: "en")
+      Fabricate(:post_localization, post: post, locale: "ja", cooked: "<p>翻訳された本文</p>")
+    end
+
+    it "returns the translated excerpt" do
+      I18n.with_locale(:ja) do
+        serializer = UserPostBookmarkSerializer.new(bookmark, scope: Guardian.new(viewer))
+
+        expect(serializer.excerpt).to eq("翻訳された本文")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Stacked on #43297.

`PostItemExcerpt` is the shared excerpt renderer behind bookmarks, group posts, the staff deleted-posts view and the solved answers list, and it read `cooked` straight off the record. A viewer whose language differs from the author saw the translation inside the topic and the original everywhere the post was summarised — most visibly on bookmarks, where the title beside the excerpt was already translated.

The module already knew which post an excerpt belongs to: `post_item_excerpt_post`, added so the excerpt could be permission-checked. Reusing that answer to resolve the translation fixes every consumer in one place and makes the next one correct by default.

The permission hook and the resolved post stay separate, because a serializer may know which post it is rendering without wanting a second guardian check on top of filtering it has already done.

`DraftSerializer` is unaffected by construction — it overrides `cooked` with the author own unsaved reply, which has no localization and must never be translated.

Two bookmark serializers defined `cooked` to point at the same post they already returned from `post_item_excerpt_post`; the module derives it now, so both go away along with the abstract `cooked` they were overriding. discourse-solved had copied the excerpt logic rather than including the module, so it never inherited any of this.

### Fixes
- `/u/:username/activity/bookmarks` excerpts
- `/g/:name/posts` excerpts
- `/u/:username/deleted-posts` excerpts
- `/solution/by_user` excerpts