### PR TITLE
FIX: Localize the user activity stream

### DIFF
--- a/app/controllers/user_actions_controller.rb
+++ b/app/controllers/user_actions_controller.rb
@@ -32,7 +32,9 @@ class UserActionsController < ApplicationController
 
     stream = UserAction.stream(opts).to_a
 
-    response = { user_actions: serialize_data(stream, UserActionSerializer) }
+    response = {
+      user_actions: serialize_data(stream, UserActionSerializer, localization_opts(stream)),
+    }
 
     if guardian.can_lazy_load_categories?
       category_ids = stream.map(&:category_id).compact.uniq
@@ -53,10 +55,25 @@ class UserActionsController < ApplicationController
 
     ensure_user_actions_visible!(user, [stream_item.action_type])
 
-    render_serialized(stream_item, UserActionSerializer)
+    render_serialized(stream_item, UserActionSerializer, localization_opts([stream_item]))
   end
 
   private
+
+  def localization_opts(stream)
+    return {} if !SiteSetting.content_localization_enabled
+
+    {
+      localized_topics:
+        Topic.where(id: stream.map(&:topic_id)).includes(:localizations).index_by(&:id),
+      localized_posts:
+        Post
+          .with_deleted
+          .where(id: stream.map(&:cooked_post_id))
+          .includes(:localizations)
+          .index_by(&:id),
+    }
+  end
 
   def ensure_user_actions_visible!(user, action_types)
     raise Discourse::NotFound unless guardian.can_see_profile?(user)

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -249,6 +249,7 @@ class UserAction < ActiveRecord::Base
         pu.uploaded_avatar_id,
         #{acting_cols.join(", ")},
         coalesce(p.cooked, p2.cooked) cooked,
+        coalesce(p.id, p2.id) cooked_post_id,
         CASE WHEN coalesce(p.deleted_at, p2.deleted_at, t.deleted_at) IS NULL THEN false ELSE true END deleted,
         p.hidden,
         p.post_type,

--- a/app/serializers/user_action_serializer.rb
+++ b/app/serializers/user_action_serializer.rb
@@ -35,6 +35,10 @@ class UserActionSerializer < ApplicationSerializer
              :closed,
              :archived
 
+  def title
+    ContentLocalization.translated_topic_title(source_topic, scope) || object.title
+  end
+
   def avatar_template
     User.avatar_template(object.username, object.uploaded_avatar_id)
   end
@@ -97,5 +101,15 @@ class UserActionSerializer < ApplicationSerializer
 
   def action_code_path
     object.action_code_path
+  end
+
+  private
+
+  def source_topic
+    @options[:localized_topics].to_h[object.topic_id]
+  end
+
+  def excerpt_source_post
+    @options[:localized_posts].to_h[object.cooked_post_id]
   end
 end

--- a/spec/requests/user_actions_controller_spec.rb
+++ b/spec/requests/user_actions_controller_spec.rb
@@ -393,4 +393,83 @@ RSpec.describe UserActionsController do
       expect(response).to have_http_status :not_found
     end
   end
+
+  describe "content localization" do
+    fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:viewer) { Fabricate(:user, locale: "ja") }
+    fab!(:staff_viewer) { Fabricate(:moderator, locale: "ja") }
+
+    let!(:topic_post) do
+      UserActionManager.enable
+      create_post(
+        user: author,
+        title: "Original english title",
+        raw: "Original topic body",
+        locale: "en",
+      )
+    end
+    let(:topic) { topic_post.topic }
+    let!(:reply) do
+      create_post(user: author, topic: topic, raw: "Original reply body", locale: "en")
+    end
+
+    let(:new_topic_action) do
+      response.parsed_body["user_actions"].find { |a| a["action_type"] == UserAction::NEW_TOPIC }
+    end
+    let(:reply_action) do
+      response.parsed_body["user_actions"].find { |a| a["action_type"] == UserAction::REPLY }
+    end
+
+    before do
+      SiteSetting.content_localization_enabled = true
+
+      Fabricate(:topic_localization, topic: topic, locale: "ja", title: "翻訳されたタイトル")
+      Fabricate(:post_localization, post: topic_post, locale: "ja", cooked: "<p>翻訳された本文</p>")
+      Fabricate(:post_localization, post: reply, locale: "ja", cooked: "<p>翻訳された返信</p>")
+
+      sign_in(viewer)
+    end
+
+    it "returns the translated title and excerpt" do
+      get "/user_actions.json", params: { username: author.username }
+
+      expect(response).to have_http_status :ok
+      expect(new_topic_action["title"]).to eq("翻訳されたタイトル")
+      expect(new_topic_action["excerpt"]).to eq("翻訳された本文")
+      expect(reply_action["excerpt"]).to eq("翻訳された返信")
+      expect(new_topic_action["slug"]).to eq(topic.slug)
+    end
+
+    it "returns the original content without preloading when localization is disabled" do
+      SiteSetting.content_localization_enabled = false
+
+      queries =
+        track_sql_queries { get "/user_actions.json", params: { username: author.username } }
+
+      expect(new_topic_action["title"]).to eq("Original english title")
+      expect(queries.grep(/FROM "?(topic|post)_localizations"?/)).to be_empty
+    end
+
+    it "returns the translated excerpt of a deleted post to staff" do
+      reply.trash!(staff_viewer)
+      sign_in(staff_viewer)
+
+      get "/user_actions.json", params: { username: author.username }
+
+      expect(reply_action["excerpt"]).to eq("翻訳された返信")
+    end
+
+    it "returns the translated title and excerpt for a single action" do
+      user_action =
+        UserAction.find_by!(
+          user_id: author.id,
+          action_type: UserAction::NEW_TOPIC,
+          target_topic_id: topic.id,
+        )
+
+      get "/user_actions/#{user_action.id}.json"
+
+      expect(response.parsed_body["user_action"]["excerpt"]).to eq("翻訳された本文")
+    end
+  end
 end


### PR DESCRIPTION
Stacked on #43297. This is the reported bug.

A post shown translated inside its topic reverted to the author language under **Profile → Activity**, and so did the topic title above it. Expanding the same row fetched the post separately and showed the translation, so one row could hold both languages at once.

`/user_actions.json` is the only user-facing read path that renders topic and post text from a hand-written query rather than ActiveRecord. Its rows are plain structs with no associations, so nothing localization needs — the source locale, the raw body, the localizations — is reachable from them, and no serializer-level mechanism could apply. That one endpoint backs the activity tabs and every notifications tab, so the gap was wide.

The fix resolves the records a row refers to once per page and hands them to the serializer.

- `title` is translated in place, because this payload has no `fancy_title` and the client escapes what it receives. `slug` keeps reading the untranslated column, so links are unchanged.
- Excerpts go through the shared hook from the previous PR rather than a second implementation.
- The excerpt does not always come from `post_id`: topic creations record a sentinel, so the query already falls back to the topic first post. That post id is now selected alongside the body it produced — without it the most common kind of row on a profile stays untranslated.
- Posts load with deleted ones included, since the stream deliberately shows those to staff.

Preloads are gated on the site setting, so a site without content localization pays nothing.