### PR TITLE
FIX: Localize topic titles outside the topic list

### DIFF
--- a/app/serializers/admin_user_action_serializer.rb
+++ b/app/serializers/admin_user_action_serializer.rb
@@ -56,7 +56,7 @@ class AdminUserActionSerializer < ApplicationSerializer
   end
 
   def title
-    topic&.title
+    ContentLocalization.translated_topic_title(topic, scope) || topic&.title
   end
 
   def category_id

--- a/app/serializers/draft_serializer.rb
+++ b/app/serializers/draft_serializer.rb
@@ -52,7 +52,7 @@ class DraftSerializer < ApplicationSerializer
   end
 
   def title
-    object.topic&.title
+    ContentLocalization.translated_topic_title(object.topic, scope) || object.topic&.title
   end
 
   def slug

--- a/app/serializers/group_post_serializer.rb
+++ b/app/serializers/group_post_serializer.rb
@@ -28,11 +28,12 @@ class GroupPostSerializer < ApplicationSerializer
   has_one :topic, serializer: BasicTopicSerializer, embed: :object
 
   def topic_title
-    object.topic.title
+    ContentLocalization.translated_topic_title(object.topic, scope) || object.topic.title
   end
 
   def topic_html_title
-    object.topic.fancy_title
+    ContentLocalization.translated_topic_fancy_title(object.topic, scope) ||
+      object.topic.fancy_title
   end
 
   def topic_slug

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -146,11 +146,11 @@ class PostSerializer < BasicPostSerializer
   end
 
   def topic_title
-    topic&.title
+    ContentLocalization.translated_topic_title(topic, scope) || topic&.title
   end
 
   def topic_html_title
-    topic&.fancy_title
+    ContentLocalization.translated_topic_fancy_title(topic, scope) || topic&.fancy_title
   end
 
   def posts_count

--- a/plugins/discourse-reactions/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js
@@ -1,7 +1,6 @@
 import EmberObject from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { emojiUnescape } from "discourse/lib/text";
-import { escapeExpression } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Post from "discourse/models/post";
 import RestModel from "discourse/models/rest";
@@ -24,7 +23,7 @@ export default class CustomReaction extends RestModel {
   }
 
   static flattenForPostList(reaction) {
-    const title = reaction.topic.title;
+    const { title, fancy_title } = reaction.topic;
     return {
       // Original reaction data
       ...reaction,
@@ -44,7 +43,7 @@ export default class CustomReaction extends RestModel {
       post_type: reaction.post.post_type,
       url: reaction.post.url,
       title,
-      titleHtml: title && emojiUnescape(escapeExpression(title)),
+      titleHtml: fancy_title && emojiUnescape(fancy_title),
       category: reaction.category,
       created_at: reaction.created_at,
     };

--- a/plugins/discourse-solved/app/serializers/discourse_solved/solved_post_serializer.rb
+++ b/plugins/discourse-solved/app/serializers/discourse_solved/solved_post_serializer.rb
@@ -58,7 +58,8 @@ class DiscourseSolved::SolvedPostSerializer < ApplicationSerializer
   end
 
   def topic_title
-    object.topic.fancy_title
+    ContentLocalization.translated_topic_fancy_title(object.topic, scope) ||
+      object.topic.fancy_title
   end
 
   def url

--- a/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
@@ -24,16 +24,19 @@ describe DiscourseSolved::SolvedTopicsController do
         expect(result["user_solved_posts"][0]["post_id"]).to eq(answer_post.id)
       end
 
-      it "returns the translated excerpt" do
+      it "returns the translated topic_title and excerpt" do
         viewer = Fabricate(:user, locale: "ja")
         SiteSetting.content_localization_enabled = true
+        topic.update!(locale: "en")
         answer_post.update!(raw: "Original answer body", locale: "en")
+        Fabricate(:topic_localization, topic: topic, locale: "ja", fancy_title: "翻訳された題名")
         Fabricate(:post_localization, post: answer_post, locale: "ja", cooked: "<p>翻訳された回答</p>")
 
         sign_in(viewer)
         get "/solution/by_user.json", params: { username: user.username }
 
         solved_post = response.parsed_body["user_solved_posts"][0]
+        expect(solved_post["topic_title"]).to eq("翻訳された題名")
         expect(solved_post["excerpt"]).to eq("翻訳された回答")
       end
 

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe DraftsController do
       expect(response.parsed_body["drafts"].first["title"]).to eq(nil)
     end
 
+    it "returns the translated topic title" do
+      viewer = Fabricate(:user, locale: "ja")
+      SiteSetting.content_localization_enabled = true
+      topic = Fabricate(:topic, locale: "en")
+      Fabricate(:topic_localization, topic: topic, locale: "ja", title: "翻訳された題名")
+      Draft.set(viewer, "topic_#{topic.id}", 0, "{}")
+
+      sign_in(viewer)
+      get "/drafts.json"
+
+      expect(response.parsed_body["drafts"].first["title"]).to eq("翻訳された題名")
+    end
+
     it "omits display user names when names are disabled" do
       SiteSetting.enable_names = false
       topic_author = Fabricate(:user, name: "Hidden Full Name")

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -804,16 +804,19 @@ RSpec.describe GroupsController do
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
-    it "returns the translated excerpt" do
+    it "returns the translated topic title and excerpt" do
       viewer = Fabricate(:user, locale: "ja")
       SiteSetting.content_localization_enabled = true
       post = Fabricate(:post, user: user, raw: "Original group post body", locale: "en")
+      post.topic.update!(locale: "en")
+      Fabricate(:topic_localization, topic: post.topic, locale: "ja", title: "翻訳された題名")
       Fabricate(:post_localization, post: post, locale: "ja", cooked: "<p>翻訳された本文</p>")
 
       sign_in(viewer)
       get "/groups/#{group.name}/posts.json"
 
       expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].first["topic_title"]).to eq("翻訳された題名")
       expect(response.parsed_body["posts"].first["excerpt"]).to eq("翻訳された本文")
     end
 


### PR DESCRIPTION
Stacked on #43299.

Topic lists localize `fancy_title` through a shared mixin, but that mixin only ever localized that one attribute. Serializers exposing the title under a different name had nowhere to opt in, so each rendered the source language while the same topic read correctly in a list:

- `title` — drafts, staff deleted-posts view
- `topic_title` / `topic_html_title` — group posts, latest posts, solved answers

A single shared helper cannot cover both shapes. `title` is plain text the client escapes; `topic_html_title` is escaped server-side and trusted by the client. One substitution would double-escape half the callers, which is why each site routes through whichever value helper matches its contract.

discourse-reactions needed no server change: its payload already carried the localized `fancy_title`, and the list was reading the untranslated `title` beside it, then escaping a value that was already escaped.