### PR TITLE
FIX: Localize post excerpts in the latest posts feed

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -83,7 +83,7 @@ class PostsController < ApplicationController
           .visible
           .where(post_type: Post.types[:regular])
           .order(id: :desc)
-          .includes(topic: :category)
+          .includes(topic: %i[category localizations])
           .includes(user: %i[primary_group flair_group])
           .includes(:reply_to_user)
           .where("categories.id" => Category.secured(guardian).select(:id))

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -153,6 +153,13 @@ class PostSerializer < BasicPostSerializer
     ContentLocalization.translated_topic_fancy_title(topic, scope) || topic&.fancy_title
   end
 
+  def excerpt
+    translated_cooked = ContentLocalization.translated_post_cooked(object, scope)
+    return object.excerpt if !translated_cooked
+
+    Post.excerpt(translated_cooked, nil, post: object)
+  end
+
   def posts_count
     topic&.posts_count
   end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -4296,6 +4296,18 @@ RSpec.describe PostsController do
   end
 
   describe "#latest" do
+    it "returns the translated excerpt" do
+      viewer = Fabricate(:user, locale: "ja")
+      SiteSetting.content_localization_enabled = true
+      post = Fabricate(:post, raw: "Original post body", locale: "en")
+      Fabricate(:post_localization, post: post, locale: "ja", cooked: "<p>翻訳された本文</p>")
+
+      sign_in(viewer)
+      get "/posts.json"
+
+      expect(response.parsed_body["latest_posts"].first["excerpt"]).to eq("翻訳された本文")
+    end
+
     context "with private posts" do
       describe "when not logged in" do
         it "should return the right response" do


### PR DESCRIPTION
Stacked on #43300.

`/posts.json` returned a translated `cooked` and an untranslated `excerpt` in the same object, because the excerpt came straight off the model while only the body went through the serializer.

Localizing `Post#excerpt` itself is not an option: the decision depends on who is looking, and most of its callers — mailers, oneboxes, push notifications, search indexing, exports — have no viewer at all. The serializer is the only layer holding a scope.

The relation behind this endpoint filters on a joined column, which turns its `includes` into a join. Rails does not batch associations on records built from a join, so the localizations were fetched one topic at a time; measured at a page of 50 that was 50 extra queries, now 2.