### PR TITLE
FIX: Vary the user summary cache by automatic translation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2362,7 +2362,13 @@ class UsersController < ApplicationController
   end
 
   def summary_cache_key(user)
-    "user_summary:#{user.id}:#{current_user ? current_user.id : 0}:#{I18n.locale}"
+    [
+      "user_summary",
+      user.id,
+      current_user&.id.to_i,
+      I18n.locale,
+      ContentLocalization.automatically_translate?(guardian),
+    ].join(":")
   end
 
   def render_invite_error(message)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4734,6 +4734,22 @@ RSpec.describe UsersController do
       user_deferred.user_stat.update!(post_count: 1)
     end
 
+    it "caches separately per automatic translation preference" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.set_locale_from_accept_language_header = true
+      topic = Fabricate(:topic, user: user, locale: "en")
+      Fabricate(:post, topic: topic, user: user)
+      Fabricate(:topic_localization, topic: topic, locale: "ja", fancy_title: "翻訳された題名")
+
+      cookies[ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE] = "false"
+      get "/u/#{user.username_lower}/summary.json", headers: { "HTTP_ACCEPT_LANGUAGE" => "ja" }
+      expect(response.parsed_body["topics"].first["fancy_title"]).to eq(topic.fancy_title)
+
+      cookies[ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE] = "true"
+      get "/u/#{user.username_lower}/summary.json", headers: { "HTTP_ACCEPT_LANGUAGE" => "ja" }
+      expect(response.parsed_body["topics"].first["fancy_title"]).to eq("翻訳された題名")
+    end
+
     it "generates summary info" do
       create_post(user: user)
 


### PR DESCRIPTION
Stacked on #43301. Independent of the rest of the stack; sequenced here only to keep one branch chain.

The summary response is cached per user, per viewer and per locale, but anonymous visitors choose whether to see translations with a cookie, and that choice was not part of the key.

Two anonymous visitors sharing a locale therefore shared one entry: whoever missed the cache first decided which language the other one got, and toggling the language switcher appeared to do nothing until the entry expired.