### PR TITLE
DEPS: Bump zendesk_api from 1.38.0.rc1 to 3.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -791,10 +791,11 @@ GEM
     yaml-lint (0.1.2)
     yard (0.9.44)
     zeitwerk (2.8.3)
-    zendesk_api (1.38.0.rc1)
+    zendesk_api (3.1.2)
+      base64
       faraday (> 2.0.0)
       faraday-multipart
-      hashie (>= 3.5.2, < 6.0.0)
+      hashie (>= 3.5.2)
       inflection
       mini_mime
       multipart-post (~> 2.0)
@@ -1330,7 +1331,7 @@ CHECKSUMS
   yaml-lint (0.1.2) sha256=e3960b171766ae187338a169815e99fe10fcb0d9c22b1c539e8d57e114324c8a
   yard (0.9.44) sha256=eb087e9b631ccd887b049f303d489963945452d5e2a7eb49a5a74a7cf6887f28
   zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5
-  zendesk_api (1.38.0.rc1) sha256=9ebe2575d223ed1c0651b2d10df6c010141cda49d524c38532b472f7e8bb3f7a
+  zendesk_api (3.1.2) sha256=3f726c133af8ed3518a9e7cfa9015a368617bd210754ed9173d984f12ddcec15
 
 RUBY VERSION
   ruby 3.4.7p58


### PR DESCRIPTION
The Gemfile has been pinned to a 2022 release candidate for years, and dependabot hasn't been bumping it because there were no further prerelease versions (until the recent 3.0.0.pre.1).

Checked every ZendeskAPI call site discourse-zendesk-plugin uses against the gem's changelog across the whole 1.38.0.rc1..3.1.2 range. None of the changes affect our usage, and plugin specs are all green.