### PR TITLE
FIX: Keep the flag pending when an "Edit post" review is cancelled

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6291,8 +6291,8 @@ en:
         complete: "Post hidden, user has been notified."
       agree_and_edit:
         title: "Edit post"
-        description: "Agree with flag and open a composer window to edit the post."
-        complete: "Flag acknowledged, you can now edit the post."
+        description: "Agree with flag once you save the edit."
+        complete: "Post edited and flag acknowledged."
       delete:
         title: "Delete"
         complete: "Post deleted."

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -475,11 +475,10 @@ export default class ReviewableItem extends Component {
       draftKey: post.get("topic.draft_key"),
       draftSequence: post.get("topic.draft_sequence"),
       skipJumpOnSave: true,
+      onSaved: () => performAction().catch(popupAjaxError),
     };
 
-    this.composer.open(opts);
-
-    return performAction();
+    return this.composer.open(opts);
   }
 
   _penalize(adminToolMethod, reviewable, performAction) {

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -137,6 +137,7 @@ export default class ComposerService extends Service {
   topic = null;
   linkLookup = null;
 
+  #onSaved = null;
   @tracked _allowPreview = null;
   @tracked _showPreview;
 
@@ -1487,6 +1488,8 @@ export default class ComposerService extends Service {
           return DiscourseURL.routeTo(result.responseJson.route_to);
         }
 
+        const onSaved = this.#onSaved;
+
         this.close();
 
         this.currentUser.set("any_posts", true);
@@ -1499,6 +1502,8 @@ export default class ComposerService extends Service {
             skipIfOnScreen: true,
           });
         }
+
+        onSaved?.();
       })
       .catch((error) => {
         composer.set("disableDrafts", false);
@@ -1604,6 +1609,7 @@ export default class ComposerService extends Service {
    @param {Boolean} [opts.skipFormTemplate] Option to skip the form template even if configured for the category
    @param {String} [opts.hijackPreview] Option to hijack the preview with a custom component, you must pass { component: CustomPreviewComponent, model: { ... } }
    @param {String} [opts.selectedTranslationLocale] The locale to use for the translation
+   @param {Function} [opts.onSaved] Called once after this composer session is saved, never if it is closed, discarded or replaced.
    **/
   async open(opts = {}) {
     if (!opts.draftKey) {
@@ -1718,6 +1724,8 @@ export default class ComposerService extends Service {
       }
 
       await this._setModel(composerModel, opts);
+
+      this.#onSaved = opts.onSaved ?? null;
     } finally {
       this.skipAutoSave = false;
       this.appEvents.trigger("composer:open", { model: this.model });
@@ -2134,6 +2142,8 @@ export default class ComposerService extends Service {
     this.set("formTemplateInitialValues", undefined);
 
     this.composerActionState.clear();
+
+    this.#onSaved = null;
   }
 
   @computed("model.action")

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -24,6 +24,13 @@ describe "Reviewables" do
     end
 
     describe "reviewable actions" do
+      let(:discard_draft_modal) { PageObjects::Modals::DiscardDraft.new }
+
+      def open_agree_and_edit
+        PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide").expand
+        find("[data-value='post-agree_and_edit']").click
+      end
+
       it "should have agree_and_edit action" do
         visit("/review")
         select_kit =
@@ -33,17 +40,42 @@ describe "Reviewables" do
         expect(select_kit).to have_option_value("post-agree_and_edit")
       end
 
-      it "agree_and_edit should open the composer" do
+      it "agree_and_edit does not touch the flag until the edit is saved" do
         visit("/review")
-        select_kit =
-          PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide")
-        select_kit.expand
 
-        find("[data-value='post-agree_and_edit']").click
+        open_agree_and_edit
 
-        expect(composer).to be_opened
-        expect(composer.composer_input.value).to eq(post.raw)
+        expect(composer).to have_value(post.raw)
+        expect(review_page).to have_reviewable_with_pending_status(short_reviewable)
+
+        composer.fill_content("The moderator changed their mind about this.")
+        composer.discard
+
+        expect(discard_draft_modal).to be_open
+
+        discard_draft_modal.click_discard
+
+        expect(composer).to be_closed
+        expect(review_page).to have_reviewable_with_pending_status(short_reviewable)
+        expect(short_reviewable.reload).to be_pending
+        expect(post.reload.revisions.count).to eq(0)
+      end
+
+      it "agree_and_edit agrees with the flag once the edit is saved" do
+        visit("/review")
+
+        open_agree_and_edit
+
+        expect(composer).to have_value(post.raw)
+
+        composer.fill_content("This post has been edited by a moderator.")
+        composer.submit
+
+        expect(composer).to be_closed
         expect(toasts).to have_success(I18n.t("reviewables.actions.agree_and_edit.complete"))
+        expect(review_page).to have_reviewable_with_approved_status(short_reviewable)
+        expect(short_reviewable.reload).to be_approved
+        expect(post.reload.raw).to eq("This post has been edited by a moderator.")
       end
 
       it "should open a modal when suspending a user" do


### PR DESCRIPTION
Reported by a moderator who cancelled an edit from the review queue and found the flag already resolved.

Picking **Yes → Edit post** on a flagged post opened the composer and fired the `agree_and_edit` request on the same tick, so the flag was resolved before the moderator had read a word of the post. Cancelling the edit left them with a post they had chosen not to change and a flag they could no longer act on.

`ComposerService` had no way to tell a caller that a session ended in a save rather than a cancel. `open()` resolves as soon as the model is installed, and its only other signals are app events that fire for every composer in the app — none of which fire at all when an untouched session is silently repurposed for a different post, so a listener could outlive its session and agree with an unrelated flag.

So `open()` gains an optional `onSaved` callback. It is stored for the session that was actually installed (after `_setModel` succeeds, so it can never attach to the previous composer), cleared in `close()` — the one funnel every cancel, discard and replacement passes through — and invoked once the save has committed. `clientEdit` defers its agree until the edit lands, which is what the action always claimed to do.

### Behaviour

| Path | Result |
|---|---|
| Save | post updated, flag agreed, toast |
| Cancel / discard | flag stays pending, dropdowns still live |
| Save fails | composer stays open, callback still armed for a retry |
| Composer abandoned or repurposed | flag stays pending |
| Page reload while composing | flag stays pending |
| Left the queue, then saved | agree still fires |

Reloading or abandoning now leaves the flag pending rather than agreed, which is the recoverable direction.

### Notes

`reviewable_claiming` is unaffected: under `required` the action dropdown only renders when the reviewable is already *manually* claimed, and the automatic claim released at the end of `_performConfirmed` was never the one protecting the request. Verified end to end across all three claiming modes.

The `complete` string moved from "Flag acknowledged, you can now edit the post." to "Post edited and flag acknowledged.", since it is now shown after the edit rather than before it.

### Tests

Two system specs, verified red on the old behaviour and green on the new one.
