### PR TITLE
DEV: Trim dead code and redundant tests around the review queue

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6410,31 +6410,6 @@ en:
       approve_and_unhide:
         title: "Yes"
         complete: "Post approved and unhidden"
-      # New separated post actions
-      post_actions:
-        bundle_title: "What do you want to do with the post?"
-      delete_post:
-        title: "Delete post"
-        description: "Delete this post"
-        complete: "Post deleted"
-      hide_post:
-        title: "Hide post"
-        description: "Hide this post from public view"
-        complete: "Post hidden"
-      unhide_post:
-        title: "Unhide post"
-        description: "Make this post visible to all users"
-        complete: "Post unhidden"
-      restore_post:
-        title: "Restore post"
-        description: "Restore this deleted post"
-        complete: "Post restored"
-      edit_post:
-        title: "Edit post"
-        description: "Edit this post content"
-        complete: "Post edited"
-      user_actions:
-        bundle_title: "What do you want to do with the user?"
       silence_user:
         title: "Silence user"
         description: "Prevent the user from posting or sending messages"

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -8,7 +8,6 @@ import { trackedObject } from "@ember/reactive/collections";
 import { service } from "@ember/service";
 import { classify, dasherize } from "@ember/string";
 import ScrubRejectedUserModal from "discourse/admin/components/modal/scrub-rejected-user";
-import ExplainReviewableModal from "discourse/components/modal/explain-reviewable";
 import RejectReasonReviewableModal from "discourse/components/modal/reject-reason-reviewable";
 import ReviseAndRejectPostReviewable from "discourse/components/modal/revise-and-reject-post-reviewable";
 import ReviewableFlagReason from "discourse/components/reviewable/flag-reason";
@@ -241,34 +240,28 @@ export default class ReviewableItem extends Component {
   }
 
   get scoreSummary() {
-    const scoreData = this.args.reviewable?.reviewable_scores?.reduce(
-      (acc, score) => {
-        if (!acc[score.score_type.type]) {
-          acc[score.score_type.type] = {
-            title: score.score_type.title,
-            type: score.score_type.type,
-            count: 0,
-          };
-        }
+    const scores = this.args.reviewable?.reviewable_scores ?? [];
+    const summaries = {};
 
-        acc[score.score_type.type].count += 1;
-        return acc;
-      },
-      {}
-    );
+    for (const { score_type } of scores) {
+      summaries[score_type.type] ??= {
+        title: score_type.title,
+        type: score_type.type,
+        count: 0,
+      };
+      summaries[score_type.type].count += 1;
+    }
 
-    return Object.values(scoreData);
+    return Object.values(summaries);
   }
 
   get reviewableTypeLabel() {
     const { reviewable } = this.args;
 
-    // handle plugin types
     if (reviewableTypeLabels[reviewable?.type]) {
       return reviewableTypeLabels[reviewable?.type];
     }
 
-    // core types
     if (reviewable?.type === "ReviewableUser") {
       return "review.user_label";
     }
@@ -288,7 +281,6 @@ export default class ReviewableItem extends Component {
       return "review.post_flagged_as";
     }
 
-    // fallback
     return "review.flagged_as";
   }
 
@@ -459,42 +451,37 @@ export default class ReviewableItem extends Component {
     if (!this.currentUser) {
       return this.dialog.alert(i18n("post.controls.edit_anonymous"));
     }
-    const post = await this.store.find("post", reviewable.post_id);
-    const topic_json = await Topic.find(post.topic_id, {});
 
-    const topic = Topic.create(topic_json);
-    post.set("topic", topic);
+    const post = await this.store.find("post", reviewable.post_id);
 
     if (!post.can_edit) {
       return false;
     }
 
-    const opts = {
+    const topic = Topic.create(await Topic.find(post.topic_id, {}));
+    post.set("topic", topic);
+
+    return this.composer.open({
       post,
       action: Composer.EDIT,
-      draftKey: post.get("topic.draft_key"),
-      draftSequence: post.get("topic.draft_sequence"),
+      draftKey: topic.draft_key,
+      draftSequence: topic.draft_sequence,
       skipJumpOnSave: true,
       onSaved: () => performAction().catch(popupAjaxError),
-    };
-
-    return this.composer.open(opts);
+    });
   }
 
   _penalize(adminToolMethod, reviewable, performAction) {
-    let adminTools = this.adminTools;
-    if (adminTools) {
-      let createdBy = reviewable.target_created_by;
-      let postId = reviewable.post_id;
-      let postEdit = reviewable.raw ?? reviewable.payload?.raw;
-
-      return adminTools[adminToolMethod](createdBy, {
-        postId,
-        postEdit,
-        reviewableId: reviewable.id,
-        before: performAction,
-      });
+    if (!this.adminTools) {
+      return;
     }
+
+    return this.adminTools[adminToolMethod](reviewable.target_created_by, {
+      postId: reviewable.post_id,
+      postEdit: reviewable.raw ?? reviewable.payload?.raw,
+      reviewableId: reviewable.id,
+      before: performAction,
+    });
   }
 
   async #claimReviewable() {
@@ -536,14 +523,6 @@ export default class ReviewableItem extends Component {
     } catch (e) {
       popupAjaxError(e);
     }
-  }
-
-  @action
-  explainReviewable(reviewable, event) {
-    event.preventDefault();
-    this.modal.show(ExplainReviewableModal, {
-      model: { reviewable },
-    });
   }
 
   @action

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-observers */
 import { tracked } from "@glimmer/tracking";
-import EmberObject, { action, computed, set } from "@ember/object";
+import EmberObject, { action, computed } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { cancel, next, scheduleOnce } from "@ember/runloop";
 import Service, { service } from "@ember/service";
@@ -122,7 +122,6 @@ export default class ComposerService extends Service {
   @service toasts;
 
   @tracked selectedTranslationLocale = null;
-  checkedMessages = false;
   messageCount = null;
   showEditReason = false;
   editReason = null;
@@ -140,9 +139,6 @@ export default class ComposerService extends Service {
   #onSaved = null;
   @tracked _allowPreview = null;
   @tracked _showPreview;
-
-  @tracked _isStaffUserOverride;
-  @tracked _whispererOverride;
 
   init() {
     super.init(...arguments);
@@ -175,51 +171,19 @@ export default class ComposerService extends Service {
     );
   }
 
-  @computed("site.mobileView", "showPreview")
-  get forcePreview() {
-    return this.site?.mobileView && this.showPreview;
-  }
-
-  @computed("site.categoriesList")
-  get categories() {
-    return this.site?.categoriesList;
-  }
-
-  set categories(value) {
-    set(this, "site.categoriesList", value);
-  }
-
   @computed("topicController.model")
   get topicModel() {
     return this.topicController?.model;
   }
 
-  set topicModel(value) {
-    set(this, "topicController.model", value);
-  }
-
   @computed("currentUser.staff")
   get isStaffUser() {
-    if (this._isStaffUserOverride !== undefined) {
-      return this._isStaffUserOverride;
-    }
     return this.currentUser?.staff;
-  }
-
-  set isStaffUser(value) {
-    this._isStaffUserOverride = value;
   }
 
   @computed("currentUser.whisperer")
   get whisperer() {
-    if (this._whispererOverride !== undefined) {
-      return this._whispererOverride;
-    }
     return this.currentUser?.whisperer;
-  }
-
-  set whisperer(value) {
-    this._whispererOverride = value;
   }
 
   @computed("model.creatingTopic", "isStaffUser")
@@ -578,11 +542,9 @@ export default class ComposerService extends Service {
 
     if (conditionType === "undefined") {
       option.condition = true;
-    } else if (conditionType === "boolean") {
-      // uses existing value
     } else if (conditionType === "function") {
       option.condition = option.condition(this);
-    } else {
+    } else if (conditionType !== "boolean") {
       option.condition = this.get(option.condition);
     }
 
@@ -1604,10 +1566,10 @@ export default class ComposerService extends Service {
    @param {Number} [opts.prioritizedCategoryId]
    @param {Number} [opts.readOnlyCategoryId] Shows category as read-only in category chooser, with a read-only badge
    @param {Number} [opts.formTemplateId]
-   @param {String} [opts.draftSequence]
+   @param {Number} [opts.draftSequence]
    @param {Boolean} [opts.skipJumpOnSave] Option to skip navigating to the post when saved in this composer session
    @param {Boolean} [opts.skipFormTemplate] Option to skip the form template even if configured for the category
-   @param {String} [opts.hijackPreview] Option to hijack the preview with a custom component, you must pass { component: CustomPreviewComponent, model: { ... } }
+   @param {Object} [opts.hijackPreview] Replaces the preview pane, as { component, model }
    @param {String} [opts.selectedTranslationLocale] The locale to use for the translation
    @param {Function} [opts.onSaved] Called once after this composer session is saved, never if it is closed, discarded or replaced.
    **/
@@ -1633,11 +1595,9 @@ export default class ComposerService extends Service {
       prioritizedCategoryId: null,
       readOnlyCategoryId: null,
       skipAutoSave: true,
+      skipJumpOnSave: !!opts.skipJumpOnSave,
+      skipFormTemplate: !!opts.skipFormTemplate,
     });
-
-    this.set("skipJumpOnSave", !!opts.skipJumpOnSave);
-
-    this.set("skipFormTemplate", !!opts.skipFormTemplate);
 
     if (opts.hijackPreview) {
       this.set("hijackPreview", opts.hijackPreview);
@@ -1671,9 +1631,8 @@ export default class ComposerService extends Service {
       opts.draftKey !== composerModel.draftKey &&
       composerModel.composeState === Composer.DRAFT
     ) {
-      // Check if content is dirty before auto-closing
       if (composerModel.anyDirty) {
-        const retry = await this.cancelComposer(opts);
+        const retry = await this.cancelComposer();
         if (retry) {
           await this.open(opts);
         }
@@ -1712,7 +1671,7 @@ export default class ComposerService extends Service {
           }
         }
 
-        const retry = await this.cancelComposer(opts);
+        const retry = await this.cancelComposer();
         if (retry) {
           await this.open(opts);
         }
@@ -1900,7 +1859,7 @@ export default class ComposerService extends Service {
     }
   }
 
-  async destroyDraft(draftSequence = null) {
+  async destroyDraft() {
     const key = this.get("model.draftKey");
     if (!key) {
       return;
@@ -1908,11 +1867,10 @@ export default class ComposerService extends Service {
 
     if (this._saveDraftPromise) {
       await this._saveDraftPromise;
-      return await this.destroyDraft();
+      return this.destroyDraft();
     }
 
-    const sequence = draftSequence || this.get("model.draftSequence");
-    await Draft.clear(key, sequence);
+    await Draft.clear(key, this.get("model.draftSequence"));
     this.appEvents.trigger("draft:destroyed", key);
   }
 
@@ -1963,20 +1921,18 @@ export default class ComposerService extends Service {
   }
 
   saveAndCloseComposer() {
-    // Always save the draft if the user had typed something
-    // or had started setting up a title/tags/category
-    if (this.model.anyDirty) {
-      this.skipAutoSave = true;
-      this._saveDraft(true);
-      this.model.clearState();
-      this.close();
-      this.appEvents.trigger("composer:cancelled");
-      this.skipAutoSave = false;
-      return true;
-    } else {
-      // Otherwise just close the composer and discard any empty draft
+    if (!this.model.anyDirty) {
       return this.cancelComposer();
     }
+
+    this.skipAutoSave = true;
+    this._saveDraft(true);
+    this.model.clearState();
+    this.close();
+    this.appEvents.trigger("composer:cancelled");
+    this.skipAutoSave = false;
+
+    return true;
   }
 
   unshrink() {
@@ -2122,24 +2078,22 @@ export default class ComposerService extends Service {
   }
 
   close() {
+    const elem = document.documentElement;
+
     // the 'fullscreen-composer' class is added to remove scrollbars from the
     // document while in fullscreen mode. If the composer is closed for any reason
     // this class should be removed
-
-    const elem = document.documentElement;
-    elem.classList.remove("fullscreen-composer");
-    elem.classList.remove("composer-open");
+    elem.classList.remove("fullscreen-composer", "composer-open");
+    elem.style.removeProperty("--composer-height");
 
     document.activeElement?.blur();
-    document.documentElement.style.removeProperty("--composer-height");
+
     this.setProperties({
       model: null,
       lastValidatedAt: null,
       _allowPreview: null,
+      formTemplateInitialValues: undefined,
     });
-
-    // This is a temporary solution to reset the saved form template state while we don't store drafts
-    this.set("formTemplateInitialValues", undefined);
 
     this.composerActionState.clear();
 

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -3,8 +3,6 @@
 module PageObjects
   module Pages
     class Review < PageObjects::Pages::Base
-      POST_BODY_TOGGLE_SELECTOR = ".post-body__toggle-btn"
-      POST_BODY_COLLAPSED_SELECTOR = ".post-body.is-collapsed"
       REVIEWABLE_ACTION_DROPDOWN = ".reviewable-action-dropdown"
 
       def visit_reviewable(reviewable)
@@ -48,26 +46,6 @@ module PageObjects
       def delete_user_from_reviewable(reviewable, action, confirm: true)
         select_bundled_action(reviewable, action, bundle_index: 1)
         PageObjects::Components::Dialog.new.click_danger if confirm
-      end
-
-      def click_post_body_toggle
-        find(POST_BODY_TOGGLE_SELECTOR).click
-      end
-
-      def has_post_body_toggle?
-        page.has_css?(POST_BODY_TOGGLE_SELECTOR)
-      end
-
-      def has_no_post_body_toggle?
-        page.has_no_css?(POST_BODY_TOGGLE_SELECTOR)
-      end
-
-      def has_post_body_collapsed?
-        page.has_css?(POST_BODY_COLLAPSED_SELECTOR)
-      end
-
-      def has_no_post_body_collapsed?
-        page.has_no_css?(POST_BODY_COLLAPSED_SELECTOR)
       end
 
       def has_reviewable_action_dropdown?

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -3,8 +3,6 @@
 describe "Reviewables" do
   let(:review_page) { PageObjects::Pages::Review.new }
   fab!(:admin)
-  fab!(:theme)
-  fab!(:long_post, :post_with_very_long_raw_content)
   fab!(:post)
   let(:composer) { PageObjects::Components::Composer.new }
   let(:moderator) { Fabricate(:moderator) }
@@ -17,27 +15,12 @@ describe "Reviewables" do
   describe "when there is a flagged post reviewable with a short post" do
     fab!(:short_reviewable) { Fabricate(:reviewable_flagged_post, target: post) }
 
-    it "should not show a button to expand/collapse the post content" do
-      visit("/review")
-      expect(review_page).to have_no_post_body_collapsed
-      expect(review_page).to have_no_post_body_toggle
-    end
-
     describe "reviewable actions" do
       let(:discard_draft_modal) { PageObjects::Modals::DiscardDraft.new }
 
       def open_agree_and_edit
         PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide").expand
         find("[data-value='post-agree_and_edit']").click
-      end
-
-      it "should have agree_and_edit action" do
-        visit("/review")
-        select_kit =
-          PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide")
-        select_kit.expand
-
-        expect(select_kit).to have_option_value("post-agree_and_edit")
       end
 
       it "agree_and_edit does not touch the flag until the edit is saved" do
@@ -137,20 +120,9 @@ describe "Reviewables" do
     end
   end
 
-  describe "when there is a queued post reviewable with a short post" do
-    fab!(:short_queued_reviewable, :reviewable_queued_post)
-
-    it "should not show a button to expand/collapse the post content" do
-      visit("/review")
-      expect(review_page).to have_no_post_body_collapsed
-      expect(review_page).to have_no_post_body_toggle
-    end
-  end
-
   describe "when there is a reviewable user" do
     fab!(:user)
     let(:rejection_reason_modal) { PageObjects::Modals::RejectReasonReviewable.new }
-    let(:scrub_user_modal) { PageObjects::Modals::ScrubRejectedUser.new }
 
     before do
       SiteSetting.must_approve_users = true
@@ -177,33 +149,6 @@ describe "Reviewables" do
       expect(mail.to).to eq([user_email])
       expect(mail.subject).to match(/You've been rejected on Discourse/)
       expect(mail.body.raw_source).to include rejection_reason
-    end
-
-    it "Allows scrubbing user data after rejection" do
-      rejection_reason = "user is spamming"
-      scrubbing_reason = "a spammer who knows how to make GDPR requests"
-      reviewable = ReviewableUser.find_by_target_id(user.id)
-
-      review_page.visit_reviewable(reviewable)
-      review_page.select_bundled_action(reviewable, "user-delete_user")
-      rejection_reason_modal.fill_in_rejection_reason(rejection_reason)
-      rejection_reason_modal.delete_user
-
-      expect(review_page).to have_reviewable_with_rejected_status(reviewable)
-
-      review_page.click_scrub_user_button
-
-      expect(scrub_user_modal.scrub_button).to be_disabled
-      scrub_user_modal.fill_in_scrub_reason(scrubbing_reason)
-      expect(scrub_user_modal.scrub_button).not_to be_disabled
-      scrub_user_modal.scrub_button.click
-
-      expect(review_page).to have_reviewable_with_scrubbed_by(reviewable, admin.username)
-      expect(review_page).to have_reviewable_with_scrubbed_reason(reviewable, scrubbing_reason)
-      expect(review_page).to have_reviewable_with_scrubbed_at(
-        reviewable,
-        reviewable.payload["scrubbed_at"],
-      )
     end
   end
 
@@ -368,7 +313,7 @@ describe "Reviewables" do
   end
 
   describe "when there is an unknown plugin reviewable" do
-    fab!(:reviewable) { Fabricate(:reviewable_flagged_post, target: long_post) }
+    fab!(:reviewable) { Fabricate(:reviewable_flagged_post, target: post) }
     fab!(:reviewable2, :reviewable)
 
     before do
@@ -428,78 +373,28 @@ describe "Reviewables" do
   describe "XSS prevention in queued post titles via server-side cooking" do
     fab!(:untrusted_user) { Fabricate(:user, trust_level: 0) }
 
-    before do
-      SiteSetting.approve_post_count = 1
-      sign_in(admin)
-    end
-
-    it "prevents stored XSS in topic title when viewing review queue" do
-      xss_payload = '<img src=x onerror="alert(\'XSS\')">'
-      reviewable =
-        ReviewableQueuedPost.needs_review!(
-          target_created_by: untrusted_user,
-          created_by: untrusted_user,
-          payload: {
-            raw: "This is the post body",
-            title: xss_payload,
-          },
-        )
+    it "escapes markup in queued post titles instead of rendering it" do
+      ReviewableQueuedPost.needs_review!(
+        target_created_by: untrusted_user,
+        created_by: untrusted_user,
+        payload: {
+          raw: "This is the post body",
+          title: "<img src=x onerror=\"alert('XSS')\"><script>alert(1)</script> & <b>Bold</b>",
+        },
+      )
 
       visit("/review")
 
-      # The title should be visible as text but not execute
-      expect(page).to have_no_css("img[src='x']")
-      expect(page).to have_no_css("img[onerror]")
+      title_html = page.find(".title-text", match: :first).native.inner_html
 
-      # Verify the XSS payload is escaped in the HTML
-      title_element = page.find(".title-text", match: :first)
-      title_html = title_element.native.inner_html
       expect(title_html).to include("&lt;img")
-      expect(title_html).to include("&gt;")
-      expect(title_html).not_to include("<img src=x onerror")
-    end
-
-    it "prevents stored XSS with script tags in topic title" do
-      xss_payload = '<script>alert("XSS")</script>Malicious Title'
-      reviewable =
-        ReviewableQueuedPost.needs_review!(
-          target_created_by: untrusted_user,
-          created_by: untrusted_user,
-          payload: {
-            raw: "This is the post body",
-            title: xss_payload,
-          },
-        )
-
-      visit("/review")
-
-      expect(page).to have_no_css("script")
-      title_element = page.find(".title-text", match: :first)
-      title_html = title_element.native.inner_html
       expect(title_html).to include("&lt;script&gt;")
-      expect(title_html).not_to include("<script>alert")
-    end
-
-    it "escapes special characters in title" do
-      special_chars_title = "Test & <b>Bold</b> & \"Quotes\" & 'Apostrophes'"
-      reviewable =
-        ReviewableQueuedPost.needs_review!(
-          target_created_by: untrusted_user,
-          created_by: untrusted_user,
-          payload: {
-            raw: "This is the post body",
-            title: special_chars_title,
-          },
-        )
-
-      visit("/review")
-
-      # The <b> tag should not render as bold
-      expect(page).to have_no_css(".title-text b")
-      title_element = page.find(".title-text", match: :first)
-      title_html = title_element.native.inner_html
-      expect(title_html).to include("&amp;")
       expect(title_html).to include("&lt;b&gt;")
+      expect(title_html).to include("&amp;")
+      expect(page).to have_no_css(
+        ".title-text img, .title-text script, .title-text b",
+        visible: :all,
+      )
     end
   end
 

--- a/spec/system/viewing_reviewable_spec.rb
+++ b/spec/system/viewing_reviewable_spec.rb
@@ -383,6 +383,8 @@ describe "Viewing reviewable item" do
 
       review_page.click_scrub_user_button
 
+      expect(scrub_user_modal.scrub_button).to be_disabled
+
       scrubbing_reason = "a spammer who knows how to make GDPR requests"
       scrub_user_modal.fill_in_scrub_reason(scrubbing_reason)
       expect(scrub_user_modal.scrub_button).not_to be_disabled


### PR DESCRIPTION
Stacked on #43309 — review that one first.

A whole-file pass over the files that PR touched, split out so the fix stays reviewable on its own. No behaviour change intended.

### Dead code

Most of this is what the review queue redesign left stranded.

- `explainReviewable` lost its only call site when the legacy component was deleted in 53d799eb8b1. It cannot be reached: the dispatcher builds handler names from an action’s `client_action`, and no action names it. Its modal import goes too — `components/modal/explain-reviewable.gjs` is now orphaned as well, left for a follow-up.
- The `post_actions` / `user_actions` locale subtrees describe actions no `build_action` call registers any more, and `build_bundle` — the only thing that could read their bundle titles — has no callers either. Its dead `perform_*_post` siblings in `reviewable_action_builder.rb` are a follow-up, since that is a shared concern.
- Nothing reads `composer.forcePreview`; the two components that mention it declare their own member, so the chain was inert end to end. The `categories`, `topicModel`, `isStaffUser` and `whisperer` setters were added mechanically by 4b2c45376db to preserve `set()` compatibility nobody uses.
- `cancelComposer` lost its parameter in 98f4e00f0dd but both callers kept passing one. `destroyDraft`’s sequence argument is passed by none of its seven callers and was dropped on its own recursive call anyway.
- `checkedMessages` on the service is shadowed by the component member of the same name; `messageCount` next to it is live and stays.

### One real bug

`scoreSummary` guarded its input with `?.` twice and then handed the result to `Object.values` unguarded, so a reviewable with no scores threw `TypeError` instead of rendering nothing.

### Tests: 26 → 17 examples

The reduction is the point rather than a side effect.

- **XSS titles, 3 → 1.** All three covered one escape site rendered into one node, and escaping is per-character, so a single payload carrying all three shapes proves the same thing. The merge also drops three unused assignments, a `before` block that signed the admin in a second time (three wasted page loads), and `expect(page).to have_no_css("script")` — which could never fail, because Capybara’s default `visible: :visible` does not match `<script>`. The replacement scopes to `.title-text` and passes `visible: :all`.
- **Both expand/collapse examples deleted.** `post-body__toggle-btn` and `.post-body.is-collapsed` have zero hits in any template; both matchers use `has_no_css?`, so they passed on a blank page. Five page-object methods follow them.
- **Scrubbing example deleted.** `viewing_reviewable_spec.rb` has a strict superset; its one unique assertion moves there.
- **`agree_and_edit` "should have action" deleted.** `open_agree_and_edit` performs the same lookup and raises if the option disappears, and the model spec already pins it.

Two non-waiting `.value ==` reads become waiting matchers, which also removes a race against the composer prefill.

### Deliberately not done

`cancelComposer` and the save-error dispatch could both be flattened, but the first has a real behaviour delta (its non-dirty branch would start resolving `true`) and both are covered by QUnit rather than system specs. Worth their own PR.