### PR TITLE
FIX: Parameterize Unsubscribe Title i18n String 

### DIFF
--- a/app/views/email/unsubscribe.html.erb
+++ b/app/views/email/unsubscribe.html.erb
@@ -14,7 +14,7 @@
     <%- end %>
   <%- else %>
     <br/>
-    <h2><%= t 'unsubscribe.title'%> <%= @user.email %></h2>
+    <h2><%= t 'unsubscribe.title', email: @user.email %></h2>
     <br/>
     <%= form_tag(email_perform_unsubscribe_path(key: params[:key])) do %>
       <%if @topic %>
@@ -92,7 +92,7 @@
       <% end %>
 
       <br/>
-      <% text = @type=='digest' ? t('unsubscribe.submit') : t('unsubscribe.title') %>
+      <% text = @type=='digest' ? t('unsubscribe.submit') : t('unsubscribe.unsubscribe') %>
       <%= submit_tag text, class: 'btn btn-danger' %>
     <%- end %>
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1347,7 +1347,8 @@ en:
     marked_insecure_from_theme_component_reason: "upload used in theme component"
 
   unsubscribe:
-    title: "Unsubscribe"
+    title: "Unsubscribe %{email}"
+    unsubscribe: "Unsubscribe"
     stop_watching_topic: "Stop watching this topic, %{link}"
     mute_topic: "Mute all notifications for this topic, %{link}"
     unwatch_category: "Stop watching all topics in %{category}"


### PR DESCRIPTION
Parameterize the email address i18n string representing the title on the Unsubscribe page so translations can place it within a phrase rather than always appending it.

Apparently the previous German "Abbestellen %{email}" is incorrect and should be "%{email} abmelden", but that wasn't possible before because the email was hardcoded after the i18n string in the page. This change allows that string to be correctly translated for German and maybe other languages.

Meta: /t/404848/62