### PR TITLE
FIX: Stop `check_username` rate limit from blocking signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -612,10 +612,19 @@ class UsersController < ApplicationController
   # Used for checking availability of a username and will return suggestions
   # if the username is not available.
   def check_username
+    # Anonymous callers are only ever running signup, so once local registration
+    # is closed the endpoint would just be a username-existence oracle.
+    if !current_user &&
+         (!SiteSetting.allow_new_registrations || SiteSetting.enable_discourse_connect)
+      raise Discourse::InvalidAccess
+    end
+
+    # The check is advisory and `create` re-validates, so a throttled caller gets
+    # an optimistic answer rather than an error that blocks the signup form.
     begin
-      RateLimiter.new(current_user, "check-username-#{request.remote_ip}", 10, 1.minute).performed!
+      RateLimiter.new(current_user, "check-username-#{request.remote_ip}", 60, 1.minute).performed!
     rescue RateLimiter::LimitExceeded
-      return render json: failed_json.merge(errors: [I18n.t("rate_limiter.slow_down")])
+      return render_available_true
     end
 
     if !params[:username].present?

--- a/frontend/discourse/app/components/username-preference.gjs
+++ b/frontend/discourse/app/components/username-preference.gjs
@@ -8,6 +8,7 @@ import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import discourseDebounce from "discourse/lib/debounce";
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import User from "discourse/models/user";
 import DButton from "discourse/ui-kit/d-button";
@@ -69,7 +70,7 @@ export default class UsernamePreference extends Component {
   }
 
   @action
-  async onInput(event) {
+  onInput(event) {
     this.newUsername = event.target.value;
     this.taken = false;
     this.errorMessage = null;
@@ -87,17 +88,7 @@ export default class UsernamePreference extends Component {
       return;
     }
 
-    const result = await User.checkUsername(
-      this.newUsername,
-      undefined,
-      this.args.user.id
-    );
-
-    if (result.errors) {
-      this.errorMessage = result.errors.join(" ");
-    } else if (result.available === false) {
-      this.taken = true;
-    }
+    discourseDebounce(this, this.#checkUsernameAvailability, 500);
   }
 
   @action
@@ -119,6 +110,25 @@ export default class UsernamePreference extends Component {
         }
       },
     });
+  }
+
+  async #checkUsernameAvailability() {
+    const username = this.newUsername;
+    const result = await User.checkUsername(
+      username,
+      undefined,
+      this.args.user.id
+    );
+
+    if (username !== this.newUsername) {
+      return;
+    }
+
+    if (result.errors) {
+      this.errorMessage = result.errors.join(" ");
+    } else if (result.available === false) {
+      this.taken = true;
+    }
   }
 
   <template>

--- a/frontend/discourse/tests/acceptance/user-preferences-account-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-account-test.js
@@ -80,8 +80,17 @@ acceptance("User Preferences - Account", function (needs) {
     assert.dom(".username-preference__input").hasValue("eviltrout");
     assert.dom(".username-preference__submit").isDisabled();
 
+    await fillIn(".username-preference__input", "taken");
+    assert.dom(".username-preference__submit").isDisabled();
+    assert
+      .dom(".pref-username .instructions")
+      .includesText(i18n("user.change_username.taken"));
+
     await fillIn(".username-preference__input", "good_trout");
     assert.dom(".username-preference__submit").isEnabled();
+    assert
+      .dom(".pref-username .instructions")
+      .doesNotIncludeText(i18n("user.change_username.taken"));
 
     await click(".username-preference__submit");
     await click(".dialog-container .btn-primary");

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2179,25 +2179,57 @@ RSpec.describe UsersController do
       expect(response.status).to eq(400)
     end
 
-    it "rate limits requests per IP" do
-      RateLimiter.enable
+    describe "rate limiting" do
+      before { RateLimiter.enable }
 
-      10.times { get "/u/check_username.json", params: { username: "available" } }
-      get "/u/check_username.json", params: { username: "available" }
+      it "reports a taken username as available once the per IP limit is exceeded" do
+        60.times { get "/u/check_username.json", params: { username: user1.username } }
+        expect(response.parsed_body["available"]).to eq(false)
 
-      expect(response.status).to eq(200)
-      expect(response.parsed_body).not_to have_key("available")
-      expect(response.parsed_body["errors"]).to contain_exactly(I18n.t("rate_limiter.slow_down"))
+        get "/u/check_username.json", params: { username: user1.username }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq("available" => true)
+      end
+
+      it "does not rate limit staff" do
+        sign_in(moderator)
+
+        61.times { get "/u/check_username.json", params: { username: user1.username } }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["available"]).to eq(false)
+      end
     end
 
-    it "does not rate limit staff" do
-      RateLimiter.enable
-      sign_in(moderator)
+    describe "when new registrations are closed" do
+      it "denies anonymous requests when new registrations are disabled" do
+        SiteSetting.allow_new_registrations = false
 
-      11.times { get "/u/check_username.json", params: { username: "available" } }
+        get "/u/check_username.json", params: { username: user1.username }
 
-      expect(response.status).to eq(200)
-      expect(response.parsed_body["available"]).to eq(true)
+        expect(response.status).to eq(403)
+      end
+
+      it "denies anonymous requests when DiscourseConnect is enabled" do
+        SiteSetting.discourse_connect_url = "http://example.com/sso"
+        SiteSetting.discourse_connect_secret = "sso_secret_12345"
+        SiteSetting.enable_discourse_connect = true
+
+        get "/u/check_username.json", params: { username: user1.username }
+
+        expect(response.status).to eq(403)
+      end
+
+      it "still answers logged in users" do
+        SiteSetting.allow_new_registrations = false
+        sign_in(user1)
+
+        get "/u/check_username.json", params: { username: "BruceWayne" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["available"]).to eq(true)
+      end
     end
 
     shared_examples "when username is unavailable" do


### PR DESCRIPTION
**Previously**, `check_username` allowed 10 requests per minute per IP and surfaced the "slow down" error inline, so a few username edits during signup (or every keystroke on the username preference page, which had no debounce) could block the form. Anonymous callers could also probe username existence on sites where registration is closed.

**In this update**, the limit is raised to 60 per minute and the endpoint fails open when throttled, matching `check_email`, since `create` re-validates on submit. Anonymous requests are refused when new registrations are disabled or DiscourseConnect is enabled, and the username preference input is debounced with a stale-response guard.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/3a9d613f-fbc8-4af7-94f9-9bb77b027309) | ![after](https://github.com/user-attachments/assets/60da2eec-d98d-4a3e-a0f6-153793c4d7b4) |