### PR TITLE
DEV: Let the fake LLM answer structured output requests

### DIFF
--- a/plugins/discourse-ai/lib/completions/endpoints/base.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/base.rb
@@ -18,6 +18,10 @@ module DiscourseAi
         # Stored in AiApiAuditLog#request_attempts for retried network failures,
         # which do not have an HTTP status code. 0 is intentionally outside the HTTP range.
         NETWORK_ERROR_RETRY_STATUS = 0
+
+        def self.schema_properties(response_format)
+          response_format&.dig(:json_schema, :schema, :properties)
+        end
         RETRIABLE_NETWORK_ERRORS = [
           Net::OpenTimeout,
           Net::ReadTimeout,
@@ -389,12 +393,10 @@ module DiscourseAi
         end
 
         def build_structured_output(model_params)
-          return if model_params[:response_format].blank?
+          properties = self.class.schema_properties(model_params[:response_format])
+          return if properties.blank?
 
-          schema_properties = model_params[:response_format].dig(:json_schema, :schema, :properties)
-          return if schema_properties.blank?
-
-          DiscourseAi::Completions::StructuredOutput.new(schema_properties)
+          DiscourseAi::Completions::StructuredOutput.new(properties)
         end
 
         def perform_completion_request_with_retries(

--- a/plugins/discourse-ai/lib/completions/endpoints/fake.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/fake.rb
@@ -76,8 +76,34 @@ module DiscourseAi
           @fake_content = content
         end
 
-        def self.fake_content
-          @fake_content || STOCK_CONTENT
+        def self.fake_content(response_format = nil)
+          return @fake_content if @fake_content
+
+          properties = schema_properties(response_format)
+          return STOCK_CONTENT if properties.blank?
+
+          properties.to_h { |key, property| [key, stock_value(key, property)] }.to_json
+        end
+
+        def self.json_object?(content)
+          content.is_a?(String) && JSON.parse(content).is_a?(Hash)
+        rescue JSON::ParserError
+          false
+        end
+
+        def self.stock_value(key, property)
+          case property[:type].to_s
+          when "integer"
+            42
+          when "number"
+            4.2
+          when "boolean"
+            true
+          when "array"
+            [stock_value(key, property[:items] || {})]
+          else
+            "fake #{key}"
+          end
         end
 
         def self.delays
@@ -132,9 +158,12 @@ module DiscourseAi
           # guard memory in test
           self.class.previous_calls.shift if self.class.previous_calls.length > 10
 
-          content = self.class.fake_content
+          content = self.class.fake_content(model_params[:response_format])
 
           content = content.shift if content.is_a?(Array)
+          structured_output = build_structured_output(model_params) if self.class.json_object?(
+            content,
+          )
 
           if block_given?
             if content.is_a?(DiscourseAi::Completions::ToolCall)
@@ -171,12 +200,21 @@ module DiscourseAi
                   break if cancel
 
                   content << chunk
-                  yield(chunk, cancel_proc)
+                  next yield(chunk, cancel_proc) if structured_output.nil?
+
+                  structured_output << chunk
+                  yield(structured_output, cancel_proc)
                 end
             end
+          elsif structured_output
+            structured_output << content
           end
 
-          content
+          return content if structured_output.nil?
+
+          structured_output.finish
+          yield(structured_output, -> {}) if block_given?
+          structured_output
         end
       end
     end

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/fake_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/fake_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Completions::Endpoints::Fake do
+  fab!(:llm_model, :fake_model)
+
+  let(:response_format) do
+    {
+      type: "json_schema",
+      json_schema: {
+        name: "reply",
+        schema: {
+          type: "object",
+          properties: {
+            verdict: {
+              type: "string",
+            },
+            confident: {
+              type: "boolean",
+            },
+            attempts: {
+              type: "integer",
+            },
+            reasons: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+    }
+  end
+
+  before { enable_current_plugin }
+
+  it "answers a structured request with a payload shaped like the schema" do
+    result =
+      llm_model.to_llm.generate(
+        "hello",
+        user: Discourse.system_user,
+        feature_name: "test",
+        response_format: response_format,
+      )
+
+    expect(result).to be_a(DiscourseAi::Completions::StructuredOutput)
+    expect(JSON.parse(result.to_s)).to eq(
+      "verdict" => "fake verdict",
+      "confident" => true,
+      "attempts" => 42,
+      "reasons" => ["fake reasons"],
+    )
+  end
+
+  it "streams the structured payload" do
+    partials = []
+
+    llm_model
+      .to_llm
+      .generate(
+        "hello",
+        user: Discourse.system_user,
+        feature_name: "test",
+        response_format: response_format,
+      ) { |partial| partials << partial }
+
+    expect(partials.last).to be_a(DiscourseAi::Completions::StructuredOutput)
+    expect(partials.last.read_buffered_property(:verdict)).to eq("fake verdict")
+  end
+
+  it "keeps returning explicitly set content", :aggregate_failures do
+    described_class.with_fake_content({ verdict: "reject" }.to_json) do
+      result =
+        llm_model.to_llm.generate(
+          "hello",
+          user: Discourse.system_user,
+          feature_name: "test",
+          response_format: response_format,
+        )
+
+      expect(result.to_s).to eq({ verdict: "reject" }.to_json)
+    end
+
+    described_class.with_fake_content("a plain summary") do
+      result =
+        llm_model.to_llm.generate(
+          "hello",
+          user: Discourse.system_user,
+          feature_name: "test",
+          response_format: response_format,
+        )
+
+      expect(result).to eq("a plain summary")
+    end
+  end
+
+  it "answers with the stock content when no schema is requested", :aggregate_failures do
+    expect(
+      llm_model.to_llm.generate("hello", user: Discourse.system_user, feature_name: "test"),
+    ).to include("Discourse Markdown Styles Showcase")
+    expect(
+      llm_model.to_llm.generate(
+        "hello",
+        user: Discourse.system_user,
+        feature_name: "test",
+        response_format: {
+          type: "json_object",
+        },
+      ),
+    ).to include("Discourse Markdown Styles Showcase")
+  end
+end


### PR DESCRIPTION
The fake provider ignored `response_format` and always replied with its stock markdown, so anything that reads an agent's structured fields saw nothing on a local install and could only be exercised against a real model.

### Changes

- A structured request is answered with a payload shaped like the requested schema, streamed through the same `StructuredOutput` the real endpoints build, and finished before the last partial so consumers that wait for a finished object still see it.
- Explicitly set fake content still wins, and is only treated as structured when it actually parses as a JSON object, so a spec that sets plain prose alongside a response format keeps getting prose.
- A request with no schema, including `json_object` mode, is unchanged.
- The schema property lookup both halves needed now lives on `Endpoints::Base`.

Stacked on #43318.