### PR TITLE
DEV: Stop `bin/lint` skipping files outside the project

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -11,6 +11,8 @@ PROJECT_ROOT_PATH = Pathname.new(PROJECT_ROOT)
 PROJECT_ROOT_REALPATH = PROJECT_ROOT_PATH.realpath
 INVOCATION_PWD = Dir.pwd
 
+LintAborted = Class.new(StandardError)
+
 module Logging
   def log(message)
     puts "[bin/lint] #{message}"
@@ -185,7 +187,10 @@ class LefthookLinter
     lint(determine_files)
     print_summary
 
-    exit 1 if @results.any? { |_, ok| !ok }
+    @results.all? { |_, ok| ok }
+  rescue LintAborted => e
+    warn "[bin/lint] #{e.message}"
+    false
   end
 
   private
@@ -234,7 +239,7 @@ class LefthookLinter
 
     if @selector.nil?
       resolved.filter_map(&:last).each { |problem| warn "[bin/lint] Skipping #{problem}" }
-      abort "[bin/lint] Nothing to lint" if files.empty?
+      raise LintAborted, "Nothing to lint" if files.empty?
     end
 
     files
@@ -275,7 +280,15 @@ class LefthookLinter
 
   def expand_directory(path)
     files =
-      git_lines("ls-files", "--cached", "--others", "--exclude-standard", "--", path, quiet: true)
+      git_lines(
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        path,
+        on_failure: :ignore,
+      )
     files = [path] if files.empty?
 
     files
@@ -283,12 +296,12 @@ class LefthookLinter
       .select { |file| File.file?(file) && lintable_file?(file) }
   end
 
-  def git_lines(*args, quiet: false)
+  def git_lines(*args, on_failure: :abort)
     output, error, status = Open3.capture3("git", *args)
     return output.lines.map(&:strip).reject(&:empty?) if status.success?
+    return [] if on_failure == :ignore
 
-    warn "[bin/lint] git #{args.first} failed: #{error.lines.first&.strip}" unless quiet
-    []
+    raise LintAborted, "git #{args.first} failed: #{error.lines.first&.strip}"
   end
 
   def recent_files
@@ -309,7 +322,7 @@ class LefthookLinter
   end
 
   def core_lintable_file?(file)
-    return false if file.start_with?("../")
+    return false if outside_project?(file)
     return true if file == "Gemfile"
 
     extension = File.extname(file)[1..]
@@ -329,14 +342,24 @@ class LefthookLinter
   end
 
   def lintable_file?(file)
-    return false if SKIPPED_PATHS.include?(file)
-    return false if file.split("/").any? { |segment| SKIPPED_SEGMENTS.include?(segment) }
+    return false if skipped_project_path?(file)
     return true if File.basename(file) == "Gemfile"
 
     extension = File.extname(file)[1..]
     return ruby_script?(file) if extension.nil? || extension.empty?
 
     LINTABLE_EXTENSIONS.include?(extension)
+  end
+
+  def outside_project?(file)
+    file.start_with?("../")
+  end
+
+  def skipped_project_path?(file)
+    return false if outside_project?(file)
+    return true if SKIPPED_PATHS.include?(file)
+
+    file.split("/").any? { |segment| SKIPPED_SEGMENTS.include?(segment) }
   end
 
   def ruby_script?(file)
@@ -354,7 +377,7 @@ class LefthookLinter
   end
 
   def external_plugin_root(file)
-    return standalone_plugin_root(file) if file.start_with?("..")
+    return standalone_plugin_root(file) if outside_project?(file)
     return nil unless file.start_with?("plugins/")
 
     parts = file.split("/")
@@ -377,7 +400,7 @@ class LefthookLinter
     @bundled_plugins ||=
       begin
         output, status = Open3.capture2(File.join(PROJECT_ROOT, "script", "list_bundled_plugins"))
-        abort "Failed to list bundled plugins" unless status.success?
+        raise LintAborted, "Failed to list bundled plugins" unless status.success?
 
         Set.new(output.lines.map(&:strip).reject(&:empty?))
       end
@@ -468,5 +491,5 @@ end
 if __FILE__ == $0
   options = parse_options
   Dir.chdir(PROJECT_ROOT) # rubocop:disable Discourse/NoChdir
-  LefthookLinter.new(options).run
+  exit 1 unless LefthookLinter.new(options).run
 end

--- a/spec/tasks/lint_cli_spec.rb
+++ b/spec/tasks/lint_cli_spec.rb
@@ -5,7 +5,36 @@ require "tmpdir"
 
 load Rails.root.join("bin/lint")
 
+module FakeExecutable
+  INVOCATIONS_ENV = "LINT_SPEC_INVOCATIONS"
+  RECORD_ARGUMENTS = "printf '%s\\n' \"$*\" >> \"$#{INVOCATIONS_ENV}\""
+
+  def with_fake_executable(name, script = nil)
+    Dir.mktmpdir("lint") do |directory|
+      original_path = ENV.fetch("PATH")
+      original_invocations = ENV[INVOCATIONS_ENV]
+      fake_bin = File.join(directory, "bin")
+      executable = File.join(fake_bin, name)
+      invocations = File.join(directory, "invocations")
+
+      FileUtils.mkdir_p(fake_bin)
+      File.write(executable, ["#!/bin/sh", RECORD_ARGUMENTS, script].compact.join("\n") + "\n")
+      FileUtils.chmod(0o755, executable)
+
+      ENV["PATH"] = "#{fake_bin}:#{original_path}"
+      ENV[INVOCATIONS_ENV] = invocations
+
+      yield directory, invocations
+    ensure
+      ENV["PATH"] = original_path
+      ENV[INVOCATIONS_ENV] = original_invocations
+    end
+  end
+end
+
 RSpec.describe LefthookLinter do
+  include FakeExecutable
+
   it "reports when a core file has no configured linter" do
     expect { described_class.new(files: ["README.md"]).run }.to output(<<~OUTPUT).to_stdout
         [bin/lint] No core linter for: README.md
@@ -14,8 +43,57 @@ RSpec.describe LefthookLinter do
   end
 
   it "does not send non-plugin files outside the project to core linters" do
-    Dir.mktmpdir("lint-outside", Rails.root.parent) do |directory|
-      file = File.join(directory, "example.rb")
+    expect_no_core_linter_outside_project("example.rb")
+  end
+
+  it "applies the skipped path list only inside the project" do
+    expect_no_core_linter_outside_project("tmp/example.rb")
+  end
+
+  it "reports a failing linter without exiting the process" do
+    with_fake_executable("pnpm", "exit 1") do
+      expect { expect(described_class.new(files: ["Gemfile"]).run).to eq(false) }.to output(
+        %r{\[bin/lint\] core linters failed},
+      ).to_stdout
+    end
+  end
+
+  it "fails on the first git error instead of linting nothing" do
+    failing_git = "printf 'fatal: detected dubious ownership\\n' >&2\nexit 128"
+
+    with_fake_executable("git", failing_git) do |_directory, invocations|
+      expect { expect(described_class.new(recent: true).run).to eq(false) }.to output(
+        %r{\[bin/lint\] git log failed: fatal: detected dubious ownership},
+      ).to_stderr
+      expect(File.readlines(invocations).size).to eq(1)
+    end
+  end
+
+  it "expands symlinked directories returned by git" do
+    symlink = Rails.root.join("themes", "lint-spec-#{Process.pid}")
+
+    with_fake_executable("pnpm") do |directory, invocations|
+      target = File.join(directory, "target")
+
+      FileUtils.mkdir_p(target)
+      File.write(File.join(target, "example.rb"), "puts :example\n")
+      File.symlink(target, symlink)
+
+      expect { described_class.new(files: [symlink.to_s]).run }.to output(
+        %r{\[bin/lint\] All lints passed},
+      ).to_stdout
+      expect(File.read(invocations)).to include(
+        "lefthook run lint-files --file themes/#{symlink.basename}/example.rb",
+      )
+    ensure
+      FileUtils.rm_f(symlink)
+    end
+  end
+
+  def expect_no_core_linter_outside_project(relative_path)
+    Dir.mktmpdir("lint") do |directory|
+      file = File.join(directory, relative_path)
+      FileUtils.mkdir_p(File.dirname(file))
       File.write(file, "puts :example\n")
       relative_file = Pathname.new(file).relative_path_from(PROJECT_ROOT_PATH)
 
@@ -25,52 +103,16 @@ RSpec.describe LefthookLinter do
         OUTPUT
     end
   end
-
-  it "expands symlinked directories returned by git" do
-    Dir.mktmpdir("lint-symlink") do |directory|
-      original_path = ENV.fetch("PATH")
-      original_invocation_log = ENV["LINT_SPEC_INVOCATIONS"]
-      target = File.join(directory, "target")
-      fake_bin = File.join(directory, "bin")
-      invocation_log = File.join(directory, "invocations")
-      symlink = Rails.root.join("themes", "lint-spec-#{Process.pid}")
-
-      FileUtils.mkdir_p([target, fake_bin])
-      File.write(File.join(target, "example.rb"), "puts :example\n")
-      File.symlink(target, symlink)
-      File.write(
-        File.join(fake_bin, "pnpm"),
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$LINT_SPEC_INVOCATIONS\"\n",
-      )
-      FileUtils.chmod(0o755, File.join(fake_bin, "pnpm"))
-
-      ENV["PATH"] = "#{fake_bin}:#{original_path}"
-      ENV["LINT_SPEC_INVOCATIONS"] = invocation_log
-
-      expect { described_class.new(files: [symlink.to_s]).run }.to output(
-        %r{\[bin/lint\] All lints passed},
-      ).to_stdout
-      expect(File.read(invocation_log)).to include(
-        "lefthook run lint-files --file themes/#{symlink.basename}/example.rb",
-      )
-    ensure
-      ENV["PATH"] = original_path
-      ENV["LINT_SPEC_INVOCATIONS"] = original_invocation_log
-      FileUtils.rm_f(symlink)
-    end
-  end
 end
 
 RSpec.describe ExternalLinter do
-  it "batches large file sets for each external linter" do
-    Dir.mktmpdir("external-lint") do |directory|
-      original_path = ENV.fetch("PATH")
-      original_invocation_log = ENV["LINT_SPEC_INVOCATIONS"]
-      source_directory = File.join(directory, "lib")
-      fake_bin = File.join(directory, "bin")
-      invocation_log = File.join(directory, "invocations")
+  include FakeExecutable
 
-      FileUtils.mkdir_p([source_directory, fake_bin])
+  it "batches large file sets for each external linter" do
+    with_fake_executable("bundle") do |directory, invocations|
+      source_directory = File.join(directory, "lib")
+
+      FileUtils.mkdir_p(source_directory)
       files = []
       argument_bytes = 0
       index = 0
@@ -83,25 +125,13 @@ RSpec.describe ExternalLinter do
         index += 1
       end
 
-      File.write(File.join(fake_bin, "bundle"), <<~RUBY)
-          #!/usr/bin/env ruby
-          File.open(ENV.fetch("LINT_SPEC_INVOCATIONS"), "a") { |file| file.puts(ARGV.join(" ")) }
-        RUBY
-      FileUtils.chmod(0o755, File.join(fake_bin, "bundle"))
-
-      ENV["PATH"] = "#{fake_bin}:#{original_path}"
-      ENV["LINT_SPEC_INVOCATIONS"] = invocation_log
-
       linter = described_class.new(directory, files, fix: false)
       expect { linter.run }.to output(%r{\[bin/lint\] Running rubocop}).to_stdout
 
-      invocations = File.readlines(invocation_log, chomp: true)
-      expect(invocations.count { |invocation| invocation.start_with?("exec stree check") }).to eq(2)
-      expect(invocations.count { |invocation| invocation.start_with?("exec rubocop") }).to eq(2)
+      recorded = File.readlines(invocations, chomp: true)
+      expect(recorded.count { |invocation| invocation.start_with?("exec stree check") }).to eq(2)
+      expect(recorded.count { |invocation| invocation.start_with?("exec rubocop") }).to eq(2)
       expect(linter.results).to all(satisfy { |_, result| result })
-    ensure
-      ENV["PATH"] = original_path
-      ENV["LINT_SPEC_INVOCATIONS"] = original_invocation_log
     end
   end
 end


### PR DESCRIPTION
Previously, `bin/lint` applied its `node_modules`/`vendor`/`tmp`/`.git` skip list to every path, including paths outside the project, so a file under the system temp directory was dropped as "not a lintable file type". That is why the spec covering "files outside the project are not sent to core linters" built its fixture in the checkout's parent directory — the nearest directory whose relative path contains no skipped segment. In discourse_docker that parent is `/var/www`, which the non-root `discourse` user cannot write to, so the spec failed with `Errno::EACCES`.

This change scopes the skip list to project-relative paths, so the fixture can live in the system temp directory and the spec no longer depends on where the checkout lives. It also moves the process exit out of `LefthookLinter`, so a failing run reports a red example instead of killing `rspec` mid-file behind a green summary, and makes a failed `git` invocation fail the run rather than quietly linting nothing (`bin/lint --recent` previously exited 0 whenever git refused the repository).

### Verifying

The two conditions that differ in a container can be simulated locally:

```bash
(chmod 555 "$(dirname "$PWD")" && trap 'chmod 755 "$(dirname "$PWD")"' EXIT
 TMPDIR=/tmp bin/rspec spec/tasks/lint_cli_spec.rb)
```

CI cannot catch this class of bug: the container job runs as root, from `/__w/discourse/discourse` rather than `/var/www/discourse`, and root ignores the permission bits. A run inside discourse_docker is the only conclusive check.
