### PR TITLE
FIX: Prevent admin report filters from overflowing

### DIFF
--- a/app/assets/stylesheets/admin/admin_report_chart.scss
+++ b/app/assets/stylesheets/admin/admin_report_chart.scss
@@ -63,6 +63,7 @@
 
   &__filters {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-start; // aligned to top to provide alignment when subcat checkbox is in play
     gap: var(--space-2);
     margin-bottom: var(--space-4);


### PR DESCRIPTION
Admin report filters can extend off screen when the admin sidebar reduces the available content width.
This change allows the filters to wrap so every control remains visible.

### Screenshots

Before

<img width="855" height="360" alt="before" src="https://github.com/user-attachments/assets/330767e4-13b1-45b8-9c16-4ce4cfbe4e06" />


After

<img width="855" height="360" alt="after" src="https://github.com/user-attachments/assets/896a7e2d-00fa-447e-ba23-16f547eabbb5" />


Internal topic: t/-/12345