### PR TITLE
FIX: Restore topic link getters on user badge inlined topics

### DIFF
--- a/frontend/discourse/app/models/user-badge.js
+++ b/frontend/discourse/app/models/user-badge.js
@@ -15,7 +15,46 @@ import {
 } from "discourse/data/warp-rest-model";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getOwnerWithFallback } from "discourse/lib/get-owner";
+import getURL from "discourse/lib/get-url";
+import { fancyTitle } from "discourse/lib/topic-fancy-title";
 import Badge from "discourse/models/badge";
+
+// The inlined `topic` attribute is plain sideloaded JSON (see UserBadgeSchema),
+// so it lacks the two computed getters the unmigrated Topic record used to
+// provide and templates read (e.g. `badges/show`). Re-add them, mirroring the
+// Topic model. Copies are memoized against the raw object so repeated reads —
+// and user badges sharing a sideloaded topic — see the same reference.
+const decoratedTopics = new WeakMap();
+
+function withTopicComputedGetters(raw) {
+  const existing = decoratedTopics.get(raw);
+  if (existing) {
+    return existing;
+  }
+
+  const topic = {
+    ...raw,
+    get url() {
+      let slug = this.slug || "";
+      if (slug.trim().length === 0) {
+        slug = "topic";
+      }
+      return `${getURL("/t/")}${slug}/${this.id}`;
+    },
+    get fancyTitle() {
+      const siteSettings = getOwnerWithFallback().lookup(
+        "service:site-settings"
+      );
+      return fancyTitle(
+        this.fancy_title,
+        siteSettings?.support_mixed_text_direction
+      );
+    },
+  };
+  decoratedTopics.set(raw, topic);
+  return topic;
+}
 
 export default class UserBadge extends RestCompatModel {
   static type = "user-badge";
@@ -52,6 +91,21 @@ export default class UserBadge extends RestCompatModel {
       this.#badge = resource ? new Badge(resource) : undefined;
     }
     return this.#badge;
+  }
+
+  #topic;
+  #topicResource;
+
+  get topic() {
+    const raw = this.__resource?.topic;
+    if (!raw) {
+      return raw;
+    }
+    if (raw !== this.#topicResource) {
+      this.#topicResource = raw;
+      this.#topic = withTopicComputedGetters(raw);
+    }
+    return this.#topic;
   }
 
   // Getter: null → undefined (test contract).

--- a/frontend/discourse/tests/fixtures/user-badges.js
+++ b/frontend/discourse/tests/fixtures/user-badges.js
@@ -22,11 +22,22 @@ const userBadgesFixtures = {
           "//www.gravatar.com/avatar/a4151b1fd72089c54e2374565a87da7f.png?s={size}\u0026r=pg\u0026d=identicon",
       },
     ],
+    topics: [
+      {
+        id: 280,
+        title: "Topic 280",
+        fancy_title: "Topic &amp; more",
+        slug: "topic-280",
+        posts_count: 10,
+      },
+    ],
     user_badge: {
       id: 665,
       granted_at: "2014-03-09T20:30:01.190-04:00",
       badge_id: 874,
       granted_by_id: 13470,
+      post_number: 5,
+      topic_id: 280,
     },
   },
   "/user-badges/:username": {

--- a/frontend/discourse/tests/unit/models/user-badge-test.js
+++ b/frontend/discourse/tests/unit/models/user-badge-test.js
@@ -30,6 +30,22 @@ module("Unit | Model | user-badge", function (hooks) {
     );
   });
 
+  test("inlined topic exposes computed url and fancyTitle", function (assert) {
+    const userBadge = UserBadge.createFromJson(
+      cloneJSON(badgeFixtures["/user_badges"])
+    );
+    assert.strictEqual(
+      userBadge.topic.url,
+      "/t/topic-280/280",
+      "topic url is computed from the sideloaded topic"
+    );
+    assert.strictEqual(
+      userBadge.topic.fancyTitle,
+      "Topic &amp; more",
+      "topic fancyTitle is computed from the sideloaded topic"
+    );
+  });
+
   test("createFromJson array", function (assert) {
     const userBadges = UserBadge.createFromJson(
       cloneJSON(badgeFixtures["/user-badges/:username"])


### PR DESCRIPTION
Since #42147 (a6e133c), topic links on badge pages no longer render: the grants list on `/badges/:id/:slug` shows blank space where the "granted on <topic>" link used to be. The API data is intact — only the client-side computed fields are missing.

Visible in the wild, e.g. https://meta.discourse.org/badges/6/nice-reply (grants list shows no topic links). Also reported by a large community instance: https://linux.do/t/topic/2851121

### Root cause

`badges/show.gjs` renders each grant as:

```hbs
<a class="post-link" href="{{ub.topic.url}}/{{ub.post_number}}">{{trustHTML ub.topic.fancyTitle}}</a>
```

Before #42147, `UserBadge.createFromJson` wrapped each entry of the payload's `topics` sideload with `Topic.create(...)`, so `ub.topic` exposed the Topic record's computed getters `url` and `fancyTitle`.

After #42147, `userBadgeResource()` in `data/normalize.js` inlines the raw JSON object instead (`attributes.topic = lookup.topic(raw.topic_id)`). That object only carries serialized fields — `BasicTopicSerializer` emits `fancy_title` (snake_case) and has no `url` field at all — so both lookups are `undefined` and the template renders an empty `<a>`.

This fix restores those two getters on the inlined topic, mirroring the Topic model:

- `url` — `getURL("/t/") + slug + "/" + id` (slug falls back to `topic`, subfolder-safe via `getURL`)
- `fancyTitle` — reuses the existing `fancyTitle` helper in `discourse/lib/topic-fancy-title`, with `support_mixed_text_direction` from the site-settings service

The wrapper is memoized against the raw sideloaded object (WeakMap), so repeated reads and user badges sharing a topic see the same reference — matching the old `topicsById` behavior. This follows the same compat pattern the model already uses for `badge` (`new Badge(resource)`).

### Notes on alternatives

- Changing the template to read raw fields (`ub.topic.fancy_title`, building the URL from `slug`/`topic_id`) also works, but leaves the getters missing for any other template/plugin reading `userBadge.topic.url`, and can't use `ub.topic_title` — that attribute is permission-filtered by `allowed_user_badge_topic_ids` (`UserBadgePostAndTopicAttributesMixin`) and is absent for anonymous visitors.
- I audited the other `userBadge` call sites touched by #42147: admin `admin-user/badges` reads `userBadge.postUrl` + `userBadge.topic_title` (unchanged legacy behavior), the grant-badge modal doesn't read `topic`, and `d-user-info` only reads raw user fields — the badge page template was the only broken consumer.

### Testing

Extended `tests/unit/models/user-badge-test.js` with a fixture carrying a `topics` sideload + `topic_id`/`post_number`, asserting `topic.url` and `topic.fancyTitle` are computed.

Repro of the bug on `main`: open any badge details page with post-linked grants on a tests-passed site — e.g. https://meta.discourse.org/badges/6/nice-reply — grants show no topic link; `user_badges.json?badge_id=6` still returns full `topics` data.
