### PR TITLE
FIX: Default event end date picker to next day

### DIFF
--- a/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -474,6 +474,18 @@ export default class CompactEventEditor extends Component {
   }
 
   @action
+  focusEndDateInput(event) {
+    if (!this.endsAt && this.startsAt) {
+      const oldConfig = this.#configSnapshot();
+      this.endsAt = this.startsAt.clone().add(1, "day");
+      this.#reconcileReminders(oldConfig, this.#configSnapshot());
+      this.#emitChange();
+    }
+
+    this.focusDateInput(event);
+  }
+
+  @action
   handleTextInputFocus(event) {
     if (this.capabilities.isIOS) {
       setTimeout(() => {
@@ -781,10 +793,11 @@ export default class CompactEventEditor extends Component {
             <div class="composer-event__date-wrapper">
               <input
                 class="composer-event__date-input"
+                min={{this.formattedStartDate}}
                 type="date"
                 value={{this.formattedEndDate}}
                 {{on "change" this.onEndDateChange}}
-                {{on "focus" this.focusDateInput}}
+                {{on "focus" this.focusEndDateInput}}
               />
               <span
                 class={{dConcatClass

--- a/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
+++ b/plugins/discourse-events/test/javascripts/integration/components/compact-event-editor-test.gjs
@@ -1,4 +1,4 @@
-import { fillIn, render } from "@ember/test-helpers";
+import { fillIn, findAll, render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import CompactEventEditor from "discourse/plugins/discourse-events/discourse/components/compact-event-editor";
@@ -171,5 +171,34 @@ module("Integration | Component | CompactEventEditor", function (hooks) {
         "Add location",
         "location stops advertising URLs once url is a separate row"
       );
+  });
+
+  test("defaults the end date to the day after the start date", async function (assert) {
+    const initialState = stateWith({
+      allDay: true,
+      startsAt: moment("2027-07-14T00:00:00Z"),
+      endsAt: null,
+    });
+    let lastState = null;
+    await renderEditor(initialState, (state) => (lastState = state));
+
+    assert
+      .dom(findAll(".composer-event__date-input")[1])
+      .hasAttribute("min", "2027-07-14");
+
+    const endDateInput = findAll(".composer-event__date-input")[1];
+    endDateInput.showPicker = () => {};
+    await triggerEvent(endDateInput, "focus");
+
+    assert.strictEqual(lastState.endsAt.format("YYYY-MM-DD"), "2027-07-15");
+    assert.dom(endDateInput).hasValue("2027-07-15");
+
+    const startDateInput = findAll(".composer-event__date-input")[0];
+    startDateInput.value = "2027-08-20";
+    await triggerEvent(startDateInput, "change");
+
+    assert
+      .dom(findAll(".composer-event__date-input")[1])
+      .hasAttribute("min", "2027-08-20");
   });
 });


### PR DESCRIPTION
This improves the compact event composer when creating a multi-day event far in the future.

Previously, the empty end-date picker had no date to anchor its native calendar. It could open on an unrelated month, requiring the user to navigate back to the selected start date.

The end-date input now:

- uses the start date as its minimum
- defaults to the following day when first opened without an existing end date
- preserves an existing end date

For example, an event starting on July 14, 2027 opens the end-date picker with July 15 selected.

Added integration coverage for the minimum date, next-day default, and updates after the start date changes. The broken and corrected behavior were also verified manually in DV.

Meta: [Optimize the selection of the month for an event](https://meta.discourse.org/t/optimize-the-selection-of-the-month-for-an-event/411753)