### PR TITLE
FIX: Guard auth routes for logged-in users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -691,6 +691,8 @@ class UsersController < ApplicationController
   end
 
   def create
+    raise Discourse::InvalidAccess if current_user && !is_api?
+
     params.require(:email)
     params.require(:username)
     params.require(:invite_code) if SiteSetting.require_invite_code

--- a/frontend/discourse/app/routes/login.js
+++ b/frontend/discourse/app/routes/login.js
@@ -20,6 +20,22 @@ export default class extends DiscourseRoute {
   beforeModel(transition) {
     const { from, wantsTo } = transition;
     const { currentUser, dialog, router } = this;
+
+    if (currentUser) {
+      const { redirect } = transition.to.queryParams;
+      if (redirect) {
+        transition.abort();
+        // Keep redirect validation on the server.
+        DiscourseURL.redirectTo(
+          getURL(`/login?redirect=${encodeURIComponent(redirect)}`)
+        );
+        return;
+      }
+
+      router.replaceWith("/").followRedirects();
+      return;
+    }
+
     const { isReadOnly, isStaffWritesOnly } = this.site;
     const { isAppWebview } = this.capabilities;
     const { auth_immediately, enable_discourse_connect, login_required } =
@@ -56,12 +72,10 @@ export default class extends DiscourseRoute {
     }
 
     // Automatically store the current URL (aka. the one **before** the transition)
-    if (!currentUser) {
-      if (isValidDestinationUrl(url)) {
-        cookie("destination_url", url + query);
-      } else if (DiscourseURL.isInternalTopic(referrer)) {
-        cookie("destination_url", referrer);
-      }
+    if (isValidDestinationUrl(url)) {
+      cookie("destination_url", url + query);
+    } else if (DiscourseURL.isInternalTopic(referrer)) {
+      cookie("destination_url", referrer);
     }
 
     // Automatically kick off the external login if it's the only one available

--- a/frontend/discourse/app/routes/signup.js
+++ b/frontend/discourse/app/routes/signup.js
@@ -20,6 +20,12 @@ export default class extends DiscourseRoute {
   beforeModel(transition) {
     const { from, wantsTo } = transition;
     const { currentUser, dialog, router } = this;
+
+    if (currentUser) {
+      router.replaceWith("/").followRedirects();
+      return;
+    }
+
     const { isReadOnly } = this.site;
     const { isAppWebview } = this.capabilities;
     const {
@@ -67,12 +73,10 @@ export default class extends DiscourseRoute {
     }
 
     // Automatically store the current URL (aka. the one **before** the transition)
-    if (!currentUser) {
-      if (isValidDestinationUrl(url)) {
-        cookie("destination_url", url + query);
-      } else if (DiscourseURL.isInternalTopic(referrer)) {
-        cookie("destination_url", referrer);
-      }
+    if (isValidDestinationUrl(url)) {
+      cookie("destination_url", url + query);
+    } else if (DiscourseURL.isInternalTopic(referrer)) {
+      cookie("destination_url", referrer);
     }
 
     // Automatically kick off the external login if it's the only one available

--- a/frontend/discourse/tests/acceptance/authentication-routes-test.js
+++ b/frontend/discourse/tests/acceptance/authentication-routes-test.js
@@ -1,0 +1,61 @@
+import { click, currentURL, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import sinon from "sinon";
+import { cloneJSON } from "discourse/lib/object";
+import DiscourseURL from "discourse/lib/url";
+import topicFixtures from "discourse/tests/fixtures/topic";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Authentication routes - logged in", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    const topic = cloneJSON(topicFixtures["/t/280/1.json"]);
+    topic.post_stream.posts[0].cooked =
+      '<p><a href="/login">Log in</a> <a href="/signup">Sign up</a> <a href="/login?redirect=%2Fmy%2Fpreferences">Log in with a destination</a></p>';
+
+    server.get("/t/280.json", () => helper.response(topic));
+    server.get("/t/280/:post_number.json", () => helper.response(topic));
+  });
+
+  test("login links with a destination use the server redirect validation", async function (assert) {
+    const redirect = sinon.stub(DiscourseURL, "redirectTo");
+    await visit("/t/internationalization-localization/280");
+    await click('.cooked a[href^="/login?redirect="]');
+
+    assert.true(
+      redirect.calledWithExactly("/login?redirect=%2Fmy%2Fpreferences"),
+      "Rails handles the login redirect"
+    );
+    assert.dom("#login-account-name").doesNotExist("login form is not shown");
+  });
+
+  for (const route of ["login", "signup"]) {
+    test(`visiting ${route} directly redirects home`, async function (assert) {
+      await visit(`/${route}`);
+
+      assert.strictEqual(currentURL(), "/", "redirects to the homepage");
+      assert.dom("#login-account-name").doesNotExist("login form is not shown");
+      assert.dom("#new-account-email").doesNotExist("signup form is not shown");
+    });
+
+    test(`clicking a ${route} link in a post redirects home`, async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      await click(`.cooked a[href="/${route}"]`);
+
+      assert.strictEqual(currentURL(), "/", "redirects to the homepage");
+      assert.dom("#login-account-name").doesNotExist("login form is not shown");
+      assert.dom("#new-account-email").doesNotExist("signup form is not shown");
+    });
+
+    test(`visiting ${route} on a login-required site redirects home`, async function (assert) {
+      this.siteSettings.login_required = true;
+
+      await visit(`/${route}`);
+
+      assert.strictEqual(currentURL(), "/", "redirects to the homepage");
+      assert.dom("#login-account-name").doesNotExist("login form is not shown");
+      assert.dom("#new-account-email").doesNotExist("signup form is not shown");
+    });
+  }
+});

--- a/frontend/discourse/tests/acceptance/email-notice-test.js
+++ b/frontend/discourse/tests/acceptance/email-notice-test.js
@@ -45,15 +45,6 @@ acceptance("Email Disabled Banner - no SMTP configured", function (needs) {
     assert.dom(".alert-emails-disabled").doesNotExist();
   });
 
-  test("shows on email-related routes when no SMTP", async function (assert) {
-    this.siteSettings.disable_emails = "no";
-    await visit("/login");
-    assert.dom(".alert-emails-disabled").exists();
-    assert
-      .dom(".alert-emails-disabled .text")
-      .hasText(i18n("emails_are_disabled_no_smtp"));
-  });
-
   test("disable_emails setting takes precedence and shows globally", async function (assert) {
     this.siteSettings.disable_emails = "yes";
     await visit("/latest");
@@ -70,6 +61,28 @@ acceptance("Email Disabled Banner - no SMTP configured", function (needs) {
     assert.dom(".alert-emails-disabled").exists();
   });
 });
+
+acceptance(
+  "Email Disabled Banner - anonymous with no SMTP configured",
+  function (needs) {
+    needs.site({ email_configured: false });
+
+    test("shows on email-related routes when no SMTP", async function (assert) {
+      this.siteSettings.disable_emails = "no";
+      await visit("/login");
+
+      assert
+        .dom(".alert-emails-disabled")
+        .exists("the missing SMTP banner is shown");
+      assert
+        .dom(".alert-emails-disabled .text")
+        .hasText(
+          i18n("emails_are_disabled_no_smtp"),
+          "explains that SMTP is not configured"
+        );
+    });
+  }
+);
 
 acceptance(
   "Email Disabled Banner - email_configured absent from site data",

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -833,6 +833,33 @@ RSpec.describe UsersController do
       post "/u.json", params: post_user_params.merge(extra_params)
     end
 
+    it "rejects signup from a logged-in browser session" do
+      sign_in(user1)
+
+      expect { post_user }.not_to change { User.count }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "rejects signup from an admin browser session" do
+      sign_in(admin)
+
+      expect { post_user }.not_to change { User.count }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "allows signup with an API key" do
+      api_key = Fabricate(:api_key, user: user1)
+
+      expect do
+        post "/u.json", params: post_user_params, headers: { HTTP_API_KEY: api_key.key }
+      end.to change { User.count }.by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["success"]).to eq(true)
+    end
+
     context "when email params is missing" do
       it "should raise the right error" do
         post "/u.json",
@@ -1742,9 +1769,9 @@ RSpec.describe UsersController do
         let(:update_user_url) { "/u/#{user1.username}.json" }
         let(:field_id) { user_field.id.to_s }
 
-        before { sign_in(user1) }
-
         context "with multple select fields" do
+          before { sign_in(user1) }
+
           let(:valid_options) { %w[Axe Sword] }
 
           fab!(:user_field) do
@@ -1830,6 +1857,8 @@ RSpec.describe UsersController do
         end
 
         context "with dropdown fields" do
+          before { sign_in(user1) }
+
           let(:valid_options) { ["Black Mesa", "Fox Hound"] }
 
           fab!(:user_field) do
@@ -5019,8 +5048,8 @@ RSpec.describe UsersController do
       end
 
       it "raises an error when logged in" do
-        sign_in(moderator)
         post_user
+        sign_in(moderator)
 
         put "/u/update-activation-email.json", params: { email: "updatedemail@example.com" }
 


### PR DESCRIPTION
Redirect logged-in users away from login and signup forms, while
keeping login destination validation on the server.

Reject account creation from authenticated browser sessions, including
admins, while preserving API access. Add acceptance and request coverage.