### PR TITLE
FIX: Allow deleting the final tag localization

### DIFF
--- a/app/services/tag_settings_updater.rb
+++ b/app/services/tag_settings_updater.rb
@@ -73,7 +73,7 @@ class TagSettingsUpdater
   end
 
   def update_localizations(localizations)
-    return if localizations.blank?
+    return if localizations.nil?
 
     submitted_locales = []
 

--- a/spec/services/tag_settings_updater_spec.rb
+++ b/spec/services/tag_settings_updater_spec.rb
@@ -169,6 +169,10 @@ describe TagSettingsUpdater do
 
         expect(TagLocalization.find_by(tag_id: tag.id, locale: "es")).to be_present
         expect(TagLocalization.find_by(tag_id: tag.id, locale: "it")).to be_nil
+
+        TagSettingsUpdater.update(tag, admin, { localizations: [] })
+
+        expect(TagLocalization.where(tag_id: tag.id)).to be_empty
       end
     end
   end

--- a/spec/system/page_objects/pages/tag_settings.rb
+++ b/spec/system/page_objects/pages/tag_settings.rb
@@ -51,6 +51,19 @@ module PageObjects
         self
       end
 
+      def remove_localization
+        find(".form-kit__collection .btn-danger").click
+        self
+      end
+
+      def has_localizations?
+        has_css?(".form-kit__collection")
+      end
+
+      def has_no_localizations?
+        has_no_css?(".form-kit__collection")
+      end
+
       def name_input
         find("input[name='name']")
       end

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -72,6 +72,10 @@ describe "Tag Settings" do
     end
 
     it "allows privileged users to edit tag, admin to delete tag" do
+      SiteSetting.content_localization_enabled = true
+      tag_1.update!(locale: "en")
+      Fabricate(:tag_localization, tag: tag_1, locale: "de", name: "gestaltung")
+
       sign_in(trust_level_4)
       tags_page.visit_tag(tag_1)
       tags_page.edit_tag_btn.click
@@ -98,6 +102,18 @@ describe "Tag Settings" do
       expect(tag_settings_page).to have_no_synonyms
 
       sign_in(admin)
+      tag_1.reload
+      tag_settings_page.visit_tab(tag_1, "localizations")
+      expect(tag_settings_page).to have_localizations
+      tag_settings_page.remove_localization
+      tag_settings_page.click_save
+
+      expect(toasts).to have_success(I18n.t("js.tagging.settings.saved"))
+
+      page.refresh
+
+      expect(tag_settings_page).to have_no_localizations
+
       tags_page.visit_tag(tag_2)
       tags_page.edit_tag_btn.click
       expect(page).to have_css(".d-page-header__actions .btn-danger")


### PR DESCRIPTION
Classic `blank` issue. Deleting all causes a no-op as `[].blank?` is true.