### PR TITLE
DEV: Collapse redundant `isDestroyed` checks into `isDestroying`

### DIFF
--- a/frontend/discourse/admin/components/admin-report.gjs
+++ b/frontend/discourse/admin/components/admin-report.gjs
@@ -441,7 +441,7 @@ export default class AdminReport extends Component {
   fetchOrRender() {
     if (this.args.preloadedData) {
       next(() => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
         this._renderReport(this._loadReport(this.args.preloadedData));
@@ -514,7 +514,7 @@ export default class AdminReport extends Component {
       let payload = this._buildPayload(["prev_period"]);
 
       const callback = (response) => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 

--- a/frontend/discourse/admin/components/modal/install-theme.gjs
+++ b/frontend/discourse/admin/components/modal/install-theme.gjs
@@ -280,7 +280,7 @@ export default class InstallThemeModal extends Component {
   #backgroundLoading() {
     if (this.loading) {
       discourseLater(() => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 

--- a/frontend/discourse/app/components/ace-editor.gjs
+++ b/frontend/discourse/app/components/ace-editor.gjs
@@ -90,7 +90,7 @@ export default class AceEditor extends Component {
     super(...arguments);
 
     loadAce().then((ace) => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/components/choose-topic.gjs
+++ b/frontend/discourse/app/components/choose-topic.gjs
@@ -48,7 +48,7 @@ export default class ChooseTopic extends Component {
       }
     }
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/composer-actions.gjs
+++ b/frontend/discourse/app/components/composer-actions.gjs
@@ -69,7 +69,7 @@ export default class ComposerActions extends Component {
     }
 
     requestAnimationFrame(() => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/components/composer-body.js
+++ b/frontend/discourse/app/components/composer-body.js
@@ -81,7 +81,7 @@ export default class ComposerBody extends Component {
   }
 
   composerResized() {
-    if (!this.element || this.isDestroying || this.isDestroyed) {
+    if (!this.element || this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/composer-messages.gjs
+++ b/frontend/discourse/app/components/composer-messages.gjs
@@ -84,7 +84,7 @@ export default class ComposerMessages extends Component {
   }
 
   _closeTop() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -98,7 +98,7 @@ export default class ComposerMessages extends Component {
   }
 
   _create(info) {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -128,7 +128,7 @@ export default class ComposerMessages extends Component {
   // Some messages only get shown after being typed.
   @debounce(INPUT_DELAY)
   async _typedReply() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -185,7 +185,7 @@ export default class ComposerMessages extends Component {
           }
         );
 
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 
@@ -225,7 +225,7 @@ export default class ComposerMessages extends Component {
   }
 
   async _findSimilar() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -269,7 +269,7 @@ export default class ComposerMessages extends Component {
       raw,
     });
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -285,7 +285,7 @@ export default class ComposerMessages extends Component {
 
   // Figure out if there are any messages that should be displayed above the composer.
   async _findMessages() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -312,7 +312,7 @@ export default class ComposerMessages extends Component {
       messages = _messagesCache.messages;
     } else {
       messages = await this.composer.store.find("composer-message", args);
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/components/composer-title.gjs
+++ b/frontend/discourse/app/components/composer-title.gjs
@@ -133,7 +133,7 @@ export default class ComposerTitle extends Component {
   }
 
   _checkForUrl() {
-    if (!this.element || this.isDestroying || this.isDestroyed) {
+    if (!this.element || this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/d-editor-original-translation-preview.gjs
+++ b/frontend/discourse/app/components/d-editor-original-translation-preview.gjs
@@ -32,7 +32,7 @@ class DecoratedPreviewCookText extends Component {
     const rawText = this.args.rawText;
     const cooked = await waitForPromise(cook(rawText, { previewing: true }));
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/discourse-topic.js
+++ b/frontend/discourse/app/components/discourse-topic.js
@@ -108,7 +108,7 @@ export default class DiscourseTopic extends Component {
   // The user has scrolled the window, or it is finished rendering and ready for processing.
   @bind
   scrolled() {
-    if (this.isDestroyed || this.isDestroying || this._state !== "inDOM") {
+    if (this.isDestroying || this._state !== "inDOM") {
       return;
     }
 

--- a/frontend/discourse/app/components/glimmer-site-header.gjs
+++ b/frontend/discourse/app/components/glimmer-site-header.gjs
@@ -101,7 +101,7 @@ export default class GlimmerSiteHeader extends Component {
   }
 
   recalculateHeaderOffset() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/header.gjs
+++ b/frontend/discourse/app/components/header.gjs
@@ -145,7 +145,7 @@ export default class GlimmerHeader extends Component {
 
   @action
   toggleSearchMenu(_, value) {
-    if (!this.site.can_search || this.isDestroying || this.isDestroyed) {
+    if (!this.site.can_search || this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/modal/gifs.gjs
+++ b/frontend/discourse/app/components/modal/gifs.gjs
@@ -92,7 +92,7 @@ export default class GifsModal extends Component {
     try {
       const response = await fetch(getURL(GIFS_CATEGORIES_URL));
 
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -102,7 +102,7 @@ export default class GifsModal extends Component {
 
       const data = await response.json();
 
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -169,7 +169,7 @@ export default class GifsModal extends Component {
     try {
       const response = await fetch(this.getEndpoint(this.query, this.offset));
 
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -178,7 +178,7 @@ export default class GifsModal extends Component {
       }
 
       const data = await response.json();
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -376,7 +376,7 @@ export default class Nested extends Component {
 
   @action
   persistScrollAnchor() {
-    if (this.isDestroying || this.isDestroyed || this.#restoringStoredScroll) {
+    if (this.isDestroying || this.#restoringStoredScroll) {
       return;
     }
 
@@ -569,7 +569,7 @@ export default class Nested extends Component {
 
   @action
   scrollMobileFocusIntoContext(element) {
-    if (!this.isMobileFocused || this.isDestroying || this.isDestroyed) {
+    if (!this.isMobileFocused || this.isDestroying) {
       return;
     }
 
@@ -630,7 +630,7 @@ export default class Nested extends Component {
 
   @action
   syncFocusFromURL() {
-    if (this.isDestroying || this.isDestroyed || !this.site.mobileView) {
+    if (this.isDestroying || !this.site.mobileView) {
       return;
     }
 
@@ -760,7 +760,7 @@ export default class Nested extends Component {
   }
 
   #scrollToTarget() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/components/nested/post-children.gjs
+++ b/frontend/discourse/app/components/nested/post-children.gjs
@@ -178,11 +178,7 @@ export default class NestedPostChildren extends Component {
       const data = await ajax(
         `/n/${this.args.topic.slug}/${this.args.topic.id}/children/${this.args.parentPostNumber}.json?${query}`
       );
-      if (
-        this.isDestroying ||
-        this.isDestroyed ||
-        this.identityKey !== identityKey
-      ) {
+      if (this.isDestroying || this.identityKey !== identityKey) {
         return;
       }
       this.childNodes = this._childrenForTopic(data.children, topicId).map(
@@ -194,11 +190,11 @@ export default class NestedPostChildren extends Component {
       this._fetchedFromServer = true;
       this._reportToCache();
     } catch (e) {
-      if (!(this.isDestroying || this.isDestroyed)) {
+      if (!this.isDestroying) {
         popupAjaxError(e);
       }
     } finally {
-      if (!(this.isDestroying || this.isDestroyed)) {
+      if (!this.isDestroying) {
         this.loading = false;
       }
     }
@@ -227,11 +223,7 @@ export default class NestedPostChildren extends Component {
       const data = await ajax(
         `/n/${this.args.topic.slug}/${this.args.topic.id}/children/${this.args.parentPostNumber}.json?${query}`
       );
-      if (
-        this.isDestroying ||
-        this.isDestroyed ||
-        this.identityKey !== identityKey
-      ) {
+      if (this.isDestroying || this.identityKey !== identityKey) {
         return;
       }
       const newNodes = this._childrenForTopic(data.children, topicId).map(
@@ -260,11 +252,11 @@ export default class NestedPostChildren extends Component {
       this.hasMore = data.has_more || false;
       this._reportToCache();
     } catch (e) {
-      if (!(this.isDestroying || this.isDestroyed)) {
+      if (!this.isDestroying) {
         popupAjaxError(e);
       }
     } finally {
-      if (!(this.isDestroying || this.isDestroyed)) {
+      if (!this.isDestroying) {
         this.loadingMore = false;
       }
     }

--- a/frontend/discourse/app/components/nested/post.gjs
+++ b/frontend/discourse/app/components/nested/post.gjs
@@ -141,7 +141,7 @@ export default class NestedPost extends Component {
   }
 
   #registerPost() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -416,7 +416,6 @@ export default class NestedPost extends Component {
       );
       if (
         this.isDestroying ||
-        this.isDestroyed ||
         this.childCacheKey !== cacheKey ||
         [this.args.topic?.id, this.args.post.post_number, this.args.sort].join(
           ":"
@@ -440,12 +439,12 @@ export default class NestedPost extends Component {
       });
       return childNodes;
     } catch (e) {
-      if (!(this.isDestroying || this.isDestroyed)) {
+      if (!this.isDestroying) {
         popupAjaxError(e);
       }
       return null;
     } finally {
-      if (!(this.isDestroying || this.isDestroyed)) {
+      if (!this.isDestroying) {
         this.loadingReplies = false;
       }
     }
@@ -460,7 +459,7 @@ export default class NestedPost extends Component {
     if (this.mobileFocusEnabled) {
       const returnAnchor = this.args.captureScrollAnchor?.();
       const children = await this.childrenForMobileFocus();
-      if (children && !(this.isDestroying || this.isDestroyed)) {
+      if (children && !this.isDestroying) {
         this.args.focusPost(this.childPathWithChildren(children), returnAnchor);
       }
       return;

--- a/frontend/discourse/app/components/post-text-selection.gjs
+++ b/frontend/discourse/app/components/post-text-selection.gjs
@@ -93,7 +93,7 @@ export default class PostTextSelection extends Component {
 
     const { markdown } = await quoteState.markdown();
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -107,7 +107,7 @@ export default class PostTextSelection extends Component {
     } else {
       const result = await ajax(`/posts/${post.id}`);
 
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -132,7 +132,7 @@ export default class PostTextSelection extends Component {
         .querySelector("#reply-control")
         ?.addEventListener("transitionend", () => {
           const textarea = document.querySelector(".d-editor-input");
-          if (!textarea || this.isDestroyed || this.isDestroying) {
+          if (!textarea || this.isDestroying) {
             return;
           }
 

--- a/frontend/discourse/app/components/topic-navigation.gjs
+++ b/frontend/discourse/app/components/topic-navigation.gjs
@@ -1,10 +1,6 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
-import {
-  isDestroyed,
-  isDestroying,
-  registerDestructor,
-} from "@ember/destroyable";
+import { isDestroying, registerDestructor } from "@ember/destroyable";
 import { array } from "@ember/helper";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
@@ -203,7 +199,7 @@ export default class TopicNavigation extends Component {
       .forEach((el) => el.classList.remove("show"));
 
     discourseLater(() => {
-      if (isDestroying(this) || isDestroyed(this)) {
+      if (isDestroying(this)) {
         return;
       }
       this.info.topicProgressExpanded = false;

--- a/frontend/discourse/app/controllers/full-page-search.js
+++ b/frontend/discourse/app/controllers/full-page-search.js
@@ -648,7 +648,7 @@ export default class FullPageSearchController extends Controller {
     this.set("searchTerm", "");
 
     schedule("afterRender", () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -669,7 +669,7 @@ export default class FullPageSearchController extends Controller {
     }
 
     schedule("afterRender", () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/controllers/invites/show.js
+++ b/frontend/discourse/app/controllers/invites/show.js
@@ -31,7 +31,7 @@ export default class InvitesShowController extends Controller {
     getAuthOptionsUsername: () => this.authOptions?.username,
     getForceValidationReason: () => this.forceValidationReason,
     siteSettings: this.siteSettings,
-    isInvalid: () => this.isDestroying || this.isDestroyed,
+    isInvalid: () => this.isDestroying,
     updateIsDeveloper: (isDeveloper) => (this.isDeveloper = isDeveloper),
     updateUsernames: (username) => {
       this.accountUsername = username;

--- a/frontend/discourse/app/controllers/signup.js
+++ b/frontend/discourse/app/controllers/signup.js
@@ -53,7 +53,7 @@ export default class SignupPageController extends Controller {
     getAuthOptionsUsername: () => this.authOptions?.username,
     getForceValidationReason: () => this.forceValidationReason,
     siteSettings: this.siteSettings,
-    isInvalid: () => this.isDestroying || this.isDestroyed,
+    isInvalid: () => this.isDestroying,
     updateIsDeveloper: (isDeveloper) => (this.isDeveloper = isDeveloper),
     updateUsernames: (username) => {
       this.accountUsername = username;
@@ -342,7 +342,7 @@ export default class SignupPageController extends Controller {
 
     return User.checkEmail(this.accountEmail)
       .then((result) => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 
@@ -454,7 +454,7 @@ export default class SignupPageController extends Controller {
 
     this._hpPromise = ajax("/session/hp.json")
       .then((json) => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 
@@ -513,7 +513,7 @@ export default class SignupPageController extends Controller {
     this.set("formSubmitted", true);
     return User.createAccount(attrs).then(
       (result) => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 

--- a/frontend/discourse/app/instance-initializers/register-media-optimization-upload-processor.js
+++ b/frontend/discourse/app/instance-initializers/register-media-optimization-upload-processor.js
@@ -28,7 +28,7 @@ export default {
         ({ isMobileDevice }) => {
           return {
             optimizeFn: (data, opts) => {
-              if (owner.isDestroyed || owner.isDestroying) {
+              if (owner.isDestroying) {
                 return Promise.resolve();
               }
 

--- a/frontend/discourse/app/lib/decorators.js
+++ b/frontend/discourse/app/lib/decorators.js
@@ -113,7 +113,7 @@ export function afterRender(target, name, descriptor) {
   const originalFunction = descriptor.value;
   descriptor.value = function () {
     schedule("afterRender", () => {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         return originalFunction.apply(this, arguments);
       }
     });

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -231,11 +231,7 @@ class _PluginApi {
   }
 
   _lookupContainer(path) {
-    if (
-      !this.container ||
-      this.container.isDestroying ||
-      this.container.isDestroyed
-    ) {
+    if (!this.container || this.container.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/lib/uppy/composer-upload.js
+++ b/frontend/discourse/app/lib/uppy/composer-upload.js
@@ -273,7 +273,7 @@ export default class UppyComposerUpload {
 
     this.uppyWrapper.uppyInstance.on("progress", (progress) => {
       run(() => {
-        if (this.composer.isDestroying || this.composer.isDestroyed) {
+        if (this.composer.isDestroying) {
           return;
         }
 
@@ -305,7 +305,7 @@ export default class UppyComposerUpload {
 
     this.uppyWrapper.uppyInstance.on("upload-progress", (file, progress) => {
       run(() => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
         const upload = this.#inProgressUploads.find(

--- a/frontend/discourse/app/lib/uppy/uppy-upload.js
+++ b/frontend/discourse/app/lib/uppy/uppy-upload.js
@@ -568,7 +568,7 @@ export default class UppyUpload {
   }
 
   #allUploadsComplete() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/services/a11y.js
+++ b/frontend/discourse/app/services/a11y.js
@@ -265,7 +265,7 @@ export default class A11y extends Service {
     // awaited by `settled()`; a live region is polled asynchronously, so the one-tick
     // delay is imperceptible.
     next(() => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/services/presence.js
+++ b/frontend/discourse/app/services/presence.js
@@ -514,7 +514,7 @@ export default class PresenceService extends Service {
   }
 
   async _updateServer() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -607,7 +607,7 @@ export default class PresenceService extends Service {
   // drop back to the last event via the regular throttle function.
   @bind
   _throttledUpdateServer() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/services/screen-track.js
+++ b/frontend/discourse/app/services/screen-track.js
@@ -190,7 +190,7 @@ export default class ScreenTrack extends Service {
         },
       });
 
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/services/user-tips.js
+++ b/frontend/discourse/app/services/user-tips.js
@@ -15,7 +15,7 @@ export default class UserTips extends Service {
   #shouldRenderSet = trackedSet();
 
   #updateRenderedId() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/d-async-content.gts
+++ b/frontend/discourse/app/ui-kit/d-async-content.gts
@@ -205,7 +205,7 @@ export default class DAsyncContent<T> extends Component<
     const asyncData = this.args.asyncData;
     const context = this.args.context;
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/d-calendar-date-time-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-calendar-date-time-input.gjs
@@ -28,7 +28,7 @@ export default class DCalendarDateTimeInput extends Component {
   @action
   setupPikaday(element) {
     this.#setupPicker(element).then((picker) => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/app/ui-kit/d-cook-text.gjs
+++ b/frontend/discourse/app/ui-kit/d-cook-text.gjs
@@ -23,7 +23,7 @@ export default class DCookText extends Component {
   async loadCookedText() {
     const rawText = this.args.rawText;
     const cooked = await waitForPromise(cook(rawText));
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
     if (this.args.rawText !== rawText) {

--- a/frontend/discourse/app/ui-kit/d-copy-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-copy-button.gjs
@@ -45,7 +45,7 @@ export default class DCopyButton extends Component {
 
   @bind
   _restoreButton() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/d-date-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-input.gjs
@@ -36,7 +36,7 @@ export default class DDateInput extends Component {
     super.didInsertElement(...arguments);
 
     schedule("afterRender", () => {
-      if (!this.element || this.isDestroying || this.isDestroying) {
+      if (!this.element || this.isDestroying) {
         return;
       }
 
@@ -135,7 +135,7 @@ export default class DDateInput extends Component {
   }
 
   _handleSelection(value) {
-    if (!this.element || this.isDestroying || this.isDestroyed) {
+    if (!this.element || this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/d-date-picker.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-picker.gjs
@@ -78,7 +78,7 @@ export default class DDatePicker extends Component {
   _handleSelection(value) {
     const formattedDate = moment(value).format(DATE_FORMAT);
 
-    if (!this.element || this.isDestroying || this.isDestroyed) {
+    if (!this.element || this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/d-editor.gjs
+++ b/frontend/discourse/app/ui-kit/d-editor.gjs
@@ -233,18 +233,13 @@ export default class DEditor extends Component {
   }
 
   async _updatePreview() {
-    if (
-      this._state !== "inDOM" ||
-      !this.processPreview ||
-      this.isDestroying ||
-      this.isDestroyed
-    ) {
+    if (this._state !== "inDOM" || !this.processPreview || this.isDestroying) {
       return;
     }
 
     const cooked = await this.cachedCookAsync(this.value, this.markdownOptions);
 
-    if (this.preview === cooked || this.isDestroying || this.isDestroyed) {
+    if (this.preview === cooked || this.isDestroying) {
       return;
     }
 
@@ -564,7 +559,7 @@ export default class DEditor extends Component {
 
   @action
   handleFocusOut() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/d-icon-grid-picker/content.gjs
+++ b/frontend/discourse/app/ui-kit/d-icon-grid-picker/content.gjs
@@ -392,7 +392,7 @@ export default class DIconGridPickerContent extends Component {
    * @returns {boolean}
    */
   #isCurrent(search) {
-    return this.#search === search && !this.isDestroying && !this.isDestroyed;
+    return this.#search === search && !this.isDestroying;
   }
 
   /**

--- a/frontend/discourse/app/ui-kit/d-multi-select.gjs
+++ b/frontend/discourse/app/ui-kit/d-multi-select.gjs
@@ -56,7 +56,7 @@ export default class DMultiSelect extends Component {
 
   @cached
   get data() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/app/ui-kit/modifiers/d-autocomplete.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-autocomplete.js
@@ -342,7 +342,7 @@ export default class DAutocompleteModifier extends Modifier {
   }
 
   async performSearch(term) {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/float-kit/components/d-menu.gts
+++ b/frontend/discourse/float-kit/components/d-menu.gts
@@ -142,7 +142,7 @@ export default class DMenu<Data = unknown> extends Component<
     this.options.onRegisterApi?.(this.menuInstance);
 
     return () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         this.menuInstance.destroy();
       }
     };

--- a/frontend/discourse/float-kit/lib/float-kit-instance.ts
+++ b/frontend/discourse/float-kit/lib/float-kit-instance.ts
@@ -1,6 +1,7 @@
 import { tracked } from "@glimmer/tracking";
-import { isDestroyed, isDestroying } from "@ember/destroyable";
+import { isDestroying } from "@ember/destroyable";
 import { action } from "@ember/object";
+import { getOwner } from "@ember/owner";
 import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
 import type {
@@ -234,7 +235,7 @@ export default abstract class FloatKitInstance {
     element.addEventListener("touchcancel", this.onTouchCancel, TOUCH_OPTIONS);
     element.addEventListener("touchend", this.onTouchCancel, TOUCH_OPTIONS);
     this.touchTimeout = discourseLater(() => {
-      if (isDestroying(this) || isDestroyed(this)) {
+      if (isDestroying(getOwner(this)!)) {
         return;
       }
 

--- a/frontend/discourse/select-kit/components/category-row.gjs
+++ b/frontend/discourse/select-kit/components/category-row.gjs
@@ -178,7 +178,7 @@ export default class CategoryRow extends Component {
       return;
     }
 
-    if (!this.isDestroying || !this.isDestroyed) {
+    if (!this.isDestroying) {
       this.args.selectKit.onHover(this.rowValue, this.args.item);
     }
     return false;

--- a/frontend/discourse/select-kit/components/form-template-chooser.js
+++ b/frontend/discourse/select-kit/components/form-template-chooser.js
@@ -47,7 +47,7 @@ export default class FormTemplateChooser extends MultiSelectComponent {
 
     const result = await FormTemplate.findAll();
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/frontend/discourse/select-kit/components/mini-tag-chooser.js
+++ b/frontend/discourse/select-kit/components/mini-tag-chooser.js
@@ -194,7 +194,7 @@ export default class MiniTagChooser extends MultiSelectComponent {
   }
 
   _transformJson(json, { skipSort = false } = {}) {
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       return [];
     }
 

--- a/frontend/discourse/select-kit/components/select-kit.js
+++ b/frontend/discourse/select-kit/components/select-kit.js
@@ -484,7 +484,7 @@ export default class SelectKit extends Component {
   }
 
   clearErrors() {
-    if (!this.element || this.isDestroyed || this.isDestroying) {
+    if (!this.element || this.isDestroying) {
       return;
     }
 
@@ -576,7 +576,7 @@ export default class SelectKit extends Component {
 
       resolve(items);
     }).finally(() => {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         if (
           this.selectKit.options.closeOnChange ||
           (isPresent(value) && this.selectKit.options.maximum === 1)
@@ -670,7 +670,7 @@ export default class SelectKit extends Component {
   }
 
   _boundaryActionHandler(actionName, ...params) {
-    if (!this.element || this.isDestroying || this.isDestroyed) {
+    if (!this.element || this.isDestroying) {
       return;
     }
 
@@ -734,7 +734,7 @@ export default class SelectKit extends Component {
   }
 
   _searchWrapper(filter) {
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       return Promise.resolve([]);
     }
 
@@ -749,7 +749,7 @@ export default class SelectKit extends Component {
 
     return Promise.resolve(this.search(filter))
       .then((result) => {
-        if (this.isDestroyed || this.isDestroying) {
+        if (this.isDestroying) {
           return [];
         }
 
@@ -818,7 +818,7 @@ export default class SelectKit extends Component {
         });
       })
       .finally(() => {
-        if (this.isDestroyed || this.isDestroying) {
+        if (this.isDestroying) {
           return;
         }
         this.set("selectKit.enterDisabled", false);
@@ -827,7 +827,7 @@ export default class SelectKit extends Component {
 
   _safeAfterRender(fn) {
     next(() => {
-      if (!this.element || this.isDestroyed || this.isDestroying) {
+      if (!this.element || this.isDestroying) {
         return;
       }
 

--- a/frontend/discourse/select-kit/components/select-kit/select-kit-body.gjs
+++ b/frontend/discourse/select-kit/components/select-kit/select-kit-body.gjs
@@ -52,7 +52,6 @@ export default class SelectKitBody extends Component {
     next(() => {
       if (
         this.isDestroying ||
-        this.isDestroyed ||
         this.selectKit.mainElement()?.contains(document.activeElement)
       ) {
         return;

--- a/frontend/discourse/select-kit/components/select-kit/select-kit-row.gjs
+++ b/frontend/discourse/select-kit/components/select-kit/select-kit-row.gjs
@@ -169,7 +169,7 @@ export default class SelectKitRow extends Component {
 
   @action
   handleMouseEnter() {
-    if (!this.isDestroying || !this.isDestroyed) {
+    if (!this.isDestroying) {
       this.selectKit.onHover(this.rowValue, this.item);
     }
     return false;

--- a/frontend/discourse/select-kit/components/tag-chooser.js
+++ b/frontend/discourse/select-kit/components/tag-chooser.js
@@ -193,7 +193,7 @@ export default class TagChooser extends MultiSelectComponent {
 
   @bind
   _transformJson(json, { skipSort = false } = {}) {
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       return [];
     }
 

--- a/frontend/discourse/select-kit/components/tag-drop.js
+++ b/frontend/discourse/select-kit/components/tag-drop.js
@@ -203,7 +203,7 @@ export default class TagDrop extends ComboBoxComponent {
 
   @bind
   _transformJson(json) {
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       return [];
     }
 

--- a/frontend/discourse/select-kit/components/tag-group-chooser.js
+++ b/frontend/discourse/select-kit/components/tag-group-chooser.js
@@ -73,7 +73,7 @@ export default class TagGroupChooser extends MultiSelectComponent {
 
   @bind
   _transformJson(json) {
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       return [];
     }
     return json.results

--- a/frontend/discourse/tests/integration/components/select-kit/category-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/category-chooser-test.gjs
@@ -4,6 +4,7 @@ import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import CategoryChooser from "discourse/select-kit/components/category-chooser";
+import CategoryRow from "discourse/select-kit/components/category-row";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import I18n, { i18n } from "discourse-i18n";
@@ -15,6 +16,35 @@ module(
 
     hooks.beforeEach(function () {
       this.set("subject", selectKit());
+    });
+
+    test("suppresses hover during teardown", function (assert) {
+      const item = { id: 1 };
+      const selectKitApi = {
+        onHover() {
+          assert.step("hover");
+        },
+      };
+      const context = {
+        args: { item, selectKit: selectKitApi },
+        isDestroyed: false,
+        isDestroying: false,
+        rowValue: item.id,
+        site: { mobileView: false },
+      };
+      const handleMouseEnter = Object.getOwnPropertyDescriptor(
+        CategoryRow.prototype,
+        "handleMouseEnter"
+      ).get.call(context);
+
+      handleMouseEnter();
+      context.isDestroying = true;
+      handleMouseEnter();
+
+      assert.verifySteps(
+        ["hover"],
+        "dispatches hover only while the row is live"
+      );
     });
 
     test("with value", async function (assert) {

--- a/frontend/discourse/tests/integration/components/select-kit/single-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/single-select-test.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import { find, render, tab } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { forceMobile } from "discourse/lib/mobile";
+import SelectKitRow from "discourse/select-kit/components/select-kit/select-kit-row";
 import SingleSelect from "discourse/select-kit/components/single-select";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -37,6 +38,35 @@ module("Integration | Component | SelectKit | SingleSelect", function (hooks) {
 
   hooks.beforeEach(function () {
     this.set("subject", selectKit());
+  });
+
+  test("suppresses hover during teardown", function (assert) {
+    const item = { id: 1 };
+    const selectKitApi = {
+      onHover() {
+        assert.step("hover");
+      },
+    };
+    const context = {
+      isDestroyed: false,
+      isDestroying: false,
+      item,
+      rowValue: item.id,
+      selectKit: selectKitApi,
+    };
+    const handleMouseEnter = Object.getOwnPropertyDescriptor(
+      SelectKitRow.prototype,
+      "handleMouseEnter"
+    ).get.call(context);
+
+    handleMouseEnter();
+    context.isDestroying = true;
+    handleMouseEnter();
+
+    assert.verifySteps(
+      ["hover"],
+      "dispatches hover only while the row is live"
+    );
   });
 
   test("content", async function (assert) {

--- a/frontend/discourse/tests/unit/float-kit/float-kit-instance-test.js
+++ b/frontend/discourse/tests/unit/float-kit/float-kit-instance-test.js
@@ -1,0 +1,50 @@
+import { destroy } from "@ember/destroyable";
+import { setOwner } from "@ember/owner";
+import { settled } from "@ember/test-helpers";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import FloatKitInstance from "discourse/float-kit/lib/float-kit-instance";
+
+class TestFloatKitInstance extends FloatKitInstance {
+  expanded = false;
+  options = {};
+  portalOutletElement = null;
+
+  async onClick() {}
+
+  async onPointerLeave() {}
+
+  async onPointerMove() {}
+
+  async onTrigger() {}
+}
+
+module("Unit | FloatKit | float-kit-instance", function (hooks) {
+  setupTest(hooks);
+
+  test("a held touch does not trigger after owner destruction begins", async function (assert) {
+    const owner = {};
+    const instance = new TestFloatKitInstance();
+    const trigger = document.createElement("button");
+    const event = {
+      stopPropagation() {},
+      touches: [{}],
+    };
+
+    setOwner(instance, owner);
+    instance.trigger = trigger;
+    instance.onTrigger = () => assert.step("trigger");
+
+    instance.onTouchStart(event);
+    await settled();
+
+    instance.onTouchStart(event);
+    destroy(owner);
+    await settled();
+
+    assert.verifySteps(
+      ["trigger"],
+      "the live touch triggers, but the touch pending during owner teardown does not"
+    );
+  });
+});

--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-group-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-group-field.gjs
@@ -36,7 +36,7 @@ export default class GroupField extends BaseField {
     Group.findAll({
       ignore_automatic: this.args.field.extra.ignore_automatic ?? false,
     }).then((groups) => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-groups-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-groups-field.gjs
@@ -17,7 +17,7 @@ export default class GroupsField extends BaseField {
     Group.findAll({
       ignore_automatic: this.args.field.extra.ignore_automatic ?? false,
     }).then((groups) => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/boards/assets/javascripts/discourse/components/auto-linked-text.gjs
+++ b/plugins/boards/assets/javascripts/discourse/components/auto-linked-text.gjs
@@ -12,7 +12,7 @@ export default class AutoLinkedText extends Component {
     if (!this.linkify) {
       generateLinkifyFunction({}).then((instance) => {
         cachedLinkify = instance;
-        if (!this.isDestroying && !this.isDestroyed) {
+        if (!this.isDestroying) {
           this.linkify = instance;
         }
       });

--- a/plugins/boards/assets/javascripts/discourse/components/boards-board-viewer.gjs
+++ b/plugins/boards/assets/javascripts/discourse/components/boards-board-viewer.gjs
@@ -165,7 +165,7 @@ export default class BoardsBoardViewer extends Component {
 
     if (this.args.initialCardId) {
       schedule("afterRender", () => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
         const card = this.#findCard(this.args.initialCardId);
@@ -179,7 +179,7 @@ export default class BoardsBoardViewer extends Component {
 
     if (this.args.highlightCardId) {
       schedule("afterRender", () => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
         this.#focusHighlightCard(this.args.highlightCardId);
@@ -188,7 +188,7 @@ export default class BoardsBoardViewer extends Component {
 
     if (this.args.openBoardSettings && this.canManage) {
       schedule("afterRender", () => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
         this.#openBoardSettingsModal({ updateUrl: false });
@@ -1128,7 +1128,7 @@ export default class BoardsBoardViewer extends Component {
         },
       })
       .then((result) => {
-        if (!this.isDestroying && !this.isDestroyed) {
+        if (!this.isDestroying) {
           DiscourseURL.replaceState(boardUrl);
 
           if (result?.reloadAfterSave) {
@@ -1287,7 +1287,7 @@ export default class BoardsBoardViewer extends Component {
     // flush, before the highlight class renders, and waitForAnimationEnd
     // would then see no animation and fall back to resolving immediately.
     next(this, async () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -1304,11 +1304,7 @@ export default class BoardsBoardViewer extends Component {
 
       await waitForAnimationEnd(cardElement);
 
-      if (
-        !this.isDestroying &&
-        !this.isDestroyed &&
-        this.linkHighlightCardId === cardId
-      ) {
+      if (!this.isDestroying && this.linkHighlightCardId === cardId) {
         this.linkHighlightCardId = null;
       }
     });
@@ -1337,7 +1333,7 @@ export default class BoardsBoardViewer extends Component {
       : { card, canWrite: this.canWrite, onUpdateCard: this.onUpdateCard };
 
     this.modal.show(ModalComponent, { model }).finally(() => {
-      if (!navigatedAway && !this.isDestroying && !this.isDestroyed) {
+      if (!navigatedAway && !this.isDestroying) {
         DiscourseURL.replaceState(boardUrl);
       }
     });
@@ -1348,7 +1344,7 @@ export default class BoardsBoardViewer extends Component {
     this.dropHighlightCardId = null;
 
     schedule("afterRender", () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/boards/assets/javascripts/discourse/components/boards-card.gjs
+++ b/plugins/boards/assets/javascripts/discourse/components/boards-card.gjs
@@ -269,7 +269,7 @@ export default class BoardsCard extends Component {
         },
       })
       .finally(() => {
-        if (!this.isDestroying && !this.isDestroyed) {
+        if (!this.isDestroying) {
           DiscourseURL.replaceState(boardUrl);
         }
       });
@@ -298,7 +298,7 @@ export default class BoardsCard extends Component {
         },
       })
       .finally(() => {
-        if (!navigatedAway && !this.isDestroying && !this.isDestroyed) {
+        if (!navigatedAway && !this.isDestroying) {
           DiscourseURL.replaceState(boardUrl);
         }
       });
@@ -439,7 +439,7 @@ export default class BoardsCard extends Component {
     this.dragHideTimer = discourseLater(this, () => {
       this.dragHideTimer = null;
 
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         if (shouldInsertSourceDropIndicator()) {
           this.#insertSourceDropIndicator(cardElement, cardHeight);
         }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
@@ -157,7 +157,7 @@ export default class ChatDrawer extends Component {
   }
 
   _performCheckSize() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
@@ -79,7 +79,7 @@ export default class ToggleChannelMembershipButton extends Component {
       })
       .catch(popupAjaxError)
       .finally(() => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-pane-state.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-pane-state.js
@@ -325,7 +325,7 @@ export default class ChatPaneState {
 
     schedule("afterRender", () => {
       const owner = getOwner(this);
-      if (owner.isDestroying || owner.isDestroyed) {
+      if (owner.isDestroying) {
         return;
       }
 

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -171,7 +171,7 @@ export default class ChatMessage {
   }
 
   async cook() {
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       return;
     }
     await this.#ensureCookFunctionInitialized();
@@ -205,7 +205,7 @@ export default class ChatMessage {
     this.highlighted = true;
 
     discourseLater(() => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-animation-end.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-animation-end.js
@@ -20,7 +20,7 @@ export default class ChatOnAnimationEnd extends Modifier {
 
   @bind
   handleAnimationEnd() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -70,7 +70,7 @@ export default class ChatOnLongPress extends Modifier {
     this.element.addEventListener("touchend", this.onCancel);
     this.element.addEventListener("touchcancel", this.onCancel);
     this.timeout = discourseLater(() => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -271,7 +271,7 @@ export default class Chat extends Service {
 
   updatePresence() {
     next(() => {
-      if (this.isDestroyed || this.isDestroying) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/google-adsense.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/google-adsense.gjs
@@ -155,7 +155,7 @@ export default class GoogleAdsense extends AdComponent {
 
     await loadAdsense();
 
-    if (this.isDestroyed || this.isDestroying) {
+    if (this.isDestroying) {
       // Component removed from DOM before script loaded
       return;
     }

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-logs.gjs
@@ -349,11 +349,7 @@ export default class AiLogs extends Component {
       const result = await ajax("/admin/plugins/discourse-ai/ai-logs.json", {
         data: this.requestParams,
       });
-      if (
-        requestId !== this._requestId ||
-        this.isDestroying ||
-        this.isDestroyed
-      ) {
+      if (requestId !== this._requestId || this.isDestroying) {
         return;
       }
 
@@ -382,19 +378,11 @@ export default class AiLogs extends Component {
         }
       }
     } catch (error) {
-      if (
-        requestId === this._requestId &&
-        !this.isDestroying &&
-        !this.isDestroyed
-      ) {
+      if (requestId === this._requestId && !this.isDestroying) {
         popupAjaxError(error);
       }
     } finally {
-      if (
-        requestId === this._requestId &&
-        !this.isDestroying &&
-        !this.isDestroyed
-      ) {
+      if (requestId === this._requestId && !this.isDestroying) {
         if (!quiet) {
           this.loading = false;
         }
@@ -418,8 +406,7 @@ export default class AiLogs extends Component {
       if (
         requestId !== this._requestId ||
         cursor !== this.meta.next_cursor ||
-        this.isDestroying ||
-        this.isDestroyed
+        this.isDestroying
       ) {
         return;
       }
@@ -428,19 +415,11 @@ export default class AiLogs extends Component {
       this.features = this.mergedFeatures(this.features, result.logs);
       this.meta = { ...this.meta, ...result.meta };
     } catch (error) {
-      if (
-        requestId === this._requestId &&
-        !this.isDestroying &&
-        !this.isDestroyed
-      ) {
+      if (requestId === this._requestId && !this.isDestroying) {
         popupAjaxError(error);
       }
     } finally {
-      if (
-        requestId === this._requestId &&
-        !this.isDestroying &&
-        !this.isDestroyed
-      ) {
+      if (requestId === this._requestId && !this.isDestroying) {
         this.loadingMore = false;
       }
     }
@@ -462,7 +441,7 @@ export default class AiLogs extends Component {
 
   schedulePoll() {
     clearTimeout(this._pollTimer);
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -483,7 +462,7 @@ export default class AiLogs extends Component {
   @action
   async pollForNewLogs() {
     clearTimeout(this._pollTimer);
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -507,7 +486,7 @@ export default class AiLogs extends Component {
           data: { ...this.requestParams, since_id: this._sinceId },
         }
       );
-      if (this.isDestroying || this.isDestroyed || epoch !== this._pollEpoch) {
+      if (this.isDestroying || epoch !== this._pollEpoch) {
         return;
       }
       if (result.new_logs_count !== undefined) {

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-usage.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-usage.gjs
@@ -147,11 +147,7 @@ export default class AiUsage extends Component {
       { data: this.reportParams }
     );
 
-    if (
-      requestId !== this._dataRequestId ||
-      this.isDestroying ||
-      this.isDestroyed
-    ) {
+    if (requestId !== this._dataRequestId || this.isDestroying) {
       return;
     }
 
@@ -170,11 +166,7 @@ export default class AiUsage extends Component {
       { data: this.baseReportParams }
     );
 
-    if (
-      requestId !== this._filterOptionsRequestId ||
-      this.isDestroying ||
-      this.isDestroyed
-    ) {
+    if (requestId !== this._filterOptionsRequestId || this.isDestroying) {
       return;
     }
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/modal/ai-log-detail-modal.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/modal/ai-log-detail-modal.gjs
@@ -42,16 +42,16 @@ export default class AiLogDetailModal extends Component {
       const log = await ajax(
         `/admin/plugins/discourse-ai/ai-logs/${this.args.model.logId}.json`
       );
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.log = log;
       }
     } catch (error) {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.failed = true;
         this.notFound = error.jqXHR?.status === 404;
       }
     } finally {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.loading = false;
       }
     }

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-category-chooser-inline-suggester.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-category-chooser-inline-suggester.js
@@ -50,7 +50,7 @@ async function applyBestSuggestion(component, selectKit, context) {
       { method: "POST", data }
     );
 
-    if (component.isDestroying || component.isDestroyed) {
+    if (component.isDestroying) {
       return;
     }
 
@@ -68,7 +68,7 @@ async function applyBestSuggestion(component, selectKit, context) {
     popupAjaxError(error);
   } finally {
     state.loading = false;
-    if (!component.isDestroying && !component.isDestroyed) {
+    if (!component.isDestroying) {
       selectKit.set("isLoading", false);
     }
   }

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-tag-chooser-inline-suggester.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-tag-chooser-inline-suggester.js
@@ -55,7 +55,7 @@ async function loadSuggestions(component, selectKit, context) {
       data,
     });
 
-    if (component.isDestroying || component.isDestroyed) {
+    if (component.isDestroying) {
       return;
     }
 
@@ -69,7 +69,7 @@ async function loadSuggestions(component, selectKit, context) {
     state.mode = "idle";
     popupAjaxError(error);
   } finally {
-    if (!component.isDestroying && !component.isDestroyed) {
+    if (!component.isDestroying) {
       selectKit.triggerSearch();
     }
   }

--- a/plugins/discourse-assign/assets/javascripts/discourse/services/task-actions.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/services/task-actions.js
@@ -86,7 +86,7 @@ export default class TaskActions extends Service {
 
     const response = await ajax("/assign/suggestions", { data });
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-workflow-ai-query.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-workflow-ai-query.gjs
@@ -81,7 +81,7 @@ export default class DataExplorerWorkflowAiQuery extends Component {
         }
       );
 
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -102,7 +102,7 @@ export default class DataExplorerWorkflowAiQuery extends Component {
         },
       });
     } catch (error) {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/share-report.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/share-report.gjs
@@ -34,7 +34,7 @@ export default class ShareReport extends Component {
 
   @action
   registerListeners(element) {
-    if (!element || this.isDestroying || this.isDestroyed) {
+    if (!element || this.isDestroying) {
       return;
     }
 

--- a/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/plugins/discourse-events/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -195,7 +195,7 @@ export default class DiscoursePostEventDates extends Component {
       // doesn’t work reliably without discourseLater
       discourseLater(() => {
         schedule("afterRender", () => {
-          if (this.isDestroying || this.isDestroyed) {
+          if (this.isDestroying) {
             return;
           }
 

--- a/plugins/discourse-events/assets/javascripts/discourse/lib/livestream-rsvp.js
+++ b/plugins/discourse-events/assets/javascripts/discourse/lib/livestream-rsvp.js
@@ -97,7 +97,7 @@ export default class LivestreamRsvp extends Component {
     } catch (e) {
       popupAjaxError(e);
     } finally {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.isSaving = false;
       }
     }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/category-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/category-control.gjs
@@ -60,11 +60,7 @@ export default class CategoryControl extends Component {
 
     await previousRequest;
 
-    if (
-      this.isDestroying ||
-      this.isDestroyed ||
-      !this.#sameIds(this.categoryIds, requestedIds)
-    ) {
+    if (this.isDestroying || !this.#sameIds(this.categoryIds, requestedIds)) {
       return;
     }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
@@ -245,7 +245,7 @@ export default class ExpressionInput extends Component {
   @action
   handleFocusOut() {
     this.#focusOutTimer = discourseLater(() => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
       const editor = this.wrapperElement?.querySelector(".cm-editor");

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/pin-data-editor.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/pin-data-editor.gjs
@@ -171,7 +171,7 @@ export default class PinDataEditor extends Component {
   async loadEditor() {
     const Editor = await loadCodemirrorEditor();
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
     this.Editor = Editor;

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
@@ -319,8 +319,7 @@ export default class WorkflowsEditor extends Component {
     if (
       !this.args.initialNodeId ||
       this.initialNodeHandled ||
-      this.isDestroying ||
-      this.isDestroyed
+      this.isDestroying
     ) {
       return;
     }
@@ -790,7 +789,7 @@ export default class WorkflowsEditor extends Component {
         },
       })
       .finally(() => {
-        if (!this.isDestroying && !this.isDestroyed) {
+        if (!this.isDestroying) {
           DiscourseURL.replaceState(workflowUrl(this.args.workflow.id));
         }
       });

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/execution/manager.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/execution/manager.gjs
@@ -99,7 +99,7 @@ export default class ExecutionsManager extends Component {
         ? `/admin/plugins/discourse-workflows/workflows/${this.args.workflowId}/executions.json`
         : "/admin/plugins/discourse-workflows/executions.json";
       const result = await ajax(url);
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -110,7 +110,7 @@ export default class ExecutionsManager extends Component {
       this.#progress.subscribe(EXECUTIONS_CHANNEL);
       this.#syncTimer();
     } catch (error) {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.#progress.scheduleRetry(error);
       }
     } finally {
@@ -176,11 +176,7 @@ export default class ExecutionsManager extends Component {
     const loadMoreToken = ++this.#loadMoreToken;
     try {
       const result = await ajax(this.loadMoreUrl);
-      if (
-        this.isDestroying ||
-        this.isDestroyed ||
-        loadMoreToken !== this.#loadMoreToken
-      ) {
+      if (this.isDestroying || loadMoreToken !== this.#loadMoreToken) {
         return;
       }
 
@@ -196,11 +192,11 @@ export default class ExecutionsManager extends Component {
       this.loadMoreUrl = result.meta?.load_more_executions;
       this.#syncTimer();
     } catch (e) {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         popupAjaxError(e);
       }
     } finally {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.loadingMore = false;
       }
     }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/executions/detail.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/executions/detail.gjs
@@ -378,7 +378,6 @@ export default class ExecutionDetail extends Component {
       );
       if (
         this.isDestroying ||
-        this.isDestroyed ||
         refreshToken !== this.#refreshToken ||
         executionId !== this.execution.id
       ) {
@@ -393,17 +392,13 @@ export default class ExecutionDetail extends Component {
       this.#progress.resetRetry();
       this.#syncLiveUpdates();
     } catch (error) {
-      if (
-        !this.isDestroying &&
-        !this.isDestroyed &&
-        refreshToken === this.#refreshToken
-      ) {
+      if (!this.isDestroying && refreshToken === this.#refreshToken) {
         this.#progress.scheduleRetry(error);
       }
     } finally {
       if (refreshToken === this.#refreshToken) {
         this.#refreshing = false;
-        if (this.#refreshRequested && !this.isDestroying && !this.isDestroyed) {
+        if (this.#refreshRequested && !this.isDestroying) {
           this.#refreshRequested = false;
           this.#refreshExecution();
         }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/node/live-preview.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/node/live-preview.gjs
@@ -106,7 +106,7 @@ export default class LivePreview extends Component {
 
   @action
   async loadPreview() {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/expression-preview.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/expression-preview.gjs
@@ -30,7 +30,7 @@ export default class ExpressionPreview extends Component {
 
   async #showTooltip() {
     const trigger = this.args.trigger;
-    if (!trigger || this.isDestroying || this.isDestroyed) {
+    if (!trigger || this.isDestroying) {
       return;
     }
 
@@ -69,7 +69,7 @@ export default class ExpressionPreview extends Component {
       portalOutletElement,
     });
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       if (instance) {
         this.tooltip.close(instance);
       }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/input.gjs
@@ -17,7 +17,7 @@ export default class VariableInput extends Component {
       this.workflowsNodeTypes.loadWorkflowVars(),
     ]);
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/reference-property-picker.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/reference-property-picker.gjs
@@ -52,7 +52,7 @@ export default class ReferencePropertyPicker extends Component {
   focusFilter(element) {
     // Next frame, so focus wins over the editor reclaiming it.
     requestAnimationFrame(() => {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         element.focus();
       }
     });

--- a/plugins/discourse-workflows/assets/javascripts/discourse/components/workflows-user-modal.gjs
+++ b/plugins/discourse-workflows/assets/javascripts/discourse/components/workflows-user-modal.gjs
@@ -49,7 +49,7 @@ export default class WorkflowsUserModal extends Component {
     // While awaiting, the server's close_modal broadcast may have already
     // closed this modal — and the workflow may have shown the next one.
     // Closing again here would close that new modal instead.
-    if (!this.isDestroying && !this.isDestroyed) {
+    if (!this.isDestroying) {
       this.args.closeModal();
     }
   }

--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-breakdown.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-breakdown.gjs
@@ -82,7 +82,7 @@ export default class PollBreakdownModal extends Component {
         }
       })
       .then((result) => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
 

--- a/plugins/voice/assets/javascripts/discourse/app/services/voice-webrtc.js
+++ b/plugins/voice/assets/javascripts/discourse/app/services/voice-webrtc.js
@@ -1637,7 +1637,7 @@ export default class VoiceWebrtcService extends Service {
   }
 
   #handleRoomMessage(roomId, payload) {
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -1646,7 +1646,7 @@ export default class VoiceWebrtcService extends Service {
     // signals arriving mid-peer-setup, role changes overlapping signals).
     this.#roomMessageQueue
       .enqueue(roomId, () => {
-        if (this.isDestroying || this.isDestroyed) {
+        if (this.isDestroying) {
           return;
         }
         return this.#processRoomMessage(roomId, payload);

--- a/plugins/voice/assets/javascripts/discourse/components/modal/voice-video-settings.gjs
+++ b/plugins/voice/assets/javascripts/discourse/components/modal/voice-video-settings.gjs
@@ -126,13 +126,13 @@ export default class VoiceVideoSettingsModal extends Component {
         ),
       });
     } catch {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.previewError = true;
       }
       return;
     }
 
-    if (epoch !== this.#previewEpoch || this.isDestroying || this.isDestroyed) {
+    if (epoch !== this.#previewEpoch || this.isDestroying) {
       stream.getTracks().forEach((track) => track.stop());
       return;
     }
@@ -144,7 +144,7 @@ export default class VoiceVideoSettingsModal extends Component {
 
   async refreshDevices() {
     const inputs = await enumerateVideoDevices();
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -170,11 +170,7 @@ export default class VoiceVideoSettingsModal extends Component {
       const rawStream = this.#previewRawStream;
       try {
         const processed = await manager.setup(rawStream, this.blurAmount);
-        if (
-          epoch !== this.#previewEpoch ||
-          this.isDestroying ||
-          this.isDestroyed
-        ) {
+        if (epoch !== this.#previewEpoch || this.isDestroying) {
           manager.teardown();
           return;
         }
@@ -235,7 +231,7 @@ export default class VoiceVideoSettingsModal extends Component {
         await this.#applyPreviewEffect();
       }
     } finally {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.busy = false;
       }
     }

--- a/plugins/voice/assets/javascripts/discourse/components/modal/voice-voice-settings.gjs
+++ b/plugins/voice/assets/javascripts/discourse/components/modal/voice-voice-settings.gjs
@@ -125,14 +125,14 @@ export default class VoiceVoiceSettingsModal extends Component {
         audio: audioConstraints(this.voiceWebrtc.inputDeviceId),
       });
     } catch {
-      if (!this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying) {
         this.micError = true;
         this.level = 0;
       }
       return;
     }
 
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       stream.getTracks().forEach((track) => track.stop());
       return;
     }
@@ -165,7 +165,7 @@ export default class VoiceVoiceSettingsModal extends Component {
 
   async refreshDevices() {
     const { inputs, outputs } = await enumerateAudioDevices();
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 
@@ -271,7 +271,7 @@ export default class VoiceVoiceSettingsModal extends Component {
         element.pause();
         element.srcObject = null;
         context.close().catch(() => {});
-        if (!this.isDestroying && !this.isDestroyed) {
+        if (!this.isDestroying) {
           this.testingOutput = false;
         }
       }, 700);

--- a/plugins/voice/assets/javascripts/discourse/components/voice/call-controls.gjs
+++ b/plugins/voice/assets/javascripts/discourse/components/voice/call-controls.gjs
@@ -314,7 +314,7 @@ export default class VoiceCallControls extends Component {
       prefetchEngineAssets(engine).catch(() => {});
     }
     const { inputs, outputs } = await enumerateAudioDevices();
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
     const defaultDevice = this.#systemDefaultDevice();
@@ -325,7 +325,7 @@ export default class VoiceCallControls extends Component {
   @action
   async loadVideoDevices() {
     const inputs = await enumerateVideoDevices();
-    if (this.isDestroying || this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
     this.videoInputDevices = [this.#systemDefaultDevice(), ...inputs];

--- a/plugins/voice/assets/javascripts/discourse/components/voice/call-widget.gjs
+++ b/plugins/voice/assets/javascripts/discourse/components/voice/call-widget.gjs
@@ -664,7 +664,7 @@ export default class VoiceCallWidget extends Component {
     }
 
     next(this, () => {
-      if (this.isDestroying || this.isDestroyed || this.room?.id !== roomId) {
+      if (this.isDestroying || this.room?.id !== roomId) {
         return;
       }
 

--- a/plugins/voice/assets/javascripts/discourse/components/voice/room-page.gjs
+++ b/plugins/voice/assets/javascripts/discourse/components/voice/room-page.gjs
@@ -249,7 +249,7 @@ export default class VoiceRoomPage extends Component {
     }
 
     next(this, () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 
@@ -266,7 +266,7 @@ export default class VoiceRoomPage extends Component {
   @action
   watchRoom() {
     next(this, () => {
-      if (this.isDestroying || this.isDestroyed) {
+      if (this.isDestroying) {
         return;
       }
 


### PR DESCRIPTION
`isDestroyed` implies `isDestroying`. Both read the same monotonic destroyable state, so every `this.isDestroying || this.isDestroyed` guard carries a dead second operand. This sweep collapses the paired form to a single `isDestroying` check across core, select-kit, admin, float-kit, and the bundled plugins. The mechanical commits change no behavior. Unpaired `isDestroyed` reads such as `owner.isDestroyed` ask a different question and are left alone.

The verbose pair is also where mistypes hide, and the sweep surfaced three real defects. Each is fixed in its own commit with a test that fails without the fix:

- `SelectKitRow` and `CategoryRow` guarded hover with `!isDestroying || !isDestroyed`. That is true throughout teardown, so `onHover` fired on rows being torn down.
- `FloatKitInstance` checked `isDestroying(this)` but is never registered as a destroyable, so a long press held across teardown still triggered. It now checks its owner, as `DMenuInstance.close` already does.

Tests cover hover staying silent once a row is destroying and a held touch dropping once the owner is destroyed. A lint rule to keep the pattern from returning is left for a follow-up.
