### PR TITLE
FIX: Backfill participation-based badges on bulk imports

### DIFF
--- a/lib/import/participation_badges.rb
+++ b/lib/import/participation_badges.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+module Import
+  class ParticipationBadges
+    PARTICIPATION_BADGE_IDS = [
+      Badge::FirstLike,
+      Badge::FirstQuote,
+      Badge::FirstLink,
+      Badge::FirstMention,
+      Badge::Welcome,
+      Badge::NicePost,
+      Badge::GoodPost,
+      Badge::GreatPost,
+      Badge::NiceTopic,
+      Badge::GoodTopic,
+      Badge::GreatTopic,
+    ].freeze
+    IMPORT_ID_FIELD = "import_id"
+    IMPORTED_POST_SELECT = PostCustomField.where(name: IMPORT_ID_FIELD).select(:post_id)
+    BATCH_SIZE = 1000
+
+    def self.grant_all
+      new.grant_all
+    end
+
+    def grant_all
+      derive_quotes
+      derive_mentions
+      derive_links
+      backfill_participation_badges
+    end
+
+    def each_imported_post_in_chronological_order(scope = Post.all, &block)
+      last_created_at = Time.at(0)
+      last_id = 0
+
+      loop do
+        batch =
+          scope
+            .where(id: IMPORTED_POST_SELECT)
+            .where("(created_at, id) > (?, ?)", last_created_at, last_id)
+            .order(:created_at, :id)
+            .limit(BATCH_SIZE)
+            .to_a
+
+        break if batch.empty?
+
+        batch.each { |post| block.call(post) }
+        last_created_at = batch.last.created_at
+        last_id = batch.last.id
+      end
+    end
+
+    def derive_quotes
+      log "Deriving quoted_posts from asides / reply-parent linkage..."
+      count = 0
+
+      each_imported_post_in_chronological_order(
+        Post.where("cooked LIKE ?", "%aside class=\"quote%"),
+      ) do |post|
+        QuotedPost.where(post_id: post.id).delete_all
+
+        targets =
+          Nokogiri::HTML5
+            .fragment(post.cooked)
+            .css("aside.quote")
+            .filter_map do |aside|
+              if aside["data-topic"].present? && aside["data-post"].present?
+                Post.where(
+                  topic_id: aside["data-topic"].to_i,
+                  post_number: aside["data-post"].to_i,
+                ).pick(:id)
+              elsif post.reply_to_post_number.present?
+                Post.where(topic_id: post.topic_id, post_number: post.reply_to_post_number).pick(
+                  :id,
+                )
+              end
+            end
+            .uniq
+
+        targets.each do |quoted_post_id|
+          next if quoted_post_id.blank? || quoted_post_id == post.id
+
+          quoted =
+            QuotedPost.find_or_initialize_by(post_id: post.id, quoted_post_id: quoted_post_id)
+          if quoted.new_record?
+            quoted.created_at = post.created_at
+            quoted.updated_at = Time.now
+            quoted.save!
+            count += 1
+          end
+        end
+
+        # Mirror the reply_quoted consistency QuotedPost.extract_from performs:
+        # when the reply target is among the quotes, mark the post so quote-as-
+        # reply tips (suppress_reply_when_quoting) don't show redundant context.
+        if post.reply_to_post_number.present?
+          reply_post_id =
+            Post.where(topic_id: post.topic_id, post_number: post.reply_to_post_number).pick(:id)
+          reply_quoted =
+            reply_post_id.present? &&
+              QuotedPost.where(post_id: post.id, quoted_post_id: reply_post_id).exists?
+          post.update_columns(reply_quoted: reply_quoted) if reply_quoted != post.reply_quoted
+        end
+      end
+
+      puts "  #{count} quoted posts derived."
+    end
+
+    def derive_mentions
+      log "Deriving mention user_actions from cooked..."
+      count = 0
+      base = Discourse.base_path
+
+      UserAction
+        .where(action_type: UserAction::MENTION)
+        .where(target_post_id: IMPORTED_POST_SELECT)
+        .delete_all
+
+      Post
+        .where("cooked LIKE ?", "%class=\"mention\"%")
+        .where(id: IMPORTED_POST_SELECT)
+        .find_each do |post|
+          Nokogiri::HTML5
+            .fragment(post.cooked)
+            .css("a.mention")
+            .each do |anchor|
+              # href <name> is percent-encoded after a possible subfolder base
+              # prefix; strip the prefix and decode so it resolves to the account.
+              href = anchor["href"].to_s
+              path = base.present? && href.start_with?("#{base}/") ? href.delete_prefix(base) : href
+              next unless path =~ %r{\A/u/([^/]+)\z}
+              raw_name = Addressable::URI.unencode_component($1)
+              next if raw_name.blank?
+
+              matches = User.where(username_lower: ::User.normalize_username(raw_name)).pluck(:id)
+              # An ambiguous username must not attribute the mention arbitrarily.
+              next if matches.size != 1
+
+              mentioned_id = matches.first
+              next if mentioned_id == post.user_id
+
+              UserAction.log_action!(
+                action_type: UserAction::MENTION,
+                user_id: mentioned_id,
+                target_topic_id: post.topic_id,
+                target_post_id: post.id,
+                acting_user_id: post.user_id,
+                created_at: post.created_at,
+              )
+              count += 1
+            end
+        end
+
+      puts "  #{count} mention actions derived."
+    end
+
+    def derive_links
+      log "Deriving topic_links from cooked (canonical TopicLink.extract_from)..."
+      count = 0
+      failures = []
+
+      reconstruct_forward_links
+
+      crawl = TopicLink.method(:crawl_link_title)
+      TopicLink.define_singleton_method(:crawl_link_title) { |_id| }
+      begin
+        each_imported_post_in_chronological_order do |post|
+          next unless post.user_id && post.cooked&.match?(/<a /)
+
+          # extract_from owns its own cleanup_entries, which only tears down this
+          # post's forward rows and its own reflections (link_post_id = post.id).
+          # Reflections other posts created pointing into this post are preserved.
+          TopicLink.extract_from(post)
+          count += 1
+        rescue StandardError => e
+          failures << { post_id: post.id, error: e }
+          warn "  Failed to extract links from post #{post.id}: #{e.class}: #{e.message}"
+        end
+      ensure
+        TopicLink.define_singleton_method(:crawl_link_title, crawl)
+      end
+
+      unless failures.empty?
+        raise "Topic link extraction failed for #{failures.size} post(s) " \
+                "(first: #{failures.first[:error].class}: #{failures.first[:error].message}); " \
+                "aborting before badge backfill"
+      end
+
+      # Rebase this import's forward-link timestamps onto their source posts' so
+      # the grant date reflects chronology. Only non-reflection rows: reflections
+      # set post_id to the linked-to post, so reading posts[post_id] would stamp
+      # them with the wrong (target) timestamp, and they aren't read by FirstLink.
+      TopicLink
+        .where(post_id: IMPORTED_POST_SELECT)
+        .where(reflection: false)
+        .where(
+          "topic_links.created_at <> (SELECT p.created_at FROM posts p WHERE p.id = topic_links.post_id)",
+        )
+        .update_all(
+          "created_at = (SELECT p.created_at FROM posts p WHERE p.id = topic_links.post_id)",
+        )
+
+      puts "  Visited #{count} posts for topic links."
+    end
+
+    def backfill_participation_badges
+      log "Backfilling participation badges..."
+      with_suppressed_badge_notifications do
+        Badge
+          .where(id: PARTICIPATION_BADGE_IDS)
+          .find_each { |badge| Jobs::BackfillBadge.new.execute(badge_id: badge.id) }
+      end
+    end
+
+    private
+
+    def reconstruct_forward_links
+      candidates =
+        TopicLink
+          .where(post_id: IMPORTED_POST_SELECT)
+          .where.not(reflection: true)
+          .where(quote: false)
+          .where(internal: true)
+          .where.not(link_post_id: nil)
+          .where("topic_id <> link_topic_id")
+
+      TopicLinkClick.where(topic_link_id: candidates.select(:id)).delete_all
+      candidates.delete_all
+    end
+
+    def with_suppressed_badge_notifications(&blk)
+      stub = Object.new
+      stub.define_singleton_method(:enabled?) { true }
+      block = proc { |_suppressed| true }
+      DiscoursePluginRegistry.register_modifier(stub, :badge_granter_suppress_notification, &block)
+      # Retained so specs can unregister the hook (allowed only in test env).
+      @badge_notification_suppression = [stub, block]
+      blk.call
+    end
+
+    def log(message)
+      puts "[#{DateTime.now.strftime("%Y-%m-%d %H:%M:%S")}] #{message}"
+    end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -799,6 +799,11 @@ task "import:rebake_uncooked_posts_with_tag", [:tag_name] => :environment do |_t
   import_rebake_posts(posts)
 end
 
+desc "Backfill participation-based badges"
+task "import:grant_participation_badges" => :environment do
+  Import::ParticipationBadges.grant_all
+end
+
 def import_rebake_posts(posts)
   Jobs.run_immediately!
   OptimizedImage.lock_per_machine = false

--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -1606,7 +1606,7 @@ class BulkImport::Base
 
   def process_group_user(group_user)
     group_user[:owner] ||= false
-    group_user[:created_at] = NOW
+    group_user[:created_at] ||= NOW
     group_user[:updated_at] = NOW
     group_user
   end
@@ -2034,6 +2034,22 @@ class BulkImport::Base
   end
 
   def process_badge(badge)
+    if (existing_badge_id = badge[:existing_id]).present?
+      if existing_badge_id.is_a?(String) && existing_badge_id !~ /^\d+$/
+        existing_badge = Badge.find_by(name: existing_badge_id)
+        existing_badge_id = existing_badge&.id
+      else
+        existing_badge_id = existing_badge_id.to_i
+      end
+
+      if existing_badge_id && Badge.exists?(id: existing_badge_id)
+        @imported_records[badge[:original_id].to_s] = existing_badge_id
+        @badge_mapping[badge[:original_id].to_s] = existing_badge_id
+        badge[:skip] = true
+        return badge
+      end
+    end
+
     badge[:id] = @last_badge_id += 1
     badge[:created_at] ||= NOW
     badge[:updated_at] ||= NOW

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -1457,7 +1457,7 @@ class BulkImport::Generic < BulkImport::Base
       next if group_id.nil?
       next unless existing_group_user_ids.add?([group_id, user_id])
 
-      { group_id: group_id, user_id: user_id, owner: row["owner"] }
+      { group_id: group_id, user_id: user_id, owner: row["owner"], created_at: row["created_at"] }
     end
 
     group_members.close
@@ -4318,6 +4318,11 @@ class BulkImport::Generic < BulkImport::Base
     max_position = BadgeGrouping.maximum(:position) || 0
 
     rows.each do |row|
+      if row["badge_group"].blank?
+        @badge_group_mapping[row["badge_group"]] = BadgeGrouping::Other
+        next
+      end
+
       grouping =
         BadgeGrouping.find_or_create_by!(name: row["badge_group"]) do |bg|
           bg.position = max_position += 1
@@ -4350,6 +4355,7 @@ class BulkImport::Generic < BulkImport::Base
 
       {
         original_id: row["id"],
+        existing_id: row["existing_id"],
         name: badge_name,
         description: row["description"],
         badge_type_id: row["badge_type_id"],

--- a/spec/lib/import/participation_badges_spec.rb
+++ b/spec/lib/import/participation_badges_spec.rb
@@ -1,0 +1,657 @@
+# frozen_string_literal: true
+
+RSpec.describe Import::ParticipationBadges do
+  let(:service) { described_class.new }
+
+  after do
+    # Unconditionally clean up the notification-suppression hook so it can never
+    # leak into later examples/spec files (leaked modifiers raise in the test
+    # environment).
+    stub, block = service.instance_variable_get(:@badge_notification_suppression)
+    if stub && block
+      DiscoursePluginRegistry.unregister_modifier(
+        stub,
+        :badge_granter_suppress_notification,
+        &block
+      )
+    end
+  end
+
+  # Marks a fabricated post as belonging to the import by writing the same
+  # import_id custom field the bulk importer leaves on every imported post, so
+  # the scoped derivations (which only rebuild imported posts) pick it up.
+  def mark_imported(post)
+    PostCustomField.create!(
+      post_id: post.id,
+      name: Import::ParticipationBadges::IMPORT_ID_FIELD,
+      value: "1",
+    )
+    post
+  end
+
+  describe "#derive_quotes" do
+    fab!(:topic)
+    fab!(:poster, :user)
+
+    it "creates quoted_posts from a quote post's reply-parent linkage gated on quote bbcode" do
+      parent = Fabricate(:post, topic: topic, post_number: 1, user: poster, raw: "the source post")
+      quoter =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 2,
+          user: poster,
+          raw: 'hi [quote="X"]..[/quote]',
+        )
+      # Mirror a real rebake: a [quote] renders as a quote aside in cooked.
+      quoter.update!(
+        cooked:
+          '<aside class="quote no-group" data-username="X"><blockquote><p>..</p></blockquote></aside>',
+      )
+      quoter.update!(reply_to_post_number: parent.post_number)
+      mark_imported(quoter)
+
+      service.derive_quotes
+
+      expect(QuotedPost.where(post_id: quoter.id, quoted_post_id: parent.id).count).to eq(1)
+    end
+
+    it "skips quote posts with no reply parent (e.g. root/self posts)" do
+      root =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 1,
+          user: poster,
+          raw: 'hi [quote="X"]..[/quote]',
+        )
+      root.update!(
+        cooked:
+          '<aside class="quote no-group" data-username="X"><blockquote><p>..</p></blockquote></aside>',
+      )
+      mark_imported(root)
+
+      service.derive_quotes
+
+      expect(QuotedPost.where(post_id: root.id).count).to eq(0)
+    end
+
+    it "does not count a post whose cooked has no quote aside (escaped [quote in code)" do
+      parent = Fabricate(:post, topic: topic, post_number: 1, user: poster, raw: "the source post")
+      code =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 2,
+          user: poster,
+          raw: 'pasted "[quote="X"]" as literal text in a code block, not a live quote',
+        )
+      # After rebake the pasted [quote=...] stays escaped text, so cooked has no
+      # quote aside even though the reply parent resolves. It must not be treated
+      # as a quote.
+      code.update!(cooked: "<p>pasted &quot;[quote=&#34;X&#34;]&quot; as literal text</p>")
+      code.update!(reply_to_post_number: parent.post_number)
+      mark_imported(code)
+
+      service.derive_quotes
+
+      expect(QuotedPost.where(post_id: code.id).count).to eq(0)
+    end
+
+    it "resolves a quote aside's explicit data-topic/data-post target over the reply parent" do
+      target = Fabricate(:post, topic: topic, post_number: 1, user: poster, raw: "the target")
+      # The reply parent differs from the explicit quote target.
+      parent = Fabricate(:post, topic: topic, post_number: 2, user: poster, raw: "reply parent")
+      quoter =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 3,
+          user: poster,
+          raw: 'hi [quote="X", post:#{target.post_number}, topic:#{topic.id}]..[/quote]',
+        )
+      quoter.update!(
+        cooked:
+          %{<aside class="quote no-group" data-username="X" data-post="#{target.post_number}" data-topic="#{topic.id}"><blockquote><p>..</p></blockquote></aside>},
+      )
+      quoter.update!(reply_to_post_number: parent.post_number)
+      mark_imported(quoter)
+
+      service.derive_quotes
+
+      expect(QuotedPost.where(post_id: quoter.id, quoted_post_id: parent.id).count).to eq(0)
+      expect(QuotedPost.where(post_id: quoter.id, quoted_post_id: target.id).count).to eq(1)
+    end
+
+    it "resolves a targeted quote even when the quote post has no reply parent" do
+      target = Fabricate(:post, topic: topic, post_number: 1, user: poster, raw: "the target")
+      quoter =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 2,
+          user: poster,
+          raw: 'hi [quote="X", post:#{target.post_number}, topic:#{topic.id}]..[/quote]',
+        )
+      quoter.update!(
+        cooked:
+          %{<aside class="quote no-group" data-username="X" data-post="#{target.post_number}" data-topic="#{topic.id}"><blockquote><p>..</p></blockquote></aside>},
+      )
+      mark_imported(quoter)
+
+      service.derive_quotes
+
+      expect(QuotedPost.where(post_id: quoter.id, quoted_post_id: target.id).count).to eq(1)
+    end
+
+    it "leaves non-imported posts' quote rows untouched (scope to this import)" do
+      parent = Fabricate(:post, topic: topic, user: poster, raw: "the source post")
+      existing = Fabricate(:post, topic: topic, user: poster, raw: "hello base site")
+      existing.update!(
+        cooked: '<aside class="quote no-group"><blockquote><p>..</p></blockquote></aside>',
+      )
+      # A pre-existing base-site quote row that must survive a delta import.
+      QuotedPost.create!(post_id: existing.id, quoted_post_id: parent.id)
+
+      service.derive_quotes
+
+      expect(QuotedPost.where(post_id: existing.id, quoted_post_id: parent.id).count).to eq(1)
+    end
+
+    it "re-derives quote rows in source-chronological order so MIN(id) picks the earliest quote" do
+      shared_target = Fabricate(:post, topic: topic, user: poster, raw: "target")
+      older = Fabricate(:post, topic: topic, user: poster, raw: "older quote")
+      older.update!(
+        cooked:
+          '<aside class="quote no-group" data-username="X"><blockquote><p>a</p></blockquote></aside>',
+        reply_to_post_number: shared_target.post_number,
+        created_at: 10.days.ago,
+      )
+      mark_imported(older)
+      newer = Fabricate(:post, topic: topic, user: poster, raw: "newer quote")
+      newer.update!(
+        cooked:
+          '<aside class="quote no-group" data-username="X"><blockquote><p>b</p></blockquote></aside>',
+        reply_to_post_number: shared_target.post_number,
+      )
+      mark_imported(newer)
+
+      service.derive_quotes
+
+      older_row = QuotedPost.find_by(post_id: older.id)
+      newer_row = QuotedPost.find_by(post_id: newer.id)
+      expect(older_row).to be_present
+      expect(newer_row).to be_present
+      # The older post's quote row is inserted first, so FirstQuote's MIN(id)
+      # resolves to it rather than the chronologically-later quote.
+      expect(older_row.id).to be < newer_row.id
+    end
+
+    it "flags reply_quoted when the reply parent is among the rebuilt quote targets" do
+      parent = Fabricate(:post, topic: topic, post_number: 1, user: poster, raw: "the reply parent")
+      quoter =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 2,
+          user: poster,
+          raw: 'hi [quote="X"]..[/quote]',
+        )
+      quoter.update!(
+        cooked:
+          '<aside class="quote no-group" data-username="X"><blockquote><p>..</p></blockquote></aside>',
+      )
+      quoter.update!(reply_to_post_number: parent.post_number, reply_quoted: false)
+      mark_imported(quoter)
+
+      service.derive_quotes
+
+      # Mirrors the reply_quoted consistency QuotedPost.extract_from applies, so
+      # quote-as-reply tips (suppress_reply_when_quoting) hide redundant context.
+      expect(quoter.reload.reply_quoted).to eq(true)
+    end
+
+    it "leaves reply_quoted false when the quote does not target the reply parent" do
+      target = Fabricate(:post, topic: topic, user: poster, raw: "a different target")
+      parent = Fabricate(:post, topic: topic, post_number: 2, user: poster, raw: "reply parent")
+      quoter =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 3,
+          user: poster,
+          raw: 'hi [quote="X"]..[/quote]',
+        )
+      # The aside targets `target` via data-topic/data-post, not the reply parent.
+      quoter.update!(
+        cooked:
+          %{<aside class="quote no-group" data-username="X" data-post="#{target.post_number}" data-topic="#{topic.id}"><blockquote><p>..</p></blockquote></aside>},
+      )
+      quoter.update!(reply_to_post_number: parent.post_number, reply_quoted: true)
+      mark_imported(quoter)
+
+      service.derive_quotes
+
+      expect(quoter.reload.reply_quoted).to eq(false)
+    end
+  end
+
+  describe "#derive_mentions" do
+    fab!(:topic)
+    fab!(:author, :user)
+    fab!(:mentioned, :user)
+    fab!(:other, :user)
+
+    def post_with_mentions(mention_users)
+      post = Fabricate(:post, topic: topic, user: author, raw: "hello")
+      mentions =
+        mention_users.map { |u| %{<a class="mention" href="/u/#{u.username}">@#{u.username}</a>} }
+      post.update!(cooked: "<p>#{mentions.join(" ")}</p>")
+      mark_imported(post)
+      post
+    end
+
+    it "logs MENTION user_actions from resolved mention anchors in cooked" do
+      post = post_with_mentions([mentioned, other])
+
+      service.derive_mentions
+
+      [mentioned, other].each do |u|
+        expect(
+          UserAction.where(
+            action_type: UserAction::MENTION,
+            user_id: u.id,
+            target_post_id: post.id,
+            acting_user_id: author.id,
+          ).count,
+        ).to eq(1)
+      end
+    end
+
+    it "only logs mentions from imported posts (leaves base-site posts untouched)" do
+      imported = post_with_mentions([mentioned])
+      native_post = Fabricate(:post, topic: topic, user: author, raw: "hello")
+      native_post.update!(
+        cooked: %{<p><a class="mention" href="/u/#{other.username}">@#{other.username}</a></p>},
+      )
+      # `native_post` has no import_id custom field → represents pre-existing
+      # base-site content whose (live) mention actions must not be recreated on
+      # delta/existing-site imports.
+
+      service.derive_mentions
+
+      expect(
+        UserAction.where(
+          action_type: UserAction::MENTION,
+          target_post_id: imported.id,
+          user_id: mentioned.id,
+        ).count,
+      ).to eq(1)
+      expect(
+        UserAction.where(action_type: UserAction::MENTION, target_post_id: native_post.id).count,
+      ).to eq(0)
+    end
+
+    it "removes stale MENTION actions whose current anchor disappeared (delta run)" do
+      # Simulate a delta re-import: the post previously mentioned `other`, then
+      # the source post's mention was removed. Rebaking does not run PostAlerter,
+      # so derive_mentions must drop the stale action before re-logging current
+      # anchors, or a revoked First Mention would linger.
+      post = post_with_mentions([])
+      UserAction.log_action!(
+        action_type: UserAction::MENTION,
+        user_id: other.id,
+        target_topic_id: topic.id,
+        target_post_id: post.id,
+        acting_user_id: author.id,
+        created_at: post.created_at,
+      )
+
+      service.derive_mentions
+
+      expect(
+        UserAction.where(action_type: UserAction::MENTION, target_post_id: post.id).count,
+      ).to eq(0)
+    end
+
+    it "replaces a mention that flipped to a self-mention (stale row dropped)" do
+      post = post_with_mentions([other])
+      UserAction.log_action!(
+        action_type: UserAction::MENTION,
+        user_id: other.id,
+        target_topic_id: topic.id,
+        target_post_id: post.id,
+        acting_user_id: author.id,
+        created_at: post.created_at,
+      )
+      # Now the post only mentions its own author (self-mention → must be skipped
+      # and the prior mention of `other` dropped).
+      post.update!(
+        cooked: %{<p><a class="mention" href="/u/#{author.username}">@#{author.username}</a></p>},
+      )
+
+      service.derive_mentions
+
+      expect(
+        UserAction.where(action_type: UserAction::MENTION, target_post_id: post.id).count,
+      ).to eq(0)
+    end
+
+    it "skips self-mentions and non-/u/ mention hrefs" do
+      post = Fabricate(:post, topic: topic, user: author, raw: "hello")
+      post.update!(
+        cooked:
+          %{<a class="mention" href="/u/#{author.username}">@#{author.username}</a> <a class="mention-group" href="/g/admins">@admins</a>},
+      )
+      mark_imported(post)
+
+      service.derive_mentions
+
+      expect(
+        UserAction.where(action_type: UserAction::MENTION, target_post_id: post.id).count,
+      ).to eq(0)
+    end
+
+    it "skips a mention that resolves to an ambiguous (duplicate) username" do
+      u1 = Fabricate(:user)
+      post = Fabricate(:post, topic: topic, user: author, raw: "hello")
+      post.update!(cooked: %{<a class="mention" href="/u/#{u1.username}">@#{u1.username}</a>})
+      mark_imported(post)
+
+      # DB uniqueness makes a real duplicate username impossible; stub the seam
+      # to simulate a lookup resolving to more than one account.
+      allow(User).to receive(:where).and_call_original
+      allow(User).to receive(:where).with(username_lower: u1.username_lower).and_return(
+        double(pluck: [u1.id, u1.id + 1]),
+      )
+
+      service.derive_mentions
+
+      expect(
+        UserAction.where(action_type: UserAction::MENTION, target_post_id: post.id).count,
+      ).to eq(0)
+    end
+
+    it "strips the base path and decodes percent-encoded usernames in mention hrefs" do
+      begin
+        SiteSetting.unicode_usernames = true
+      rescue Discourse::InvalidParameters
+        # already enabled / not tunable in this install; proceed with the default
+      end
+      user = Fabricate(:user, username: "名ab")
+      allow(Discourse).to receive(:base_path).and_return("/forum")
+      post = Fabricate(:post, topic: topic, user: author, raw: "hello")
+      post.update!(
+        cooked:
+          %{<a class="mention" href="/forum/u/#{UrlHelper.encode_component(user.username)}">@名</a>},
+      )
+      mark_imported(post)
+
+      service.derive_mentions
+
+      expect(
+        UserAction.where(
+          action_type: UserAction::MENTION,
+          user_id: user.id,
+          target_post_id: post.id,
+          acting_user_id: author.id,
+        ).count,
+      ).to eq(1)
+    end
+  end
+
+  describe "#derive_links" do
+    fab!(:topic)
+    fab!(:poster, :user)
+    fab!(:author, :user)
+
+    it "runs TopicLink.extract_from only for posts whose cooked contains an anchor" do
+      with_link = Fabricate(:post, topic: topic, user: poster, raw: "see this")
+      with_link.update!(cooked: '<p><a href="https://example.com/x">x</a></p>')
+      mark_imported(with_link)
+      no_link = Fabricate(:post, topic: topic, user: author, raw: "no links here")
+      mark_imported(no_link)
+
+      visited = []
+      allow(TopicLink).to receive(:extract_from) { |post| visited << post.id }
+
+      service.derive_links
+
+      expect(visited).to include(with_link.id)
+      expect(visited).not_to include(no_link.id)
+    end
+
+    it "suppresses the external title-crawl during the pass and restores it" do
+      with_link = Fabricate(:post, topic: topic, user: poster, raw: "see this")
+      with_link.update!(cooked: '<p><a href="https://example.com/x">x</a></p>')
+      mark_imported(with_link)
+
+      suppressed_during = nil
+      allow(TopicLink).to receive(:extract_from) do
+        suppressed_during = TopicLink.crawl_link_title(1).nil?
+      end
+      allow(Jobs).to receive(:enqueue)
+
+      service.derive_links
+
+      # Crawl is a no-op while the pass runs…
+      expect(suppressed_during).to eq(true)
+      # …and is restored afterwards (enqueues the crawl job again).
+      TopicLink.crawl_link_title(1)
+      expect(Jobs).to have_received(:enqueue).with(:crawl_topic_link, topic_link_id: 1)
+    end
+
+    it "preserves reflections other posts placed on a re-derived post (no blanket delete)" do
+      # A chronologically-later post that qualifies for re-derivation carries a
+      # reflection created by an earlier post (post_id = this post, link_post_id
+      # = the linking post). Re-deriving it must not wipe that reflection the way
+      # a blanket `TopicLink.where(post_id:).delete_all` would.
+      other_topic = Fabricate(:topic)
+      target = Fabricate(:post, topic: topic, user: poster, raw: "target")
+      target.update!(cooked: '<p><a href="https://example.com/x">x</a></p>')
+      mark_imported(target)
+      other = Fabricate(:post, topic: other_topic, user: poster, raw: "other")
+
+      reflection =
+        TopicLink.create!(
+          post_id: target.id,
+          user_id: poster.id,
+          topic_id: topic.id,
+          url: "https://example.com/reflected",
+          domain: "example.com",
+          reflection: true,
+          link_topic_id: other_topic.id,
+          link_post_id: other.id,
+        )
+
+      # Isolate the deletion behaviour; the per-post cleanup must not remove it.
+      allow(TopicLink).to receive(:extract_from)
+
+      service.derive_links
+
+      expect(TopicLink.find_by(id: reflection.id)).to be_present
+    end
+
+    it "recreates forward links in source order so FirstLink MIN(id) picks the earliest link" do
+      other_topic = Fabricate(:topic, user: poster)
+      target_a = Fabricate(:post, topic: other_topic, user: poster, raw: "a target")
+      target_b = Fabricate(:post, topic: other_topic, user: poster, raw: "b target")
+      base = Discourse.base_url
+
+      url_a = "#{base}/t/#{other_topic.slug}/#{other_topic.id}/#{target_a.post_number}"
+      url_b = "#{base}/t/#{other_topic.slug}/#{other_topic.id}/#{target_b.post_number}"
+
+      earlier = Fabricate(:post, topic: topic, user: poster, raw: "earlier")
+      earlier.update!(cooked: %{<p>see <a href="#{url_a}">a</a></p>})
+      earlier.update!(created_at: 10.days.ago)
+      mark_imported(earlier)
+      later = Fabricate(:post, topic: topic, user: poster, raw: "later")
+      later.update!(cooked: %{<p>see <a href="#{url_b}">b</a></p>})
+      mark_imported(later)
+
+      # Simulate the earlier (id-shuffled) rebake: the *later* post's forward row
+      # was created first and so has the lower id. Without reconstruction,
+      # extract_from's ON CONFLICT DO NOTHING would keep these ids, so FirstLink's
+      # MIN(id) would still pick the later post.
+      later_link =
+        TopicLink.create!(
+          post_id: later.id,
+          user_id: poster.id,
+          topic_id: topic.id,
+          url: url_b,
+          domain: URI.parse(base).host,
+          internal: true,
+          link_topic_id: other_topic.id,
+          link_post_id: target_b.id,
+        )
+      earlier_link =
+        TopicLink.create!(
+          post_id: earlier.id,
+          user_id: poster.id,
+          topic_id: topic.id,
+          url: url_a,
+          domain: URI.parse(base).host,
+          internal: true,
+          link_topic_id: other_topic.id,
+          link_post_id: target_a.id,
+        )
+      expect(earlier_link.id).to be > later_link.id
+
+      service.derive_links
+
+      earlier_row = TopicLink.find_by(post_id: earlier.id)
+      later_row = TopicLink.find_by(post_id: later.id)
+      expect(earlier_row).to be_present
+      expect(later_row).to be_present
+      # Reconstruction restored source order so MIN(topic_links.id) = earlier's row.
+      expect(earlier_row.id).to be < later_row.id
+    end
+
+    it "preserves non-badge topic links and their click records during reconstruction" do
+      # External and same-topic (or quote) links are not FirstLink candidates, so
+      # reconstruction must leave them — and the Docker title/crawl data and any
+      # click records attached to them — intact instead of deleting them.
+      with_link = Fabricate(:post, topic: topic, user: poster, raw: "see this")
+      with_link.update!(cooked: %{<p><a href="https://example.com/x">x</a></p>})
+      mark_imported(with_link)
+
+      external =
+        TopicLink.create!(
+          post_id: with_link.id,
+          user_id: poster.id,
+          topic_id: topic.id,
+          url: "https://example.com/x",
+          domain: "example.com",
+          title: "A crawled title",
+        )
+      # A click record whose topic_link would be orphaned by a blanket delete_all.
+      click = Fabricate(:topic_link_click, topic_link: external)
+
+      allow(TopicLink).to receive(:extract_from)
+
+      service.derive_links
+
+      expect(TopicLink.find_by(id: external.id)).to be_present
+      expect(external.reload.title).to eq("A crawled title")
+      expect(TopicLinkClick.find_by(id: click.id)).to be_present
+    end
+
+    it "does not re-timestamp reflection rows to their (imported) target post's created_at" do
+      other_topic = Fabricate(:topic, user: poster)
+      # A reflection stored on this imported post but owned by a non-imported
+      # source post in another topic.
+      target = Fabricate(:post, topic: topic, user: poster, raw: "target")
+      target.update!(created_at: 10.days.ago)
+      mark_imported(target)
+      source = Fabricate(:post, topic: other_topic, user: poster, raw: "source")
+      source.update!(created_at: 1.day.ago)
+
+      reflection =
+        TopicLink.create!(
+          post_id: target.id,
+          user_id: poster.id,
+          topic_id: topic.id,
+          url: "https://example.com/r",
+          domain: "example.com",
+          reflection: true,
+          link_topic_id: other_topic.id,
+          link_post_id: source.id,
+          created_at: source.created_at,
+        )
+
+      allow(TopicLink).to receive(:extract_from)
+
+      service.derive_links
+
+      reflection.reload
+      # post_id is the (imported) target; only a forward-only rebase guard keeps
+      # the reflection's timestamp (its source post's) intact instead of stamping
+      # it with the target's 10-days-ago created_at.
+      expect(reflection.created_at).to be_within(1.second).of(source.created_at)
+    end
+
+    it "aborts instead of proceeding when link extraction fails" do
+      with_link = Fabricate(:post, topic: topic, user: poster, raw: "see this")
+      with_link.update!(cooked: %{<p><a href="https://example.com/x">x</a></p>})
+      mark_imported(with_link)
+
+      allow(TopicLink).to receive(:extract_from).and_raise("boom")
+
+      # Forward candidates were already torn down; a silent rescue would hand the
+      # auto-revoking badge backfill incomplete link data, so the failure must
+      # surface and stop the pass.
+      expect { service.derive_links }.to raise_error(RuntimeError, /aborting before badge backfill/)
+    end
+  end
+
+  describe "#backfill_participation_badges" do
+    it "backfills each participation badge via Jobs::BackfillBadge" do
+      badge1 = Fabricate(:badge, name: "Backfill Alpha")
+      badge2 = Fabricate(:badge, name: "Backfill Beta")
+      allow(Badge).to receive(:where).with(
+        id: Import::ParticipationBadges::PARTICIPATION_BADGE_IDS,
+      ).and_return(Badge.where(id: [badge1.id, badge2.id]))
+
+      job = instance_double(Jobs::BackfillBadge)
+      allow(Jobs::BackfillBadge).to receive(:new).and_return(job)
+      allow(job).to receive(:execute)
+
+      service.backfill_participation_badges
+
+      expect(job).to have_received(:execute).with(badge_id: badge1.id)
+      expect(job).to have_received(:execute).with(badge_id: badge2.id)
+      # Notification suppression was active for the pass.
+      expect(service.instance_variable_get(:@badge_notification_suppression)).to be_present
+    end
+  end
+
+  describe "#grant_all" do
+    it "runs every derivation then the backfill" do
+      service = described_class.new
+      allow(service).to receive(:derive_quotes)
+      allow(service).to receive(:derive_mentions)
+      allow(service).to receive(:derive_links)
+      allow(service).to receive(:backfill_participation_badges)
+
+      service.grant_all
+
+      expect(service).to have_received(:derive_quotes).ordered
+      expect(service).to have_received(:derive_mentions).ordered
+      expect(service).to have_received(:derive_links).ordered
+      expect(service).to have_received(:backfill_participation_badges).ordered
+    end
+
+    it "aborts before the badge backfill when link extraction raises" do
+      service = described_class.new
+      allow(service).to receive(:derive_quotes)
+      allow(service).to receive(:derive_mentions)
+      allow(service).to receive(:derive_links).and_raise("link extraction broke")
+      allow(service).to receive(:backfill_participation_badges)
+
+      expect { service.grant_all }.to raise_error("link extraction broke")
+
+      # The auto-revoking backfill must never run on incomplete link data.
+      expect(service).not_to have_received(:backfill_participation_badges)
+    end
+  end
+end

--- a/spec/script/bulk_import/generic_bulk_spec.rb
+++ b/spec/script/bulk_import/generic_bulk_spec.rb
@@ -1493,6 +1493,62 @@ if generic_import_dependencies_available
         source_db&.close
       end
     end
+
+    describe "#raw_with_placeholders_interpolated" do
+      it "still interpolates token-bearing mention/quote placeholders as before" do
+        importer = described_class.allocate
+        importer.instance_variable_set(:@user_ids_by_username_lower, { "alice" => 5 })
+        importer.instance_variable_set(:@mapped_usernames, {})
+        importer.instance_variable_set(:@post_number_by_post_id, { 1202 => 3 })
+        importer.instance_variable_set(:@topic_id_by_post_id, { 1202 => 22 })
+        def importer.username_from_id(_id) = "alice"
+        def importer.user_full_name_from_id(id) = id == 5 ? "Alice" : nil
+        def importer.user_id_from_imported_id(id) = id == 20 ? 5 : nil
+        def importer.topic_id_from_imported_post_id(id) = id == 202 ? 22 : nil
+        def importer.post_number_from_imported_id(id) = id == 202 ? 3 : nil
+
+        row = {
+          "id" => 101,
+          "placeholders" => {
+            "mentions" => [{ "type" => "user", "id" => 20, "placeholder" => "[@mention|abc]" }],
+            "quotes" => [{ "post_id" => 202, "user_id" => 20, "placeholder" => "[quote|xyz]" }],
+          }.to_json,
+        }
+
+        result =
+          importer.raw_with_placeholders_interpolated("see [@mention|abc] and [quote|xyz]", row)
+        expect(result).to include("@alice")
+        expect(result).to include('quote="Alice')
+        expect(result).not_to include("[@mention|abc]")
+        expect(result).not_to include("[quote|xyz]")
+      end
+    end
+
+    describe "#import_badge_groupings" do
+      it "maps any blank badge_group (nil, '', whitespace-only) to the default Other grouping so COPY cannot abort" do
+        # badges.badge_grouping_id is NOT NULL and BADGE_COLUMNS always supplies it
+        # during COPY; a blank/whitespace group name must resolve to
+        # BadgeGrouping::Other (5) rather than leaving a nil grouping id, or the
+        # whole COPY batch would fail.
+        source_db = SQLite3::Database.new(":memory:", results_as_hash: true)
+        source_db.execute("CREATE TABLE badges (id INTEGER PRIMARY KEY, badge_group TEXT)")
+        source_db.execute(
+          "INSERT INTO badges (id, badge_group) VALUES (1, 'Core'), (2, NULL), (3, ''), (4, '   ')",
+        )
+        importer = described_class.allocate
+        importer.instance_variable_set(:@source_db, source_db)
+
+        importer.import_badge_groupings
+        mapping = importer.instance_variable_get(:@badge_group_mapping)
+
+        expect(mapping[nil]).to eq(BadgeGrouping::Other)
+        expect(mapping[""]).to eq(BadgeGrouping::Other)
+        expect(mapping["   "]).to eq(BadgeGrouping::Other)
+        expect(mapping["Core"]).to eq(BadgeGrouping.find_by!(name: "Core").id)
+      ensure
+        source_db&.close
+      end
+    end
   end
 
   RSpec.describe BulkImport::Base do


### PR DESCRIPTION
Add an Import::ParticipationBadges service and an
`import:grant_participation_badges` rake task so sites migrated via the bulk importer can retroactively award participation-based badges (FirstLike, FirstQuote, Welcome, Nice/Good/Great Post & Topic, etc.).

Before badges can be granted their underlying signals must exist, so the service first derives them from the imported posts' cooked content:
- quote links (QuotedPost) from asides / reply-parent linkage,
- mentions (UserAction::MENTION) from mention anchors,
- topic links via the canonical TopicLink.extract_from, reconstructing forward-link rows whose id order was scrambled by the earlier id-shuffle so FirstLink's MIN(id) reflects true chronological order, then runs Jobs::BackfillBadge per badge with notifications suppressed.

Link extraction failures abort the pass so the auto-revoking badge backfill never runs on incomplete link data.

Also harden the generic bulk importer so badge/group-user holds can be mapped onto already-existing records:
- process_badge maps an existing badge by name or id and skips re-import,
- blank badge groups resolve to the default Other grouping so COPY can't abort on a NULL badge_grouping_id,
- process_group_user preserves a source created_at instead of forcing NOW.