### PR TITLE
DEV: Prepare specs for RSpec blank-line cops

### DIFF
--- a/migrations/converters/spec/lib/migrations/converters_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Migrations::Converters do
     allow(described_class).to receive(:private_converters_path).and_return(private_path)
     reset_memoization(described_class, :@all_converters)
   end
+
   after do
     FileUtils.remove_dir(root_path, force: true)
     reset_memoization(described_class, :@all_converters)

--- a/plugins/automation/spec/scripts/auto_tag_topic_spec.rb
+++ b/plugins/automation/spec/scripts/auto_tag_topic_spec.rb
@@ -94,6 +94,7 @@ describe "AutoTagTopic" do
             target: "script",
           )
         end
+
         it "works" do
           automation.trigger!("topic" => topic, "status" => :automatically)
 
@@ -106,6 +107,7 @@ describe "AutoTagTopic" do
           expect(topic.reload.tags.pluck(:name)).to be_empty
         end
       end
+
       context "when closed_manually is set" do
         before do
           automation.upsert_field!("tags", "tags", { value: %w[tag1 tag2] })

--- a/plugins/automation/spec/scripts/topic_spec.rb
+++ b/plugins/automation/spec/scripts/topic_spec.rb
@@ -3,6 +3,7 @@
 describe "Topic" do
   let!(:raw) { "this is me testing a new topic by automation" }
   let!(:title) { "This is a new topic created by automation" }
+
   fab!(:category)
   fab!(:tag1, :tag)
   fab!(:tag2, :tag)

--- a/plugins/automation/spec/scripts/user_group_membership_through_badge_spec.rb
+++ b/plugins/automation/spec/scripts/user_group_membership_through_badge_spec.rb
@@ -14,6 +14,7 @@ describe "UserGroupMembershipThroughBadge" do
   end
 
   before { BadgeGranter.enable_queue }
+
   after do
     BadgeGranter.disable_queue
     BadgeGranter.clear_queue!

--- a/plugins/automation/spec/triggers/category_created_edited_spec.rb
+++ b/plugins/automation/spec/triggers/category_created_edited_spec.rb
@@ -20,6 +20,7 @@ describe "CategoryCreatedEdited" do
 
     context "when category is restricted" do
       let(:parent_category_id) { Category.first.id }
+
       before do
         automation.upsert_field!(
           "restricted_category",

--- a/plugins/automation/spec/triggers/user_promoted_spec.rb
+++ b/plugins/automation/spec/triggers/user_promoted_spec.rb
@@ -28,6 +28,7 @@ describe "UserPromoted" do
 
   context "when there is a group restriction" do
     let!(:group) { Fabricate(:group) }
+
     before do
       automation.upsert_field!(
         "restricted_group",

--- a/plugins/chat/spec/jobs/regular/chat/notify_watching_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/notify_watching_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe Jobs::Chat::NotifyWatching do
           args
         end
       end
+
       it "Allows for changes to the translation args" do
         plugin_instance = Plugin::Instance.new
         plugin_instance.register_modifier(:chat_notification_translation_args, &modifier_block)

--- a/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
@@ -72,6 +72,7 @@ describe Jobs::Chat::ProcessMessage do
 
   describe "pull hotlinked images" do
     let(:image_url) { "https://example.com/img.png" }
+
     fab!(:hotlinked_message) do
       Fabricate(:chat_message, message: "![](https://example.com/img.png)")
     end

--- a/plugins/chat/spec/lib/chat/duplicate_message_validator_spec.rb
+++ b/plugins/chat/spec/lib/chat/duplicate_message_validator_spec.rb
@@ -2,6 +2,7 @@
 
 describe Chat::DuplicateMessageValidator do
   let(:message) { "goal!" }
+
   fab!(:category_channel, :chat_channel)
   fab!(:dm_channel, :direct_message_channel)
   fab!(:user)

--- a/plugins/chat/spec/models/chat/category_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/category_channel_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe Chat::CategoryChannel do
           SiteSetting.slug_generation_method = "encoded"
           channel.slug = "测试"
         end
+
         after { SiteSetting.slug_generation_method = "ascii" }
 
         it "creates a slug with the correct escaping" do

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Chat::DirectMessageChannel do
       channel.chatable.update!(group: false)
       expect(channel).not_to be_direct_message_group
     end
+
     it "returns true if the DirectMessage chatable is for a group DM" do
       channel.chatable.update!(group: true)
       expect(channel).to be_direct_message_group

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -814,6 +814,7 @@ describe Chat::Message do
 
   describe "blocking duplicate messages" do
     let(:message) { "this is duplicate" }
+
     fab!(:chat_channel)
     fab!(:user)
 

--- a/plugins/chat/spec/models/user_option_spec.rb
+++ b/plugins/chat/spec/models/user_option_spec.rb
@@ -6,21 +6,25 @@ RSpec.describe UserOption do
       expect(described_class.new.chat_separate_sidebar_mode).to eq("default")
     end
   end
+
   describe "#show_thread_title_prompts" do
     it "is present" do
       expect(described_class.new.show_thread_title_prompts).to eq(true)
     end
   end
+
   describe "#chat_announce_new_messages" do
     it "defaults to true" do
       expect(described_class.new.chat_announce_new_messages).to eq(true)
     end
   end
+
   describe "#chat_new_message_sound" do
     it "defaults to false" do
       expect(described_class.new.chat_new_message_sound).to eq(false)
     end
   end
+
   describe "#chat_quick_reaction_type" do
     it "is present with frequent as default" do
       expect(described_class.new.chat_quick_reaction_type).to eq("frequent")

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -87,6 +87,7 @@ describe Chat do
     let!(:user) { Fabricate(:user) }
     let!(:guardian) { Guardian.new(user) }
     let(:serializer) { UserCardSerializer.new(target_user, scope: guardian) }
+
     fab!(:group)
 
     context "when chat enabled" do

--- a/plugins/chat/spec/queries/chat/messages_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/messages_query_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe Chat::MessagesQuery do
 
       context "when thread_id is provided" do
         let(:thread_id) { thread.id }
+
         it "does include messages which are part of a thread" do
           message_3.update!(
             thread: thread,

--- a/plugins/chat/spec/queries/chat/tracking_state_report_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/tracking_state_report_query_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Chat::TrackingStateReportQuery do
   let(:include_threads) { false }
   let(:include_read) { true }
   let(:include_last_reply_details) { false }
+
   context "when channel_ids empty" do
     it "returns empty object for channel_tracking" do
       expect(query.channel_tracking).to eq({})
@@ -80,6 +81,7 @@ RSpec.describe Chat::TrackingStateReportQuery do
 
     context "when include_threads is true" do
       let(:include_threads) { true }
+
       fab!(:thread_1) { Fabricate(:chat_thread, channel: channel_1) }
       fab!(:thread_2) { Fabricate(:chat_thread, channel: channel_2) }
 

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -316,6 +316,7 @@ RSpec.describe Chat::Api::ChannelThreadsController do
   describe "update" do
     let(:title) { "New title" }
     let(:params) { { title: title } }
+
     fab!(:thread) do
       Fabricate(:chat_thread, channel: public_channel, original_message_user: current_user)
     end

--- a/plugins/chat/spec/requests/chat/api/channels_current_user_membership_follows_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_current_user_membership_follows_controller_spec.rb
@@ -23,6 +23,7 @@ describe Chat::Api::ChannelsCurrentUserMembershipController do
 
       context "when channel is not found" do
         before { channel_1.destroy! }
+
         it "returns a 404" do
           delete "/chat/api/channels/-999/memberships/me/follows"
 

--- a/plugins/chat/spec/requests/chat/api/channels_messages_flags_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_messages_flags_controller_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Chat::Api::ChannelsMessagesFlagsController do
         expect(response.status).to eq(404)
       end
     end
+
     context "when channel is not found" do
       it "returns a 404" do
         post "/chat/api/channels/-999/messages/#{message_1.id}/flags", params: params

--- a/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Chat::AddUsersToChannel do
     let(:groups) { "group1" }
 
     it { is_expected.to validate_presence_of :channel_id }
+
     it do
       is_expected.to validate_length_of(:usernames)
         .is_at_most(SiteSetting.chat_max_direct_message_users)

--- a/plugins/chat/spec/services/chat/auto_leave_channels_spec.rb
+++ b/plugins/chat/spec/services/chat/auto_leave_channels_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe Chat::AutoLeaveChannels do
 
           context "with another category/channel/user" do
             let(:params) { { event: :generic_event } }
+
             fab!(:user_2) { Fabricate(:user, trust_level: 1) }
             fab!(:category_2) { Fabricate(:private_category, group:) }
             fab!(:chat_channel_2) { Fabricate(:chat_channel, chatable: category_2) }

--- a/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Chat::ListChannelMessages do
     it { is_expected.to validate_presence_of(:channel_id) }
     it { is_expected.to allow_values(1, options.max_page_size, nil).for(:page_size) }
     it { is_expected.not_to allow_values(0).for(:page_size) }
+
     it do
       is_expected.to validate_inclusion_of(:direction).in_array(
         Chat::MessagesQuery::VALID_DIRECTIONS,

--- a/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Chat::ListChannelThreadMessages do
     it { is_expected.to validate_presence_of(:channel_id) }
     it { is_expected.to allow_values(1, options.max_page_size, nil).for(:page_size) }
     it { is_expected.not_to allow_values(0).for(:page_size) }
+
     it do
       is_expected.to validate_inclusion_of(:direction).in_array(
         Chat::MessagesQuery::VALID_DIRECTIONS,

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe ::Chat::LookupChannelThreads::Contract, type: :model do
   it { is_expected.to validate_presence_of(:channel_id) }
   it { is_expected.to allow_values(1, 0, nil, "a").for(:limit) }
+
   it do
     is_expected.not_to allow_values(::Chat::LookupChannelThreads::THREADS_LIMIT + 1).for(:limit)
   end

--- a/plugins/chat/spec/services/chat/restore_message_spec.rb
+++ b/plugins/chat/spec/services/chat/restore_message_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Chat::RestoreMessage do
   fab!(:current_user, :user)
   let!(:guardian) { Guardian.new(current_user) }
+
   fab!(:message) { Fabricate(:chat_message, user: current_user) }
 
   before do

--- a/plugins/chat/spec/services/chat/update_channel_status_spec.rb
+++ b/plugins/chat/spec/services/chat/update_channel_status_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe(Chat::UpdateChannelStatus) do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:channel_id) }
+
     it do
       is_expected.to validate_inclusion_of(:status).in_array(Chat::Channel.editable_statuses.keys)
     end

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Chat::UpdateMessage do
 
   describe "with validation" do
     let(:guardian) { Guardian.new(user1) }
+
     fab!(:admin1, :admin)
     fab!(:admin2, :admin)
     fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }

--- a/plugins/chat/spec/services/chat/workflows/approval/resume_interaction_spec.rb
+++ b/plugins/chat/spec/services/chat/workflows/approval/resume_interaction_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe Chat::Workflows::Approval::ResumeInteraction do
           "channel_id" => channel.id.to_s,
         }
       end
+
       it { is_expected.to fail_to_find_a_model(:resolved_interaction) }
     end
 

--- a/plugins/chat/spec/support/examples/chat_channel_model.rb
+++ b/plugins/chat/spec/support/examples/chat_channel_model.rb
@@ -15,6 +15,7 @@ RSpec.shared_examples "a chat channel model" do
   it { is_expected.to have_many(:user_chat_channel_memberships) }
   it { is_expected.to have_one(:chat_channel_archive) }
   it { is_expected.to delegate_method(:empty?).to(:chat_messages).with_prefix }
+
   it do
     is_expected.to define_enum_for(:status).with_values(
       open: 0,
@@ -26,6 +27,7 @@ RSpec.shared_examples "a chat channel model" do
 
   describe "Validations" do
     it { is_expected.to validate_presence_of(:name).allow_nil }
+
     it do
       is_expected.to validate_length_of(:name).is_at_most(
         SiteSetting.max_topic_title_length,

--- a/plugins/chat/spec/system/admin/csv_exports_spec.rb
+++ b/plugins/chat/spec/system/admin/csv_exports_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe "Admin Chat CSV exports" do
   let(:dialog) { PageObjects::Components::Dialog.new }
   let(:csv_export_pm_page) { PageObjects::Pages::CSVExportPM.new }
+
   fab!(:current_user, :admin)
 
   before do

--- a/plugins/chat/spec/system/bookmark_message_spec.rb
+++ b/plugins/chat/spec/system/bookmark_message_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Bookmark message" do
 
       expect(channel_page).to have_bookmarked_message(message_1)
     end
+
     context "when in a long thread" do
       it "supports linking to a bookmark in a long thread" do
         category_channel_1.update!(threading_enabled: true)

--- a/plugins/checklist/spec/services/checklist/toggle_checkbox_spec.rb
+++ b/plugins/checklist/spec/services/checklist/toggle_checkbox_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Checklist::ToggleCheckbox do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:post_id) }
     it { is_expected.to validate_presence_of(:toggles) }
+
     it "limits the batch size" do
       toggles =
         Array.new(Checklist::ToggleCheckbox::MAX_BATCH_SIZE + 1) do |index|
@@ -21,6 +22,7 @@ RSpec.describe Checklist::ToggleCheckbox do
       expect(contract).not_to be_valid
       expect(contract.errors[:toggles]).to be_present
     end
+
     it { is_expected.to validate_presence_of(:expected_raw) }
     it { is_expected.to validate_length_of(:expected_raw).is_at_most(SiteSetting.max_post_length) }
     it { is_expected.to validate_presence_of(:expected_updated_at) }

--- a/plugins/discourse-ai/spec/configuration/llm_validator_spec.rb
+++ b/plugins/discourse-ai/spec/configuration/llm_validator_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe DiscourseAi::Configuration::LlmValidator do
 
   describe "#valid_value?" do
     let(:validator) { described_class.new(name: :ai_default_llm_model) }
+
     fab!(:llm_model)
 
     before do
@@ -44,6 +45,7 @@ RSpec.describe DiscourseAi::Configuration::LlmValidator do
 
   describe "#run_test" do
     let(:validator) { described_class.new }
+
     fab!(:llm_model)
 
     it "exercises both non-streaming and streaming completions" do

--- a/plugins/discourse-ai/spec/evals/runners/inference_spec.rb
+++ b/plugins/discourse-ai/spec/evals/runners/inference_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DiscourseAi::Evals::Runners::Inference do
       read_buffered_property: %w[concept_a concept_b],
     )
   end
+
   before do
     stub_runner_bot(agent: DiscourseAi::Agents::ConceptFinder.new) do |blk|
       blk.call(structured_output, nil, :structured_output)

--- a/plugins/discourse-ai/spec/jobs/regular/digest_rag_upload_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/digest_rag_upload_spec.rb
@@ -99,6 +99,7 @@ describe Jobs::DigestRagUpload do
         expect(parsed).to eq(parsed_document_with_metadata.read.delete_suffix("\n"))
       end
     end
+
     context "when processing an upload for the first time" do
       before { File.expects(:open).returns(document_file) }
 

--- a/plugins/discourse-ai/spec/jobs/regular/stream_composer_helper_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/stream_composer_helper_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Jobs::StreamComposerHelper do
 
   describe "#execute" do
     let!(:input) { "I liek to eet pie fur brakefast becuz it is delishus." }
+
     fab!(:user, :leader)
 
     before do

--- a/plugins/discourse-ai/spec/lib/agents/tool_runner/discourse_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tool_runner/discourse_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe DiscourseAi::Agents::ToolRunner do
   fab!(:llm_model) { Fabricate(:llm_model, name: "claude-2") }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:bot_user) { Fabricate(:user, admin: true, refresh_auto_groups: true) }
   fab!(:topic)

--- a/plugins/discourse-ai/spec/lib/agents/tool_runner/http_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tool_runner/http_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe DiscourseAi::Agents::ToolRunner do
   fab!(:llm_model) { Fabricate(:llm_model, name: "claude-2") }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:bot_user) { Discourse.system_user }
 
   def create_tool(script:)

--- a/plugins/discourse-ai/spec/lib/agents/tool_runner/index_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tool_runner/index_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe DiscourseAi::Agents::ToolRunner do
   fab!(:llm_model) { Fabricate(:llm_model, name: "claude-2") }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:bot_user) { Discourse.system_user }
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:tool) do

--- a/plugins/discourse-ai/spec/lib/agents/tool_runner/llm_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tool_runner/llm_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe DiscourseAi::Agents::ToolRunner do
   fab!(:llm_model) { Fabricate(:llm_model, name: "claude-2") }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:bot_user) { Discourse.system_user }
 
   def create_tool(script:)

--- a/plugins/discourse-ai/spec/lib/agents/tools/add_reviewable_note_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/add_reviewable_note_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DiscourseAi::Agents::Tools::AddReviewableNote do
   fab!(:llm_model)
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:admin)
 
   before do

--- a/plugins/discourse-ai/spec/lib/agents/tools/create_artifact_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/create_artifact_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe DiscourseAi::Agents::Tools::CreateArtifact do
   fab!(:llm_model)
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:post)
 
   before do

--- a/plugins/discourse-ai/spec/lib/agents/tools/list_reviewables_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/list_reviewables_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DiscourseAi::Agents::Tools::ListReviewables do
   fab!(:llm_model)
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:admin)
 
   before do

--- a/plugins/discourse-ai/spec/lib/agents/tools/perform_reviewable_action_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/perform_reviewable_action_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DiscourseAi::Agents::Tools::PerformReviewableAction do
   fab!(:llm_model)
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:admin)
 
   before do

--- a/plugins/discourse-ai/spec/lib/agents/tools/read_artifact_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/read_artifact_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe DiscourseAi::Agents::Tools::ReadArtifact do
   fab!(:llm_model)
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
+
   fab!(:post)
   fab!(:post2) { Fabricate(:post, user: post.user) }
   fab!(:artifact) do

--- a/plugins/discourse-ai/spec/lib/agents/tools/read_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/read_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe DiscourseAi::Agents::Tools::Read do
       expect(results[:content]).to include("hello there")
       expect(results[:content]).not_to include("mister sam")
     end
+
     it "can read a topic" do
       topic_id = topic_with_tags.id
       results = tool.invoke

--- a/plugins/discourse-ai/spec/lib/agents/tools/update_artifact_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/update_artifact_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe DiscourseAi::Agents::Tools::UpdateArtifact do
   fab!(:llm_model)
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
+
   fab!(:post)
   fab!(:artifact) do
     AiArtifact.create!(

--- a/plugins/discourse-ai/spec/lib/completions/dialects/chat_gpt_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/dialects/chat_gpt_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe DiscourseAi::Completions::Dialects::ChatGpt do
       expect(translated.last[:role]).to eq("user")
       expect(translated.last[:content].length).to be < (8000 * 4)
     end
+
     it "renders converted document uploads as text content parts" do
       llm_model.update!(allowed_attachment_types: ["docx"])
       converted_text = "Uploaded document: sample.docx (13 Bytes)\n\nConverted text"

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/aws_bedrock_converse_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/aws_bedrock_converse_spec.rb
@@ -401,6 +401,7 @@ RSpec.describe DiscourseAi::Completions::Endpoints::AwsBedrockConverse do
       )
       expect(AiApiAuditLog.last.response_status).to be_nil
     end
+
     it "records SDK error response status when available" do
       client = instance_double(Aws::BedrockRuntime::Client)
       context = Seahorse::Client::RequestContext.new

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -825,6 +825,7 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
           *[{ type: :user, id: user.username, content: third_post.raw }],
         )
       end
+
       it "starts from the last compressed checkpoint" do
         builder.push(type: :user, content: "Old request")
         builder.push(type: :model, content: "Old response")
@@ -1109,6 +1110,7 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
           ],
         )
       end
+
       it "normalizes saved thinking provider info" do
         custom_prompt = [
           [

--- a/plugins/discourse-ai/spec/lib/discourse_automation/automation_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discourse_automation/automation_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe DiscourseAi::Automation do
 
   describe "manually configured model" do
     let!(:llm_model) { Fabricate(:llm_model) }
+
     it "returns a list of available models for automation" do
       models = DiscourseAi::Automation.available_models
       expect(models).to be_an(Array)

--- a/plugins/discourse-ai/spec/lib/guardian_extensions_spec.rb
+++ b/plugins/discourse-ai/spec/lib/guardian_extensions_spec.rb
@@ -53,6 +53,7 @@ describe DiscourseAi::GuardianExtensions do
 
     context "when the topic is a PM" do
       before { assign_agent_to(:ai_summarization_agent, [group.id]) }
+
       let(:pm) { Fabricate(:private_message_topic) }
 
       it "returns false" do
@@ -95,6 +96,7 @@ describe DiscourseAi::GuardianExtensions do
 
   describe "#can_see_gists?" do
     before { assign_agent_to(:ai_summary_gists_agent, [group.id]) }
+
     let(:guardian) { Guardian.new(user) }
 
     context "when access is restricted to the user's group" do

--- a/plugins/discourse-ai/spec/lib/modules/ai_moderation/spam_scanner_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_moderation/spam_scanner_spec.rb
@@ -332,6 +332,7 @@ RSpec.describe DiscourseAi::AiModeration::SpamScanner do
   describe "integration test" do
     fab!(:llm_model)
     let(:api_audit_log) { Fabricate(:api_audit_log) }
+
     fab!(:post_with_uploaded_image)
 
     before { Jobs.run_immediately! }

--- a/plugins/discourse-ai/spec/lib/modules/sentiment/emotion_filter_order_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/sentiment/emotion_filter_order_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe DiscourseAi::Sentiment::EmotionFilterOrder do
       TopicsFilter.new(guardian:).filter_from_query_string("order:emotion_love-asc").pluck(:id),
     ).to contain_exactly(post_2.topic.id, post_1.topic.id)
   end
+
   it "sorts emotion in default descending order" do
     expect(
       TopicsFilter.new(guardian:).filter_from_query_string("order:emotion_love").pluck(:id),

--- a/plugins/discourse-ai/spec/lib/modules/summarization/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/summarization/entry_point_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe DiscourseAi::Summarization::EntryPoint do
       describe "topic_list_item serializer's ai_summary" do
         context "when hot topic summarization is disabled" do
           before { SiteSetting.ai_summary_gists_enabled = false }
+
           it "doesn't include summaries" do
             gist_topic = topic_query.list_hot.topics.find { |t| t.id == topic_ai_gist.target_id }
 

--- a/plugins/discourse-ai/spec/lib/translation/base_translator_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/base_translator_spec.rb
@@ -16,6 +16,7 @@ describe DiscourseAi::Translation::BaseTranslator do
     let(:target_locale) { "de" }
     let(:content_description) { "A tag about cats" }
     let(:llm_response) { "hur dur hur dur!" }
+
     fab!(:post)
     fab!(:topic) { post.topic }
 

--- a/plugins/discourse-ai/spec/lib/translation/post_locale_detector_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_locale_detector_spec.rb
@@ -2,6 +2,7 @@
 
 describe DiscourseAi::Translation::PostLocaleDetector do
   before { enable_current_plugin }
+
   describe ".detect_locale" do
     fab!(:post) { Fabricate(:post, cooked: "Hello world", locale: nil) }
 

--- a/plugins/discourse-ai/spec/lib/utils/diff_utils/hunk_diff_spec.rb
+++ b/plugins/discourse-ai/spec/lib/utils/diff_utils/hunk_diff_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe DiscourseAi::Utils::DiffUtils::HunkDiff do
     context "without markers" do
       let(:original_text) { "hello" }
       let(:diff) { "world" }
+
       it "will append to the end" do
         expect(apply_hunk).to eq("hello\nworld")
       end

--- a/plugins/discourse-ai/spec/lib/utils/diff_utils/safety_checker_spec.rb
+++ b/plugins/discourse-ai/spec/lib/utils/diff_utils/safety_checker_spec.rb
@@ -13,21 +13,25 @@ RSpec.describe DiscourseAi::Utils::DiffUtils::SafetyChecker do
 
       context "with normal HTML tags" do
         let(:text) { "Here is <strong>bold</strong> and <em>italic</em> text." }
+
         it { is_expected.to eq(true) }
       end
 
       context "with balanced markdown and no partial emoji" do
         let(:text) { "This is **bold**, *italic*, and a smiley :smile:!" }
+
         it { is_expected.to eq(true) }
       end
 
       context "with balanced quote blocks" do
         let(:text) { "[quote]Quoted text[/quote]" }
+
         it { is_expected.to eq(true) }
       end
 
       context "with complete image markdown" do
         let(:text) { "![alt text](https://example.com/image.png)" }
+
         it { is_expected.to eq(true) }
       end
     end
@@ -35,46 +39,55 @@ RSpec.describe DiscourseAi::Utils::DiffUtils::SafetyChecker do
     context "with unsafe text" do
       context "with unclosed markdown link" do
         let(:text) { "This is a [link(https://example.com)" }
+
         it { is_expected.to eq(false) }
       end
 
       context "with unclosed raw HTML tag" do
         let(:text) { "Text with <div unclosed tag" }
+
         it { is_expected.to eq(false) }
       end
 
       context "with trailing incomplete URL" do
         let(:text) { "Check this out https://example.com/something" } # no closing punctuation
+
         it { is_expected.to eq(false) }
       end
 
       context "with unclosed backticks" do
         let(:text) { "Here is some `inline code without closing" }
+
         it { is_expected.to eq(false) }
       end
 
       context "with unbalanced bold or italic markdown" do
         let(:text) { "This is *italic without closing" }
+
         it { is_expected.to eq(false) }
       end
 
       context "with incomplete image markdown" do
         let(:text) { "Image ![alt text](https://example.com/image.png" } # missing closing )
+
         it { is_expected.to eq(false) }
       end
 
       context "with unbalanced quote blocks" do
         let(:text) { "[quote]Unclosed quote block" }
+
         it { is_expected.to eq(false) }
       end
 
       context "with unclosed triple backticks" do
         let(:text) { "```code block without closing" }
+
         it { is_expected.to eq(false) }
       end
 
       context "with partial emoji" do
         let(:text) { "A partial emoji :smile" }
+
         it { is_expected.to eq(false) }
       end
     end

--- a/plugins/discourse-ai/spec/lib/utils/search_spec.rb
+++ b/plugins/discourse-ai/spec/lib/utils/search_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe DiscourseAi::Utils::Search do
 
     context "when using semantic search" do
       let(:query) { "this is an expanded search" }
+
       after do
         if defined?(DiscourseAi::Embeddings::SemanticSearch)
           DiscourseAi::Embeddings::SemanticSearch.clear_cache_for(query)

--- a/plugins/discourse-ai/spec/models/ai_tool_spec.rb
+++ b/plugins/discourse-ai/spec/models/ai_tool_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe AiTool do
   fab!(:llm_model) { Fabricate(:llm_model, name: "claude-2") }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+
   fab!(:bot_user) { Discourse.system_user }
 
   def create_tool(

--- a/plugins/discourse-ai/spec/models/reviewable_ai_post_spec.rb
+++ b/plugins/discourse-ai/spec/models/reviewable_ai_post_spec.rb
@@ -125,6 +125,7 @@ describe ReviewableAiPost do
     let(:reviewable) do
       described_class.needs_review!(target: target, created_by: Discourse.system_user)
     end
+
     fab!(:admin)
 
     before do

--- a/plugins/discourse-ai/spec/requests/admin/ai_features_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_features_controller_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe DiscourseAi::Admin::AiFeaturesController do
   let(:controller) { described_class.new }
+
   fab!(:admin)
   fab!(:group)
   fab!(:llm_model)

--- a/plugins/discourse-ai/spec/requests/ai_helper/assistant_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_helper/assistant_controller_spec.rb
@@ -638,6 +638,7 @@ RSpec.describe DiscourseAi::AiHelper::AssistantController do
             "I love apples",
           ]
         end
+
         it "returns title suggestions based on the input text" do
           DiscourseAi::Completions::Llm.with_prepared_responses([title_suggestions]) do
             post "/discourse-ai/ai-helper/suggest_title", params: { text: post_1.raw }

--- a/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
@@ -148,6 +148,7 @@ describe DiscourseAi::Discover::DiscoveriesController do
     let(:query) { "What is Discourse?" }
     let(:context) { "Discourse is an open-source discussion platform." }
     let(:request_id) { SecureRandom.uuid }
+
     fab!(:source_post, :post)
 
     context "when the user is allowed to discover" do

--- a/plugins/discourse-ai/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "AI Composer helper" do
 
     context "when not a member of custom prompt group" do
       let(:mode) { DiscourseAi::AiHelper::Assistant::CUSTOM_PROMPT }
+
       before { custom_prompts_agent.update!(allowed_group_ids: [non_member_group.id]) }
 
       it "does not show custom prompt option" do
@@ -542,6 +543,7 @@ RSpec.describe "AI Composer helper" do
 
   context "when the suggestions feature is disabled" do
     let(:mode) { DiscourseAi::AiHelper::Assistant::GENERATE_TITLES }
+
     before { SiteSetting.ai_helper_enabled_features = "context_menu" }
 
     it "does not offer title suggestions in the AI helper menu" do

--- a/plugins/discourse-ai/spec/system/ai_helper/ai_split_topic_suggestion_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_helper/ai_split_topic_suggestion_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "AI Post helper" do
   end
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:suggestion_menu) { PageObjects::Components::AiSplitTopicSuggester.new }
+
   fab!(:video, :tag)
   fab!(:music, :tag)
   fab!(:cloud, :tag)

--- a/plugins/discourse-ai/spec/system/ai_moderation/ai_spam_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_moderation/ai_spam_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "AI Spam Configuration" do
       expect(toggle.unchecked?).to eq(true)
     end
   end
+
   context "when LLMs are configured" do
     fab!(:llm_model)
     it "can properly configure spam settings" do

--- a/plugins/discourse-ai/spec/system/ai_user_preferences_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_user_preferences_spec.rb
@@ -4,6 +4,7 @@ describe "User AI preferences" do
   fab!(:user) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:llm_model)
   let(:user_preferences_ai_page) { PageObjects::Pages::UserPreferencesAi.new }
+
   fab!(:discovery_agent) { Fabricate(:ai_agent, allowed_group_ids: [Group::AUTO_GROUPS[:admins]]) }
 
   before do

--- a/plugins/discourse-ai/spec/system/llms/ai_llm_spec.rb
+++ b/plugins/discourse-ai/spec/system/llms/ai_llm_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe "Managing LLM configurations" do
       reasoning = form.field("provider_params.enable_reasoning")
       expect(reasoning).to be_checked
     end
+
     it "correctly changes the provider params" do
       visit "/admin/plugins/discourse-ai/ai-llms"
       find("[data-llm-id='none'] button").click()

--- a/plugins/discourse-assign/spec/integration/assign_spec.rb
+++ b/plugins/discourse-assign/spec/integration/assign_spec.rb
@@ -19,6 +19,7 @@ describe "integration tests" do
     let(:user) { pm.allowed_users.first }
     let(:user2) { pm.allowed_users.last }
     let(:channel) { "/private-messages/assigned" }
+
     fab!(:group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:everyone]) }
 
     include_context "with group that is allowed to assign"
@@ -143,6 +144,7 @@ describe "integration tests" do
     fab!(:post)
     fab!(:post_2) { Fabricate(:post, topic: post.topic) }
     let(:topic) { post.topic }
+
     fab!(:user)
 
     include_context "with group that is allowed to assign"

--- a/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/assign_topic/v1_spec.rb
+++ b/plugins/discourse-assign/spec/lib/discourse_workflows/nodes/assign_topic/v1_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DiscourseWorkflows::Nodes::AssignTopic::V1 do
 
   let(:assign_allowed_group) { Group.find_by(name: "staff") }
   let(:sandbox) { DiscourseWorkflows::JsSandbox.new({ "$json" => {} }) }
+
   after { sandbox.dispose }
 
   before do

--- a/plugins/discourse-assign/spec/serializers/user_bookmark_base_serializer_spec.rb
+++ b/plugins/discourse-assign/spec/serializers/user_bookmark_base_serializer_spec.rb
@@ -15,6 +15,7 @@ describe UserBookmarkBaseSerializer do
 
   context "for Topic bookmarkable" do
     let!(:bookmark) { Fabricate(:bookmark, user: user, bookmarkable: post.topic) }
+
     it "includes assigned user in serializer" do
       Assigner.new(topic, user).assign(user)
       serializer = UserTopicBookmarkSerializer.new(bookmark, scope: guardian)
@@ -36,6 +37,7 @@ describe UserBookmarkBaseSerializer do
 
   context "for Post bookmarkable" do
     let!(:bookmark) { Fabricate(:bookmark, user: user, bookmarkable: post) }
+
     it "includes assigned user in serializer" do
       Assigner.new(post, user).assign(user)
       serializer = UserPostBookmarkSerializer.new(bookmark, scope: guardian)

--- a/plugins/discourse-assign/spec/system/assign_post_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_post_spec.rb
@@ -3,6 +3,7 @@
 describe "Assign | Assigning posts" do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:assign_modal) { PageObjects::Modals::Assign.new }
+
   fab!(:staff_user) { Fabricate(:user, groups: [Group[:staff]]) }
   fab!(:admin)
   fab!(:topic)

--- a/plugins/discourse-assign/spec/system/assign_topic_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_topic_spec.rb
@@ -3,6 +3,7 @@
 describe "Assign | Assigning topics" do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:assign_modal) { PageObjects::Modals::Assign.new }
+
   fab!(:admin1, :admin)
   fab!(:admin2, :admin)
   fab!(:topic)

--- a/plugins/discourse-assign/spec/system/bulk_assign_spec.rb
+++ b/plugins/discourse-assign/spec/system/bulk_assign_spec.rb
@@ -5,6 +5,7 @@ describe "Assign | Bulk Assign" do
   let(:assign_modal) { PageObjects::Modals::Assign.new }
   let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
   let(:topic_list) { PageObjects::Components::TopicList.new }
+
   fab!(:staff_user) { Fabricate(:user, groups: [Group[:staff]]) }
   fab!(:admin)
   fab!(:assignable_group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:everyone]) }

--- a/plugins/discourse-captcha/spec/services/problem_check/hcaptcha_configuration_spec.rb
+++ b/plugins/discourse-captcha/spec/services/problem_check/hcaptcha_configuration_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ProblemCheck::HcaptchaConfiguration do
         SiteSetting.hcaptcha_secret_key = "just a string"
         SiteSetting.hcaptcha_site_key = "just a string"
       end
+
       include_examples "passes_problem_check"
     end
   end
@@ -70,6 +71,7 @@ RSpec.describe ProblemCheck::HcaptchaConfiguration do
         SiteSetting.hcaptcha_secret_key = "just a string"
         SiteSetting.hcaptcha_site_key = "just a string"
       end
+
       include_examples "passes_problem_check"
     end
   end

--- a/plugins/discourse-captcha/spec/services/problem_check/recaptcha_configuration_spec.rb
+++ b/plugins/discourse-captcha/spec/services/problem_check/recaptcha_configuration_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ProblemCheck::RecaptchaConfiguration do
         SiteSetting.recaptcha_secret_key = "just a string"
         SiteSetting.recaptcha_site_key = "just a string"
       end
+
       include_examples "passes_problem_check"
     end
   end
@@ -70,6 +71,7 @@ RSpec.describe ProblemCheck::RecaptchaConfiguration do
         SiteSetting.recaptcha_secret_key = "just a string"
         SiteSetting.recaptcha_site_key = "just a string"
       end
+
       include_examples "passes_problem_check"
     end
   end

--- a/plugins/discourse-chat-integration/spec/helpers/helper_spec.rb
+++ b/plugins/discourse-chat-integration/spec/helpers/helper_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
 
     context "with some rules" do
       let(:group) { Fabricate(:group) }
+
       before do
         DiscourseChatIntegration::Rule.create!(
           channel: chan1,

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/slack/slack_transcript_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/slack/slack_transcript_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe DiscourseChatIntegration::Provider::SlackProvider::SlackTranscrip
   end
 
   let(:transcript) { described_class.new(channel_name: "#general", channel_id: "G1234") }
+
   before { SiteSetting.chat_integration_slack_access_token = "abcde" }
 
   it "doesn't raise an error when there are no messages to guess" do

--- a/plugins/discourse-chat-integration/spec/system/setup_provider_spec.rb
+++ b/plugins/discourse-chat-integration/spec/system/setup_provider_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Chat integration setup provider" do
 
   describe "adding more providers when at least one provider is enabled" do
     before { SiteSetting.chat_integration_teams_enabled = true }
+
     it "sets up Discord" do
       setup_provider_from_menu("discord")
 

--- a/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
   let(:user_guardian) { user.guardian }
 
   before { SiteSetting.data_explorer_enabled = true }
+
   let(:query_ids_to_invalidate) { [visible_query.id] }
 
   after do

--- a/plugins/discourse-data-explorer/spec/requests/api/queries_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/api/queries_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe "JSON:API queries", type: :request do
 
     context "when the request includes the author and the groups" do
       let(:query_parameters) { { include: "user,groups" } }
+
       it "sends every related record under its own namespace" do
         expect(parsed_body["included"]).to contain_exactly(
           {

--- a/plugins/discourse-events/spec/integration/outgoing_web_hooks_spec.rb
+++ b/plugins/discourse-events/spec/integration/outgoing_web_hooks_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "Outgoing calendar event webhooks" do
 
   describe "calendar_event_destroyed" do
     let(:event_post) { create_post_with_event(user) }
+
     it "fires when event markup is removed from a post" do
       event_post
 

--- a/plugins/discourse-events/spec/jobs/regular/discourse_post_event/bump_topic_spec.rb
+++ b/plugins/discourse-events/spec/jobs/regular/discourse_post_event/bump_topic_spec.rb
@@ -38,6 +38,7 @@ describe Jobs::DiscoursePostEventBumpTopic do
           Jobs::DiscoursePostEventBumpTopic.new.execute(date: "2019-12-10 5:00")
         }.not_to raise_error
       end
+
       it "does not throw an error if the date param is missing" do
         expect { Jobs::DiscoursePostEventBumpTopic.new.execute({}) }.not_to raise_error
       end

--- a/plugins/discourse-events/spec/models/discourse_events/events/event_spec.rb
+++ b/plugins/discourse-events/spec/models/discourse_events/events/event_spec.rb
@@ -440,6 +440,7 @@ describe DiscourseEvents::Events::Event do
             expect(second_post.topic.custom_fields).to be_blank
           end
         end
+
         describe "notify an user" do
           describe "before the event starts" do
             it "does notify the user" do
@@ -448,6 +449,7 @@ describe DiscourseEvents::Events::Event do
               }.by(1)
             end
           end
+
           describe "after the event starts" do
             it "doesn't notify the user" do
               expect { late_event.create_notification!(notified_user, first_post) }.not_to change {

--- a/plugins/discourse-events/spec/services/discourse_events/events/create_invitee_spec.rb
+++ b/plugins/discourse-events/spec/services/discourse_events/events/create_invitee_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe(DiscourseEvents::Events::CreateInvitee) do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:event_id) }
+
     it do
       is_expected.to validate_inclusion_of(:status).in_array(
         DiscourseEvents::Events::Invitee.statuses.keys.map(&:to_s),

--- a/plugins/discourse-events/spec/services/discourse_events/events/update_invitee_spec.rb
+++ b/plugins/discourse-events/spec/services/discourse_events/events/update_invitee_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe(DiscourseEvents::Events::UpdateInvitee) do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:event_id) }
     it { is_expected.to validate_presence_of(:invitee_id) }
+
     it do
       is_expected.to validate_inclusion_of(:status).in_array(
         DiscourseEvents::Events::Invitee.statuses.keys.map(&:to_s),

--- a/plugins/discourse-events/spec/system/livestream_zoom_webinar_spec.rb
+++ b/plugins/discourse-events/spec/system/livestream_zoom_webinar_spec.rb
@@ -20,6 +20,7 @@ describe "Discourse Livestream - Livestream with Zoom webinar" do
 
   context "when user is signed in" do
     before { sign_in(current_user) }
+
     it "shows a Join Zoom button for livestream events which have a Zoom location" do
       topic_livestream.create_livestream_event_topic(
         composer,

--- a/plugins/discourse-gamification/spec/lib/discourse_workflows/nodes/gamification_score/v1_spec.rb
+++ b/plugins/discourse-gamification/spec/lib/discourse_workflows/nodes/gamification_score/v1_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DiscourseWorkflows::Nodes::GamificationScore::V1 do
   fab!(:user)
 
   let(:sandbox) { DiscourseWorkflows::JsSandbox.new({ "$json" => {} }) }
+
   after { sandbox.dispose }
 
   before do

--- a/plugins/discourse-gamification/spec/lib/scorables/shared_scorables_spec.rb
+++ b/plugins/discourse-gamification/spec/lib/scorables/shared_scorables_spec.rb
@@ -33,6 +33,7 @@ RSpec.shared_examples "Category Scoped Scorable Type" do
   describe "updates gamification score" do
     let!(:create_score) { class_action_fabricator }
     let!(:trigger_after_create_hook) { after_create_hook }
+
     before { DiscourseGamification::LeaderboardCachedView.create_all }
 
     it "#{described_class} updates scores for action in the category configured" do

--- a/plugins/discourse-gamification/spec/requests/gamification_leaderboard_controller_spec.rb
+++ b/plugins/discourse-gamification/spec/requests/gamification_leaderboard_controller_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe DiscourseGamification::GamificationLeaderboardController do
   end
   let!(:create_score_for_user_3) { UserVisit.create(user_id: user_3.id, visited_at: 2.days.ago) }
   let!(:create_topic) { Fabricate(:topic, user: current_user) }
+
   fab!(:leaderboard) do
     Fabricate(:gamification_leaderboard, name: "test", created_by_id: current_user.id)
   end

--- a/plugins/discourse-login-with-amazon/spec/system/associated_account_prefs_spec.rb
+++ b/plugins/discourse-login-with-amazon/spec/system/associated_account_prefs_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Amazon Associated Account Preferences" do
 
     describe "with user revoke enabled" do
       before { SiteSetting.login_with_amazon_user_can_revoke = true }
+
       it "shows the revoke button" do
         sign_in(user)
         user_account_preferences_page.visit(user)
@@ -55,6 +56,7 @@ RSpec.describe "Amazon Associated Account Preferences" do
 
     describe "with user revoke disabled" do
       before { SiteSetting.login_with_amazon_user_can_revoke = false }
+
       it "shows the revoke button" do
         sign_in(user)
         user_account_preferences_page.visit(user)

--- a/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
@@ -280,6 +280,7 @@ describe OpenIDConnectAuthenticator do
         userinfo_endpoint: "https://id.example.com/userinfo",
       }.to_json
     end
+
     after { Discourse.cache.delete("openid-connect-discovery-#{document_url}") }
 
     it "loads the document correctly" do

--- a/plugins/discourse-openid-connect/spec/requests/rp_initiated_logout_spec.rb
+++ b/plugins/discourse-openid-connect/spec/requests/rp_initiated_logout_spec.rb
@@ -14,6 +14,7 @@ describe "OIDC RP-Initiated Logout" do
       end_session_endpoint: "https://id.example.com/endsession",
     }
   end
+
   fab!(:user)
 
   before do

--- a/plugins/discourse-post-voting/spec/lib/topic_view_spec.rb
+++ b/plugins/discourse-post-voting/spec/lib/topic_view_spec.rb
@@ -207,6 +207,7 @@ describe TopicView do
         [answer_minus_2_votes.id, answer_minus_1_vote.id, answer_0_votes.id],
       )
     end
+
     describe "#next_page" do
       it "returns the next page properly when the highest id post is not the last" do
         expect(TopicView.new(topic.id, user, { post_number: post.post_number }).next_page).to eql(2)

--- a/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
@@ -26,6 +26,7 @@ describe PostSerializer do
       created_at: 20.minutes.ago,
     )
   end
+
   fab!(:like) do
     Fabricate(
       :post_action,

--- a/plugins/discourse-rss-polling/spec/jobs/poll_feed_spec.rb
+++ b/plugins/discourse-rss-polling/spec/jobs/poll_feed_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
 
       context "with rss polling set to true" do
         before { SiteSetting.rss_polling_update_tags = true }
+
         it "updates tags by default" do
           topic = author.topics.last
           job.execute(

--- a/plugins/discourse-rss-polling/spec/models/feed_item_spec.rb
+++ b/plugins/discourse-rss-polling/spec/models/feed_item_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DiscourseRssPolling::FeedItem do
     it { expect(feed_item.content).to eq(expected[:content]) }
     it { expect(feed_item.url).to eq(expected[:url]) }
     it { expect(feed_item.title).to eq(expected[:title]) }
+
     if expected.key?(:cook_method)
       it { expect(feed_item.cook_method).to eq(expected[:cook_method]) }
     end
@@ -17,6 +18,7 @@ RSpec.describe DiscourseRssPolling::FeedItem do
 
   context "with empty item" do
     let(:raw_feed_item) { {} }
+
     include_examples("correctly parses the feed", content: nil, url: nil, title: nil)
   end
 

--- a/plugins/discourse-solved/spec/components/post_revisor_spec.rb
+++ b/plugins/discourse-solved/spec/components/post_revisor_spec.rb
@@ -140,6 +140,7 @@ describe PostRevisor do
 
     describe "with multiple solutions enabled" do
       before { SiteSetting.solved_allow_multiple_solutions = true }
+
       it "unaccepts all answers when both category changes to unsolved and solved tag is removed" do
         topic = Fabricate(:topic, category: category_solved, tags: [solved_tag])
         post = Fabricate(:post, topic: topic)

--- a/plugins/discourse-solved/spec/integration/solved_spec.rb
+++ b/plugins/discourse-solved/spec/integration/solved_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe "Managing Posts solved status" do
 
         describe "when allow solved on all topics is enabled" do
           before { SiteSetting.allow_solved_on_all_topics = true }
+
           it "only returns posts where the post is not solved" do
             result = Search.execute("status:unsolved")
             expect(result.posts.pluck(:id)).to match_array(
@@ -478,6 +479,7 @@ RSpec.describe "Managing Posts solved status" do
 
     describe "with multiple solutions enabled" do
       let(:p2) { Fabricate(:post, topic: topic) }
+
       before { SiteSetting.solved_allow_multiple_solutions = true }
 
       it "can mark multiple posts as accepted, only creating one timer" do
@@ -644,6 +646,7 @@ RSpec.describe "Managing Posts solved status" do
 
     describe "with multiple solutions enabled" do
       let(:p2) { Fabricate(:post, topic: topic) }
+
       before { SiteSetting.solved_allow_multiple_solutions = true }
 
       describe "when solved_topics_auto_close_hours is enabled" do
@@ -713,6 +716,7 @@ RSpec.describe "Managing Posts solved status" do
 
   context "with discourse-assign installed", if: defined?(DiscourseAssign) do
     let(:admin) { Fabricate(:admin) }
+
     fab!(:group)
     before do
       SiteSetting.solved_enabled = true
@@ -977,6 +981,7 @@ RSpec.describe "Managing Posts solved status" do
 
     describe "with multiple solutions enabled" do
       before { SiteSetting.solved_allow_multiple_solutions = true }
+
       it "lists all solutions in topic" do
         t1 = Fabricate(:topic_with_op)
 

--- a/plugins/discourse-solved/spec/lib/post_mover_extension_spec.rb
+++ b/plugins/discourse-solved/spec/lib/post_mover_extension_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DiscourseSolved::PostMoverExtension do
   fab!(:destination_topic) { Fabricate(:topic_with_op, category: category) }
 
   let!(:post_ids) { topic.posts.order(:post_number).pluck(:id) }
+
   fab!(:solved) { Fabricate(:solved_topic, topic: topic, answer_post: reply) }
 
   before { SiteSetting.allow_solved_on_all_topics = true }

--- a/plugins/discourse-solved/spec/requests/list_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/list_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ListController do
   describe "with multiple solutions enabled" do
     fab!(:p4) { Fabricate(:post, topic: p1.topic) }
     before { SiteSetting.solved_allow_multiple_solutions = true }
+
     it "shows the user who posted the accepted answers second" do
       TopicFeaturedUsers.ensure_consistency!
       DiscourseSolved::AcceptAnswer.call!(params: { post_id: p3.id }, guardian: p1.user.guardian)

--- a/plugins/discourse-solved/spec/serializers/discourse_solved/accepted_answer_serializer_spec.rb
+++ b/plugins/discourse-solved/spec/serializers/discourse_solved/accepted_answer_serializer_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe DiscourseSolved::AcceptedAnswerSerializer do
 
   context "when display_name_on_posts is set" do
     before { SiteSetting.display_name_on_posts = true }
+
     it "also includes the poster's name" do
       expect(json["name"]).to eq(user.name)
     end
@@ -58,6 +59,7 @@ RSpec.describe DiscourseSolved::AcceptedAnswerSerializer do
 
     context "when display_name_on_posts is set" do
       before { SiteSetting.display_name_on_posts = true }
+
       it "also includes the accepter name" do
         expect(json["accepter_username"]).to eq(accepter.username)
         expect(json["accepter_name"]).to eq(accepter.name)

--- a/plugins/discourse-solved/spec/services/discourse_solved/accept_answer_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/accept_answer_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe DiscourseSolved::AcceptAnswer do
 
         describe "with multiple solutions enabled" do
           before { SiteSetting.solved_allow_multiple_solutions = true }
+
           it "keeps both solutions" do
             expect { result }.to change { DiscourseSolved::TopicAnswer.count }.by(1)
           end

--- a/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           customer_id: "y",
         )
       end
+
       context "when not showing contributors" do
         it "returns nothing if not set to show contributors" do
           SiteSetting.discourse_subscriptions_campaign_show_contributors = false

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/execution_store_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/execution_store_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe DiscourseWorkflows::Executor::ExecutionStore do
       )
       expect(messages.first.data.to_json).not_to include("not published")
     end
+
     it "publishes terminal state after persistence" do
       execution = store.start!
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/code/js_task_runner_sandbox_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/code/js_task_runner_sandbox_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Code::JsTaskRunnerSandbox do
   end
 
   before { @exec_ctx, @resolver, @sandbox = build_exec_ctx }
+
   after do
     @resolver&.dispose
     @sandbox&.dispose

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/code_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/code_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe DiscourseWorkflows::Nodes::Code::V1 do
   let(:sandbox) { DiscourseWorkflows::JsSandbox.new({}) }
+
   after { sandbox.dispose }
 
   def build_exec_ctx(items, resolver_context: nil, parameters: {}, **kwargs)

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/templates_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/templates_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DiscourseWorkflows::TemplatesController do
     DiscourseWorkflows::TemplateStore.reset_cache!
     sign_in(admin)
   end
+
   after { DiscourseWorkflows::TemplateStore.reset_cache! }
 
   context "when not logged in as admin" do

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/data_table/create_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/data_table/create_spec.rb
@@ -4,9 +4,11 @@ RSpec.describe DiscourseWorkflows::DataTable::Create do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
+
     it do
       is_expected.to allow_values("valid_name", "Name 123", "_underscore", "Table A").for(:name)
     end
+
     it { is_expected.not_to allow_values("123start", "name!@#").for(:name) }
   end
 

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/data_table/update_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/data_table/update_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe DiscourseWorkflows::DataTable::Update do
     it { is_expected.to validate_presence_of(:data_table_id) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
+
     it do
       is_expected.to allow_values("valid_name", "Name 123", "_underscore", "Table A").for(:name)
     end
+
     it { is_expected.not_to allow_values("123start", "name!@#").for(:name) }
   end
 

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/data_table_column/create_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/data_table_column/create_spec.rb
@@ -4,23 +4,29 @@ RSpec.describe DiscourseWorkflows::DataTableColumn::Create do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:data_table_id) }
     it { is_expected.to validate_presence_of(:name) }
+
     it do
       is_expected.to validate_length_of(:name).is_at_most(
         DiscourseWorkflows::DataTable::MAX_COLUMN_NAME_LENGTH,
       )
     end
+
     it { is_expected.to allow_values("valid_col", "column_1", "_col").for(:name) }
+
     it do
       is_expected.not_to allow_values("123col", "col space", "col!@#", "id", "created_at").for(
         :name,
       )
     end
+
     it { is_expected.to validate_presence_of(:column_type) }
+
     it do
       is_expected.to allow_values(*DiscourseWorkflows::DataTable::VALID_COLUMN_TYPES).for(
         :column_type,
       )
     end
+
     it { is_expected.not_to allow_values("text", "unknown_type").for(:column_type) }
   end
 

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/data_table_column/rename_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/data_table_column/rename_spec.rb
@@ -5,12 +5,15 @@ RSpec.describe DiscourseWorkflows::DataTableColumn::Rename do
     it { is_expected.to validate_presence_of(:data_table_id) }
     it { is_expected.to validate_presence_of(:column_name) }
     it { is_expected.to validate_presence_of(:name) }
+
     it do
       is_expected.to validate_length_of(:name).is_at_most(
         DiscourseWorkflows::DataTable::MAX_COLUMN_NAME_LENGTH,
       )
     end
+
     it { is_expected.to allow_values("valid_col", "column_1", "_col").for(:name) }
+
     it do
       is_expected.not_to allow_values("123col", "col space", "col!@#", "id", "created_at").for(
         :name,

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/template/show_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/template/show_spec.rb
@@ -3,9 +3,11 @@
 RSpec.describe DiscourseWorkflows::Template::Show do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:template_id) }
+
     it do
       is_expected.to allow_values("auto-tag-topics", "my_template", "test123").for(:template_id)
     end
+
     it do
       is_expected.not_to allow_values("../etc/passwd", "UPPER", "with spaces", "with/slash").for(
         :template_id,

--- a/plugins/discourse-zendesk-plugin/spec/lib/discourse_zendesk_plugin/helper_spec.rb
+++ b/plugins/discourse-zendesk-plugin/spec/lib/discourse_zendesk_plugin/helper_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe DiscourseZendeskPlugin::Helper do
 
       context "with different author" do
         let(:post_user) { other_user }
+
         it "should be true" do
           expect(eligible).to be_truthy
         end
@@ -178,6 +179,7 @@ RSpec.describe DiscourseZendeskPlugin::Helper do
 
       context "with different author" do
         let(:post_user) { other_user }
+
         it "should be false" do
           expect(eligible).to be_falsey
         end

--- a/plugins/discourse-zendesk-plugin/spec/requests/issues_controller_spec.rb
+++ b/plugins/discourse-zendesk-plugin/spec/requests/issues_controller_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe DiscourseZendeskPlugin::IssuesController do
         },
       )
     end
+
     it "does not create a zendesk ticket for a topic the moderator cannot see" do
       admin = Fabricate(:admin)
       moderator = Fabricate(:moderator)

--- a/plugins/poll/spec/lib/polls_updater_spec.rb
+++ b/plugins/poll/spec/lib/polls_updater_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe DiscoursePoll::PollsUpdater do
         expect(digests.size).to eq(2)
         expect(poll_record.poll_votes.count).to eq(1)
       end
+
       describe "when there are no votes" do
         it "at any time" do
           post # create the post

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -253,6 +253,7 @@ RSpec.describe ApplicationHelper do
     it "encodes tags" do
       expect(helper.escape_unicode("<tag>")).to eq("\u003ctag>")
     end
+
     it "survives junk text" do
       expect(helper.escape_unicode("hello \xc3\x28 world")).to match(/hello.*world/)
     end
@@ -287,6 +288,7 @@ RSpec.describe ApplicationHelper do
           expect(helper.render_sitelinks_search_tag).to be_nil
         end
       end
+
       context "when not on homepage" do
         it "will not return sitelinks search tag" do
           helper.stubs(:current_page?).returns(true)
@@ -296,6 +298,7 @@ RSpec.describe ApplicationHelper do
         end
       end
     end
+
     context "for subfolder install" do
       context "when on homepage" do
         it "will return sitelinks search tag" do
@@ -306,6 +309,7 @@ RSpec.describe ApplicationHelper do
           expect(helper.render_sitelinks_search_tag).to include("subfolder-base-path")
         end
       end
+
       context "when not on homepage" do
         it "will not return sitelinks search tag" do
           Discourse.stubs(:base_path).returns("/subfolder-base-path/")

--- a/spec/integration/json_api_kit/cursors_spec.rb
+++ b/spec/integration/json_api_kit/cursors_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "a listing read from a cursor" do
       expect(sorted_listing[:data].map { it[:meta][:page][:cursor] }).to all(be_present)
     end
   end
+
   let(:pages) do
     sorted_listing[:data].map do
       listing_of({ sort:, page: { after: cursor_of(it) }, fields: { topics: [:title] } })

--- a/spec/jobs/clean_up_tags_spec.rb
+++ b/spec/jobs/clean_up_tags_spec.rb
@@ -31,6 +31,7 @@ describe Jobs::CleanUpTags do
       ),
     ]
   end
+
   fab!(:unused_tag) do
     Fabricate(
       :tag,

--- a/spec/jobs/clean_up_unused_staged_users_spec.rb
+++ b/spec/jobs/clean_up_unused_staged_users_spec.rb
@@ -23,28 +23,33 @@ RSpec.describe Jobs::CleanUpUnusedStagedUsers do
 
       context "with staged admin" do
         before { staged_user.update!(admin: true) }
+
         include_examples "does not delete"
       end
 
       context "with staged moderator" do
         before { staged_user.update!(moderator: true) }
+
         include_examples "does not delete"
       end
 
       context "when job is disabled" do
         before { SiteSetting.clean_up_unused_staged_users_after_days = 0 }
+
         include_examples "does not delete"
       end
     end
 
     context "when staged user is not old enough" do
       before { staged_user.update!(created_at: 5.months.ago) }
+
       include_examples "does not delete"
     end
   end
 
   context "when staged user has posts" do
     before { Fabricate(:post, user: staged_user) }
+
     include_examples "does not delete"
   end
 

--- a/spec/jobs/emit_web_hook_event_spec.rb
+++ b/spec/jobs/emit_web_hook_event_spec.rb
@@ -351,6 +351,7 @@ RSpec.describe Jobs::EmitWebHookEvent do
           headers
         end
       end
+
       it "Allows for header modifications" do
         plugin_instance = Plugin::Instance.new
         plugin_instance.register_modifier(:web_hook_event_headers, &modifier_block)

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -285,6 +285,7 @@ RSpec.describe Jobs::ExportUserArchive do
 
     context "with auth token logs" do
       let(:component) { "auth_token_logs" }
+
       it "includes details such as the path" do
         data, _csv_out = make_component_csv
         expect(data.length).to eq(1)

--- a/spec/jobs/invite_email_spec.rb
+++ b/spec/jobs/invite_email_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Jobs::InviteEmail do
 
     context "with an invite id" do
       let(:mailer) { Mail::Message.new(to: "eviltrout@test.domain") }
+
       fab!(:invite)
 
       it "delegates to the test mailer" do

--- a/spec/jobs/notify_category_change_spec.rb
+++ b/spec/jobs/notify_category_change_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe ::Jobs::NotifyCategoryChange do
 
   context "when mailing list mode is enabled" do
     before { SiteSetting.disable_mailing_list_mode = false }
+
     before do
       regular_user.user_option.update(mailing_list_mode: true, mailing_list_mode_frequency: 1)
     end
+
     before { Jobs.run_immediately! }
 
     it "notifies mailing list subscribers" do

--- a/spec/jobs/notify_mailing_list_subscribers_spec.rb
+++ b/spec/jobs/notify_mailing_list_subscribers_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
   before do
     mailing_list_user.user_option.update(mailing_list_mode: true, mailing_list_mode_frequency: 1)
   end
+
   before { SiteSetting.tagging_enabled = true }
 
   fab!(:tag)
@@ -40,6 +41,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
 
   context "when mailing list mode is globally disabled" do
     before { SiteSetting.disable_mailing_list_mode = true }
+
     include_examples "no emails"
   end
 
@@ -53,31 +55,37 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
 
         User.update_all(approved: false)
       end
+
       include_examples "no emails"
     end
 
     context "with an invalid post_id" do
       before { post.destroy! }
+
       include_examples "no emails"
     end
 
     context "with a deleted post" do
       before { post.trash! }
+
       include_examples "no emails"
     end
 
     context "with a empty post" do
       before { post.update_columns(raw: "") }
+
       include_examples "no emails"
     end
 
     context "with a user_deleted post" do
       before { post.update(user_deleted: true) }
+
       include_examples "no emails"
     end
 
     context "with a deleted topic" do
       before { post.topic.update(deleted_at: Time.now) }
+
       include_examples "no emails"
     end
 
@@ -87,22 +95,26 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
         TopicAllowedUser.create(topic: post.topic, user: mailing_list_user)
         post.topic.reload
       end
+
       include_examples "no emails"
     end
 
     context "with a valid post from another user" do
       context "when to an inactive user" do
         before { mailing_list_user.update(active: false) }
+
         include_examples "no emails"
       end
 
       context "when to a silenced user" do
         before { mailing_list_user.update(silenced_till: 1.year.from_now) }
+
         include_examples "no emails"
       end
 
       context "when to a suspended user" do
         before { mailing_list_user.update(suspended_till: 1.day.from_now) }
+
         include_examples "no emails"
       end
 
@@ -113,26 +125,31 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
 
       context "when to an user who has disabled mailing list mode" do
         before { mailing_list_user.user_option.update(mailing_list_mode: false) }
+
         include_examples "no emails"
       end
 
       context "when to an user who has frequency set to 'always'" do
         before { mailing_list_user.user_option.update(mailing_list_mode_frequency: 1) }
+
         include_examples "one email"
       end
 
       context "when to an user who has frequency set to 'no echo'" do
         before { mailing_list_user.user_option.update(mailing_list_mode_frequency: 2) }
+
         include_examples "one email"
       end
 
       context "when from a muted user" do
         before { MutedUser.create(user: mailing_list_user, muted_user: user) }
+
         include_examples "no emails"
       end
 
       context "when from an ignored user" do
         before { Fabricate(:ignored_user, user: mailing_list_user, ignored_user: user) }
+
         include_examples "no emails"
       end
 
@@ -144,6 +161,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
             notification_level: TopicUser.notification_levels[:muted],
           )
         end
+
         include_examples "no emails"
       end
 
@@ -155,11 +173,13 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
             notification_level: CategoryUser.notification_levels[:muted],
           )
         end
+
         include_examples "no emails"
       end
 
       context "with mute all categories by default setting" do
         before { SiteSetting.mute_all_categories_by_default = true }
+
         include_examples "no emails"
       end
 
@@ -172,6 +192,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
             notification_level: CategoryUser.notification_levels[:watching],
           )
         end
+
         include_examples "one email"
       end
 
@@ -184,6 +205,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
             notification_level: TagUser.notification_levels[:watching],
           )
         end
+
         include_examples "one email"
       end
 
@@ -196,6 +218,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
             notification_level: TopicUser.notification_levels[:watching],
           )
         end
+
         include_examples "one email"
       end
 
@@ -207,6 +230,7 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
             notification_level: TagUser.notification_levels[:muted],
           )
         end
+
         include_examples "no emails"
       end
 
@@ -276,16 +300,19 @@ RSpec.describe Jobs::NotifyMailingListSubscribers do
 
       context "when to an user who has frequency set to 'daily'" do
         before { mailing_list_user.user_option.update(mailing_list_mode_frequency: 0) }
+
         include_examples "no emails"
       end
 
       context "when to an user who has frequency set to 'always'" do
         before { mailing_list_user.user_option.update(mailing_list_mode_frequency: 1) }
+
         include_examples "one email"
       end
 
       context "when to an user who has frequency set to 'no echo'" do
         before { mailing_list_user.user_option.update(mailing_list_mode_frequency: 2) }
+
         include_examples "no emails"
       end
     end

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
     )
   end
   let(:upload_path) { Discourse.store.upload_path }
+
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   before do

--- a/spec/jobs/regular/site_setting_update_default_tags_spec.rb
+++ b/spec/jobs/regular/site_setting_update_default_tags_spec.rb
@@ -12,6 +12,7 @@ describe Jobs::SiteSettingUpdateDefaultTags do
       let(:tracking) { NotificationLevels.all[:tracking] }
 
       let(:tags) { 3.times.collect { Fabricate(:tag) } }
+
       before do
         SiteSetting.default_tags_watching = tags.first(2).pluck(:name).join("|")
         TagUser.create!(tag_id: tags.last.id, notification_level: tracking, user: user2)

--- a/spec/jobs/scheduled/notify_admins_of_available_upcoming_changes_spec.rb
+++ b/spec/jobs/scheduled/notify_admins_of_available_upcoming_changes_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Jobs::NotifyAdminsOfAvailableUpcomingChanges do
   end
 
   let(:test_upcoming_change_status) { :beta }
+
   fab!(:admin_1, :admin)
   fab!(:admin_2, :admin)
 

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -388,6 +388,7 @@ RSpec.describe Jobs::UserEmail do
 
     context "with confirm_new_email" do
       let(:email_token) { Fabricate(:email_token, user: user) }
+
       before do
         EmailChangeRequest.create!(
           user: user,
@@ -400,6 +401,7 @@ RSpec.describe Jobs::UserEmail do
 
       context "when the change was requested by admin" do
         let(:requested_by) { Fabricate(:admin) }
+
         it "passes along true for the requested_by_admin param which changes the wording in the email" do
           Jobs::UserEmail.new.execute(
             type: :confirm_new_email,
@@ -413,6 +415,7 @@ RSpec.describe Jobs::UserEmail do
 
       context "when the change was requested by the user" do
         let(:requested_by) { user }
+
         it "passes along false for the requested_by_admin param which changes the wording in the email" do
           Jobs::UserEmail.new.execute(
             type: :confirm_new_email,
@@ -426,6 +429,7 @@ RSpec.describe Jobs::UserEmail do
 
       context "when requested_by record is not present" do
         let(:requested_by) { nil }
+
         it "passes along false for the requested_by_admin param which changes the wording in the email" do
           Jobs::UserEmail.new.execute(
             type: :confirm_new_email,
@@ -487,6 +491,7 @@ RSpec.describe Jobs::UserEmail do
               data: { original_post_id: post.id }.to_json,
             )
           end
+
           fab!(:moderator)
           fab!(:regular_user, :user)
 

--- a/spec/lib/auth/github_authenticator_spec.rb
+++ b/spec/lib/auth/github_authenticator_spec.rb
@@ -18,6 +18,7 @@ end
 
 RSpec.describe Auth::GithubAuthenticator do
   let(:authenticator) { described_class.new }
+
   fab!(:user)
 
   describe "after_authenticate" do

--- a/spec/lib/backup_restore/creator_spec.rb
+++ b/spec/lib/backup_restore/creator_spec.rb
@@ -248,6 +248,7 @@ describe BackupRestore::Creator do
 
     context "when the result is successful" do
       let(:success) { true }
+
       it "refreshes disk stats" do
         store.expects(:reset_cache).at_least_once
         run

--- a/spec/lib/bookmark_manager_spec.rb
+++ b/spec/lib/bookmark_manager_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe BookmarkManager do
 
   describe ".destroy" do
     let!(:bookmark) { Fabricate(:bookmark, user: user, bookmarkable: post) }
+
     it "deletes the existing bookmark" do
       manager.destroy(bookmark.id)
       expect(Bookmark.exists?(id: bookmark.id)).to eq(false)
@@ -27,6 +28,7 @@ RSpec.describe BookmarkManager do
 
     context "if the bookmark is belonging to some other user" do
       let!(:bookmark) { Fabricate(:bookmark, user: Fabricate(:admin), bookmarkable: post) }
+
       it "raises an invalid access error" do
         expect { manager.destroy(bookmark.id) }.to raise_error(Discourse::InvalidAccess)
       end
@@ -89,6 +91,7 @@ RSpec.describe BookmarkManager do
 
     context "if the bookmark is belonging to some other user" do
       let!(:bookmark) { Fabricate(:bookmark, user: Fabricate(:admin), bookmarkable: post) }
+
       it "raises an invalid access error" do
         expect { update_bookmark }.to raise_error(Discourse::InvalidAccess)
       end
@@ -96,6 +99,7 @@ RSpec.describe BookmarkManager do
 
     context "if the bookmark no longer exists" do
       before { bookmark.destroy! }
+
       it "raises a not found error" do
         expect { update_bookmark }.to raise_error(Discourse::NotFound)
       end
@@ -133,6 +137,7 @@ RSpec.describe BookmarkManager do
 
   describe ".send_reminder_notification" do
     let(:bookmark) { Fabricate(:bookmark, user: user) }
+
     it "sets the reminder_last_sent_at" do
       expect(bookmark.reminder_last_sent_at).to eq(nil)
       described_class.send_reminder_notification(bookmark.id)
@@ -148,6 +153,7 @@ RSpec.describe BookmarkManager do
 
     context "when the bookmark does no longer exist" do
       before { bookmark.destroy }
+
       it "does not error, and does not create a notification" do
         described_class.send_reminder_notification(bookmark.id)
         expect(notifications_for_user.any?).to eq(false)
@@ -156,6 +162,7 @@ RSpec.describe BookmarkManager do
 
     context "if the post has been deleted" do
       before { bookmark.bookmarkable.trash! }
+
       it "does not error and does not create a notification" do
         described_class.send_reminder_notification(bookmark.id)
         bookmark.reload
@@ -188,6 +195,7 @@ RSpec.describe BookmarkManager do
 
     context "if the bookmark is belonging to some other user" do
       let!(:bookmark) { Fabricate(:bookmark, user: Fabricate(:admin)) }
+
       it "raises an invalid access error" do
         expect { manager.toggle_pin(bookmark_id: bookmark.id) }.to raise_error(
           Discourse::InvalidAccess,
@@ -197,6 +205,7 @@ RSpec.describe BookmarkManager do
 
     context "if the bookmark no longer exists" do
       before { bookmark.destroy! }
+
       it "raises a not found error" do
         expect { manager.toggle_pin(bookmark_id: bookmark.id) }.to raise_error(Discourse::NotFound)
       end
@@ -389,6 +398,7 @@ RSpec.describe BookmarkManager do
 
     context "when the post is inaccessible for the user" do
       before { post.trash! }
+
       it "raises an invalid access error" do
         expect {
           manager.create_for(bookmarkable_id: post.id, bookmarkable_type: "Post", name: name)
@@ -398,6 +408,7 @@ RSpec.describe BookmarkManager do
 
     context "when the topic is inaccessible for the user" do
       before { post.topic.update(category: Fabricate(:private_category, group: Fabricate(:group))) }
+
       it "raises an invalid access error" do
         expect {
           manager.create_for(bookmarkable_id: post.id, bookmarkable_type: "Post", name: name)

--- a/spec/lib/category_guardian_spec.rb
+++ b/spec/lib/category_guardian_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CategoryGuardian do
       it "returns false for anonymous user" do
         expect(Guardian.new.can_post_in_category?(category)).to eq(false)
       end
+
       it "returns true for admin" do
         expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
       end

--- a/spec/lib/concern/second_factor_manager_spec.rb
+++ b/spec/lib/concern/second_factor_manager_spec.rb
@@ -47,12 +47,14 @@ RSpec.describe SecondFactorManager do
         "otpauth://totp/#{SiteSetting.title}:#{ERB::Util.url_encode(user.email)}?secret=#{user_second_factor_totp.data}&issuer=#{SiteSetting.title}",
       )
     end
+
     it "should handle a colon in the site title" do
       SiteSetting.title = "Spaceballs: The Discourse"
       expect(user.user_second_factors.totps.first.totp_provisioning_uri).to eq(
         "otpauth://totp/Spaceballs%20The%20Discourse:#{ERB::Util.url_encode(user.email)}?secret=#{user_second_factor_totp.data}&issuer=Spaceballs%20The%20Discourse",
       )
     end
+
     it "should handle a two words before a colon in the title" do
       SiteSetting.title = "Our Spaceballs: The Discourse"
       expect(user.user_second_factors.totps.first.totp_provisioning_uri).to eq(
@@ -330,6 +332,7 @@ RSpec.describe SecondFactorManager do
             second_factor_method: UserSecondFactor.methods[:security_key],
           }
         end
+
         it "returns OK" do
           expect(user.authenticate_second_factor(params, server_session).ok).to eq(true)
         end
@@ -353,6 +356,7 @@ RSpec.describe SecondFactorManager do
             second_factor_method: UserSecondFactor.methods[:security_key],
           }
         end
+
         it "returns not OK" do
           result = user.authenticate_second_factor(params, server_session)
           expect(result.ok).to eq(false)
@@ -372,6 +376,7 @@ RSpec.describe SecondFactorManager do
             second_factor_method: UserSecondFactor.methods[:totp],
           }
         end
+
         it "returns OK" do
           expect(user.authenticate_second_factor(params, server_session).ok).to eq(true)
         end
@@ -387,6 +392,7 @@ RSpec.describe SecondFactorManager do
         let(:params) do
           { second_factor_token: "blah", second_factor_method: UserSecondFactor.methods[:totp] }
         end
+
         it "returns not OK" do
           result = user.authenticate_second_factor(params, server_session)
           expect(result.ok).to eq(false)
@@ -434,6 +440,7 @@ RSpec.describe SecondFactorManager do
 
           context "when the user does not have TOTP enabled" do
             let(:token) { "test" }
+
             before { user.totps.destroy_all }
 
             it "returns an error" do
@@ -458,6 +465,7 @@ RSpec.describe SecondFactorManager do
           let(:params) do
             { second_factor_token: valid_security_key_auth_post_data, second_factor_method: method }
           end
+
           it "returns OK" do
             expect(user.authenticate_second_factor(params, server_session).ok).to eq(true)
           end

--- a/spec/lib/content_buffer_spec.rb
+++ b/spec/lib/content_buffer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ContentBuffer do
     c.apply_transform!(start: { row: 0, col: 0 }, finish: { col: 1, row: 1 }, operation: :delete)
     expect(c.to_s).to eq("c\nc")
   end
+
   it "handles deletion inside lines properly" do
     c = ContentBuffer.new("hello world")
     c.apply_transform!(start: { row: 0, col: 1 }, finish: { col: 4, row: 0 }, operation: :delete)

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -410,16 +410,19 @@ RSpec.describe CookedPostProcessor do
 
         context "with invalid width" do
           let(:image_sizes) { { "http://foo.bar/image.png" => { "width" => 0, "height" => 222 } } }
+
           include_examples "leave dimensions alone"
         end
 
         context "with invalid height" do
           let(:image_sizes) { { "http://foo.bar/image.png" => { "width" => 111, "height" => 0 } } }
+
           include_examples "leave dimensions alone"
         end
 
         context "with invalid width & height" do
           let(:image_sizes) { { "http://foo.bar/image.png" => { "width" => 0, "height" => 0 } } }
+
           include_examples "leave dimensions alone"
         end
       end

--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -1132,6 +1132,7 @@ RSpec.describe DiscourseTagging do
     let!(:staff_tag_group) do
       Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
     end
+
     fab!(:topic) { Fabricate(:topic, tags: [tag1, tag2, tag3, hidden_tag]) }
 
     it "returns all tags to staff" do
@@ -1397,6 +1398,7 @@ RSpec.describe DiscourseTagging do
       let!(:staff_tag_group) do
         Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
       end
+
       fab!(:topic) { Fabricate(:topic, user: user) }
       fab!(:post) { Fabricate(:post, user: user, topic: topic, post_number: 1) }
 

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe DiscourseUpdates do
     context "when a good version check request happened recently" do
       context "when server is up-to-date" do
         let(:time) { 12.hours.ago }
+
         before { stub_data(Discourse::VERSION::STRING, 0, time) }
 
         it "returns all the version fields" do
@@ -62,6 +63,7 @@ RSpec.describe DiscourseUpdates do
 
       context "when server is not up-to-date" do
         let(:time) { 12.hours.ago }
+
         before { stub_data("0.9.0", 2, time) }
 
         it "returns all the version fields" do
@@ -117,11 +119,13 @@ RSpec.describe DiscourseUpdates do
 
       context "when installed is latest" do
         before { stub_data(Discourse::VERSION::STRING, 1, 8.hours.ago) }
+
         include_examples "queue version check and report that version is ok"
       end
 
       context "when installed does not match latest version, but missing_versions_count is 0" do
         before { stub_data("0.10.10.123", 0, 8.hours.ago) }
+
         include_examples "queue version check and report that version is ok"
       end
     end
@@ -146,11 +150,13 @@ RSpec.describe DiscourseUpdates do
 
     context "when missing_versions_count is 0" do
       before { stub_data("0.9.7", 0, 8.hours.ago) }
+
       include_examples "when last_installed_version is old"
     end
 
     context "when missing_versions_count is not 0" do
       before { stub_data("0.9.7", 1, 8.hours.ago) }
+
       include_examples "when last_installed_version is old"
     end
   end

--- a/spec/lib/discourse_webauthn/authentication_service_spec.rb
+++ b/spec/lib/discourse_webauthn/authentication_service_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
 
   context "when params is blank" do
     let(:params) { nil }
+
     it "raises a MalformedPublicKeyCredentialError" do
       expect { service.authenticate_security_key }.to raise_error(
         DiscourseWebauthn::MalformedPublicKeyCredentialError,
@@ -120,6 +121,7 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
 
   context "when params is not blank and not a hash" do
     let(:params) { "test" }
+
     it "raises a MalformedPublicKeyCredentialError" do
       expect { service.authenticate_security_key }.to raise_error(
         DiscourseWebauthn::MalformedPublicKeyCredentialError,

--- a/spec/lib/email/authentication_results_spec.rb
+++ b/spec/lib/email/authentication_results_spec.rb
@@ -210,16 +210,19 @@ RSpec.describe Email::AuthenticationResults do
     context "with a single authentication-results header" do
       context "with a valid fail" do
         let(:headers) { "valid.com; dmarc=fail" }
+
         include_examples "is verdict", :fail
       end
 
       context "with a valid pass" do
         let(:headers) { "valid.com; dmarc=pass" }
+
         include_examples "is verdict", :pass
       end
 
       context "with a valid error" do
         let(:headers) { "valid.com; dmarc=error" }
+
         include_examples "is verdict", :gray
       end
 
@@ -228,11 +231,13 @@ RSpec.describe Email::AuthenticationResults do
 
         context "with a fail" do
           let(:headers) { "foobar.com; dmarc=fail" }
+
           include_examples "is verdict", :gray
         end
 
         context "with a pass" do
           let(:headers) { "foobar.com; dmarc=pass" }
+
           include_examples "is verdict", :gray
         end
       end
@@ -241,16 +246,19 @@ RSpec.describe Email::AuthenticationResults do
     context "with multiple authentication-results headers" do
       context "with a valid fail, and an invalid pass" do
         let(:headers) { ["valid.com; dmarc=fail", "invalid.com; dmarc=pass"] }
+
         include_examples "is verdict", :fail
       end
 
       context "with a valid fail, and a valid pass" do
         let(:headers) { ["valid.com; dmarc=fail", "valid.com; dmarc=pass"] }
+
         include_examples "is verdict", :fail
       end
 
       context "with a valid error, and a valid pass" do
         let(:headers) { ["valid.com; dmarc=foobar", "valid.com; dmarc=pass"] }
+
         include_examples "is verdict", :pass
       end
 
@@ -259,6 +267,7 @@ RSpec.describe Email::AuthenticationResults do
 
         context "with an error, and a pass" do
           let(:headers) { ["foobar.com; dmarc=foobar", "foobar.com; dmarc=pass"] }
+
           include_examples "is verdict", :gray
         end
       end

--- a/spec/lib/email/processor_spec.rb
+++ b/spec/lib/email/processor_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Email::Processor do
 
     context "when reply via email is too short" do
       let(:mail) { file_from_fixtures("chinese_reply.eml", "emails").read }
+
       fab!(:post)
       fab!(:user) { Fabricate(:user, email: "discourse@bar.com", refresh_auto_groups: true) }
 
@@ -52,6 +53,7 @@ RSpec.describe Email::Processor do
         )
       end
     end
+
     describe "from reply to email address" do
       let(:mail) do
         "Date: Fri, 15 Jan 2016 00:12:43 +0100\nFrom: reply@bar.com\nTo: reply@bar.com\nSubject: FOO BAR\n\nFoo foo bar bar?"

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe Email::Receiver do
 
     context "with reply_by_email configured" do
       before { configure_reply_by_email }
+
       it "invites everyone in the chain but emails configured as 'incoming' (via reply, group or category)" do
         expect { process(:cc) }.to change(Topic, :count)
 
@@ -583,6 +584,7 @@ RSpec.describe Email::Receiver do
         process(:email_to_group_email_username_1)
         Topic.last
       end
+
       fab!(:user_in_group) do
         u = Fabricate(:user)
         Fabricate(:group_user, user: u, group: group)
@@ -2003,6 +2005,7 @@ RSpec.describe Email::Receiver do
           Email::Receiver::ReplyNotAllowedError,
         )
       end
+
       it "works" do
         expect { process(:reply_user_matching) }.to change { topic.posts.count }
       end

--- a/spec/lib/email/renderer_spec.rb
+++ b/spec/lib/email/renderer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Email::Renderer do
 
   context "with email_renderer_html modifier" do
     after { DiscoursePluginRegistry.reset! }
+
     it "can modify the html" do
       Plugin::Instance
         .new

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -4,6 +4,7 @@ require "email/sender"
 
 RSpec.describe Email::Sender do
   before { SiteSetting.secure_uploads_allow_embed_images_in_emails = false }
+
   fab!(:post)
   let(:mock_smtp_transaction_response) do
     "250 Ok: queued as 2l3Md07BObzB8kRyHZeoN0baSUAhzc7A-NviRioOr80=@mailhog.example"

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe Email::Styles do
     end
 
     let(:attachments) { { "testimage.png" => stub(url: "email/test.png") } }
+
     it "replaces secure uploads within a link with a placeholder" do
       frag =
         html_fragment(
@@ -534,6 +535,7 @@ RSpec.describe Email::Styles do
   <div style="clear: both"></div>
 </aside>
           HTML
+
         it "keeps the special onebox styles" do
           strip_and_inline
           expect(@frag.to_s).to include("cid:email/test.png")

--- a/spec/lib/file_store/s3_store_spec.rb
+++ b/spec/lib/file_store/s3_store_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe FileStore::S3Store do
   fab!(:optimized_image)
   let(:optimized_image_file) { file_from_fixtures("logo.png") }
   let(:uploaded_file) { file_from_fixtures("logo.png") }
+
   fab!(:upload) { Fabricate(:upload, sha1: Digest::SHA1.hexdigest("secret image string")) }
 
   before do

--- a/spec/lib/guardian/flag_guardian_spec.rb
+++ b/spec/lib/guardian/flag_guardian_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FlagGuardian do
   fab!(:moderator)
 
   after(:each) { Flag.reset_flag_settings! }
+
   describe "#can_create_flag?" do
     it "returns true for admin and when custom flags limit is not reached" do
       SiteSetting.custom_flags_limit = 1

--- a/spec/lib/guardian/invite_guardian_spec.rb
+++ b/spec/lib/guardian/invite_guardian_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe InviteGuardian do
         SiteSetting.invite_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
         user.update!(trust_level: 2)
       end
+
       fab!(:category) { Fabricate(:category, read_restricted: true) }
       fab!(:topic)
       fab!(:private_topic) { Fabricate(:topic, category: category) }

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -461,6 +461,7 @@ RSpec.describe PostGuardian do
       fab!(:private_message) { Fabricate(:system_message_topic, user: user) }
 
       before { user.save! }
+
       it "allows the user to reply to system messages" do
         expect(Guardian.new(user).can_create_post?(private_message)).to eq(true)
         SiteSetting.enable_system_message_replies = false
@@ -1040,6 +1041,7 @@ RSpec.describe PostGuardian do
         SiteSetting.allow_likes_in_anonymous_mode = false
         SiteSetting.allow_anonymous_mode = true
       end
+
       describe "an anonymous user" do
         let(:post_action) do
           user.id = anon.id

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -673,12 +673,14 @@ RSpec.describe UserGuardian do
 
     context "for moderators" do
       let(:guardian) { Guardian.new(moderator) }
+
       include_examples "can_delete_user examples"
       include_examples "can_delete_user staff examples"
     end
 
     context "for admins" do
       let(:guardian) { Guardian.new(admin) }
+
       include_examples "can_delete_user examples"
       include_examples "can_delete_user staff examples"
     end
@@ -694,6 +696,7 @@ RSpec.describe UserGuardian do
 
     context "for moderators" do
       let(:guardian) { Guardian.new(moderator) }
+
       include_examples "can_merge_user examples"
 
       it "isn't allowed if current_user is not an admin" do
@@ -703,6 +706,7 @@ RSpec.describe UserGuardian do
 
     context "for admins" do
       let(:guardian) { Guardian.new(admin) }
+
       include_examples "can_merge_user examples"
     end
   end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe Guardian do
 
     context "when personal_message_enabled_groups does not contain the user" do
       let(:group) { Fabricate(:group) }
+
       before { SiteSetting.personal_message_enabled_groups = group.id }
 
       it "returns false if user is not staff member" do
@@ -410,6 +411,7 @@ RSpec.describe Guardian do
 
     context "when personal_message_enabled_groups does contain the user" do
       let(:group) { Fabricate(:group) }
+
       before { SiteSetting.personal_message_enabled_groups = group.id }
 
       it "returns true" do
@@ -422,6 +424,7 @@ RSpec.describe Guardian do
 
     context "when personal_message_enabled_groups does not contain the user" do
       let(:group) { Fabricate(:group) }
+
       before { SiteSetting.personal_message_enabled_groups = group.id }
 
       it "returns false if user is not staff member" do
@@ -488,6 +491,7 @@ RSpec.describe Guardian do
       global_setting :allow_impersonation, false
       expect(Guardian.new(admin).can_impersonate?(moderator)).to be_falsey
     end
+
     it "allows impersonation correctly" do
       expect(Guardian.new(admin).can_impersonate?(nil)).to be_falsey
       expect(Guardian.new.can_impersonate?(user)).to be_falsey
@@ -1269,6 +1273,7 @@ RSpec.describe Guardian do
       context "with first post of a static page doc" do
         let!(:tos_topic) { Fabricate(:topic, user: Discourse.system_user) }
         let!(:tos_first_post) { Fabricate(:post, topic: tos_topic, user: tos_topic.user) }
+
         before { SiteSetting.tos_topic_id = tos_topic.id }
 
         it "restricts static doc posts" do
@@ -2405,6 +2410,7 @@ RSpec.describe Guardian do
 
       context "with posts" do
         before { target_user.stubs(:post_count).returns(1) }
+
         include_examples "staff can always change usernames"
         it "is false for the user to change their own username" do
           expect(Guardian.new(target_user).can_edit_username?(target_user)).to be_falsey
@@ -2738,6 +2744,7 @@ RSpec.describe Guardian do
 
     context "when ignorer is staff" do
       let(:guardian) { Guardian.new(admin) }
+
       it "allows ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end
@@ -2745,6 +2752,7 @@ RSpec.describe Guardian do
 
     context "when ignorer is not in required trust level group" do
       let(:guardian) { Guardian.new(trust_level_0) }
+
       it "does not allow ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(false)
       end
@@ -2752,6 +2760,7 @@ RSpec.describe Guardian do
 
     context "when ignorer is in the required trust level group" do
       let(:guardian) { Guardian.new(trust_level_1) }
+
       it "allows ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end
@@ -2759,6 +2768,7 @@ RSpec.describe Guardian do
 
     context "when ignorer is in a higher than required trust level group" do
       let(:guardian) { Guardian.new(trust_level_3) }
+
       it "allows ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end
@@ -2790,6 +2800,7 @@ RSpec.describe Guardian do
 
     context "when muter's trust level is below tl1" do
       let(:guardian) { Guardian.new(trust_level_0) }
+
       fab!(:trust_level_0)
 
       it "does not allow muting user" do
@@ -2914,6 +2925,7 @@ RSpec.describe Guardian do
 
     context "when post is older than post_edit_time_limit" do
       let(:old_post) { Fabricate(:post, user: trust_level_2, created_at: 6.minutes.ago) }
+
       before do
         SiteSetting.self_wiki_allowed_groups = "1|2|12"
         SiteSetting.tl2_post_edit_time_limit = 5
@@ -3242,6 +3254,7 @@ RSpec.describe Guardian do
 
   describe "topic featured link category restriction" do
     before { SiteSetting.topic_featured_link_enabled = true }
+
     let(:guardian) { Guardian.new(user) }
     let(:uncategorized) { Category.find(SiteSetting.uncategorized_category_id) }
 

--- a/spec/lib/json_api_kit/declarations/relationship_spec.rb
+++ b/spec/lib/json_api_kit/declarations/relationship_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe JsonApiKit::Declarations::Relationship do
       end
     end
   end
+
   let(:groups_resource) { Class.new(JsonApiKit::Resource) { type :groups } }
   let(:users_resource) do
     related = groups_resource

--- a/spec/lib/json_api_kit/request/contract/collection_spec.rb
+++ b/spec/lib/json_api_kit/request/contract/collection_spec.rb
@@ -61,9 +61,11 @@ RSpec.describe JsonApiKit::Request::Contract::Collection, type: :model do
     it { is_expected.to allow_value("", "created_at", "-created_at").for(:sort) }
     it { is_expected.to allow_value("created_at,-title").for(:sort) }
     it { is_expected.not_to allow_value({ secrets: :asc }).for(:sort) }
+
     it do
       is_expected.not_to allow_value({ created_at: :sideways }, { created_at: "asc" }).for(:sort)
     end
+
     it { is_expected.not_to allow_value("secrets", "created_at,secrets").for(:sort) }
     it { is_expected.not_to allow_value(%w[created_at], 5).for(:sort) }
 
@@ -218,9 +220,11 @@ RSpec.describe JsonApiKit::Request::Contract::Collection, type: :model do
         .is_less_than_or_equal_to(50)
         .allow_nil
     end
+
     it { is_expected.not_to allow_value("").for(:size) }
     it { is_expected.to allow_value(cursor).for(:after) }
     it { is_expected.to allow_value(cursor).for(:before) }
+
     it do
       is_expected.not_to allow_value(
         "not-a-cursor",
@@ -229,6 +233,7 @@ RSpec.describe JsonApiKit::Request::Contract::Collection, type: :model do
         cursor_not_matching_segment,
       ).for(:after)
     end
+
     it do
       is_expected.not_to allow_value(
         "not-a-cursor",
@@ -276,12 +281,14 @@ RSpec.describe JsonApiKit::Request::Contract::Collection, type: :model do
         .is_greater_than_or_equal_to(0)
         .allow_nil
     end
+
     it do
       is_expected.to validate_numericality_of(:after_size)
         .only_integer
         .is_greater_than_or_equal_to(0)
         .allow_nil
     end
+
     it { is_expected.not_to allow_value("").for(:before_size) }
     it { is_expected.not_to allow_value("").for(:after_size) }
 

--- a/spec/lib/json_api_kit/schema_spec.rb
+++ b/spec/lib/json_api_kit/schema_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe JsonApiKit::Schema do
       end
     end
   end
+
   describe "#table_of" do
     subject(:table) { schema.table_of(:user) }
 

--- a/spec/lib/json_error_spec.rb
+++ b/spec/lib/json_error_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe JsonError do
 
   describe "an activerecord object with errors" do
     let(:invalid_user) { User.new }
+
     it "returns the errors correctly" do
       expect(invalid_user).not_to be_valid
       result = creator.create_errors_json(invalid_user)

--- a/spec/lib/message_id_service_spec.rb
+++ b/spec/lib/message_id_service_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Email::MessageIdService do
     let(:gmail_format_message_id) do
       "<CAPGrNgZ7QEFuPcsxJBRZLhBhAYPO_ruYpCANSdqiQEbc9Otpiw@mail.gmail.com>"
     end
+
     it "finds a post based only on a discourse-format message id" do
       expect(described_class.find_post_from_message_ids([discourse_format_message_id])).to eq(post)
     end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -747,6 +747,7 @@ RSpec.describe Middleware::RequestTracker do
 
       context "when SiteSetting.trigger_browser_pageview_events is true" do
         before { SiteSetting.trigger_browser_pageview_events = true }
+
         it "triggers event for anonymous user page views when `login_required` site setting is false" do
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
           DiscourseIpInfo.stubs(:get).returns(country_code: "AU")

--- a/spec/lib/new_post_manager_spec.rb
+++ b/spec/lib/new_post_manager_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe NewPostManager do
         SiteSetting.approve_post_count = 100
         topic.user.trust_level = 0
       end
+
       it "will return an enqueue result" do
         result = NewPostManager.default_handler(manager)
         expect(NewPostManager.queue_enabled?).to eq(true)
@@ -162,6 +163,7 @@ RSpec.describe NewPostManager do
         SiteSetting.approve_post_count = 100
         topic.user.trust_level = 1
       end
+
       it "will return an enqueue result" do
         result = NewPostManager.default_handler(manager)
         expect(NewPostManager.queue_enabled?).to eq(true)
@@ -203,6 +205,7 @@ RSpec.describe NewPostManager do
 
     context "with a high trust level setting" do
       before { SiteSetting.approve_unless_allowed_groups = Group::AUTO_GROUPS[:trust_level_4] }
+
       it "will return an enqueue result" do
         result = NewPostManager.default_handler(manager)
         expect(NewPostManager.queue_enabled?).to eq(true)
@@ -251,6 +254,7 @@ RSpec.describe NewPostManager do
       before do
         SiteSetting.approve_new_topics_unless_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
       end
+
       it "doesn't return a result action" do
         result = NewPostManager.default_handler(manager)
         expect(result).to eq(nil)
@@ -397,10 +401,12 @@ RSpec.describe NewPostManager do
     let(:manager) do
       NewPostManager.new(user, raw: "this is new topic content", title: "new topic title")
     end
+
     context "with a high trust level setting for new topics" do
       before do
         SiteSetting.approve_new_topics_unless_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
       end
+
       it "will return an enqueue result" do
         result = NewPostManager.default_handler(manager)
         expect(NewPostManager.queue_enabled?).to eq(true)
@@ -645,6 +651,7 @@ RSpec.describe NewPostManager do
         context "when there is a minimum number of tags required from a certain tag group for the category" do
           let(:tag_group) { Fabricate(:tag_group) }
           let(:tag) { Fabricate(:tag) }
+
           before do
             TagGroupMembership.create(tag: tag, tag_group: tag_group)
             category.update(

--- a/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
+++ b/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Onebox::Engine::AllowlistedGenericOnebox do
       let(:canonical_url) do
         "https://www.etsy.com/in-en/listing/87673424/personalized-word-pillow-case-letter"
       end
+
       before do
         stub_request(:get, mobile_url).to_return(status: 200, body: onebox_response("etsy_mobile"))
         stub_request(:get, canonical_url).to_return(status: 200, body: onebox_response("etsy"))
@@ -132,6 +133,7 @@ RSpec.describe Onebox::Engine::AllowlistedGenericOnebox do
       let(:discourse_topic_reply_url) do
         "https://meta.discourse.org/t/congratulations-most-stars-in-2013-github-octoverse/12483/2"
       end
+
       before do
         stub_request(:get, discourse_topic_url).to_return(
           status: 200,
@@ -192,6 +194,7 @@ RSpec.describe Onebox::Engine::AllowlistedGenericOnebox do
 
   describe "missing description" do
     let(:url) { "https://en-americas-support.nintendo.com/app/answers/detail/a_id/67660" }
+
     before do
       stub_request(:get, url).to_return(status: 200, body: onebox_response("title_no_description"))
       stub_request(

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
         let(:tweet_content) { "I've never played Minecraft" }
         include_context "with standard tweet info"
         before { @onebox_fixture = "twitterstatus_noclient" }
+
         include_context "with engines"
 
         let(:avatar) do
@@ -169,6 +170,7 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
       @link = "https://x.com/MKBHD/status/1625192182859632661"
       @onebox_fixture = "xstatus_noclient"
     end
+
     include_context "with engines"
 
     it_behaves_like "an engine"

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Onebox::Helpers do
   describe ".truncate" do
     let(:test_string) { "Chops off on spaces" }
+
     it { expect(described_class.truncate(test_string)).to eq(test_string) }
     it { expect(described_class.truncate(test_string, 5)).to eq("Chops...") }
     it { expect(described_class.truncate(test_string, 7)).to eq("Chops...") }
@@ -253,32 +254,39 @@ RSpec.describe Onebox::Helpers do
         "http://example.com/fo%20o",
       )
     end
+
     it do
       expect(described_class.normalize_url_for_output("http://example.com/fo'o")).to eq(
         "http://example.com/fo&apos;o",
       )
     end
+
     it do
       expect(described_class.normalize_url_for_output('http://example.com/fo"o')).to eq(
         "http://example.com/fo&quot;o",
       )
     end
+
     it do
       expect(described_class.normalize_url_for_output("http://example.com/fo<o>")).to eq(
         "http://example.com/foo",
       )
     end
+
     it do
       expect(described_class.normalize_url_for_output("http://example.com/d’écran-à")).to eq(
         "http://example.com/d’écran-à",
       )
     end
+
     it do
       expect(described_class.normalize_url_for_output("//example.com/hello")).to eq(
         "//example.com/hello",
       )
     end
+
     it { expect(described_class.normalize_url_for_output("example.com/hello")).to eq("") }
+
     it do
       expect(
         described_class.normalize_url_for_output(
@@ -297,6 +305,7 @@ RSpec.describe Onebox::Helpers do
         ),
       ).to eq("https://meta.discourse.org/favicon.ico")
     end
+
     it do
       expect(
         described_class.get_absolute_image_url(
@@ -305,6 +314,7 @@ RSpec.describe Onebox::Helpers do
         ),
       ).to eq("http://meta.discourse.org/favicon.ico")
     end
+
     it do
       expect(
         described_class.get_absolute_image_url(
@@ -313,11 +323,13 @@ RSpec.describe Onebox::Helpers do
         ),
       ).to eq("https://meta.discourse.org/favicon.ico")
     end
+
     it do
       expect(
         described_class.get_absolute_image_url("/favicon.ico", "https://meta.discourse.org"),
       ).to eq("https://meta.discourse.org/favicon.ico")
     end
+
     it do
       expect(
         described_class.get_absolute_image_url(
@@ -326,6 +338,7 @@ RSpec.describe Onebox::Helpers do
         ),
       ).to eq("https://meta.discourse.org/favicon.ico")
     end
+
     it do
       expect(
         described_class.get_absolute_image_url(
@@ -342,31 +355,37 @@ RSpec.describe Onebox::Helpers do
         "http://example.com/f%22o&o?%5Bb%22ar%5D",
       )
     end
+
     it do
       expect(described_class.uri_encode("http://example.com/f.o~o;?<ba'r>")).to eq(
         "http://example.com/f.o~o;?%3Cba%27r%3E",
       )
     end
+
     it do
       expect(described_class.uri_encode("http://example.com/<+pa'th>(foo)?b+a+r")).to eq(
         "http://example.com/%3C+pa'th%3E(foo)?b+a+r",
       )
     end
+
     it do
       expect(described_class.uri_encode("http://example.com/p,a:t!h-f$o@o*?b!a#r@")).to eq(
         "http://example.com/p,a:t!h-f$o@o*?b%21a#r%40",
       )
     end
+
     it do
       expect(described_class.uri_encode("http://example.com/path&foo?b'a<r>&qu(er)y=1")).to eq(
         "http://example.com/path&foo?b%27a%3Cr%3E&qu%28er%29y=1",
       )
     end
+
     it do
       expect(
         described_class.uri_encode("http://example.com/index&<script>alert('XSS');</script>"),
       ).to eq("http://example.com/index&%3Cscript%3Ealert('XSS');%3C/script%3E")
     end
+
     it do
       expect(
         described_class.uri_encode(
@@ -376,6 +395,7 @@ RSpec.describe Onebox::Helpers do
         "http://example.com/index.html?message=%3Cscript%3Ealert%28%27XSS%27%29%3B%3C%2Fscript%3E",
       )
     end
+
     it do
       expect(
         described_class.uri_encode(
@@ -385,6 +405,7 @@ RSpec.describe Onebox::Helpers do
         "http://example.com/index.php/%3CIFRAME%20SRC=source.com%20onload='alert(document.cookie)'%3E%3C/IFRAME%3E",
       )
     end
+
     it do
       expect(
         described_class.uri_encode("https://en.wiktionary.org/wiki/greengrocer%27s_apostrophe"),
@@ -396,11 +417,13 @@ RSpec.describe Onebox::Helpers do
         described_class.uri_encode("https://example.com/random%2Bpath?q=random%2Bquery"),
       ).to eq("https://example.com/random%2Bpath?q=random%2Bquery")
     end
+
     it do
       expect(described_class.uri_encode("https://glitch.com/edit/#!/equinox-watch")).to eq(
         "https://glitch.com/edit/#!/equinox-watch",
       )
     end
+
     it do
       expect(
         described_class.uri_encode("https://gitpod.io/#https://github.com/eclipse-theia/theia"),

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Oneboxer do
 
   describe "#invalidate" do
     let(:url) { "http://test.com" }
+
     it "clears the cached preview for the onebox URL and the failed URL cache" do
       Discourse.cache.write(Oneboxer.onebox_cache_key(url), "test")
       Discourse.cache.write(Oneboxer.onebox_failed_cache_key(url), true)

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -947,6 +947,7 @@ TEXT
 
   describe "#register_notification_consolidation_plan" do
     let(:plugin) { Plugin::Instance.new }
+
     fab!(:topic)
 
     after { DiscoursePluginRegistry.reset_register!(:notification_consolidation_plans) }

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -353,6 +353,7 @@ RSpec.describe PostDestroyer do
 
             context "when the topic is deleted" do
               before { @reply.topic.trash! }
+
               it "changes deleted_at to nil" do
                 changes_deleted_at_to_nil
               end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -394,6 +394,7 @@ describe PostRevisor do
       describe "with PMs" do
         fab!(:pm, :private_message_topic)
         let(:first_post) { create_post(user: admin, topic: pm, allow_uncategorized_topics: false) }
+
         fab!(:category) { Fabricate(:category, topic_count: 1) }
         it "Does not create a category change small_action post when converting to a topic" do
           expect do
@@ -1779,6 +1780,7 @@ describe PostRevisor do
 
       context "with secure uploads uploads" do
         let!(:image5) { Fabricate(:secure_upload) }
+
         before do
           Jobs.run_immediately!
           setup_s3

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -327,6 +327,7 @@ RSpec.describe PrettyText do
       let(:default_avatar) do
         "//test.localhost/uploads/default/avatars/42d/57c/46ce7ee487/{size}.png"
       end
+
       fab!(:group)
       fab!(:user) { Fabricate(:user, primary_group: group) }
 
@@ -2216,6 +2217,7 @@ HTML
 
     context "with watched words as regular expressions" do
       before { SiteSetting.watched_words_regular_expressions = true }
+
       it "supports words as regular expressions" do
         %w[xyz* plee+ase].each do |word|
           Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: word)

--- a/spec/lib/promotion_spec.rb
+++ b/spec/lib/promotion_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe Promotion do
         stat.posts_read_count = SiteSetting.tl1_requires_read_posts
         stat.time_read = SiteSetting.tl1_requires_time_spent_mins * 60
       end
+
       it "sends promotion message by default" do
         SiteSetting.send_tl1_welcome_message = true
         @result = promotion.review

--- a/spec/lib/s3_cors_rulesets_spec.rb
+++ b/spec/lib/s3_cors_rulesets_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe S3CorsRulesets do
 
     context "when S3 is set up with global settings" do
       let(:use_db_s3_config) { false }
+
       before do
         global_setting :s3_use_iam_profile, true
         global_setting :s3_bucket, "s3-upload-bucket"

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe Search do
       let!(:staff_tag_group) do
         Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
       end
+
       fab!(:topic) { Fabricate(:topic, tags: [hidden_tag]) }
       fab!(:post) { Fabricate(:post, topic: topic) }
 
@@ -3115,6 +3116,7 @@ RSpec.describe Search do
 
   describe "ignore_diacritics" do
     before { SiteSetting.search_ignore_accents = true }
+
     let!(:post1) { Fabricate(:post, raw: "สวัสดี Rágis hello") }
 
     it("allows strips correctly") do
@@ -3137,6 +3139,7 @@ RSpec.describe Search do
 
   describe "include_diacritics" do
     before { SiteSetting.search_ignore_accents = false }
+
     let!(:post1) { Fabricate(:post, raw: "สวัสดี Régis hello") }
 
     it("allows strips correctly") do
@@ -3332,7 +3335,9 @@ RSpec.describe Search do
 
   describe "exclude_topics filter" do
     before { SiteSetting.tagging_enabled = true }
+
     let!(:user) { Fabricate(:user) }
+
     fab!(:group) { Fabricate(:group, name: "bruce-world-fans") }
     fab!(:topic) { Fabricate(:topic, title: "Bruce topic not a result") }
 
@@ -3393,6 +3398,7 @@ RSpec.describe Search do
       SearchIndexer.enable
       DiscoursePluginRegistry.clear_modifiers!
     end
+
     after do
       SearchIndexer.disable
 

--- a/spec/lib/second_factor/auth_manager_spec.rb
+++ b/spec/lib/second_factor/auth_manager_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe SecondFactor::AuthManager do
   fab!(:user)
   let(:guardian) { Guardian.new(user) }
+
   fab!(:user_totp) { Fabricate(:user_second_factor_totp, user: user) }
 
   def create_request(request_method: "GET", path: "/")

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -320,6 +320,7 @@ RSpec.describe SiteSettingExtension do
       settings.setting(:image_list_test, "", type: :uploaded_image_list)
       settings.refresh!
     end
+
     it "correctly nukes overrides" do
       settings.test_override = "bla"
       settings.remove_override!(:test_override)

--- a/spec/lib/site_settings/type_supervisor_spec.rb
+++ b/spec/lib/site_settings/type_supervisor_spec.rb
@@ -24,84 +24,111 @@ RSpec.describe SiteSettings::TypeSupervisor do
       it "'string' should be at 1st position" do
         expect(SiteSettings::TypeSupervisor.types[:string]).to eq(1)
       end
+
       it "'time' should be at 2nd position" do
         expect(SiteSettings::TypeSupervisor.types[:time]).to eq(2)
       end
+
       it "'integer' should be at 3rd position" do
         expect(SiteSettings::TypeSupervisor.types[:integer]).to eq(3)
       end
+
       it "'float' should be at 4th position" do
         expect(SiteSettings::TypeSupervisor.types[:float]).to eq(4)
       end
+
       it "'bool' should be at 5th position" do
         expect(SiteSettings::TypeSupervisor.types[:bool]).to eq(5)
       end
+
       it "'null' should be at 6th position" do
         expect(SiteSettings::TypeSupervisor.types[:null]).to eq(6)
       end
+
       it "'enum' should be at 7th position" do
         expect(SiteSettings::TypeSupervisor.types[:enum]).to eq(7)
       end
+
       it "'list' should be at 8th position" do
         expect(SiteSettings::TypeSupervisor.types[:list]).to eq(8)
       end
+
       it "'url_list' should be at 9th position" do
         expect(SiteSettings::TypeSupervisor.types[:url_list]).to eq(9)
       end
+
       it "'host_list' should be at 10th position" do
         expect(SiteSettings::TypeSupervisor.types[:host_list]).to eq(10)
       end
+
       it "'category_list' should be at 11th position" do
         expect(SiteSettings::TypeSupervisor.types[:category_list]).to eq(11)
       end
+
       it "'value_list' should be at 12th position" do
         expect(SiteSettings::TypeSupervisor.types[:value_list]).to eq(12)
       end
+
       it "'regex' should be at 13th position" do
         expect(SiteSettings::TypeSupervisor.types[:regex]).to eq(13)
       end
+
       it "'email' should be at 14th position" do
         expect(SiteSettings::TypeSupervisor.types[:email]).to eq(14)
       end
+
       it "'username' should be at 15th position" do
         expect(SiteSettings::TypeSupervisor.types[:username]).to eq(15)
       end
+
       it "'category' should be at 16th position" do
         expect(SiteSettings::TypeSupervisor.types[:category]).to eq(16)
       end
+
       it "'uploaded_image_list' should be at 17th position" do
         expect(SiteSettings::TypeSupervisor.types[:uploaded_image_list]).to eq(17)
       end
+
       it "'upload' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:upload]).to eq(18)
       end
+
       it "'group' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:group]).to eq(19)
       end
+
       it "'group_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:group_list]).to eq(20)
       end
+
       it "'tag_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:tag_list]).to eq(21)
       end
+
       it "'color' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:color]).to eq(22)
       end
+
       it "'simple_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:simple_list]).to eq(23)
       end
+
       it "'emoji_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:emoji_list]).to eq(24)
       end
+
       it "'tag_group_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:tag_group_list]).to eq(26)
       end
+
       it "'file_size_restriction' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:file_size_restriction]).to eq(27)
       end
+
       it "'datetime' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:datetime]).to eq(31)
       end
+
       it "'date' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:date]).to eq(33)
       end

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe SiteSettings::Validations do
         let(:error_message) do
           I18n.t("errors.site_settings.second_factor_cannot_be_enforced_with_disabled_local_login")
         end
+
         before { SiteSetting.enable_local_logins = false }
 
         it "should raise an error" do
@@ -165,6 +166,7 @@ RSpec.describe SiteSettings::Validations do
             "errors.site_settings.second_factor_cannot_be_enforced_with_discourse_connect_enabled",
           )
         end
+
         before do
           SiteSetting.discourse_connect_url = "https://www.example.com/sso"
           SiteSetting.discourse_connect_secret = "x" * 10
@@ -236,6 +238,7 @@ RSpec.describe SiteSettings::Validations do
 
         context "if secure uploads is enabled" do
           let(:error_message) { I18n.t("errors.site_settings.page_publishing_requirements") }
+
           before { enable_secure_uploads }
 
           it "is not ok" do

--- a/spec/lib/tasks/s3_rake_spec.rb
+++ b/spec/lib/tasks/s3_rake_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "s3:upload_assets rake task" do
 
   let(:task) { Rake::Task["s3:upload_assets"] }
   let(:logger) { instance_double(Logger) }
+
   before do
     allow(Logger).to receive(:new).and_return(logger)
     allow(logger).to receive(:<<)

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1150,6 +1150,7 @@ RSpec.describe TopicQuery do
   describe "categorized" do
     fab!(:category, :category_with_definition)
     let(:topic_category) { category.topic }
+
     fab!(:topic_no_cat, :topic)
     fab!(:topic_in_cat1) do
       Fabricate(:topic, category: category, bumped_at: 10.minutes.ago, created_at: 10.minutes.ago)

--- a/spec/lib/topic_upload_security_manager_spec.rb
+++ b/spec/lib/topic_upload_security_manager_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe TopicUploadSecurityManager do
 
         context "when changing the topic to a non-private category" do
           before { topic.update(category: Fabricate(:category)) }
+
           it "changes the upload secure statuses to false and updates ACLs and rebakes" do
             expect_upload_status_to_change_and_rebake
           end
@@ -71,6 +72,7 @@ RSpec.describe TopicUploadSecurityManager do
 
         context "when making the PM into a public topic" do
           before { topic.update(archetype: Archetype.default) }
+
           it "changes the upload secure statuses to false and updates ACLs and rebakes" do
             expect_upload_status_to_change_and_rebake
           end

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -948,11 +948,13 @@ RSpec.describe TopicView do
     context "with uncategorized topic" do
       context "when topic_page_title_includes_category is false" do
         before { SiteSetting.topic_page_title_includes_category = false }
+
         it { is_expected.to eq(topic.title) }
       end
 
       context "when topic_page_title_includes_category is true" do
         before { SiteSetting.topic_page_title_includes_category = true }
+
         it { is_expected.to eq(topic.title) }
 
         context "with tagged topic" do
@@ -1024,11 +1026,13 @@ RSpec.describe TopicView do
 
       context "when topic_page_title_includes_category is false" do
         before { SiteSetting.topic_page_title_includes_category = false }
+
         it { is_expected.to eq(topic.title) }
       end
 
       context "when topic_page_title_includes_category is true" do
         before { SiteSetting.topic_page_title_includes_category = true }
+
         it { is_expected.to start_with(topic.title) }
         it { is_expected.to end_with(category.name) }
 

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TopicsFilter do
 
   describe "#option_info" do
     let(:options) { TopicsFilter.option_info(Guardian.new) }
+
     it "should return a correct hash with name and description keys for all" do
       expect(options).to be_an(Array)
       expect(options).to all(be_a(Hash))
@@ -344,6 +345,7 @@ RSpec.describe TopicsFilter do
         ).to start_with(t1.id, t2.id)
       end
     end
+
     describe "when filtering with multiple filters" do
       fab!(:tag) { Fabricate(:tag, name: "tag1") }
       fab!(:tag2) { Fabricate(:tag, name: "tag2") }
@@ -411,6 +413,7 @@ RSpec.describe TopicsFilter do
             )
           end
         end
+
         before { user_for_new_filters.user_option.update!(new_topic_duration_minutes: 1.day.ago) }
 
         it "in:new-topics returns only new topics" do
@@ -1654,6 +1657,7 @@ RSpec.describe TopicsFilter do
 
       describe "when query string is `tags:tag_name`" do
         before { tag.update!(name: "tag_with_underscore") }
+
         it "should return topics even when tag contains underscore" do
           expect(
             TopicsFilter

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -755,6 +755,7 @@ RSpec.describe UploadCreator do
 
         context "if type of upload is in the composer" do
           let(:opts) { { type: "composer" } }
+
           it "sets the upload to secure and sets the original_sha1 column, because we don't know the context of the composer" do
             expect(result.secure).to eq(true)
             expect(result.original_sha1).not_to eq(nil)
@@ -763,6 +764,7 @@ RSpec.describe UploadCreator do
 
         context "if the upload is for a PM" do
           let(:opts) { { for_private_message: true } }
+
           it "sets the upload to secure and sets the original_sha1" do
             expect(result.secure).to eq(true)
             expect(result.original_sha1).not_to eq(nil)
@@ -771,6 +773,7 @@ RSpec.describe UploadCreator do
 
         context "if the upload is for a group message" do
           let(:opts) { { for_group_message: true } }
+
           it "sets the upload to secure and sets the original_sha1" do
             expect(result.secure).to eq(true)
             expect(result.original_sha1).not_to eq(nil)
@@ -779,6 +782,7 @@ RSpec.describe UploadCreator do
 
         context "if SiteSetting.login_required" do
           before { SiteSetting.login_required = true }
+
           it "sets the upload to secure and sets the original_sha1" do
             expect(result.secure).to eq(true)
             expect(result.original_sha1).not_to eq(nil)

--- a/spec/lib/upload_security_spec.rb
+++ b/spec/lib/upload_security_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe UploadSecurity do
         context "when uploading in public context" do
           describe "for a public type badge_image" do
             let(:type) { "badge_image" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -46,6 +47,7 @@ RSpec.describe UploadSecurity do
 
           describe "for a public type group_flair" do
             let(:type) { "group_flair" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -53,6 +55,7 @@ RSpec.describe UploadSecurity do
 
           describe "for a public type avatar" do
             let(:type) { "avatar" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -60,6 +63,7 @@ RSpec.describe UploadSecurity do
 
           describe "for a public type custom_emoji" do
             let(:type) { "custom_emoji" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -67,6 +71,7 @@ RSpec.describe UploadSecurity do
 
           describe "for a public type profile_background" do
             let(:type) { "profile_background" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -74,6 +79,7 @@ RSpec.describe UploadSecurity do
 
           describe "for a public type category_logo" do
             let(:type) { "category_logo" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -81,6 +87,7 @@ RSpec.describe UploadSecurity do
 
           describe "for a public type category_background" do
             let(:type) { "category_background" }
+
             it "returns false" do
               expect(security.should_be_secure?).to eq(false)
             end
@@ -155,6 +162,7 @@ RSpec.describe UploadSecurity do
 
       context "when uploading in the composer" do
         let(:type) { "composer" }
+
         it "returns true" do
           expect(security.should_be_secure?).to eq(true)
         end
@@ -162,6 +170,7 @@ RSpec.describe UploadSecurity do
 
       context "when uploading for a group message" do
         before { upload.stubs(:for_group_message).returns(true) }
+
         it "returns true" do
           expect(security.should_be_secure?).to eq(true)
         end
@@ -169,6 +178,7 @@ RSpec.describe UploadSecurity do
 
       context "when uploading for a PM" do
         before { upload.stubs(:for_private_message).returns(true) }
+
         it "returns true" do
           expect(security.should_be_secure?).to eq(true)
         end
@@ -176,6 +186,7 @@ RSpec.describe UploadSecurity do
 
       context "when upload is already secure" do
         before { upload.update(secure: true) }
+
         it "returns true" do
           expect(security.should_be_secure?).to eq(true)
         end
@@ -186,6 +197,7 @@ RSpec.describe UploadSecurity do
 
         context "when the access control post has_secure_uploads?" do
           before { upload.update(access_control_post: post_in_secure_context) }
+
           it "returns true" do
             expect(security.should_be_secure?).to eq(true)
           end

--- a/spec/lib/validators/post_validator_spec.rb
+++ b/spec/lib/validators/post_validator_spec.rb
@@ -525,6 +525,7 @@ RSpec.describe PostValidator do
 
   describe "staged user" do
     before { post.acting_user = build(:user, staged: true) }
+
     include_examples "almost no validations"
   end
 end

--- a/spec/lib/validators/quality_title_validator_spec.rb
+++ b/spec/lib/validators/quality_title_validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe QualityTitleValidator do
   let(:meaningless_title) { "asdf asdf asdf asdf" }
   let(:loud_title) { "ALL CAPS INVALID TITLE" }
   let(:pretentious_title) { "superverylongwordintitlefornoparticularreason" }
+
   fab!(:topic) { Fabricate(:post).topic }
 
   before { SiteSetting.title_prettify = false }

--- a/spec/lib/validators/user_password_validator_spec.rb
+++ b/spec/lib/validators/user_password_validator_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe UserPasswordValidator do
       end
     end
   end
+
   context "when password is commonly used" do
     before do
       SiteSetting.min_password_length = 8

--- a/spec/lib/version_compatibility_spec.rb
+++ b/spec/lib/version_compatibility_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Discourse do
         2.4.4.beta6: twofourfourbetasix
         2.4.2.beta1: twofourtwobetaone
         YML
+
       include_examples "test compatible resource"
     end
 
@@ -109,6 +110,7 @@ RSpec.describe Discourse do
         2.5.0.beta2: twofivebetatwo
         2.4.4.beta6: twofourfourbetasix
         YML
+
       include_examples "test compatible resource"
     end
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe InviteMailer do
         fab!(:invite)
         let(:plugin) { Plugin::Instance.new }
         let(:custom_template) { "plugin_custom_invite_template" }
+
         before do
           I18n.backend.store_translations(
             :en,

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1324,6 +1324,7 @@ RSpec.describe UserNotifications do
   describe "user mentioned email" do
     include_examples "notification email building" do
       let(:notification_type) { :mentioned }
+
       include_examples "respect for private_email"
       include_examples "supports reply by email"
       include_examples "sets user locale"
@@ -1347,6 +1348,7 @@ RSpec.describe UserNotifications do
   describe "user replied" do
     include_examples "notification email building" do
       let(:notification_type) { :replied }
+
       include_examples "respect for private_email"
       include_examples "supports reply by email"
       include_examples "sets user locale"
@@ -1356,6 +1358,7 @@ RSpec.describe UserNotifications do
   describe "user quoted" do
     include_examples "notification email building" do
       let(:notification_type) { :quoted }
+
       include_examples "respect for private_email"
       include_examples "supports reply by email"
       include_examples "sets user locale"
@@ -1365,6 +1368,7 @@ RSpec.describe UserNotifications do
   describe "user posted" do
     include_examples "notification email building" do
       let(:notification_type) { :posted }
+
       include_examples "respect for private_email"
       include_examples "supports reply by email"
       include_examples "sets user locale"
@@ -1465,6 +1469,7 @@ RSpec.describe UserNotifications do
   describe "watching first post" do
     include_examples "notification email building" do
       let(:notification_type) { :invited_to_topic }
+
       include_examples "respect for private_email"
       include_examples "no reply by email"
       include_examples "sets user locale"
@@ -1570,6 +1575,7 @@ RSpec.describe UserNotifications do
         include_examples "with notification derived from template" do
           let(:locale) { "fr" }
           let(:mail_type) { mail_type }
+
           it "sets the locale" do
             expects_build_with(has_entry(:locale, "fr"))
           end
@@ -1593,6 +1599,7 @@ RSpec.describe UserNotifications do
         include_examples "with notification derived from template" do
           let(:locale) { "fr" }
           let(:mail_type) { mail_type }
+
           it "sets the locale" do
             expects_build_with(has_entry(:locale, "en"))
           end

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -83,16 +83,19 @@ RSpec.describe Badge do
 
     context "when system badge" do
       before { badge.system = true }
+
       it { is_expected.to be false }
     end
 
     context "when has query" do
       before { badge.query = "SELECT id FROM users" }
+
       it { is_expected.to be true }
     end
 
     context "when not a system badge" do
       before { badge.update_columns(system: false) }
+
       it { is_expected.to be true }
     end
   end
@@ -164,6 +167,7 @@ RSpec.describe Badge do
 
     context "when a translation key not for a badge is provided" do
       let(:translation_key) { "reports.flags.title" }
+
       it "returns nil" do
         expect(Badge.find_system_badge_id_from_translation_key(translation_key)).to eq(nil)
       end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -759,6 +759,7 @@ RSpec.describe Category do
       let(:new_category) do
         Fabricate(:category_with_definition, name: "2nd Category", user: category.user)
       end
+
       before do
         topic.change_category_to_id(new_category.id)
         topic.reload
@@ -1507,6 +1508,7 @@ RSpec.describe Category do
   describe "#cannot_delete_reason" do
     fab!(:admin)
     let(:guardian) { Guardian.new(admin) }
+
     fab!(:category)
 
     describe "when category is uncategorized" do
@@ -1637,6 +1639,7 @@ RSpec.describe Category do
 
   describe "allowed_tags=" do
     let(:category) { Fabricate(:category) }
+
     fab!(:tag)
     fab!(:tag2, :tag)
 

--- a/spec/models/category_user_spec.rb
+++ b/spec/models/category_user_spec.rb
@@ -348,6 +348,7 @@ RSpec.describe CategoryUser do
 
     context "for anon" do
       let(:user) { nil }
+
       before do
         SiteSetting.default_categories_watching = category1.id.to_s
         SiteSetting.default_categories_tracking = category2.id.to_s
@@ -355,6 +356,7 @@ RSpec.describe CategoryUser do
         SiteSetting.default_categories_normal = category4.id.to_s
         SiteSetting.default_categories_muted = category5.id.to_s
       end
+
       it "every category from the default_categories_* site settings get overridden to regular, except for muted" do
         levels = CategoryUser.notification_levels_for(user)
         expect(levels[category1.id]).to eq(CategoryUser.notification_levels[:regular])
@@ -393,6 +395,7 @@ RSpec.describe CategoryUser do
           notification_level: CategoryUser.notification_levels[:muted],
         )
       end
+
       it "gets the category_user notification levels for all categories the user is tracking and does not
       include categories the user is not tracking at all" do
         category6 = Fabricate(:category)
@@ -462,6 +465,7 @@ RSpec.describe CategoryUser do
         category2
         category3
       end
+
       it "calculates muted categories based on parent category state" do
         expect(CategoryUser.indirectly_muted_category_ids(user)).to eq([])
 

--- a/spec/models/email_log_spec.rb
+++ b/spec/models/email_log_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe EmailLog do
 
   describe ".addressed_to_user scope" do
     let(:user) { Fabricate(:user, email: "test@test.com") }
+
     before do
       Fabricate(:email_log, to_address: "john@smith.com")
       Fabricate(:email_log, cc_addresses: "jane@jones.com;elle@someplace.org")

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -472,6 +472,7 @@ RSpec.describe Invite do
         user = invite.redeem
         expect(user.groups).to contain_exactly(group)
       end
+
       it "should not raise error when both group & site tag preferences same" do
         tag = Fabricate(:tag)
         group.tracking_tags = [tag.name]

--- a/spec/models/optimized_image_spec.rb
+++ b/spec/models/optimized_image_spec.rb
@@ -4,6 +4,7 @@ require "chunky_png"
 
 RSpec.describe OptimizedImage do
   let(:upload) { build(:upload) }
+
   before { upload.id = 42 }
 
   describe ".crop" do
@@ -303,6 +304,7 @@ RSpec.describe OptimizedImage do
 
     context "when using an internal store" do
       let(:store) { FakeInternalStore.new }
+
       before { Discourse.stubs(:store).returns(store) }
 
       context "when an error happened while generating the thumbnail" do

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -601,6 +601,7 @@ RSpec.describe PostAction do
       post.reload
       expect(post.hidden).to eq(true)
     end
+
     it "hide tl0 posts that are flagged as spam by a tl3 user" do
       newuser = Fabricate(:newuser, refresh_auto_groups: true)
       post = create_post(user: newuser)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2998,6 +2998,7 @@ RSpec.describe PostMover do
       fab!(:user)
 
       before { SiteSetting.delete_merged_stub_topics_after_days = 0 }
+
       let(:modifier_block) do
         Proc.new do |is_currently_allowed_to_delete, topic, who_is_merging|
           expect(is_currently_allowed_to_delete).to eq(false)
@@ -3005,6 +3006,7 @@ RSpec.describe PostMover do
           user.id == who_is_merging.id
         end
       end
+
       it "lets user merge topics immediately" do
         plugin_instance = Plugin::Instance.new
         plugin_instance.register_modifier(:is_allowed_to_delete_after_merge, &modifier_block)
@@ -3208,6 +3210,7 @@ RSpec.describe PostMover do
         fab!(:user)
 
         before { SiteSetting.delete_merged_stub_topics_after_days = 0 }
+
         let(:modifier_block) { Proc.new { |continue, _| false } }
 
         it "does not create small action post when modifier returns false" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe Post do
 
     context "with a post with links" do
       let(:post) { Fabricate(:post_with_external_links) }
+
       before do
         post.trash!
         post.reload
@@ -185,6 +186,7 @@ RSpec.describe Post do
 
       context "if the topic category is read_restricted" do
         let(:category) { Fabricate(:private_category, group: Fabricate(:group)) }
+
         before { topic.change_category_to_id(category.id) }
 
         it "returns true" do
@@ -1010,6 +1012,7 @@ RSpec.describe Post do
     let!(:p1) { Fabricate(:post, post_args.merge(score: 4, percent_rank: 0.33)) }
     let!(:p2) { Fabricate(:post, post_args.merge(score: 10, percent_rank: 0.66)) }
     let!(:p3) { Fabricate(:post, post_args.merge(score: 5, percent_rank: 0.99)) }
+
     fab!(:p4) { Fabricate(:post, percent_rank: 0.99) }
 
     it "returns the OP and posts above the threshold in summary mode" do
@@ -2019,6 +2022,7 @@ RSpec.describe Post do
 
         context "for custom emoji" do
           before { CustomEmoji.create(name: "meme", upload: image_upload) }
+
           it "never sets an access control post because they should not be secure" do
             post.link_post_uploads
             expect(image_upload.reload.access_control_post_id).to eq(nil)

--- a/spec/models/reviewable_note_spec.rb
+++ b/spec/models/reviewable_note_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe ReviewableNote do
     subject { build(:reviewable_note, reviewable: reviewable, user: admin) }
 
     it { is_expected.to validate_presence_of(:content) }
+
     it do
       is_expected.to validate_length_of(:content).is_at_least(1).is_at_most(
         ReviewableNote::MAX_CONTENT_LENGTH,
       )
     end
+
     it { is_expected.to validate_presence_of(:reviewable_id) }
     it { is_expected.to validate_presence_of(:user_id) }
 

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -309,6 +309,7 @@ RSpec.describe Reviewable, type: :model do
       fab!(:category) { Fabricate(:category, read_restricted: true) }
       let(:topic) { Fabricate(:topic, category: category) }
       let(:post) { Fabricate(:post, topic: topic) }
+
       fab!(:moderator)
       fab!(:admin)
 

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ReviewableUser, type: :model do
     user.activate
     user
   end
+
   fab!(:admin)
 
   describe "#actions_for" do

--- a/spec/models/screened_email_spec.rb
+++ b/spec/models/screened_email_spec.rb
@@ -96,7 +96,9 @@ RSpec.describe ScreenedEmail do
       let!(:screened_email) do
         Fabricate(:screened_email, email: email, action_type: ScreenedEmail.actions[:block])
       end
+
       it { is_expected.to eq(true) }
+
       include_examples "when a ScreenedEmail record matches"
     end
 
@@ -104,7 +106,9 @@ RSpec.describe ScreenedEmail do
       let!(:screened_email) do
         Fabricate(:screened_email, email: email, action_type: ScreenedEmail.actions[:do_nothing])
       end
+
       it { is_expected.to eq(false) }
+
       include_examples "when a ScreenedEmail record matches"
     end
   end

--- a/spec/models/screened_ip_address_spec.rb
+++ b/spec/models/screened_ip_address_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe ScreenedIpAddress do
       context "when using exact match" do
         fab!(:existing, :screened_ip_address)
         let(:ip_address_arg) { existing.ip_address }
+
         include_examples "exact match of ip address"
       end
 
@@ -162,11 +163,13 @@ RSpec.describe ScreenedIpAddress do
 
         context "with exact address" do
           let(:ip_address_arg) { "99.232.23.124" }
+
           include_examples "exact match of ip address"
         end
 
         context "with address in same subnet" do
           let(:ip_address_arg) { "99.232.23.135" }
+
           include_examples "exact match of ip address"
         end
       end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -406,6 +406,7 @@ RSpec.describe SiteSetting do
 
   describe "creating upload references for type objects settings with upload fields" do
     let(:provider) { SiteSettings::DbProvider.new(SiteSetting) }
+
     fab!(:upload)
     fab!(:upload2, :upload)
 

--- a/spec/models/tag_group_spec.rb
+++ b/spec/models/tag_group_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe TagGroup do
 
   describe "tag_names=" do
     let(:tag_group) { Fabricate(:tag_group) }
+
     fab!(:tag)
 
     before { SiteSetting.tagging_enabled = true }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Tag do
   let(:tag) { Fabricate(:tag) }
   let(:tag2) { Fabricate(:tag) }
   let(:topic) { Fabricate(:topic, tags: [tag]) }
+
   fab!(:user)
 
   before do

--- a/spec/models/tag_user_spec.rb
+++ b/spec/models/tag_user_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe TagUser do
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:watched_tag, :tag)
     let(:muted_tag) { Fabricate(:tag) }
+
     fab!(:tracked_tag, :tag)
 
     context "with some tag notification settings" do
@@ -418,12 +419,14 @@ RSpec.describe TagUser do
 
     context "for anon" do
       let(:user) { nil }
+
       before do
         SiteSetting.default_tags_watching = tag1.name
         SiteSetting.default_tags_tracking = tag2.name
         SiteSetting.default_tags_watching_first_post = tag3.name
         SiteSetting.default_tags_muted = tag4.name
       end
+
       it "every tag from the default_tags_* site settings get overridden to watching_first_post, except for muted" do
         levels = TagUser.notification_levels_for(user)
         expect(levels[tag1.id][:level]).to eq(TagUser.notification_levels[:regular])
@@ -435,6 +438,7 @@ RSpec.describe TagUser do
 
     context "for a user" do
       let(:user) { Fabricate(:user) }
+
       before do
         TagUser.create(
           user: user,

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe TopicEmbed do
     let(:contents) do
       "<p>hello world new post <a href='/hello'>hello</a> <img src='images/wat.jpg'></p>"
     end
+
     fab!(:embeddable_host)
     fab!(:category)
     fab!(:tag)
@@ -913,6 +914,7 @@ RSpec.describe TopicEmbed do
     let(:title) { "How to turn a fish from good to evil in 30 seconds" }
     let(:url) { "http://eviltrout.com/123" }
     let(:contents) { "<p>hello world new post :D</p>" }
+
     fab!(:embeddable_host)
     fab!(:category)
     fab!(:tag)

--- a/spec/models/topic_link_spec.rb
+++ b/spec/models/topic_link_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe TopicLink do
   let(:test_uri) { URI.parse(Discourse.base_url) }
+
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:topic) { Fabricate(:topic, user: user, title: "unique topic name") }
   fab!(:post)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe Topic do
   let(:now) { Time.zone.local(2013, 11, 20, 8, 0) }
+
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:whisperers_group, :group)
@@ -1739,6 +1740,7 @@ RSpec.describe Topic do
 
     context "when closed" do
       let(:status) { "closed" }
+
       it_behaves_like "a status that closes a topic"
 
       it "should archive group message" do
@@ -1760,6 +1762,7 @@ RSpec.describe Topic do
 
     context "when autoclosed" do
       let(:status) { "autoclosed" }
+
       it_behaves_like "a status that closes a topic"
 
       context "when topic was set to close when it was created" do
@@ -2229,6 +2232,7 @@ RSpec.describe Topic do
 
         describe "tracking state notifications" do
           before { SiteSetting.experimental_topic_category_change_notification = true }
+
           it "publishes category change when moving to a restricted category" do
             restricted_category =
               Fabricate(:category_with_definition, read_restricted: true, user: user)
@@ -3306,6 +3310,7 @@ RSpec.describe Topic do
 
   describe "featured link" do
     before { SiteSetting.topic_featured_link_enabled = true }
+
     fab!(:topic)
 
     it "can validate featured link" do

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -160,11 +160,13 @@ RSpec.describe TranslationOverride do
           "This has {COUNT, plural, one{one member} other{# members}}.",
         ).for(:value).against(:base)
       end
+
       it do
         is_expected.not_to allow_value(
           "This has {COUNT, plural, one{one member} many{# members} other{# members}}.",
         ).for(:value).with_message(/plural case many is not valid/, against: :base)
       end
+
       it do
         is_expected.not_to allow_value("This has {COUNT, ").for(:value).with_message(
           /invalid syntax/,

--- a/spec/models/upload_reference_spec.rb
+++ b/spec/models/upload_reference_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe UploadReference do
 
   describe "site setting uploads" do
     let(:provider) { SiteSettings::DbProvider.new(SiteSetting) }
+
     fab!(:upload)
     fab!(:upload2, :upload)
 

--- a/spec/models/user_avatar_spec.rb
+++ b/spec/models/user_avatar_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe UserAvatar do
 
   describe "#update_gravatar!" do
     let(:temp) { Tempfile.new("test") }
+
     fab!(:upload) { Fabricate(:upload, user: user) }
 
     describe "when working" do

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe UserPassword do
   describe "#ensure_password_is_hashed" do
     let(:password) { SecureRandom.hex }
+
     fab!(:user_password)
 
     it "ensures password_hash, password_salt, password_algorithm are saved correctly" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -376,6 +376,7 @@ RSpec.describe User do
     describe "#user_fields" do
       fab!(:user_field) { Fabricate(:user_field, show_on_profile: true) }
       let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
+
       fab!(:watched_word) { Fabricate(:watched_word, word: "bad") }
 
       before { user.set_user_field(user_field.id, value) }
@@ -397,6 +398,7 @@ RSpec.describe User do
 
             it { is_expected.to be_valid }
           end
+
           context "when SiteSetting.disable_watched_word_checking_in_user_fields is true" do
             before { SiteSetting.disable_watched_word_checking_in_user_fields = true }
 
@@ -452,6 +454,7 @@ RSpec.describe User do
               user.save!
               expect(user_field_value).to eq "word replaced"
             end
+
             context "when SiteSetting.disable_watched_word_checking_in_user_fields is true" do
               before { SiteSetting.disable_watched_word_checking_in_user_fields = true }
 
@@ -530,6 +533,7 @@ RSpec.describe User do
 
         context "with a censored word" do
           let(:value) { %w[Axe bad Sword] }
+
           before { watched_word.action = WatchedWord.actions[:censor] }
 
           it "does not censor the word since it is not user generated-content" do
@@ -555,6 +559,7 @@ RSpec.describe User do
 
         context "with a censored word" do
           let(:value) { true }
+
           before { watched_word.action = WatchedWord.actions[:censor] }
 
           it "does not censor the word since it is not user generated-content" do
@@ -588,6 +593,7 @@ RSpec.describe User do
       Fabricate(:user, created_at: 2.days.ago)
       Fabricate(:user, created_at: 4.days.ago)
     end
+
     let(:signups_by_day) do
       { 1.day.ago.to_date => 2, 2.days.ago.to_date => 1, Time.now.utc.to_date => 1 }
     end
@@ -664,6 +670,7 @@ RSpec.describe User do
 
   describe "reviewable" do
     let(:user) { Fabricate(:user, active: false) }
+
     fab!(:admin)
 
     before { Jobs.run_immediately! }
@@ -767,6 +774,7 @@ RSpec.describe User do
     fab!(:posts) { [post1, post2, post3] }
     fab!(:post_ids) { [post1.id, post2.id, post3.id] }
     let(:guardian) { Guardian.new(Fabricate(:admin)) }
+
     fab!(:reviewable_queued_post) { Fabricate(:reviewable_queued_post, target_created_by: user) }
 
     it "deletes only one batch of posts" do
@@ -1502,6 +1510,7 @@ RSpec.describe User do
     context "if timezone is provided" do
       context "if the timezone is valid" do
         let(:timezone) { "Australia/Melbourne" }
+
         context "if no timezone exists on user option" do
           it "sets the timezone for the user" do
             user.update_timezone_if_missing(timezone)
@@ -1512,6 +1521,7 @@ RSpec.describe User do
 
       context "if the timezone is not valid" do
         let(:timezone) { "Jupiter" }
+
         context "if no timezone exists on user option" do
           it "does not set the timezone for the user" do
             user.update_timezone_if_missing(timezone)
@@ -1717,11 +1727,13 @@ RSpec.describe User do
         expect(Fabricate(:user, username: "foo", name: nil).readable_name).to eq("foo")
       end
     end
+
     context "when name and username are identical" do
       it "returns just the username" do
         expect(Fabricate(:user, username: "foo", name: "foo").readable_name).to eq("foo")
       end
     end
+
     context "when name and username are not identical" do
       it "returns the name and username" do
         expect(Fabricate(:user, username: "foo", name: "Bar Baz").readable_name).to eq(
@@ -2049,6 +2061,7 @@ RSpec.describe User do
     context "with a UserVisit record" do
       fab!(:user)
       let!(:now) { Time.zone.now }
+
       before { user.update_last_seen!(now) }
       after { reset_last_seen_cache!(user) }
 
@@ -3093,6 +3106,7 @@ RSpec.describe User do
 
   describe "#email=" do
     let(:new_email) { "newprimary@example.com" }
+
     it "sets the primary email" do
       user.update!(email: new_email)
       expect(User.find(user.id).email).to eq(new_email)
@@ -3456,6 +3470,7 @@ RSpec.describe User do
     describe "#create_or_fetch_secure_identifier" do
       context "if the user already has a secure identifier" do
         let(:sec_ident) { SecureRandom.hex(20) }
+
         before { user.update(secure_identifier: sec_ident) }
 
         it "returns the identifier" do

--- a/spec/models/user_stat_spec.rb
+++ b/spec/models/user_stat_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe UserStat do
   describe ".update_distinct_badge_count" do
     fab!(:user)
     let(:stat) { user.user_stat }
+
     fab!(:badge1, :badge)
     fab!(:badge2, :badge)
 

--- a/spec/models/user_visit_spec.rb
+++ b/spec/models/user_visit_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe UserVisit do
       user.user_visits.create(visited_at: 2.days.ago)
       user.user_visits.create(visited_at: 4.days.ago)
     end
+
     let(:visits_by_day) do
       { 1.day.ago.to_date => 2, 2.days.ago.to_date => 1, Time.zone.now.to_date => 1 }
     end

--- a/spec/models/watched_word_group_spec.rb
+++ b/spec/models/watched_word_group_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe WatchedWordGroup do
   fab!(:watched_word_group)
   let!(:watched_word_1) { watched_word_group.watched_words.first }
+
   fab!(:watched_word_2) { Fabricate(:watched_word, watched_word_group_id: watched_word_group.id) }
 
   describe "#create_or_update_members" do

--- a/spec/requests/admin/config/fonts_controller_spec.rb
+++ b/spec/requests/admin/config/fonts_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Admin::Config::FontsController do
   describe "#fonts" do
     context "when logged in as an admin" do
       before { sign_in(admin) }
+
       it "updates the fonts and text size" do
         put "/admin/config/fonts.json",
             params: {
@@ -38,6 +39,7 @@ RSpec.describe Admin::Config::FontsController do
 
     context "when logged in as a moderator" do
       before { sign_in(moderator) }
+
       it "denies access with a 403 response" do
         put "/admin/config/fonts.json",
             params: {

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -981,6 +981,7 @@ RSpec.describe Admin::DashboardController do
 
     context "when logged in as an admin" do
       before { sign_in(admin) }
+
       context "when there are no problems" do
         it "returns an empty array" do
           post "/admin/dashboard/problems.json"

--- a/spec/requests/admin/emojis_controller_spec.rb
+++ b/spec/requests/admin/emojis_controller_spec.rb
@@ -305,11 +305,13 @@ RSpec.describe Admin::EmojiController do
 
     context "when logged in as a moderator" do
       before { sign_in(moderator) }
+
       include_examples "export not allowed"
     end
 
     context "when logged in as a non-staff user" do
       before { sign_in(user) }
+
       include_examples "export not allowed"
     end
   end
@@ -446,11 +448,13 @@ RSpec.describe Admin::EmojiController do
 
     context "when logged in as a moderator" do
       before { sign_in(moderator) }
+
       include_examples "import preview not allowed"
     end
 
     context "when logged in as a non-staff user" do
       before { sign_in(user) }
+
       include_examples "import preview not allowed"
     end
   end
@@ -602,11 +606,13 @@ RSpec.describe Admin::EmojiController do
 
     context "when logged in as a moderator" do
       before { sign_in(moderator) }
+
       include_examples "import confirm not allowed"
     end
 
     context "when logged in as a non-staff user" do
       before { sign_in(user) }
+
       include_examples "import confirm not allowed"
     end
   end

--- a/spec/requests/admin/form_templates_controller_spec.rb
+++ b/spec/requests/admin/form_templates_controller_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe Admin::FormTemplatesController do
 
     context "when logged in as a non-admin user" do
       before { sign_in(user) }
+
       it "prevents deletion with a 404 response" do
         expect do
           delete "/admin/customize/form-templates/#{form_template.id}.json"

--- a/spec/requests/admin/staff_action_logs_controller_spec.rb
+++ b/spec/requests/admin/staff_action_logs_controller_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe Admin::StaffActionLogsController do
 
       context "when staff actions are extended" do
         let(:plugin_extended_action) { :confirmed_ham }
+
         before { UserHistory.stubs(:staff_actions).returns([plugin_extended_action]) }
         after { UserHistory.unstub(:staff_actions) }
 

--- a/spec/requests/admin/unknown_reviewables_controller_spec.rb
+++ b/spec/requests/admin/unknown_reviewables_controller_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Admin::UnknownReviewablesController do
   let(:admin) { Fabricate(:admin) }
   let(:user) { Fabricate(:user) }
+
   fab!(:reviewable)
   fab!(:unknown_reviewable) { Fabricate(:reviewable, type: "ReviewablePost") }
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -2899,6 +2899,7 @@ RSpec.describe Admin::UsersController do
 
           expect(response.status).to eq(200)
         end
+
         it "should succeed with totp" do
           user.security_keys.destroy_all
 
@@ -3076,6 +3077,7 @@ RSpec.describe Admin::UsersController do
   describe "#delete_posts_decider" do
     shared_examples "delete_posts_decider accessible" do |acting_user_role|
       let(:acting_user) { send(acting_user_role) }
+
       context "when user exists" do
         fab!(:target_user, :user)
 
@@ -3135,11 +3137,13 @@ RSpec.describe Admin::UsersController do
 
     context "when logged in as an admin" do
       before { sign_in(admin) }
+
       include_examples "delete_posts_decider accessible", :admin
     end
 
     context "when logged in as a moderator" do
       before { sign_in(moderator) }
+
       include_examples "delete_posts_decider accessible", :moderator
 
       context "when target user is another moderator" do

--- a/spec/requests/admin/web_hooks_controller_spec.rb
+++ b/spec/requests/admin/web_hooks_controller_spec.rb
@@ -430,6 +430,7 @@ RSpec.describe Admin::WebHooksController do
           headers
         end
       end
+
       it "modifies the headers & saves the updated headers to the webhook event" do
         plugin_instance = Plugin::Instance.new
         plugin_instance.register_modifier(:web_hook_event_headers, &modifier_block)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -260,6 +260,7 @@ RSpec.describe ApplicationController do
 
   describe "#redirect_to_second_factor_if_required" do
     let(:admin) { Fabricate(:admin) }
+
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
     before do
@@ -722,6 +723,7 @@ RSpec.describe ApplicationController do
     let!(:theme) { Fabricate(:theme, user_selectable: true) }
     let!(:theme2) { Fabricate(:theme, user_selectable: true) }
     let!(:non_selectable_theme) { Fabricate(:theme, user_selectable: false) }
+
     fab!(:user)
     fab!(:admin)
 
@@ -1883,6 +1885,7 @@ RSpec.describe ApplicationController do
   describe "#banner_json" do
     let(:admin) { Fabricate(:admin) }
     let(:user) { Fabricate(:user) }
+
     fab!(:banner_topic)
     fab!(:p1) { Fabricate(:post, topic: banner_topic, raw: "A banner topic") }
 
@@ -1892,6 +1895,7 @@ RSpec.describe ApplicationController do
 
     context "with login_required" do
       before { SiteSetting.login_required = true }
+
       it "does not include banner info for anonymous users" do
         get "/login"
 
@@ -1914,6 +1918,7 @@ RSpec.describe ApplicationController do
 
     context "with login not required" do
       before { SiteSetting.login_required = false }
+
       it "does include banner info for anonymous users" do
         get "/login"
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe CategoriesController do
   let!(:admin) { Fabricate(:admin) }
   let!(:category) { Fabricate(:category, user: admin) }
+
   fab!(:user)
 
   describe "#index" do

--- a/spec/requests/edit_directory_columns_controller_spec.rb
+++ b/spec/requests/edit_directory_columns_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe EditDirectoryColumnsController do
     describe "#update" do
       describe "when user is an admin or moderator" do
         before { sign_in(admin) }
+
         describe "user saves a new configuration" do
           it "logs the new information using StaffActionLogger" do
             expect { put edit_directory_columns_path(params: payload) }.to change {
@@ -56,6 +57,7 @@ RSpec.describe EditDirectoryColumnsController do
 
     describe "when user is not an admin or moderator" do
       before { sign_in(user) }
+
       describe "user saves a new configuration" do
         it "does not allow saving" do
           put edit_directory_columns_path(params: payload)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GroupsController do
   fab!(:other_user, :user)
   let(:group) { Fabricate(:group, users: [user]) }
   let(:moderator_group_id) { Group::AUTO_GROUPS[:moderators] }
+
   fab!(:admin)
   fab!(:moderator)
 
@@ -3388,6 +3389,7 @@ RSpec.describe GroupsController do
             "Invalid credentials",
           )
         end
+
         it "uses the friendly error message functionality to return the message to the user" do
           post "/groups/#{group.id}/test_email_settings.json", params: params
           expect(response.status).to eq(422)
@@ -3477,6 +3479,7 @@ RSpec.describe GroupsController do
 
       context "when the protocol is not accepted" do
         let(:protocol) { "sigma" }
+
         it "raises an invalid params error" do
           post "/groups/#{group.id}/test_email_settings.json", params: params
           expect(response.status).to eq(400)
@@ -3486,6 +3489,7 @@ RSpec.describe GroupsController do
 
       context "when user is a regular user without staff access" do
         before { sign_in(user) }
+
         it "errors if the user does not have access to the group" do
           post "/groups/#{group.id}/test_email_settings.json", params: params
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1312,6 +1312,7 @@ RSpec.describe PostsController do
 
     context "when the user still has bookmarks in the topic" do
       before { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:post, topic: post.topic)) }
+
       it "marks topic_bookmarked as true" do
         delete "/posts/#{post.id}/bookmark.json"
         expect(response.parsed_body["topic_bookmarked"]).to eq(true)
@@ -3548,6 +3549,7 @@ RSpec.describe PostsController do
 
     context "with a tagged topic" do
       let(:tag) { Fabricate(:tag) }
+
       it "works" do
         SiteSetting.tagging_enabled = true
 

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -360,6 +360,7 @@ RSpec.describe SessionController do
               expect(session[:current_user_id]).to eq(nil)
             end
           end
+
           context "when using backup code method" do
             it "does not log in with incorrect backup code" do
               post "/session/email-login/#{email_token.token}.json",
@@ -390,6 +391,7 @@ RSpec.describe SessionController do
               expect(session[:current_user_id]).to eq(user.id)
             end
           end
+
           context "when using backup code method" do
             it "logs in correctly" do
               post "/session/email-login/#{email_token.token}.json",
@@ -2098,6 +2100,7 @@ RSpec.describe SessionController do
   describe "#sso_provider" do
     let(:headers) { { host: Discourse.current_hostname } }
     let(:logo_fixture) { "http://#{Discourse.current_hostname}/uploads/logo.png" }
+
     fab!(:user) { Fabricate(:user, password: "myfrogs123ADMIN", active: true, admin: true) }
 
     before do
@@ -2567,6 +2570,7 @@ RSpec.describe SessionController do
 
         post "/session.json", params: { login: user.username, password: "myawesomepassword" }
       end
+
       it_behaves_like "failed to continue local login"
     end
 
@@ -2578,6 +2582,7 @@ RSpec.describe SessionController do
 
         post "/session.json", params: { login: user.username, password: "myawesomepassword" }
       end
+
       it_behaves_like "failed to continue local login"
     end
 
@@ -2586,6 +2591,7 @@ RSpec.describe SessionController do
         SiteSetting.enable_local_logins_via_email = false
         EmailToken.confirm(email_token.token)
       end
+
       it "doesn't matter, logs in correctly" do
         post "/session.json", params: { login: user.username, password: "myawesomepassword" }
         expect(response.status).to eq(200)
@@ -3554,6 +3560,7 @@ RSpec.describe SessionController do
           SiteSetting.enable_local_logins = false
           post "/session/forgot_password.json", params: { login: user.username }
         end
+
         it_behaves_like "failed to continue local login"
       end
 
@@ -3565,6 +3572,7 @@ RSpec.describe SessionController do
 
           post "/session.json", params: { login: user.username, password: "myawesomepassword" }
         end
+
         it_behaves_like "failed to continue local login"
       end
 
@@ -3574,11 +3582,13 @@ RSpec.describe SessionController do
 
           post "/session.json", params: { login: user.username, password: "myawesomepassword" }
         end
+
         it_behaves_like "failed to continue local login"
       end
 
       context "when local logins via email are disabled" do
         before { SiteSetting.enable_local_logins_via_email = false }
+
         it "does not matter, generates a new token for a made up username" do
           expect do
             post "/session/forgot_password.json", params: { login: user.username }

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe StaticController do
           expect(response.status).to eq(404)
         end
       end
+
       it "rejects fallback paths that traverse outside the fallback directory" do
         Dir.mktmpdir do |tmpdir|
           fallback_dir = File.join(tmpdir, "fallback_assets")
@@ -511,6 +512,7 @@ RSpec.describe StaticController do
         expect(response).to redirect_to("/page/login/1")
       end
     end
+
     context "when the redirect path is invalid" do
       it "redirects to the root URL" do
         post "/login.json", params: { redirect: "test" }

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe TagsController do
 
     context "with tags_listed_by_group enabled" do
       before { SiteSetting.tags_listed_by_group = true }
+
       include_examples "retrieves the right tags"
 
       it "does not list tags of a visible group when they are restricted to a category the user can't see" do
@@ -317,6 +318,7 @@ RSpec.describe TagsController do
 
     context "with tags_listed_by_group disabled" do
       before { SiteSetting.tags_listed_by_group = false }
+
       include_examples "retrieves the right tags"
 
       it "hides tags only used in personal messages from category tag lists for regular users" do
@@ -2367,6 +2369,7 @@ RSpec.describe TagsController do
 
       describe "with `SiteSetting.force_lowercase_tags = false" do
         before { SiteSetting.force_lowercase_tags = false }
+
         it "does not fail if tags already exist" do
           Fabricate(:tag, name: "tag1")
           Fabricate(:tag, name: "CAPITALTAG2")

--- a/spec/requests/theme_javascripts_controller_spec.rb
+++ b/spec/requests/theme_javascripts_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ThemeJavascriptsController do
   let(:javascript_cache) do
     JavascriptCache.create!(content: 'console.log("hello");', theme_field: theme_field)
   end
+
   before { clear_disk_cache }
   after { clear_disk_cache }
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3902,6 +3902,7 @@ RSpec.describe TopicsController do
       let(:deleted_private_topic) { @deleted_private_topic }
 
       let!(:nonexistent_topic_id) { Topic.last.id + 10_000 }
+
       fab!(:secure_accessible_topic) { Fabricate(:topic, category: accessible_category) }
 
       shared_examples "various scenarios" do |expected, request_json:|
@@ -3942,6 +3943,7 @@ RSpec.describe TopicsController do
 
         context "when anonymous with login required" do
           before { SiteSetting.login_required = true }
+
           expected = {
             normal_topic: 302,
             secure_topic: 302,
@@ -3957,6 +3959,7 @@ RSpec.describe TopicsController do
 
         context "when anonymous with login required, requesting json" do
           before { SiteSetting.login_required = true }
+
           expected = {
             normal_topic: 403,
             secure_topic: 403,
@@ -4054,6 +4057,7 @@ RSpec.describe TopicsController do
 
         context "when anonymous with login required" do
           before { SiteSetting.login_required = true }
+
           expected = {
             normal_topic: 302,
             secure_topic: 302,
@@ -5238,6 +5242,7 @@ RSpec.describe TopicsController do
       fab!(:topic_2, :topic)
 
       before { sign_in(user) }
+
       let!(:operation) { { type: "change_category", category_id: "1", silent: true } }
       let!(:topic_ids) { [1, 2, 3] }
 
@@ -7018,6 +7023,7 @@ RSpec.describe TopicsController do
 
     context "when logged in as a TL4 user" do
       before { SiteSetting.enable_category_group_moderation = true }
+
       it "raises an error if the user can't see the topic" do
         user.update!(trust_level: TrustLevel[4])
         sign_in(user)

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -751,6 +751,7 @@ RSpec.describe UploadsController do
 
       context "when the upload is an attachment file" do
         before { upload.update(original_filename: "test.pdf") }
+
         it "redirects to the signed_url_for_path" do
           sign_in(user)
           get secure_url

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe UserBadgesController do
     fab!(:private_message_post)
     let(:topic) { post.topic }
     let(:private_message_topic) { private_message_post.topic }
+
     fab!(:group)
     fab!(:private_category) { Fabricate(:private_category, group: group) }
     fab!(:restricted_topic) { Fabricate(:topic, category: private_category) }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe UsersController do
           expect(response.parsed_body["redirect_to"]).to eq(destination_url)
         end
       end
+
       context "when destination URL doesn't have a query" do
         it "should redirect to the URL" do
           destination_url = "http://thisisasite.com/somepath"
@@ -1029,6 +1030,7 @@ RSpec.describe UsersController do
         end
 
         after { DiscoursePluginRegistry.reset! }
+
         it "creates User record" do
           params = {
             username: "foobar",
@@ -1596,6 +1598,7 @@ RSpec.describe UsersController do
 
     context "when honeypot value is wrong" do
       before { UsersController.any_instance.stubs(:honeypot_value).returns("abc") }
+
       let(:create_params) do
         {
           name: @user.name,
@@ -1605,11 +1608,13 @@ RSpec.describe UsersController do
           password_confirmation: "wrong",
         }
       end
+
       include_examples "honeypot fails"
     end
 
     context "when challenge answer is wrong" do
       before { UsersController.any_instance.stubs(:challenge_value).returns("abc") }
+
       let(:create_params) do
         {
           name: @user.name,
@@ -1619,6 +1624,7 @@ RSpec.describe UsersController do
           challenge: "abc",
         }
       end
+
       include_examples "honeypot fails"
     end
 
@@ -1658,6 +1664,7 @@ RSpec.describe UsersController do
       let(:create_params) do
         { name: @user.name, username: @user.username, password: "", email: @user.email }
       end
+
       include_examples "failed signup"
     end
 
@@ -1670,6 +1677,7 @@ RSpec.describe UsersController do
           email: @user.email,
         }
       end
+
       include_examples "failed signup"
     end
 
@@ -1688,6 +1696,7 @@ RSpec.describe UsersController do
 
     context "when password param is missing" do
       let(:create_params) { { name: @user.name, username: @user.username, email: @user.email } }
+
       include_examples "failed signup"
     end
 
@@ -1695,7 +1704,9 @@ RSpec.describe UsersController do
       let(:create_params) do
         { name: @user.name, username: "Reserved", email: @user.email, password: "strongpassword" }
       end
+
       before { SiteSetting.reserved_usernames = "a|reserved|b" }
+
       include_examples "failed signup"
     end
 
@@ -1708,6 +1719,7 @@ RSpec.describe UsersController do
           password: "strongpassword",
         }
       end
+
       include_examples "failed signup"
     end
 
@@ -1762,6 +1774,7 @@ RSpec.describe UsersController do
         let(:create_params) do
           { name: @user.name, password: "watwatwat", username: @user.username, email: @user.email }
         end
+
         include_examples "failed signup"
       end
 
@@ -2049,6 +2062,7 @@ RSpec.describe UsersController do
     context "while logged in" do
       let(:old_username) { "OrigUsername" }
       let(:new_username) { "#{old_username}1234" }
+
       fab!(:user) { Fabricate(:user, username: "OrigUsername", refresh_auto_groups: true) }
 
       before do
@@ -2251,11 +2265,13 @@ RSpec.describe UsersController do
 
     context "when username is available" do
       before { get "/u/check_username.json", params: { username: "BruceWayne" } }
+
       include_examples "when username is available"
     end
 
     context "when username is unavailable" do
       before { get "/u/check_username.json", params: { username: user1.username } }
+
       include_examples "when username is unavailable"
     end
 
@@ -2264,6 +2280,7 @@ RSpec.describe UsersController do
 
       context "when checking a reserved username" do
         before { get "/u/check_username.json", params: { username: "reserved" } }
+
         include_examples "when username is unavailable"
       end
 
@@ -2273,11 +2290,13 @@ RSpec.describe UsersController do
         context "when user already exists" do
           fab!(:user) { Fabricate(:user, username: "reserved") }
           before { get "/u/check_username.json", params: { username: "reserved" } }
+
           include_examples "when username is unavailable"
         end
 
         context "when user does not exist" do
           before { get "/u/check_username.json", params: { username: "reserved" } }
+
           include_examples "when username is available"
         end
       end
@@ -2293,6 +2312,7 @@ RSpec.describe UsersController do
 
     context "when has invalid characters" do
       before { get "/u/check_username.json", params: { username: "bad username" } }
+
       include_examples "checking an invalid username"
 
       it "should return the invalid characters message" do
@@ -2308,6 +2328,7 @@ RSpec.describe UsersController do
               username: SecureRandom.alphanumeric(SiteSetting.max_username_length.to_i + 1),
             }
       end
+
       include_examples "checking an invalid username"
 
       it 'should return the "too long" message' do
@@ -2326,6 +2347,7 @@ RSpec.describe UsersController do
 
           get "/u/check_username.json", params: { username: "HanSolo" }
         end
+
         include_examples "when username is available"
       end
 
@@ -2337,6 +2359,7 @@ RSpec.describe UsersController do
 
           get "/u/check_username.json", params: { username: "HanSolo" }
         end
+
         include_examples "when username is unavailable"
       end
 
@@ -2347,6 +2370,7 @@ RSpec.describe UsersController do
 
           get "/u/check_username.json", params: { username: "HanSolo", for_user_id: user.id }
         end
+
         include_examples "when username is available"
       end
     end
@@ -3806,6 +3830,7 @@ RSpec.describe UsersController do
 
       context "without an existing email_token" do
         let(:user) { post_user }
+
         before do
           user.email_tokens.each { |t| t.destroy }
           user.reload
@@ -4570,6 +4595,7 @@ RSpec.describe UsersController do
 
   describe "#update_primary_email" do
     let(:user_email) { user1.primary_email }
+
     fab!(:other_email) { Fabricate(:secondary_email, user: user1) }
 
     it "requires login" do
@@ -6576,6 +6602,7 @@ RSpec.describe UsersController do
                second_factor_token: "123456",
              }
       end
+
       it "shows a helpful error message to the user" do
         expect(response.parsed_body["error"]).to eq(I18n.t("login.invalid_second_factor_code"))
       end
@@ -6586,6 +6613,7 @@ RSpec.describe UsersController do
         create_totp
         post "/users/enable_second_factor_totp.json", params: { second_factor_token: "123456" }
       end
+
       it "shows a helpful error message to the user" do
         expect(response.parsed_body["error"]).to eq(I18n.t("login.missing_second_factor_name"))
       end
@@ -6596,6 +6624,7 @@ RSpec.describe UsersController do
         create_totp
         post "/users/enable_second_factor_totp.json", params: { name: "test" }
       end
+
       it "shows a helpful error message to the user" do
         expect(response.parsed_body["error"]).to eq(I18n.t("login.missing_second_factor_code"))
       end
@@ -6670,6 +6699,7 @@ RSpec.describe UsersController do
 
         context "when token is valid" do
           before { stub_server_session_confirmed }
+
           it "should allow second factor for the user to be renamed" do
             put "/users/second_factor.json",
                 params: {
@@ -6715,6 +6745,7 @@ RSpec.describe UsersController do
               .stubs(:server_session)
               .returns("confirmed-session-#{user1.id}" => "true")
           end
+
           it "should allow second factor backup for the user to be disabled" do
             put "/users/second_factor.json",
                 params: {
@@ -7054,6 +7085,7 @@ RSpec.describe UsersController do
 
   describe "#delete_passkey" do
     before { SiteSetting.enable_passkeys = true }
+
     fab!(:passkey) { Fabricate(:passkey_with_random_credential, user: user1) }
 
     it "fails if user does not have a confirmed session" do

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -5,6 +5,7 @@ require "rotp"
 RSpec.describe UsersEmailController do
   fab!(:user)
   let!(:email_token) { Fabricate(:email_token, user: user) }
+
   fab!(:moderator)
 
   describe "#confirm-new-email" do

--- a/spec/serializers/basic_group_serializer_spec.rb
+++ b/spec/serializers/basic_group_serializer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe BasicGroupSerializer do
   subject(:serializer) { described_class.new(group, scope: guardian, root: false) }
 
   let(:guardian) { Guardian.new }
+
   fab!(:group)
 
   describe "#display_name" do

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe BasicUserSerializer do
       let(:serializer) do
         PostActionUserSerializer.new(post_action, scope: Guardian.new(user), root: false)
       end
+
       it "returns the user correctly" do
         expect(serializer.user.username).to eq(user.username)
       end

--- a/spec/serializers/found_user_serializer_spec.rb
+++ b/spec/serializers/found_user_serializer_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe FoundUserSerializer do
 
     context "when status is disabled in site settings" do
       before { SiteSetting.enable_user_status = false }
+
       let(:serializer) { FoundUserSerializer.new(user, root: false, include_status: true) }
 
       it "doesn't add user status" do

--- a/spec/serializers/reviewable_note_serializer_spec.rb
+++ b/spec/serializers/reviewable_note_serializer_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe ReviewableNoteSerializer do
   end
   describe "serialization" do
     let(:json) { serialized_note(note) }
+
     it "includes basic attributes" do
       expect(json[:id]).to eq(note.id)
       expect(json[:content]).to eq("Test note content")
       expect(json[:created_at]).to be_present
       expect(json[:updated_at]).to be_present
     end
+
     it "includes user information" do
       expect(json[:user]).to be_present
       expect(json[:user][:id]).to eq(admin.id)

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe ReviewableScoreSerializer do
       let(:link) do
         "<a href=\"#{Discourse.base_url}/admin/customize/watched_words\">#{I18n.t("reviewables.reasons.links.watched_word")}</a>"
       end
+
       it "tries to guess the watched words if they weren't recorded at the time of flagging" do
         raw = "I'm a post with some bad words like 'bad' and 'words'."
         reviewable.target = Fabricate(:post, raw:)

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe UserSerializer do
     fab!(:user)
     let(:serializer) { UserSerializer.new(user, scope: scope, root: false) }
     let(:json) { serializer.as_json }
+
     fab!(:upload)
     fab!(:upload2, :upload)
 
@@ -321,6 +322,7 @@ RSpec.describe UserSerializer do
 
     describe "second_factor_enabled" do
       let(:scope) { Guardian.new(user) }
+
       it "is false by default" do
         expect(json[:second_factor_enabled]).to eq(false)
       end

--- a/spec/services/design_wizard/apply_spec.rb
+++ b/spec/services/design_wizard/apply_spec.rb
@@ -12,31 +12,37 @@ RSpec.describe DesignWizard::Apply do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:theme_id) }
     it { is_expected.to validate_inclusion_of(:theme_id).in_array(Theme::CORE_THEMES.values) }
+
     it do
       is_expected.to validate_inclusion_of(:base_font).in_array(
         BaseFontSetting.values.map { |font| font[:value] },
       ).allow_nil
     end
+
     it do
       is_expected.to validate_inclusion_of(:heading_font).in_array(
         BaseFontSetting.values.map { |font| font[:value] },
       ).allow_nil
     end
+
     it do
       is_expected.to validate_inclusion_of(:homepage).in_array(
         %w[latest new hot categories],
       ).allow_nil
     end
+
     it do
       is_expected.to validate_inclusion_of(:category_page_style).in_array(
         CategoryPageStyle.values.map { |style| style[:value] },
       ).allow_nil
     end
+
     it do
       is_expected.to validate_inclusion_of(:welcome_banner_location).in_array(
         WelcomeBannerLocation.values.map { |location| location[:value] },
       ).allow_nil
     end
+
     it do
       is_expected.to validate_inclusion_of(:search_experience).in_array(
         SearchExperienceSiteSetting.values.map { |experience| experience[:value] },

--- a/spec/services/email_settings_validator_spec.rb
+++ b/spec/services/email_settings_validator_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe EmailSettingsValidator do
 
     context "when the domain is not provided" do
       let(:domain) { nil }
+
       it "gets the domain from the host" do
         net_smtp_stub.expects(:start).with("gmail.com", username, password, :plain)
         described_class.validate_smtp(

--- a/spec/services/groups/create_spec.rb
+++ b/spec/services/groups/create_spec.rb
@@ -7,22 +7,27 @@ RSpec.describe Groups::Create do
     let(:attributes) { {} }
 
     it { is_expected.to validate_presence_of :name }
+
     it do
       is_expected.to validate_inclusion_of(:mentionable_level).in_array(Group::ALIAS_LEVELS.values)
     end
+
     it do
       is_expected.to validate_inclusion_of(:messageable_level).in_array(Group::ALIAS_LEVELS.values)
     end
+
     it do
       is_expected.to validate_inclusion_of(:visibility_level).in_array(
         Group.visibility_levels.values,
       )
     end
+
     it do
       is_expected.to validate_inclusion_of(:members_visibility_level).in_array(
         Group.visibility_levels.values,
       )
     end
+
     it do
       is_expected.to validate_inclusion_of(:default_notification_level).in_array(
         GroupUser.notification_levels.values,

--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -762,8 +762,10 @@ RSpec.describe InlineUploads do
         expect(raw).to eq("look at this:\n![logo](#{image_upload.short_url})")
       end
     end
+
     context "when raw has an image URL with a square bracket in filename" do
       let!(:image_upload) { Fabricate(:image_upload, original_filename: "image]1.jpg") }
+
       it "does not make broken markdown" do
         origin = "http://foo.bar/#{image_upload.original_filename}"
         raw =

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -757,6 +757,7 @@ RSpec.describe PostAlerter do
     let(:post) do
       create_post_with_alerts(raw: "Hello @here how are you?", user: tl2_user, topic: topic)
     end
+
     fab!(:other_post) { Fabricate(:post, topic: topic) }
 
     before { Jobs.run_immediately! }
@@ -813,6 +814,7 @@ RSpec.describe PostAlerter do
       Fabricate(:group, name: "group", mentionable_level: Group::ALIAS_LEVELS[:everyone])
     end
     let(:post) { create_post_with_alerts(raw: "Hello @group how are you?") }
+
     before { group.add(evil_trout) }
 
     it "notifies users correctly" do
@@ -980,6 +982,7 @@ RSpec.describe PostAlerter do
         %i[watching tracking regular].each do |notification_level|
           context "when notification level is '#{notification_level}'" do
             before { set_topic_notification_level(alice, pm_topic, notification_level) }
+
             let(:expected_notification) do
               notification_level == :watching ? :private_message : :mentioned
             end

--- a/spec/services/problem_check/starttls_disabled_spec.rb
+++ b/spec/services/problem_check/starttls_disabled_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe ProblemCheck::StarttlsDisabled do
   describe ".call" do
     context "with STARTTLS enabled" do
       before { GlobalSetting.stubs(:smtp_enable_start_tls).returns(true) }
+
       it { expect(check).to be_chill_about_it }
     end
 
     context "with STARTTLS disabled" do
       before { GlobalSetting.stubs(:smtp_enable_start_tls).returns(false) }
+
       it do
         expect(check).to have_a_problem.with_priority("high").with_message(
           I18n.t("dashboard.problem.#{check.identifier}"),

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -295,6 +295,7 @@ RSpec.describe PushNotificationPusher do
           payload
         end
       end
+
       it "Allows modifications to the payload passed to the translation" do
         plugin_instance = Plugin::Instance.new
         plugin_instance.register_modifier(:push_notification_pusher_title_payload, &modifier_block)

--- a/spec/services/themes/bulk_destroy_spec.rb
+++ b/spec/services/themes/bulk_destroy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Themes::BulkDestroy do
     it { is_expected.to validate_presence_of(:theme_ids) }
     it { is_expected.to allow_values([1], (1..50).to_a).for(:theme_ids) }
     it { is_expected.not_to allow_values([], (1..51).to_a).for(:theme_ids) }
+
     it do
       is_expected.not_to allow_values([1, 0, -3]).for(:theme_ids).with_message(
         /must all be positive/,

--- a/spec/services/user/action/trigger_post_action_spec.rb
+++ b/spec/services/user/action/trigger_post_action_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe User::Action::TriggerPostAction do
 
     context "when post_action is 'none'" do
       let(:post_action) { "none" }
+
       it "does nothing" do
         expect { action }.not_to change { Post.count }
       end

--- a/spec/services/user/silence_spec.rb
+++ b/spec/services/user/silence_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe User::Silence do
     it { is_expected.to validate_presence_of(:reason) }
     it { is_expected.to validate_presence_of(:silenced_till) }
     it { is_expected.to validate_length_of(:reason).is_at_most(300) }
+
     it do
       is_expected.to validate_length_of(:other_user_ids).as_array.is_at_most(
         User::MAX_SIMILAR_USERS,
       )
     end
+
     it do
       is_expected.to validate_inclusion_of(:post_action).in_array(
         %w[delete delete_replies edit none],

--- a/spec/services/user/suspend_spec.rb
+++ b/spec/services/user/suspend_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe User::Suspend do
     it { is_expected.to validate_presence_of(:reason) }
     it { is_expected.to validate_presence_of(:suspend_until) }
     it { is_expected.to validate_length_of(:reason).is_at_most(300) }
+
     it do
       is_expected.to validate_length_of(:other_user_ids).as_array.is_at_most(
         User::MAX_SIMILAR_USERS,
       )
     end
+
     it do
       is_expected.to validate_inclusion_of(:post_action).in_array(
         %w[delete delete_replies delete_all edit none],

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe UserAnonymizer do
 
     let(:original_email) { "edward@example.net" }
     let(:user) { Fabricate(:user, username: "edward", email: original_email) }
+
     fab!(:another_user, :evil_trout)
 
     it "changes username" do

--- a/spec/services/username_changer_spec.rb
+++ b/spec/services/username_changer_spec.rb
@@ -377,6 +377,7 @@ RSpec.describe UsernameChanger do
 
         context "when using Unicode usernames" do
           before { SiteSetting.unicode_usernames = true }
+
           let(:user) { Fabricate(:user, username: "թռչուն") }
 
           it "it correctly updates mentions" do

--- a/spec/system/admin_backups_spec.rb
+++ b/spec/system/admin_backups_spec.rb
@@ -32,6 +32,7 @@ describe "Admin Backups Page" do
       root_directory + "/" + RailsMultisite::ConnectionManagement.current_db,
     )
   end
+
   after { teardown_local_backups(root_directory: root_directory) }
 
   it "shows a list of backups" do

--- a/spec/system/admin_color_palettes_config_area_spec.rb
+++ b/spec/system/admin_color_palettes_config_area_spec.rb
@@ -299,6 +299,7 @@ describe "Admin Color Palettes Config Area Page" do
         dark_color_scheme: default_dark_scheme,
       )
     end
+
     it "sorts schemes in order: selectable, custom, current default theme, alphabetical for horizon theme" do
       SiteSetting.default_theme_id = Theme.horizon_theme.id
       config_area.visit

--- a/spec/system/admin_logo_spec.rb
+++ b/spec/system/admin_logo_spec.rb
@@ -12,6 +12,7 @@ describe "Admin Logo Page" do
 
   describe "primary section" do
     let(:primary_section_logos) { %i[logo logo_dark large_icon favicon logo_small logo_small_dark] }
+
     it "can upload images and dark versions" do
       logo_page.visit
 
@@ -64,6 +65,7 @@ describe "Admin Logo Page" do
 
   describe "mobile section" do
     let(:mobile_section_logos) { %i[mobile_logo mobile_logo_dark manifest_icon apple_touch_icon] }
+
     it "can upload images and dark versions" do
       logo_page.visit
       logo_page.form.expand_mobile_section
@@ -113,6 +115,7 @@ describe "Admin Logo Page" do
 
   describe "email section" do
     let(:email_section_logos) { %i[digest_logo] }
+
     it "can upload images" do
       logo_page.visit
       logo_page.form.expand_email_section
@@ -156,6 +159,7 @@ describe "Admin Logo Page" do
 
   describe "social media section" do
     let(:social_media_section_logos) { %i[opengraph_image] }
+
     it "can upload images" do
       logo_page.visit
       logo_page.form.expand_social_media_section

--- a/spec/system/admin_site_setting_bulk_action_spec.rb
+++ b/spec/system/admin_site_setting_bulk_action_spec.rb
@@ -4,6 +4,7 @@ describe "Admin Site Setting Bulk Action" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
   let(:banner) { PageObjects::Components::AdminChangesBanner.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
+
   fab!(:admin)
 
   before { sign_in(admin) }

--- a/spec/system/admin_site_setting_category_spec.rb
+++ b/spec/system/admin_site_setting_category_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin site setting category" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
   fab!(:category)
 

--- a/spec/system/admin_site_setting_enum_spec.rb
+++ b/spec/system/admin_site_setting_enum_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin site setting enum" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
 
   before { sign_in(admin) }

--- a/spec/system/admin_site_setting_group_spec.rb
+++ b/spec/system/admin_site_setting_group_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin site setting group" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
   fab!(:group)
 

--- a/spec/system/admin_site_setting_label_formatting_spec.rb
+++ b/spec/system/admin_site_setting_label_formatting_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin Site Setting Formatting" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
 
   before { sign_in(admin) }

--- a/spec/system/admin_site_setting_locale_spec.rb
+++ b/spec/system/admin_site_setting_locale_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin Site Setting Locales" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
 
   before do

--- a/spec/system/admin_site_setting_requires_confirmation_spec.rb
+++ b/spec/system/admin_site_setting_requires_confirmation_spec.rb
@@ -3,6 +3,7 @@
 describe "Admin Site Setting Requires Confirmation" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
+
   fab!(:admin)
 
   before do

--- a/spec/system/admin_site_setting_search_spec.rb
+++ b/spec/system/admin_site_setting_search_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin Site Setting Search" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
 
   before do

--- a/spec/system/admin_site_setting_string_spec.rb
+++ b/spec/system/admin_site_setting_string_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Admin site setting string" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
   fab!(:admin)
 
   before { sign_in(admin) }

--- a/spec/system/admin_site_setting_topic_chooser_spec.rb
+++ b/spec/system/admin_site_setting_topic_chooser_spec.rb
@@ -3,6 +3,7 @@
 describe "Admin Site Setting Topic Selector Component" do
   let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
   let(:banner) { PageObjects::Components::AdminChangesBanner.new }
+
   fab!(:admin)
   fab!(:topic) { Fabricate(:topic, title: "Moderator guide", fancy_title: "Moderator guide") }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/spec/system/admin_whats_new_spec.rb
+++ b/spec/system/admin_whats_new_spec.rb
@@ -3,6 +3,7 @@
 describe "Admin What's New Page" do
   let(:whats_new_page) { PageObjects::Pages::AdminWhatsNew.new }
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
+
   fab!(:admin)
 
   before do

--- a/spec/system/categories_page_spec.rb
+++ b/spec/system/categories_page_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Categories Page" do
   fab!(:subcategory) { Fabricate(:category, parent_category: category) }
   fab!(:topics) { Fabricate.times(3, :topic_with_op, category: subcategory) }
   let(:category_page) { PageObjects::Pages::Category.new }
+
   before { CategoryFeaturedTopic.feature_topics }
 
   describe "hashtag icons in category descriptions" do
@@ -28,6 +29,7 @@ RSpec.describe "Categories Page" do
 
   describe "subcategories_with_featured_topics" do
     before { SiteSetting.desktop_category_page_style = "subcategories_with_featured_topics" }
+
     it "displays subcategories and topics" do
       category_page.visit_categories
 

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -24,11 +24,13 @@ describe "Default to Subcategory when parent Category doesn't allow posting" do
 
   describe "logged in user" do
     before { sign_in(user) }
+
     describe "default_subcategory_on_read_only_category setting enabled and can't post on parent category" do
       before { SiteSetting.default_subcategory_on_read_only_category = true }
 
       describe "default_composer_category set" do
         before { SiteSetting.default_composer_category = default_latest_category.id }
+
         describe "Can't post on parent category" do
           describe "Category has subcategory" do
             it "should have 'New Topic' button enabled and default Subcategory set in the composer" do
@@ -40,6 +42,7 @@ describe "Default to Subcategory when parent Category doesn't allow posting" do
               expect(select_kit).to have_selected_value(subcategory.id)
             end
           end
+
           describe "Category does not have subcategory" do
             it "should have the 'New Topic' button enabled and no category set in the composer" do
               category_page.visit(category_with_no_subcategory)
@@ -53,6 +56,7 @@ describe "Default to Subcategory when parent Category doesn't allow posting" do
             end
           end
         end
+
         describe "Can post on home page" do
           it "should have the default category set in the composer" do
             page.visit("latest")
@@ -70,6 +74,7 @@ describe "Default to Subcategory when parent Category doesn't allow posting" do
           SiteSetting.default_composer_category = ""
           SiteSetting.allow_uncategorized_topics = false
         end
+
         describe "Can't post on parent category" do
           describe "Category does not have subcategory" do
             it "opens composer with no category selected" do
@@ -83,6 +88,7 @@ describe "Default to Subcategory when parent Category doesn't allow posting" do
             end
           end
         end
+
         describe "Can post on home page" do
           it "composer should open" do
             page.visit("latest")

--- a/spec/system/composer/post_validation_spec.rb
+++ b/spec/system/composer/post_validation_spec.rb
@@ -35,11 +35,13 @@ describe "Composer Post Validations" do
 
   describe "trust level 0 user" do
     before { sign_in(tl0_user) }
+
     include_examples "post length validation"
   end
 
   describe "trust level 1 user" do
     before { sign_in(tl1_user) }
+
     include_examples "post length validation"
   end
 

--- a/spec/system/composer/prosemirror_images_spec.rb
+++ b/spec/system/composer/prosemirror_images_spec.rb
@@ -168,6 +168,7 @@ describe "Composer - ProseMirror - Images" do
 
   describe "auto-grid functionality with enable_auto_grid_images" do
     before { SiteSetting.enable_auto_grid_images = true }
+
     it "automatically wraps 3+ uploaded images in a grid" do
       open_composer
       file_path_1 = file_from_fixtures("logo.png", "images").path

--- a/spec/system/composer/prosemirror_pasting_spec.rb
+++ b/spec/system/composer/prosemirror_pasting_spec.rb
@@ -128,6 +128,7 @@ describe "Composer - ProseMirror - Pasting content" do
 
   context "when unauthorized to upload" do
     before { SiteSetting.authorized_extensions = "" }
+
     it "allows pasting text" do
       cdp.allow_clipboard
       open_composer

--- a/spec/system/discourse_connect_provider_spec.rb
+++ b/spec/system/discourse_connect_provider_spec.rb
@@ -11,6 +11,7 @@ describe "Discourse Connect Provider" do
   fab!(:user) { Fabricate(:user, username: "john", password: "supersecurepassword") }
   let(:login_form) { PageObjects::Pages::Login.new }
   let!(:return_url) { "http://localhost:#{sso_port}/test/url" }
+
   before do
     SiteSetting.enable_discourse_connect_provider = true
     SiteSetting.discourse_connect_provider_secrets = "localhost|Test"
@@ -71,6 +72,7 @@ describe "Discourse Connect Provider" do
   context "with two-factor authentication" do
     let!(:user_second_factor) { Fabricate(:user_second_factor_totp, user: user) }
     let!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup, user: user) }
+
     fab!(:other_user) { Fabricate(:user, username: "jane", password: "supersecurepassword") }
 
     it "redirects back to the return_sso_url" do

--- a/spec/system/discourse_connect_spec.rb
+++ b/spec/system/discourse_connect_spec.rb
@@ -46,6 +46,7 @@ describe "Discourse Connect" do
 
         context "when visiting /" do
           before { visit "/" }
+
           it_behaves_like "shows the homepage"
         end
 
@@ -60,6 +61,7 @@ describe "Discourse Connect" do
 
         context "when visiting /login" do
           before { visit "/login" }
+
           it_behaves_like "redirects to SSO"
         end
       end
@@ -69,6 +71,7 @@ describe "Discourse Connect" do
 
         context "when visiting /" do
           before { visit "/" }
+
           it_behaves_like "shows the homepage"
         end
 
@@ -83,6 +86,7 @@ describe "Discourse Connect" do
 
         context "when visiting /login" do
           before { visit "/login" }
+
           it_behaves_like "redirects to SSO"
         end
 
@@ -106,6 +110,7 @@ describe "Discourse Connect" do
 
         context "when visiting /" do
           before { visit "/" }
+
           it_behaves_like "shows the login splash"
         end
 
@@ -120,6 +125,7 @@ describe "Discourse Connect" do
 
         context "when visiting /login" do
           before { visit "/login" }
+
           it_behaves_like "redirects to SSO"
         end
       end
@@ -129,11 +135,13 @@ describe "Discourse Connect" do
 
         context "when visiting /" do
           before { visit "/" }
+
           it_behaves_like "redirects to SSO"
         end
 
         context "when visiting /login" do
           before { visit "/login" }
+
           it_behaves_like "redirects to SSO"
         end
       end

--- a/spec/system/edit_category_general_spec.rb
+++ b/spec/system/edit_category_general_spec.rb
@@ -5,6 +5,7 @@ describe "Edit Category General" do
   fab!(:category)
   let(:category_page) { PageObjects::Pages::Category.new }
   let(:form) { PageObjects::Components::FormKit.new(".form-kit") }
+
   before { sign_in(admin) }
 
   context "when changing background color" do

--- a/spec/system/emojis/emoji_deny_list_spec.rb
+++ b/spec/system/emojis/emoji_deny_list_spec.rb
@@ -4,12 +4,14 @@ describe "Emoji deny list" do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:composer) { PageObjects::Components::Composer.new }
   let(:emoji_picker) { PageObjects::Components::EmojiPicker.new }
+
   fab!(:admin)
 
   before { sign_in(admin) }
 
   describe "when editing admin settings" do
     before { SiteSetting.emoji_deny_list = "" }
+
     let(:site_settings_page) { PageObjects::Pages::AdminSiteSettings.new }
 
     it "allows admin to update emoji deny list" do

--- a/spec/system/groups/group_members_spec.rb
+++ b/spec/system/groups/group_members_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Group members" do
   let(:group_page) { PageObjects::Pages::Group.new }
+
   fab!(:admin)
   fab!(:group)
 

--- a/spec/system/groups/group_spec.rb
+++ b/spec/system/groups/group_spec.rb
@@ -5,6 +5,7 @@ describe "Group" do
   let(:group_index_page) { PageObjects::Pages::GroupIndex.new }
   let(:group_form_page) { PageObjects::Pages::GroupForm.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
+
   fab!(:admin)
   fab!(:group)
 
@@ -93,6 +94,7 @@ describe "Group" do
 
   describe "update default notification level" do
     let(:default_notifications_modal) { PageObjects::Modals::GroupDefaultNotifications.new }
+
     fab!(:user1, :user)
     fab!(:user2, :user)
 

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe "Glimmer Header" do
   let(:header) { PageObjects::Pages::Header.new }
   let(:search) { PageObjects::Pages::Search.new }
+
   fab!(:current_user, :user)
   fab!(:topic)
 

--- a/spec/system/locale_spec.rb
+++ b/spec/system/locale_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "Locale choice" do
         },
       )
     end
+
     after { JsLocaleHelper.clear_cache! }
 
     it "handles fallback correctly" do

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -306,6 +306,7 @@ shared_examples "login scenarios" do
   context "with two-factor authentication" do
     let!(:user_second_factor) { Fabricate(:user_second_factor_totp, user: user) }
     let!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup, user: user) }
+
     fab!(:other_user) { Fabricate(:user, username: "jane", password: "supersecurepassword") }
 
     before do

--- a/spec/system/post_menu_spec.rb
+++ b/spec/system/post_menu_spec.rb
@@ -149,6 +149,7 @@ describe "Post menu" do
         expect(topic_page).to have_post_action_button(post, :admin)
         expect(topic_page).to have_post_action_button(post2, :admin)
       end
+
       it "does not display the admin button when the group is not allowed" do
         SiteSetting.change_post_ownership_allowed_groups = ""
         sign_in(allowed_group_user)

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -965,6 +965,7 @@ describe "Request tracking" do
 
     context "when logged in" do
       before { sign_in(user) }
+
       let(:expected_username) { user.username }
 
       include_examples "logs piggyback and beacon entries on home and topic"

--- a/spec/system/search_menu_hashtag_spec.rb
+++ b/spec/system/search_menu_hashtag_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Search menu hashtag autocomplete" do
   let(:search_page) { PageObjects::Pages::Search.new }
+
   fab!(:user)
   fab!(:category) { Fabricate(:category, name: "UX", slug: "ux") }
   fab!(:tag) { Fabricate(:tag, name: "design") }

--- a/spec/system/social_authentication_spec.rb
+++ b/spec/system/social_authentication_spec.rb
@@ -206,6 +206,7 @@ shared_examples "social authentication scenarios" do
         SiteSetting.linkedin_oidc_client_secret = "abcde"
         SiteSetting.enable_linkedin_oidc_logins = true
       end
+
       after { reset_omniauth_config(:linkedin_oidc) }
 
       it "fills the signup form" do
@@ -249,6 +250,7 @@ shared_examples "social authentication scenarios" do
         SiteSetting.auth_overrides_name = true
         SiteSetting.auth_overrides_username = true
       end
+
       after { reset_omniauth_config(:google_oauth2) }
 
       it "fills the signup form and disables the inputs" do
@@ -273,6 +275,7 @@ shared_examples "social authentication scenarios" do
         SiteSetting.enable_google_oauth2_logins = true
         SiteSetting.auth_skip_create_confirm = true
       end
+
       after { reset_omniauth_config(:google_oauth2) }
 
       it "creates the account directly" do
@@ -300,6 +303,7 @@ shared_examples "social authentication scenarios" do
         SiteSetting.enable_google_oauth2_logins = true
         SiteSetting.enable_local_logins = false
       end
+
       after { reset_omniauth_config(:google_oauth2) }
 
       context "when login is required" do
@@ -564,6 +568,7 @@ shared_examples "social authentication scenarios" do
         SiteSetting.linkedin_oidc_client_secret = "abcde"
         SiteSetting.enable_linkedin_oidc_logins = true
       end
+
       after { reset_omniauth_config(:linkedin_oidc) }
 
       it "logs in user" do

--- a/spec/system/user_page/hide_from_public_spec.rb
+++ b/spec/system/user_page/hide_from_public_spec.rb
@@ -2,6 +2,7 @@
 
 describe "hide_user_profiles_from_public" do
   let(:user) { Fabricate(:user) }
+
   before { SiteSetting.hide_user_profiles_from_public = true }
 
   it "displays an error when navigating straight to a profile" do

--- a/spec/system/user_page/user_invites_spec.rb
+++ b/spec/system/user_page/user_invites_spec.rb
@@ -40,6 +40,7 @@ describe "User invites" do
 
   describe "expired invites" do
     let(:user_invite_expired_page) { PageObjects::Pages::UserInvitedExpired.new }
+
     it "correctly shows expired invites" do
       user_invite_expired_page.visit(user)
       expect(user_invite_expired_page.invites_list.size).to eq(invites_expired.size)

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -174,6 +174,7 @@ describe "Welcome banner" do
 
       context "for text color setting" do
         let(:red) { "#ff0000" }
+
         before { SiteSetting.welcome_banner_text_color = red }
 
         it "doesn't set text color without background image" do

--- a/themes/horizon/spec/system/horizon_high_level_spec.rb
+++ b/themes/horizon/spec/system/horizon_high_level_spec.rb
@@ -20,6 +20,7 @@ describe "Horizon theme | High level" do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
   let(:palette_selector) { PageObjects::Components::UserColorPaletteSelector.new }
+
   fab!(:incorrect_scheme) do
     Fabricate(:color_scheme, name: "Incorrect Scheme", user_selectable: true)
   end

--- a/themes/horizon/spec/system/sidebar_topic_button_spec.rb
+++ b/themes/horizon/spec/system/sidebar_topic_button_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe "Sidebar New Topic Button" do
   before { upload_theme }
+
   fab!(:group)
   fab!(:user) { Fabricate(:user, trust_level: 3, groups: [group]) }
   fab!(:category)


### PR DESCRIPTION
This commit adds the blank lines required by the following RuboCop rules:

- `RSpec/EmptyLineAfterExample`
- `RSpec/EmptyLineAfterExampleGroup`
- `RSpec/EmptyLineAfterFinalLet`
- `RSpec/EmptyLineAfterHook`