### PR TITLE
FIX: Revert ruby-i18n update in #41242 and add regression test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     chunky_png (1.4.0)
     coderay (1.1.3)
     colored2 (4.0.3)
-    concurrent-ruby (1.3.8)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     console (1.37.0)
       fiber-annotation
@@ -283,7 +283,7 @@ GEM
       reline
     htmlentities (4.4.2)
     http_accept_language (2.1.1)
-    i18n (1.15.2)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_optim (0.32.0)
       exifr (~> 1.2, >= 1.2.2)
@@ -1023,7 +1023,7 @@ CHECKSUMS
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   colored2 (4.0.3) sha256=63e1038183976287efc43034f5cca17fb180b4deef207da8ba78d051cbce2b37
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   console (1.37.0) sha256=8093b286c2595a063849c098594fee5155ecc7967d36f3aa8cbe7569c8f3efd7
   cose (1.3.1) sha256=d5d4dbcd6b035d513edc4e1ab9bc10e9ce13b4011c96e3d1b8fe5e6413fd6de5
@@ -1088,7 +1088,7 @@ CHECKSUMS
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
   htmlentities (4.4.2) sha256=bbafbdf69f2eca9262be4efef7e43e6a1de54c95eb600f26984f71d2fe96c5c3
   http_accept_language (2.1.1) sha256=0043f0d55a148cf45b604dbdd197cb36437133e990016c68c892d49dbea31634
-  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_optim (0.32.0) sha256=457d5ea28ee93244c2aabc7134e06455587fb670f210e88e1be40aea882c2ba3
   image_size (3.6.0) sha256=1b9c4196cb658bf503a887920543a3991e927a4b767a5c770fb9665bce0dcb28
   in_threads (1.6.0) sha256=91a7e6138d279dc632f59b8a9a409e47148948e297c0f69c92f9a2479a182149

--- a/spec/lib/i18n/config_spec.rb
+++ b/spec/lib/i18n/config_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe I18n::Config do
+  it "does not leak an explicit locale into a new thread" do
+    original_default_locale = I18n.default_locale
+    original_locale = I18n.locale
+
+    I18n.default_locale = :en
+    I18n.locale = :zh_CN
+
+    other_thread_locale = Thread.new { I18n.locale }.value
+
+    expect(other_thread_locale).to eq(:en)
+  ensure
+    I18n.default_locale = original_default_locale
+    I18n.locale = original_locale
+  end
+end


### PR DESCRIPTION
In #41242, we
updated the ruby-i18n to 1.15.x, however, this upstream version has a defection.

---

The configuration is now stored on the Fiber:

```ruby
Fiber[:i18n_config]
```

The new implementation detects when a Fiber inherited a configuration owned by another Fiber:

```ruby
if current.respond_to?(:owned_by?) && !current.owned_by?(Fiber.current)
  current = current.dup
  Fiber[:i18n_config] = current
end
```

The problem is in `I18n::Config#initialize_copy`:

```ruby
def initialize_copy(other)
  @owner = Fiber.current
end
```

It changes the owner of the copied configuration, but it does not clear the copied `@locale`, i.e., Child Fiber inherits parent's explicit `@locale`.

So if the parent Fiber currently has:

```ruby
I18n.locale == :zh_CN
```

a child Fiber can inherit a copied configuration that still contains:

```ruby
@locale == :zh_CN
```

even though that child Fiber now represents a different request that should resolve to English.

---

This cause a problem in discourse. When the user is using a display language different from the default language. Say, Chinese as the site default language and English as the display language, pages may accidentally display in Chinese, or a combination of English and Chinese.

This commit rollback the version update and added some spec, maybe pausing the update until upstream fix that will be a great idea.

Related issue: https://github.com/ruby-i18n/i18n/issues/742