### PR TITLE
DEV: Report backport push failures on the PR instead of crashing

### DIFF
--- a/script/backport.rb
+++ b/script/backport.rb
@@ -160,8 +160,23 @@ backport_versions.each do |version|
     next
   end
 
-  # Push the backport branch
-  run("git", "push", "-f", "origin", backport_branch)
+  push = run("git", "push", "-f", "origin", backport_branch, allow_failure: true)
+
+  unless push.success
+    puts "Failed to push #{backport_branch}:\n#{push.stderr}"
+    results << {
+      version: version,
+      success: false,
+      error: push.stderr,
+      release_branch: release_branch,
+      backport_branch: backport_branch,
+      cherry_pick_range: cherry_pick_range,
+      backport_title: backport_title,
+      backport_body: backport_body,
+    }
+    run("git", "checkout", "main", allow_failure: true)
+    next
+  end
 
   # Create or update PR
   # Try to create the PR
@@ -230,7 +245,7 @@ if failed.any?
         git checkout -B #{r[:backport_branch]} FETCH_HEAD
         git cherry-pick #{r[:cherry_pick_range]}
 
-        # Resolve the conflicts, then push the branch and open the PR:
+        # Resolve any conflicts, then push the branch and open the PR:
         git push -f #{repo_url} #{r[:backport_branch]}:#{r[:backport_branch]}
         #{gh_create}
         ```


### PR DESCRIPTION
When the push of a backport branch fails, the script raised and exited before posting the summary comment. The PR was left with a "Backport started" comment and nothing else, and any remaining target versions were skipped. This happened when a PR changed a workflow file and the push token did not have the `workflow` scope.

- Treat a failed `git push` like a failed cherry-pick: record it, move on to the next version, and include the manual instructions in the summary comment.
- Reword the manual instructions since they now also cover the case where the cherry-pick applied cleanly.