### PR TITLE
DEV: Pin the compiler defaults the plugin tsconfig relies on

### DIFF
--- a/frontend/discourse-types/tsconfig-plugin.json
+++ b/frontend/discourse-types/tsconfig-plugin.json
@@ -6,11 +6,33 @@
     "experimentalDecorators": true,
     "allowJs": true,
     "skipLibCheck": true,
+    "strict": false,
+    "noUncheckedSideEffectImports": false,
     "noEmit": true,
     "noEmitOnError": false,
     "declaration": true,
     "outDir": "declarations",
     "composite": true,
-    "typeRoots": ["./external-types"]
+    "typeRoots": ["./external-types"],
+    "types": [
+      "discourse-i18n",
+      "ember-compat__tracked-built-ins",
+      "ember-modifier",
+      "ember-qunit",
+      "ember-source",
+      "ember-truth-helpers",
+      "ember__render-modifiers",
+      "ember__string",
+      "ember__test-helpers",
+      "floating-ui__dom",
+      "glimmer__component",
+      "glimmer__syntax",
+      "glint__template",
+      "jquery",
+      "pretender",
+      "qunit",
+      "rsvp",
+      "sinon"
+    ]
   }
 }


### PR DESCRIPTION
TypeScript 6 changes several defaults. The one that matters for plugins is `types`, which stops defaulting to every package under `typeRoots` and becomes an empty array. Plugins rely on that auto-inclusion to see the ambient `@glint/template` declarations in `external-types`, and without them template-only components fail declaration emit with a "not portable" error.

This lists the `external-types` stubs explicitly and pins `strict` and `noUncheckedSideEffectImports` to their current values. Nothing changes under TypeScript 5.9, which lets this ship in `@discourse/types` ahead of the compiler upgrade.