### PR TITLE
FIX: Rebuild theme javascript when the compiler version changes on save

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -171,9 +171,12 @@ class Theme < ActiveRecord::Base
 
     reload
     settings_field&.ensure_baked! # Other fields require setting to be **baked**
+
+    stale_extra_js =
+      theme_fields.any? { |f| f.extra_js_field? && f.compiler_version != Theme.compiler_version }
     theme_fields.each(&:ensure_baked!)
 
-    update_javascript_cache! if any_extra_js_fields_changed
+    update_javascript_cache! if any_extra_js_fields_changed || stale_extra_js
 
     remove_from_cache!
     ColorScheme.hex_cache.clear

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AssetProcessor
-  BASE_COMPILER_VERSION = 119
+  BASE_COMPILER_VERSION = 120
 
   BUNDLE =
     PrecompiledBundle.new(

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -794,6 +794,19 @@ RSpec.describe Theme do
         end
     end
 
+    it "rebuilds the javascript cache when saved with a stale compiler version" do
+      theme.set_field(target: :extra_js, name: "test.js.es6", value: "const hello = 'world';")
+      theme.save!
+      theme.reload.javascript_cache.update_columns(content: "stale")
+
+      theme.save!
+      expect(theme.reload.javascript_cache.content).to eq("stale")
+
+      ThemeField.where(theme_id: theme.id).update_all(compiler_version: "OLD_HASH")
+      theme.save!
+      expect(theme.reload.javascript_cache.content).to include("compatModules")
+    end
+
     it "recompiles when the hostname changes" do
       theme.set_field(target: :settings, name: :yaml, value: "name: bob")
       theme.set_field(


### PR DESCRIPTION
We were only rebuilding if the theme_fields themselves were changed. We also need to rebuild if only the `AssetProcessor::VERSION` changes. 