### PR TITLE
FEATURE: Allow Ask AI without embeddings

### DIFF
--- a/plugins/discourse-ai/lib/discoveries.rb
+++ b/plugins/discourse-ai/lib/discoveries.rb
@@ -53,7 +53,6 @@ module DiscourseAi
         return false if !SiteSetting.discourse_ai_enabled || !SiteSetting.ai_ask_ai_enabled
         return false if !user.in_any_groups?(SiteSetting.ai_ask_ai_allowed_groups_map)
         return false if Guardian.new(user).is_silenced?
-        return false if !retrieval_configured?
 
         agent = discover_agent
         if agent.nil? || !agent.enabled? || !user.in_any_groups?(agent.allowed_group_ids.to_a)
@@ -241,10 +240,6 @@ module DiscourseAi
 
       def work_token(user_id, request_id)
         "#{user_id}:#{request_id.downcase}"
-      end
-
-      def retrieval_configured?
-        SiteSetting.ai_embeddings_enabled && SiteSetting.ai_embeddings_semantic_search_enabled
       end
     end
   end

--- a/plugins/discourse-ai/lib/discoveries/retrieval.rb
+++ b/plugins/discourse-ai/lib/discoveries/retrieval.rb
@@ -32,7 +32,7 @@ module DiscourseAi
         rankings =
           if self.class.explicit_filters_except_private_messages?(query)
             [retrieve(@lexical_retriever, query)]
-          elsif semantic_query.blank? ||
+          elsif !DiscourseAi::Embeddings.enabled? || semantic_query.blank? ||
                 self.class.explicit_filters_except_private_messages?(keyword_query)
             [retrieve(@lexical_retriever, keyword_query)]
           else

--- a/plugins/discourse-ai/spec/jobs/regular/stream_discover_reply_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/stream_discover_reply_spec.rb
@@ -116,6 +116,9 @@ describe Jobs::StreamDiscoverReply do
   end
 
   it "publishes searching, validated sources, streamed answer, and completion events" do
+    SiteSetting.ai_embeddings_enabled = false
+    SiteSetting.ai_embeddings_semantic_search_enabled = false
+
     messages =
       MessageBus
         .track_publish("/discourse-ai/discoveries") do

--- a/plugins/discourse-ai/spec/lib/discoveries/retrieval_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discoveries/retrieval_spec.rb
@@ -13,6 +13,13 @@ describe DiscourseAi::Discoveries::Retrieval do
   fab!(:post_2) { Fabricate(:post, topic: topic_2, user: staff_user, raw: "Second useful answer") }
   fab!(:post_3) { Fabricate(:post, topic: topic_3, raw: "Third useful answer") }
   fab!(:private_post) { Fabricate(:post, topic: private_topic, raw: "Private answer") }
+  fab!(:embedding_definition)
+
+  before do
+    enable_current_plugin
+    SiteSetting.ai_embeddings_selected_model = embedding_definition.id
+    SiteSetting.ai_embeddings_enabled = true
+  end
 
   def source(post, excerpt: post.raw)
     {
@@ -27,6 +34,22 @@ describe DiscourseAi::Discoveries::Retrieval do
   end
 
   describe "#call" do
+    it "uses semantic retrieval with embeddings configured even when full-page semantic search is disabled" do
+      SiteSetting.ai_embeddings_semantic_search_enabled = false
+
+      result =
+        described_class.new(
+          user:,
+          lexical_retriever: ->(_query) { [source(post_1)] },
+          semantic_retriever: ->(_query) { [source(post_2)] },
+        ).call("猫")
+
+      expect(result.candidates.map { |candidate| candidate.fetch("topic_id") }).to contain_exactly(
+        topic_1.id,
+        topic_2.id,
+      )
+    end
+
     it "uses separate prepared queries for keyword and semantic retrieval" do
       lexical_retriever = instance_spy(Proc, call: [source(post_1)])
       semantic_retriever = instance_spy(Proc, call: [source(post_2)])
@@ -335,6 +358,17 @@ describe DiscourseAi::Discoveries::Retrieval do
     before { SearchIndexer.enable }
     after { SearchIndexer.disable }
 
+    it "finds keyword matches without requesting embeddings when embeddings are disabled" do
+      SiteSetting.ai_embeddings_enabled = false
+      embedding_request = stub_request(:post, embedding_definition.url).to_return(status: 500)
+      SearchIndexer.index(post_1, force: true)
+
+      result = described_class.new(user:).call("useful")
+
+      expect(result.candidates.map { |candidate| candidate.fetch("topic_id") }).to eq([topic_1.id])
+      expect(embedding_request).not_to have_been_requested
+    end
+
     it "preserves category filters, includes subcategories, and excludes inaccessible topics" do
       child_category = Fabricate(:category, parent_category: category)
       token = "discoveryneedle#{SecureRandom.hex(6)}"
@@ -352,7 +386,9 @@ describe DiscourseAi::Discoveries::Retrieval do
       )
     end
 
-    it "finds only personal messages the user can see" do
+    it "finds only personal messages the user can see without embeddings" do
+      SiteSetting.ai_embeddings_enabled = false
+      embedding_request = stub_request(:post, embedding_definition.url).to_return(status: 500)
       token = "privateneedle#{SecureRandom.hex(6)}"
       personal_message = Fabricate(:private_message_post, recipient: user, raw: token)
       inaccessible_message = Fabricate(:private_message_post, raw: token)
@@ -360,11 +396,12 @@ describe DiscourseAi::Discoveries::Retrieval do
         SearchIndexer.index(post, force: true)
       end
 
-      result = described_class.new(user:).call("#{token} in:messages", semantic_query: "")
+      result = described_class.new(user:).call("#{token} in:messages")
 
       expect(result.candidates.map { |candidate| candidate.fetch("topic_id") }).to eq(
         [personal_message.topic_id],
       )
+      expect(embedding_request).not_to have_been_requested
     end
   end
 end

--- a/plugins/discourse-ai/spec/lib/discoveries_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discoveries_spec.rb
@@ -21,7 +21,7 @@ describe DiscourseAi::Discoveries do
   end
 
   describe ".enabled_for_user?" do
-    it "allows a user who satisfies the site, agent, model, and retrieval policies" do
+    it "allows a user who satisfies the site, agent, and model policies" do
       expect(described_class.enabled_for_user?(user)).to eq(true)
     end
 
@@ -49,10 +49,17 @@ describe DiscourseAi::Discoveries do
       expect(described_class.enabled_for_user?(user)).to eq(true)
     end
 
-    it "requires semantic search" do
+    it "allows Ask AI when full-page semantic search is disabled" do
       SiteSetting.ai_embeddings_semantic_search_enabled = false
 
-      expect(described_class.enabled_for_user?(user)).to eq(false)
+      expect(described_class.enabled_for_user?(user)).to eq(true)
+    end
+
+    it "allows Ask AI when embeddings are disabled and no embedding model is selected" do
+      SiteSetting.ai_embeddings_enabled = false
+      SiteSetting.ai_embeddings_selected_model = ""
+
+      expect(described_class.enabled_for_user?(user)).to eq(true)
     end
   end
 

--- a/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
@@ -29,6 +29,19 @@ describe DiscourseAi::Discover::DiscoveriesController do
       allowed_group.add(user)
     end
 
+    it "queues an Ask AI reply when embeddings and semantic search are disabled" do
+      group.add(user)
+      SiteSetting.ai_embeddings_enabled = false
+      SiteSetting.ai_embeddings_semantic_search_enabled = false
+
+      expect_enqueued_with(job: :stream_discover_reply, args: { user_id: user.id, request_id: }) do
+        post "/discourse-ai/discoveries/reply", params: { query: "What is Discourse?", request_id: }
+      end
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["request_id"]).to eq(request_id)
+    end
+
     context "when the user doesn't have access to the agent" do
       it "returns a 403" do
         post "/discourse-ai/discoveries/reply", params: { query: "What is Discourse?", request_id: }

--- a/plugins/discourse-ai/spec/system/ai_discoveries_search_mode_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_discoveries_search_mode_spec.rb
@@ -28,7 +28,10 @@ describe "AI Discoveries search modes" do
 
   after { SearchIndexer.disable }
 
-  it "enables Ask AI as the default for new users" do
+  it "enables Ask AI as the default for new users without embeddings or semantic search" do
+    SiteSetting.ai_embeddings_enabled = false
+    SiteSetting.ai_embeddings_semantic_search_enabled = false
+
     visit "/"
     discoveries_search.open.fill_query("miyazaki").select_ask
 


### PR DESCRIPTION
Use keyword search when embeddings are disabled or no embedding model is available. Ask AI no longer requires full-page semantic search to be enabled.