### PR TITLE
DEV: Log Ask AI queries, responses, and outcomes

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1328,6 +1328,50 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: ask_ai_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ask_ai_logs (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    query text NOT NULL,
+    keyword_query text,
+    semantic_query text,
+    query_locale character varying,
+    candidate_post_ids bigint[] DEFAULT '{}'::bigint[] NOT NULL,
+    source_post_ids bigint[] DEFAULT '{}'::bigint[] NOT NULL,
+    answer_title text,
+    answer text,
+    suggested_follow_up text,
+    ask_outcome integer,
+    failure_stage integer,
+    asked_at timestamp(6) without time zone NOT NULL,
+    time_to_first_answer_ms integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: ask_ai_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ask_ai_logs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ask_ai_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ask_ai_logs_id_seq OWNED BY public.ask_ai_logs.id;
+
+
+--
 -- Name: assignments; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -13309,6 +13353,13 @@ ALTER TABLE ONLY public.application_requests ALTER COLUMN id SET DEFAULT nextval
 
 
 --
+-- Name: ask_ai_logs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ask_ai_logs ALTER COLUMN id SET DEFAULT nextval('public.ask_ai_logs_id_seq'::regclass);
+
+
+--
 -- Name: assignments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -15701,6 +15752,14 @@ ALTER TABLE ONLY public.application_requests
 
 ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: ask_ai_logs ask_ai_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ask_ai_logs
+    ADD CONSTRAINT ask_ai_logs_pkey PRIMARY KEY (id);
 
 
 --
@@ -19743,6 +19802,20 @@ CREATE INDEX index_api_keys_on_user_id ON public.api_keys USING btree (user_id);
 --
 
 CREATE UNIQUE INDEX index_application_requests_on_date_and_req_type ON public.application_requests USING btree (date, req_type);
+
+
+--
+-- Name: index_ask_ai_logs_on_asked_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ask_ai_logs_on_asked_at ON public.ask_ai_logs USING btree (asked_at);
+
+
+--
+-- Name: index_ask_ai_logs_on_user_id_and_asked_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ask_ai_logs_on_user_id_and_asked_at ON public.ask_ai_logs USING btree (user_id, asked_at);
 
 
 --
@@ -24408,6 +24481,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260908112615'),
 ('20260904065041'),
 ('20260904063128'),
 ('20260903195501'),

--- a/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
@@ -26,20 +26,7 @@ module DiscourseAi
 
         RateLimiter.new(current_user, "ai_discover_#{current_user.id}", 8, 1.minute).performed!
 
-        binding =
-          DiscourseAi::Discoveries.bind_request(user_id: current_user.id, request_id:, query:)
-        if binding == :created
-          result_settings = DiscourseAi::Discoveries.result_settings
-          Jobs.enqueue(
-            :stream_discover_reply,
-            user_id: current_user.id,
-            query:,
-            request_id:,
-            queued_at: Time.now.to_f,
-            summary_detail: result_settings[:summary_detail].to_s,
-            related_count: result_settings[:related_count],
-          )
-        end
+        DiscourseAi::Discoveries.enqueue_reply(user: current_user, request_id:, query:)
 
         DiscourseAi::Discoveries.record_recent_ask(user_id: current_user.id, query:)
 

--- a/plugins/discourse-ai/app/jobs/regular/stream_discover_reply.rb
+++ b/plugins/discourse-ai/app/jobs/regular/stream_discover_reply.rb
@@ -11,6 +11,11 @@ module Jobs
     def execute(args)
       return execute_legacy(args) if args[:request_id].blank?
 
+      ask_log = AskAiLog.find_by(id: args[:ask_ai_log_id], user_id: args[:user_id]) if args[
+        :ask_ai_log_id
+      ]
+      return if ask_log&.ask_outcome.present?
+
       return if (user = User.find_by(id: args[:user_id])).nil?
       return if (query = args[:query]).blank?
       return if !DiscourseAi::Discoveries.enabled_for_user?(user)
@@ -26,6 +31,7 @@ module Jobs
       base = { query:, request_id: args[:request_id] }
       queued_at = Float(args[:queued_at], exception: false)
       if queued_at && Time.now.to_f - queued_at > MAX_QUEUE_DELAY
+        ask_log.ask_outcome = :failed if ask_log
         publish_unavailable(user, base)
         return
       end
@@ -33,6 +39,7 @@ module Jobs
       admitted =
         DiscourseAi::Discoveries.admit_request(user_id: user.id, request_id: args[:request_id])
       if !admitted
+        ask_log.ask_outcome = :failed if ask_log
         publish_unavailable(user, base)
         return
       end
@@ -45,12 +52,22 @@ module Jobs
       end
       publish_update(user, base.merge(done: false, phase: "searching"))
 
+      stage = :rewrite
       rewritten_queries = rewrite_queries(user:, query:, cancel_manager:)
+      if ask_log
+        ask_log.assign_attributes(
+          keyword_query: rewritten_queries.keyword_query,
+          semantic_query: rewritten_queries.semantic_query,
+          query_locale: rewritten_queries.original_query_locale,
+        )
+        ask_log.failure_stage = :rewrite if rewritten_queries.failed
+      end
       if cancel_manager.cancelled? || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
         return
       end
       return if !active_request?(user, args[:request_id])
 
+      stage = :retrieval
       retrieval = DiscourseAi::Discoveries::Retrieval.new(user:)
       retrieval_result =
         retrieval.call(
@@ -62,12 +79,15 @@ module Jobs
         return
       end
       return if !active_request?(user, args[:request_id])
+      ask_log.candidate_post_ids = retrieval_result.synthesis_candidates.pluck("post_id") if ask_log
       if retrieval_result.synthesis_candidates.empty?
+        ask_log.ask_outcome = :no_answer if ask_log
         publish_no_answer(user, base)
         return
       end
       candidate_topic_ids = retrieval_result.candidates.pluck("topic_id").uniq
 
+      stage = :synthesis
       result_settings = request_result_settings(args)
       synthesis =
         DiscourseAi::Discoveries::Synthesis.new(user:, ai_agent:, llm_model:, cancel_manager:)
@@ -137,6 +157,12 @@ module Jobs
               ai_discover_reply: last_published_answer,
             ),
           )
+          if ask_log && ask_log.time_to_first_answer_ms.nil?
+            ask_log.time_to_first_answer_ms = [
+              (Time.current - ask_log.asked_at) * 1000,
+              0,
+            ].max.round
+          end
         end
 
       if cancel_manager.cancelled? || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline ||
@@ -153,6 +179,13 @@ module Jobs
           DiscourseAi::Discoveries::Synthesis.meaningful_answer?(result.answer)
 
       if answerable
+        ask_log&.assign_attributes(
+          ask_outcome: :answered,
+          answer_title: result.title,
+          answer: result.answer,
+          suggested_follow_up: result.follow_up,
+          source_post_ids: final_sources.pluck("post_id"),
+        )
         selected_sources = final_sources
         DiscourseAi::Discoveries.store_result(
           user_id: user.id,
@@ -177,17 +210,30 @@ module Jobs
           ),
         )
       else
+        ask_log.ask_outcome = :no_answer if ask_log
         publish_no_answer(user, base)
       end
     rescue LlmCreditAllocation::CreditLimitExceeded => e
+      ask_log&.assign_attributes(ask_outcome: :failed, failure_stage: stage)
       publish_error_update(user, e, base) if request_still_owned?(user, args[:request_id])
     rescue StandardError => e
+      ask_log&.assign_attributes(ask_outcome: :failed, failure_stage: stage)
       Rails.logger.error("Discourse AI Discoveries request #{args[:request_id]} failed: #{e.class}")
       publish_processing_error(user, base) if request_still_owned?(user, args[:request_id]) && base
     ensure
       cancel_manager&.stop_monitor
       if admitted
         DiscourseAi::Discoveries.release_request(user_id: user.id, request_id: args[:request_id])
+      end
+      if ask_log
+        if ask_log.ask_outcome.nil?
+          if deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            ask_log.assign_attributes(ask_outcome: :failed, failure_stage: stage)
+          else
+            ask_log.ask_outcome = :cancelled
+          end
+        end
+        ask_log.save! if ask_log.changed?
       end
     end
 

--- a/plugins/discourse-ai/app/models/ask_ai_log.rb
+++ b/plugins/discourse-ai/app/models/ask_ai_log.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AskAiLog < ActiveRecord::Base
+  belongs_to :user
+
+  enum :ask_outcome, { answered: 0, no_answer: 1, failed: 2, cancelled: 3 }, prefix: true
+  enum :failure_stage, { rewrite: 0, retrieval: 1, synthesis: 2 }, prefix: true
+end
+
+# == Schema Information
+#
+# Table name: ask_ai_logs
+#
+#  id                      :bigint           not null, primary key
+#  answer                  :text
+#  answer_title            :text
+#  ask_outcome             :integer
+#  asked_at                :datetime         not null
+#  candidate_post_ids      :bigint           default([]), not null, is an Array
+#  failure_stage           :integer
+#  keyword_query           :text
+#  query                   :text             not null
+#  query_locale            :string
+#  semantic_query          :text
+#  source_post_ids         :bigint           default([]), not null, is an Array
+#  suggested_follow_up     :text
+#  time_to_first_answer_ms :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  user_id                 :bigint           not null
+#
+# Indexes
+#
+#  index_ask_ai_logs_on_asked_at              (asked_at)
+#  index_ask_ai_logs_on_user_id_and_asked_at  (user_id,asked_at)
+#

--- a/plugins/discourse-ai/db/migrate/20260908112615_create_ask_ai_logs.rb
+++ b/plugins/discourse-ai/db/migrate/20260908112615_create_ask_ai_logs.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CreateAskAiLogs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ask_ai_logs do |t|
+      t.bigint :user_id, null: false
+      t.text :query, null: false
+      t.text :keyword_query
+      t.text :semantic_query
+      t.string :query_locale
+      t.bigint :candidate_post_ids, array: true, default: [], null: false
+      t.bigint :source_post_ids, array: true, default: [], null: false
+      t.text :answer_title
+      t.text :answer
+      t.text :suggested_follow_up
+      t.integer :ask_outcome
+      t.integer :failure_stage
+      t.datetime :asked_at, null: false
+      t.integer :time_to_first_answer_ms
+      t.timestamps
+    end
+
+    add_index :ask_ai_logs, :asked_at
+    add_index :ask_ai_logs, %i[user_id asked_at]
+  end
+end

--- a/plugins/discourse-ai/lib/discoveries.rb
+++ b/plugins/discourse-ai/lib/discoveries.rb
@@ -112,6 +112,27 @@ module DiscourseAi
         }
       end
 
+      def enqueue_reply(user:, request_id:, query:)
+        return if bind_request(user_id: user.id, request_id:, query:) != :created
+
+        asked_at = Time.current
+        ask_log = AskAiLog.create!(user:, query:, asked_at:)
+        settings = result_settings
+        Jobs.enqueue(
+          :stream_discover_reply,
+          user_id: user.id,
+          query:,
+          request_id:,
+          ask_ai_log_id: ask_log.id,
+          queued_at: asked_at.to_f,
+          summary_detail: settings[:summary_detail].to_s,
+          related_count: settings[:related_count],
+        )
+      rescue StandardError
+        ask_log&.update!(ask_outcome: :failed)
+        raise
+      end
+
       def bind_request(user_id:, request_id:, query:)
         normalized_query = query.to_s.unicode_normalize(:nfc).squish
         result =

--- a/plugins/discourse-ai/lib/discoveries/query_rewriter.rb
+++ b/plugins/discourse-ai/lib/discoveries/query_rewriter.rb
@@ -12,7 +12,13 @@ module DiscourseAi
       ].freeze
 
       Result =
-        Struct.new(:keyword_query, :semantic_query, :original_query_locale, keyword_init: true)
+        Struct.new(
+          :keyword_query,
+          :semantic_query,
+          :original_query_locale,
+          :failed,
+          keyword_init: true,
+        )
 
       def initialize(user:, ai_agent:, llm_model:, cancel_manager: nil)
         @user = user
@@ -71,6 +77,7 @@ module DiscourseAi
           keyword_query: original_query,
           semantic_query: original_query,
           original_query_locale: @user.effective_locale,
+          failed: true,
         )
       end
 

--- a/plugins/discourse-ai/spec/jobs/regular/stream_discover_reply_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/stream_discover_reply_spec.rb
@@ -544,4 +544,228 @@ describe Jobs::StreamDiscoverReply do
     expect(synthesis).not_to have_received(:call)
     expect(messages.map { |message| message[:phase] }).to eq(%w[searching])
   end
+
+  describe "Ask logging" do
+    fab!(:ask_log) do
+      AskAiLog.create!(user:, query: "how do I create a plugin", asked_at: Time.current)
+    end
+    let(:args) { { user_id: user.id, query:, request_id:, ask_ai_log_id: ask_log.id } }
+
+    it "records the rewrite, candidates, final answer, and time to the first answer" do
+      freeze_time
+      ask_log.update!(asked_at: 2.seconds.ago)
+      answer = "Start with a plugin."
+      allow(synthesis).to receive(:call) do |**_, &stream|
+        stream.call(answerable: true, source_refs: %w[source_1], title: "Plugins", answer:)
+        freeze_time 1.second.from_now
+        stream.call(
+          answerable: true,
+          source_refs: %w[source_1],
+          title: "Plugins",
+          answer: "#{answer} Next step.",
+        )
+        DiscourseAi::Discoveries::Synthesis::Result.new(
+          answerable: true,
+          source_refs: %w[source_1],
+          title: "Plugins",
+          answer: "#{answer} Next step.",
+          follow_up: "How do I install it?",
+        )
+      end
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "answered",
+        keyword_query: query,
+        semantic_query: query,
+        query_locale: user.effective_locale,
+        candidate_post_ids: [source_post.id],
+        source_post_ids: [source_post.id],
+        answer_title: "Plugins",
+        answer: "#{answer} Next step.",
+        suggested_follow_up: "How do I install it?",
+        time_to_first_answer_ms: 2000,
+        failure_stage: nil,
+      )
+    end
+
+    it "records an empty retrieval without inventing an answer latency" do
+      allow(retrieval).to receive(:call).and_return(
+        DiscourseAi::Discoveries::Retrieval::Result.new(candidates: []),
+      )
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "no_answer",
+        candidate_post_ids: [],
+        source_post_ids: [],
+        answer: nil,
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "records a synthesis failure and retains the retrieval context" do
+      allow(synthesis).to receive(:call).and_raise(StandardError, "provider failed")
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "failed",
+        failure_stage: "synthesis",
+        keyword_query: query,
+        candidate_post_ids: [source_post.id],
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "records a recovered rewrite failure alongside the final answer" do
+      allow(query_rewriter).to receive(:call).and_return(
+        DiscourseAi::Discoveries::QueryRewriter::Result.new(
+          keyword_query: query,
+          semantic_query: query,
+          original_query_locale: "en",
+          failed: true,
+        ),
+      )
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "answered",
+        failure_stage: "rewrite",
+        keyword_query: query,
+      )
+    end
+
+    it "records a request superseded before processing as cancelled" do
+      DiscourseAi::Discoveries.bind_request(
+        user_id: user.id,
+        request_id: SecureRandom.uuid,
+        query: "new question",
+      )
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "cancelled",
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "records queue expiry as failed without assigning an LLM failure stage" do
+      job.execute(args.merge(queued_at: 3.seconds.ago.to_f))
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "failed",
+        failure_stage: nil,
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "retains all synthesis candidates separately from final sources" do
+      other_post = Fabricate(:post)
+      candidates = [
+        candidate,
+        candidate.merge(
+          "post_id" => other_post.id,
+          "topic_id" => other_post.topic_id,
+          "source_ref" => "source_2",
+        ),
+      ]
+      allow(retrieval).to receive(:call).and_return(
+        DiscourseAi::Discoveries::Retrieval::Result.new(candidates:),
+      )
+      allow(retrieval).to receive(:validated_sources).and_return([candidate])
+      allow(synthesis).to receive(:call) do |**_, &stream|
+        stream.call(answerable: true, source_refs: %w[source_1], answer: "Answer")
+        DiscourseAi::Discoveries::Synthesis::Result.new(
+          answerable: true,
+          source_refs: %w[source_1],
+          answer: "Answer",
+        )
+      end
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        candidate_post_ids: [source_post.id, other_post.id],
+        source_post_ids: [source_post.id],
+      )
+    end
+
+    it "records retrieval errors before any answer is available" do
+      allow(retrieval).to receive(:call).and_raise(StandardError)
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "failed",
+        failure_stage: "retrieval",
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "keeps first-answer timing when synthesis subsequently fails" do
+      freeze_time
+      ask_log.update!(asked_at: 1.second.ago)
+      allow(synthesis).to receive(:call) do |**_, &stream|
+        stream.call(answerable: true, source_refs: %w[source_1], answer: "A partial answer")
+        raise StandardError
+      end
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "failed",
+        failure_stage: "synthesis",
+        time_to_first_answer_ms: 1000,
+        answer: nil,
+        source_post_ids: [],
+      )
+    end
+
+    it "does not save rejected references as final sources" do
+      allow(retrieval).to receive(:validated_sources).and_return([])
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "no_answer",
+        source_post_ids: [],
+        answer: nil,
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "records a deadline expiry as failed rather than cancelled" do
+      expired = false
+      allow(Process).to receive(:clock_gettime).and_wrap_original do |original, *arguments|
+        value = original.call(*arguments)
+        expired && arguments == [Process::CLOCK_MONOTONIC] ? value + 30 : value
+      end
+      allow(retrieval).to receive(:call) do
+        expired = true
+        retrieval_result
+      end
+
+      job.execute(args)
+
+      expect(ask_log.reload).to have_attributes(
+        ask_outcome: "failed",
+        failure_stage: "retrieval",
+        time_to_first_answer_ms: nil,
+      )
+    end
+
+    it "preserves a completed log when the job is delivered again" do
+      job.execute(args)
+      original = ask_log.reload.attributes
+
+      job.execute(args)
+
+      expect(ask_log.reload.attributes).to eq(original)
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/discoveries/query_rewriter_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discoveries/query_rewriter_spec.rb
@@ -112,6 +112,7 @@ describe DiscourseAi::Discoveries::QueryRewriter do
       keyword_query: "猫",
       semantic_query: "猫",
       original_query_locale: user.effective_locale,
+      failed: true,
     )
     expect(Rails.logger).to have_received(:warn).with(
       "Discourse AI Discoveries query rewrite failed: StandardError",

--- a/plugins/discourse-ai/spec/lib/discoveries_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discoveries_spec.rb
@@ -56,6 +56,23 @@ describe DiscourseAi::Discoveries do
     end
   end
 
+  describe ".enqueue_reply" do
+    it "records a failed ask if the job cannot be queued" do
+      allow(Jobs).to receive(:enqueue).and_raise(StandardError, "queue unavailable")
+
+      expect {
+        described_class.enqueue_reply(user:, request_id: SecureRandom.uuid, query: "猫")
+      }.to raise_error(StandardError, "queue unavailable")
+
+      expect(AskAiLog.last).to have_attributes(
+        user_id: user.id,
+        query: "猫",
+        ask_outcome: "failed",
+        failure_stage: nil,
+      )
+    end
+  end
+
   describe ".result_settings" do
     it "returns the configured Ask AI presentation settings" do
       SiteSetting.ai_ask_ai_summary_detail = "detailed"

--- a/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
@@ -34,6 +34,7 @@ describe DiscourseAi::Discover::DiscoveriesController do
         post "/discourse-ai/discoveries/reply", params: { query: "What is Discourse?", request_id: }
 
         expect(response.status).to eq(403)
+        expect(AskAiLog.count).to eq(0)
       end
     end
 
@@ -64,10 +65,28 @@ describe DiscourseAi::Discover::DiscoveriesController do
         end
       end
 
+      it "logs each accepted ask once without consolidating repeated questions" do
+        query = "How do I search for 猫?"
+        params = { query:, request_id: }
+
+        expect {
+          2.times { post "/discourse-ai/discoveries/reply", params: }
+          post "/discourse-ai/discoveries/reply", params: { query:, request_id: SecureRandom.uuid }
+        }.to change(AskAiLog, :count).by(2)
+
+        logs = AskAiLog.order(:id).last(2)
+        expect(logs).to all(have_attributes(user_id: user.id, query:, ask_outcome: nil))
+        expect(logs.map(&:asked_at)).to all(be_present)
+        expect(
+          Jobs::StreamDiscoverReply.jobs.last(2).map { |job| job["args"].first["ask_ai_log_id"] },
+        ).to eq(logs.map(&:id))
+      end
+
       it "returns a 400 if the query is missing" do
         post "/discourse-ai/discoveries/reply", params: { request_id: }
 
         expect(response.status).to eq(400)
+        expect(AskAiLog.count).to eq(0)
       end
 
       it "returns a 400 if the request ID is invalid" do
@@ -77,6 +96,7 @@ describe DiscourseAi::Discover::DiscoveriesController do
                request_id: "not-a-uuid",
              }
         expect(response.status).to eq(400)
+        expect(AskAiLog.count).to eq(0)
       end
 
       it "does not enqueue the same request twice" do


### PR DESCRIPTION
Currently, Ask AI only has individual LLM API audit logs, which makes it difficult to measure usage and outcomes for each ask.

This PR adds `ask_ai_logs`, with one row per ask, including failed and cancelled attempts. It records the original and rewritten queries, candidate and source posts, generated answer, outcome, failure stage, and time to the first streamed answer text. This gives us the data needed for Ask AI reporting.