### PR TITLE
DEV: Convert SettingValidationMessage to a glimmer component

### DIFF
--- a/frontend/discourse/admin/components/setting-validation-message.gjs
+++ b/frontend/discourse/admin/components/setting-validation-message.gjs
@@ -1,16 +1,12 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
-@tagName("")
-export default class SettingValidationMessage extends Component {
-  <template>
-    <div ...attributes>
-      <div class="validation-error {{unless this.message 'hidden'}}">
-        {{dIcon "xmark"}}
-        {{this.message}}
-      </div>
+const SettingValidationMessage = <template>
+  <div ...attributes>
+    <div class="validation-error {{unless @message 'hidden'}}">
+      {{dIcon "xmark"}}
+      {{@message}}
     </div>
-  </template>
-}
+  </div>
+</template>;
+
+export default SettingValidationMessage;


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* drop the backing class
