### PR TITLE
DEV: Resolve memory leaks in qunit tests

### DIFF
--- a/frontend/discourse/app/instance-initializers/narrow-desktop.js
+++ b/frontend/discourse/app/instance-initializers/narrow-desktop.js
@@ -1,3 +1,4 @@
+import { registerDestructor } from "@ember/destroyable";
 import NarrowDesktop from "discourse/lib/narrow-desktop";
 
 export default {
@@ -12,12 +13,17 @@ export default {
     // even when the user zooms the page.
     const mediaQuery = window.matchMedia("(min-width: 48rem)");
 
-    mediaQuery.addEventListener("change", () => {
+    const onChange = () => {
       if (owner.isDestroyed) {
         return;
       }
 
       NarrowDesktop.update(owner, !mediaQuery.matches);
-    });
+    };
+
+    mediaQuery.addEventListener("change", onChange);
+    registerDestructor(owner, () =>
+      mediaQuery.removeEventListener("change", onChange)
+    );
   },
 };

--- a/frontend/discourse/app/lib/textarea-text-manipulation.ts
+++ b/frontend/discourse/app/lib/textarea-text-manipulation.ts
@@ -1,3 +1,4 @@
+import { destroy } from "@ember/destroyable";
 import { type default as Owner, getOwner, setOwner } from "@ember/owner";
 import { trackedObject } from "@ember/reactive/collections";
 import { next, schedule } from "@ember/runloop";
@@ -113,6 +114,8 @@ export default class TextareaTextManipulation implements TextManipulation {
   @service declare siteSettings: SiteSettings;
 
   @service declare capabilities: CapabilitiesService;
+
+  autocompletes: object[] = [];
 
   allowPreview = true;
 
@@ -1004,13 +1007,21 @@ export default class TextareaTextManipulation implements TextManipulation {
     }
   }
 
-  autocomplete(options: AutocompleteOptions): unknown {
-    return dAutocomplete.setupAutocomplete(
+  autocomplete(options: AutocompleteOptions | "destroy"): unknown {
+    if (options === "destroy") {
+      this.autocompletes.forEach((modifier) => destroy(modifier));
+      this.autocompletes = [];
+      return;
+    }
+
+    const modifier = dAutocomplete.setupAutocomplete(
       getOwner(this),
       this.textarea,
       this.autocompleteHandler,
       options
     );
+    this.autocompletes.push(modifier);
+    return modifier;
   }
 
   #applyWholeLineSurround(

--- a/frontend/discourse/app/lib/uppy/uppy-upload.js
+++ b/frontend/discourse/app/lib/uppy/uppy-upload.js
@@ -146,7 +146,7 @@ export default class UppyUpload {
         `upload-mixin:${this.config.id}:cancel-upload`,
         this.cancelSingleUpload
       );
-      this.uppyWrapper.uppyInstance.close?.();
+      this.uppyWrapper.uppyInstance.destroy();
     }
   }
 

--- a/frontend/discourse/app/models/composer.js
+++ b/frontend/discourse/app/models/composer.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-observers */
 import { tracked } from "@glimmer/tracking";
 import EmberObject, { computed, set } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
@@ -6,7 +5,7 @@ import { next, throttle } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isHTMLSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
-import { observes, on } from "@ember-decorators/object";
+import { on } from "@ember-decorators/object";
 import { Promise } from "rsvp";
 import { extractError, throwAjaxError } from "discourse/lib/ajax-error";
 import { tinyAvatar } from "discourse/lib/avatar-utils";
@@ -233,6 +232,36 @@ export default class Composer extends RestModel {
   @tracked _archetypesOverride;
 
   @tracked _user;
+
+  @tracked _composeState;
+
+  @tracked _archetypeId;
+
+  @dependentKeyCompat
+  get composeState() {
+    return this._composeState;
+  }
+
+  set composeState(value) {
+    if (value === this._composeState) {
+      return;
+    }
+    this._composeState = value;
+    this.composeStateChanged();
+  }
+
+  @dependentKeyCompat
+  get archetypeId() {
+    return this._archetypeId;
+  }
+
+  set archetypeId(value) {
+    if (value === this._archetypeId) {
+      return;
+    }
+    this._archetypeId = value;
+    this.set("metaData", EmberObject.create());
+  }
 
   @dependentKeyCompat
   get user() {
@@ -856,7 +885,6 @@ export default class Composer extends RestModel {
     return true;
   }
 
-  @observes("composeState")
   composeStateChanged() {
     const oldOpen = this.composerOpened;
     const elem = document.documentElement;
@@ -878,11 +906,6 @@ export default class Composer extends RestModel {
       this.set("composerOpened", null);
       elem.classList.remove("composer-open");
     }
-  }
-
-  @observes("archetype")
-  archetypeChanged() {
-    return this.set("metaData", EmberObject.create());
   }
 
   // called whenever the user types to update the typing time

--- a/frontend/discourse/app/static/prosemirror/lib/text-manipulation.ts
+++ b/frontend/discourse/app/static/prosemirror/lib/text-manipulation.ts
@@ -1,3 +1,4 @@
+import { destroy } from "@ember/destroyable";
 import { type default as Owner, getOwner, setOwner } from "@ember/owner";
 import { trackedObject } from "@ember/reactive/collections";
 import { next } from "@ember/runloop";
@@ -90,6 +91,8 @@ function isPlainTextFragment(fragment: Fragment, schema: Schema): boolean {
 }
 
 export default class ProsemirrorTextManipulation implements TextManipulation {
+  autocompletes: object[] = [];
+
   allowPreview = false;
 
   schema: Schema;
@@ -181,13 +184,21 @@ export default class ProsemirrorTextManipulation implements TextManipulation {
     });
   }
 
-  autocomplete(options: AutocompleteOptions): unknown {
-    return dAutocomplete.setupAutocomplete(
+  autocomplete(options: AutocompleteOptions | "destroy"): unknown {
+    if (options === "destroy") {
+      this.autocompletes.forEach((modifier) => destroy(modifier));
+      this.autocompletes = [];
+      return;
+    }
+
+    const modifier = dAutocomplete.setupAutocomplete(
       getOwner(this),
       this.view.dom,
       this.autocompleteHandler,
       options
     );
+    this.autocompletes.push(modifier);
+    return modifier;
   }
 
   applySurroundSelection(

--- a/frontend/discourse/app/ui-kit/modifiers/d-autocomplete.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-autocomplete.js
@@ -1,5 +1,8 @@
 import { tracked } from "@glimmer/tracking";
-import { registerDestructor } from "@ember/destroyable";
+import {
+  associateDestroyableChild,
+  registerDestructor,
+} from "@ember/destroyable";
 import { action } from "@ember/object";
 import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
@@ -54,6 +57,7 @@ export default class DAutocompleteModifier extends Modifier {
       named: {},
       positional: [],
     });
+    associateDestroyableChild(owner, modifier);
 
     const modifierOptions = {
       ...options,

--- a/frontend/discourse/dialog-holder/components/dialog-holder.gjs
+++ b/frontend/discourse/dialog-holder/components/dialog-holder.gjs
@@ -19,7 +19,7 @@ export default class DialogHolder extends Component {
       this.dialog.hide();
     });
 
-    () => {
+    return () => {
       dialogInstance.hide();
       dialogInstance.destroy();
     };

--- a/frontend/discourse/tests/setup-tests.js
+++ b/frontend/discourse/tests/setup-tests.js
@@ -335,6 +335,11 @@ export default async function setupTests(config) {
       app.destroy();
     });
 
+    // The inspector shim's global list would otherwise pin the destroyed app's registry.
+    globalThis.emberInspectorApps = globalThis.emberInspectorApps?.filter(
+      (entry) => entry.app !== app
+    );
+
     resetPretender();
     clearPresenceState();
 

--- a/patches/@warp-drive__legacy@5.9.0-alpha.15.patch
+++ b/patches/@warp-drive__legacy@5.9.0-alpha.15.patch
@@ -1,0 +1,25 @@
+diff --git a/dist/index.js b/dist/index.js
+index 566dc18edcce674cb20c1c07f60ff9d4f783eb35..8fc5700da577050452329140a01754fa3347b900 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -9,7 +9,7 @@ import '@ember/debug';
+ import '@warp-drive/utilities/string';
+ import { macroCondition, getGlobalConfig } from '@embroider/macros';
+ import '@warp-drive/core/store/-private';
+-import "./errors-Cz5KrzBk.js";
++import { L as LEGACY_SUPPORT } from "./errors-Cz5KrzBk.js";
+ import "./schema-provider-DJCV_6AF.js";
+ import { i as instantiateRecord, t as teardownRecord, m as modelFor } from "./hooks-D6diaM34.js";
+ import { registerDerivations as registerDerivations$1, DelegatingSchemaService } from './model/migration-support.js';
+@@ -109,6 +109,11 @@ function useLegacyStore(options, StoreKlass = Store) {
+       if (this.schema.isDelegated(key)) {
+         return teardownRecord.call(this, record);
+       }
++      const support = LEGACY_SUPPORT.get(key);
++      if (support) {
++        support.destroy();
++        LEGACY_SUPPORT.delete(key);
++      }
+       return teardownRecord$1(record);
+     }
+     modelFor(type) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ patchedDependencies:
   '@ember-compat/tracked-built-ins@0.9.1':
     hash: febdd1f1d24565f6f3be7747fd89cbc86a4476e2836e383610c6bc430436a842
     path: patches/@ember-compat__tracked-built-ins@0.9.1.patch
+  '@warp-drive/legacy@5.9.0-alpha.15':
+    hash: de74ff6c540d75d173dcb41244cb6c4f6c86dabdb41908170a9d1c0e47ee099f
+    path: patches/@warp-drive__legacy@5.9.0-alpha.15.patch
   babel-plugin-debug-macros@0.3.4:
     hash: 387f93bad78f3a98b20dc742f4f0b7a165c7e6ebc65cc60356748346c0725c7f
     path: patches/babel-plugin-debug-macros@0.3.4.patch
@@ -314,7 +317,7 @@ importers:
         version: 5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0))
       '@warp-drive/legacy':
         specifier: 5.9.0-alpha.15
-        version: 5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0))(@warp-drive/utilities@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)))
+        version: 5.9.0-alpha.15(patch_hash=de74ff6c540d75d173dcb41244cb6c4f6c86dabdb41908170a9d1c0e47ee099f)(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0))(@warp-drive/utilities@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)))
       '@warp-drive/utilities':
         specifier: 5.9.0-alpha.15
         version: 5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0))
@@ -11255,7 +11258,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/legacy@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0))(@warp-drive/utilities@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)))':
+  '@warp-drive/legacy@5.9.0-alpha.15(patch_hash=de74ff6c540d75d173dcb41244cb6c4f6c86dabdb41908170a9d1c0e47ee099f)(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0))(@warp-drive/utilities@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)(@warp-drive/core@5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)))':
     dependencies:
       '@embroider/macros': 1.20.6(@babel/core@7.29.7)(@glint/template@1.9.0)
       '@warp-drive/core': 5.9.0-alpha.15(@babel/core@7.29.7)(@glint/template@1.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,6 +70,8 @@ patchedDependencies:
   "babel-plugin-debug-macros@0.3.4": "patches/babel-plugin-debug-macros@0.3.4.patch"
   "licensee@11.1.1": "patches/licensee@11.1.1.patch"
   "@ember-compat/tracked-built-ins@0.9.1": "patches/@ember-compat__tracked-built-ins@0.9.1.patch"
+  # https://github.com/warp-drive-data/warp-drive/pull/11037
+  "@warp-drive/legacy@5.9.0-alpha.15": "patches/@warp-drive__legacy@5.9.0-alpha.15.patch"
   "ember-source@6.10.1": "patches/ember-source@6.10.1.patch"
   "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch"
   "ember-buffered-proxy": "patches/ember-buffered-proxy.patch"


### PR DESCRIPTION
Every qunit test builds a fresh `Discourse` application, and until now each one stayed reachable after teardown, about 4MB of live heap per acceptance test. We were pushing the 4GB heap cap, and the Ember 7 branch tips things over the edge.

Seven separate things were holding references to the destroyed apps. With all of them fixed, the acceptance suite holds steady at about 300MB heap.

- DEV: drop destroyed test apps from the inspector shim's global list
- FIX: remove the narrow-desktop matchMedia listener when the owner is destroyed
- FIX: return the dialog holder's cleanup function from its modifier
- FIX: call `destroy()` when tearing down an Uppy instance
- FIX: destroy hand-made autocomplete modifiers with their editor and owner
- FIX: patch WarpDrive to release legacy support for schema-backed records
- FIX: replace the composer model's observers with tracked accessors
