### PR TITLE
FIX: Respect chat avatar flair styling

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-user-avatar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-user-avatar.scss
@@ -28,11 +28,16 @@
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
+      color: var(--primary);
+
+      &.rounded {
+        border-radius: 50%;
+      }
 
       .d-icon {
         width: 100%;
         height: 100%;
-        color: var(--primary);
+        color: inherit;
       }
     }
 


### PR DESCRIPTION
Chat avatar flairs displayed square backgrounds and ignored configured icon colors.

This change rounds flair backgrounds and respects configured icon colors, while preserving the theme’s primary color as the default.

### Screenshots

Isolated component reproduction with synthetic users at 200% zoom.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/7e52bffc-7685-42f4-8be9-5bbacdaab1b9) | ![After](https://github.com/user-attachments/assets/6e25e1f4-0676-4f54-8b65-341c36691434) |