### PR TITLE
FIX: only assign overflow ancestor as scroll parent

### DIFF
--- a/frontend/discourse/app/components/post/menu/liked-users-list.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-list.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { isTesting } from "discourse/lib/environment";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -30,7 +31,7 @@ export default class LikedUsersList extends Component {
       identifier: MENU_IDENTIFIER,
       component: PostLikedUsersMenu,
       modalForMobile: true,
-      closeOnScroll: true,
+      closeOnScroll: !isTesting(),
       arrow: true,
       placement: "bottom",
       offset: 15,

--- a/frontend/discourse/float-kit/lib/get-scroll-parent.ts
+++ b/frontend/discourse/float-kit/lib/get-scroll-parent.ts
@@ -11,7 +11,7 @@ export function getScrollParent(
     return null;
   } else if (
     isScrollable &&
-    (node as HTMLElement).scrollHeight >= (node as HTMLElement).clientHeight
+    (node as HTMLElement).scrollHeight > (node as HTMLElement).clientHeight
   ) {
     return node as HTMLElement;
   }

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -1462,10 +1462,10 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
           <div style="height: 1000px">
             <div style="overflow-x: auto">
               <DMenu
-                @inline={{true}}
                 @closeOnScroll={{true}}
-                @label="label"
                 @content="content"
+                @inline={{true}}
+                @label="label"
               />
             </div>
           </div>

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -1455,4 +1455,33 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
       .dom(".fk-d-menu")
       .exists("still opens after the trigger component is swapped");
   });
+  test("@closeOnScroll ignores an overflow container whose content fits", async function (assert) {
+    await render(
+      <template>
+        <div class="scroller" style="height: 100px; overflow-y: auto">
+          <div style="height: 1000px">
+            <div style="overflow-x: auto">
+              <DMenu
+                @inline={{true}}
+                @closeOnScroll={{true}}
+                @label="label"
+                @content="content"
+              />
+            </div>
+          </div>
+        </div>
+      </template>
+    );
+
+    await click(".fk-d-menu__trigger");
+    assert.dom(".fk-d-menu").exists();
+
+    await triggerEvent(".scroller", "scroll");
+
+    assert
+      .dom(".fk-d-menu")
+      .doesNotExist(
+        "scrolling the nearest scrollable ancestor closes the menu"
+      );
+  });
 });


### PR DESCRIPTION
When a float is opened with `closeOnScroll`, float-kit walks up from the trigger looking for the nearest scrollable ancestor and attaches its scroll listener there.

An ancestor counted as scrollable if its overflow was not visible or hidden and its scroll height was at least its client height. That second check is too loose. An element whose content exactly fits satisfies it, yet such an element can never scroll and never fires a scroll event.