### PR TITLE
DEV: Prepare @discourse/types for TypeScript 7

### DIFF
--- a/frontend/discourse-types/generate-external-types.js
+++ b/frontend/discourse-types/generate-external-types.js
@@ -32,6 +32,17 @@ const packageNames = [
   "pretender",
 ];
 
+// A module whose default export is a namespace hides that namespace's types
+// from consumers' declaration emit, which then expands them structurally
+// without bound. Exporting the namespace by name gives the types a path.
+function exportDefaultNamespaces(dts) {
+  return dts.replace(/^(\t) namespace (\w+) \{$/gm, (line, indent, name) =>
+    new RegExp(`^\\texport default ${name};$`, "m").test(dts)
+      ? `${indent}export namespace ${name} {`
+      : line
+  );
+}
+
 (async function () {
   try {
     rmSync("./external-types", { recursive: true });
@@ -101,6 +112,11 @@ const packageNames = [
 
         cpSync(path, `${targetPackagePath}/${relativePath}`);
       }
+
+      writeFileSync(
+        `${targetPackagePath}/types/index.d.ts`,
+        'export * from "./stable/index";\n'
+      );
     } else {
       function transformPath(relativePath) {
         // Declarations emitted by newer TypeScript keep explicit extensions on
@@ -132,9 +148,10 @@ const packageNames = [
         }
       }
 
+      const out = `${targetPackagePath}/index.d.ts`;
       await generateDtsBundle({
         project: resolve(packagePath) + "/",
-        out: `${targetPackagePath}/index.d.ts`,
+        out,
         resolveModuleId({ currentModuleId }) {
           return transformPath(currentModuleId);
         },
@@ -148,6 +165,7 @@ const packageNames = [
           }
         },
       });
+      writeFileSync(out, exportDefaultNamespaces(readFileSync(out, "utf-8")));
     }
   }
 })().then(() => {

--- a/frontend/discourse-types/package.json
+++ b/frontend/discourse-types/package.json
@@ -22,25 +22,49 @@
   "exports": {
     "./tsconfig-plugin": "./tsconfig-plugin.json",
     "./tests/*": {
-      "types": "./declarations/tests/*.d.ts"
+      "types": [
+        "./declarations/tests/*.d.ts",
+        "./declarations/tests/*.d.gjs.ts",
+        "./declarations/tests/*.d.gts.ts"
+      ]
     },
     "./admin/*": {
-      "types": "./declarations/admin/*.d.ts"
+      "types": [
+        "./declarations/admin/*.d.ts",
+        "./declarations/admin/*.d.gjs.ts",
+        "./declarations/admin/*.d.gts.ts"
+      ]
     },
     "./dialog-holder/*": {
-      "types": "./declarations/dialog-holder/*.d.ts"
+      "types": [
+        "./declarations/dialog-holder/*.d.ts",
+        "./declarations/dialog-holder/*.d.gjs.ts",
+        "./declarations/dialog-holder/*.d.gts.ts"
+      ]
     },
     "./float-kit/*": {
-      "types": "./declarations/float-kit/*.d.ts"
+      "types": [
+        "./declarations/float-kit/*.d.ts",
+        "./declarations/float-kit/*.d.gjs.ts",
+        "./declarations/float-kit/*.d.gts.ts"
+      ]
     },
     "./select-kit/*": {
-      "types": "./declarations/select-kit/*.d.ts"
+      "types": [
+        "./declarations/select-kit/*.d.ts",
+        "./declarations/select-kit/*.d.gjs.ts",
+        "./declarations/select-kit/*.d.gts.ts"
+      ]
     },
     "./truth-helpers": {
       "types": "./declarations/truth-helpers/index.d.ts"
     },
     "./truth-helpers/*": {
-      "types": "./declarations/truth-helpers/*.d.ts"
+      "types": [
+        "./declarations/truth-helpers/*.d.ts",
+        "./declarations/truth-helpers/*.d.gjs.ts",
+        "./declarations/truth-helpers/*.d.gts.ts"
+      ]
     },
     "./blocks": {
       "types": "./declarations/app/blocks/index.d.ts"
@@ -52,7 +76,11 @@
       "types": "./declarations/app/lib/blocks/index.d.ts"
     },
     "./*": {
-      "types": "./declarations/app/*.d.ts"
+      "types": [
+        "./declarations/app/*.d.ts",
+        "./declarations/app/*.d.gjs.ts",
+        "./declarations/app/*.d.gts.ts"
+      ]
     }
   },
   "devDependencies": {

--- a/frontend/discourse-types/tsconfig-plugin.json
+++ b/frontend/discourse-types/tsconfig-plugin.json
@@ -34,5 +34,11 @@
       "rsvp",
       "sinon"
     ]
-  }
+  },
+  "contentMappers": [
+    {
+      "package": "ember-content-mapper",
+      "extensions": [".gts", ".gjs"]
+    }
+  ]
 }


### PR DESCRIPTION
TypeScript 7 checks .gts and .gjs files through a content mapper instead of Glint, and its declaration emit names those files `foo.d.gts.ts` and `foo.d.gjs.ts`. This makes the published types package work with both compilers, so plugins can move over once core does.

- `tsconfig-plugin.json` registers `ember-content-mapper` for `.gts` and `.gjs`. TypeScript 6 ignores the `contentMappers` key.
- The package `exports` fall back to the `.d.gjs.ts` and `.d.gts.ts` declaration names when there is no plain `.d.ts`.
- Generated ambient stubs now export a namespace that a module only exposed as its default export. Without a name for `RSVP.Promise`, declaration emit expanded the type structurally for every plugin file that used a promise from rsvp. TypeScript 6 stops at a depth limit, but tsgo has no such limit and runs until it is out of memory.
- `ember-source/types/index.d.ts` is generated so that a `/// <reference types="ember-source/types" />` resolves inside the package.