### PR TITLE
DEV: Convert DiscourseReactionsUserNotificationReactions to a glimmer component

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/connectors/user-notifications-bottom/discourse-reactions-user-notification-reactions.gjs
@@ -1,12 +1,12 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
-import { tagName } from "@ember-decorators/component";
+import { service } from "@ember/service";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class DiscourseReactionsUserNotificationReactions extends Component {
+  @service siteSettings;
+
   <template>
     <li
       class="user-notifications-bottom-outlet discourse-reactions-user-notification-reactions"


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* add missing `siteSettings` service injection
