### PR TITLE
FIX: Revalidate topic visibility for presence channels

### DIFF
--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -353,9 +353,9 @@ class PresenceChannel
 
     if config.public
       # no params required
-    elsif config.allowed_user_ids || config.allowed_group_ids
-      params[:user_ids] = config.allowed_user_ids
-      params[:group_ids] = config.allowed_group_ids
+    elsif config.allowed_user_ids.present? || config.allowed_group_ids.present?
+      params[:user_ids] = config.allowed_user_ids if config.allowed_user_ids.present?
+      params[:group_ids] = config.allowed_group_ids if config.allowed_group_ids.present?
     else
       # nobody is allowed... don't publish anything
       return

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -30,8 +30,116 @@ after_initialize do
 
       config
     elsif topic_id = channel_name[%r{/discourse-presence/whisper/(\d+)}, 1]
-      Topic.find(topic_id) # Just ensure it exists
-      PresenceChannel::Config.new(allowed_group_ids: SiteSetting.whispers_allowed_groups_map)
+      topic = Topic.find(topic_id)
+      config = PresenceChannel::Config.new
+
+      if topic.private_message?
+        config.allowed_user_ids = topic.allowed_users.pluck(:id)
+        config.allowed_group_ids = topic.allowed_groups.pluck(:id).presence
+      else
+        config.allowed_group_ids = SiteSetting.whispers_allowed_groups_map
+        config.allowed_group_ids &= topic.secure_group_ids if topic.secure_group_ids
+      end
+
+      config
+      whisper_allowed_group_ids = SiteSetting.whispers_allowed_groups_map
+
+      if !topic.private_message? && topic.shared_draft?
+        shared_draft_group_ids = SiteSetting.shared_drafts_allowed_groups_map
+        required_group_ids = [whisper_allowed_group_ids]
+        if (
+             shared_draft_group_ids &
+               [::Group::AUTO_GROUPS[:everyone], ::Group::AUTO_GROUPS[:logged_in_users]]
+           ).blank?
+          required_group_ids << shared_draft_group_ids
+        end
+        required_group_ids << topic.secure_group_ids if topic.secure_group_ids
+        shared_group_ids = required_group_ids.reduce(:&)
+        allowed_users = GroupUser.where(group_id: required_group_ids.first)
+
+        required_group_ids
+          .drop(1)
+          .each do |group_ids|
+            allowed_users =
+              allowed_users.where(user_id: GroupUser.where(group_id: group_ids).select(:user_id))
+          end
+
+        if shared_group_ids.present?
+          allowed_users =
+            allowed_users.where.not(
+              user_id: GroupUser.where(group_id: shared_group_ids).select(:user_id),
+            )
+        end
+
+        allowed_user_ids = allowed_users.distinct.pluck(:user_id)
+
+        # Admins bypass shared-draft visibility unless secured categories are suppressed.
+        if !SiteSetting.suppress_secured_categories_from_admin &&
+             !whisper_allowed_group_ids.include?(::Group::AUTO_GROUPS[:admins])
+          allowed_user_ids.concat(
+            GroupUser
+              .where(group_id: whisper_allowed_group_ids)
+              .where(
+                user_id: GroupUser.where(group_id: ::Group::AUTO_GROUPS[:admins]).select(:user_id),
+              )
+              .distinct
+              .pluck(:user_id),
+          )
+        else
+          if !SiteSetting.suppress_secured_categories_from_admin
+            shared_group_ids << ::Group::AUTO_GROUPS[:admins]
+          end
+        end
+
+        next(
+          PresenceChannel::Config.new(
+            allowed_user_ids: allowed_user_ids.uniq.presence,
+            allowed_group_ids: shared_group_ids.uniq.presence,
+          )
+        )
+      end
+
+      if topic.private_message?
+        topic_allowed_group_ids = topic.allowed_groups.pluck(:id)
+        topic_allowed_user_ids = topic.all_allowed_users.pluck(:id)
+      elsif secure_group_ids = topic.secure_group_ids
+        topic_allowed_group_ids = secure_group_ids.dup
+        topic_allowed_user_ids = []
+      else
+        next PresenceChannel::Config.new(allowed_group_ids: whisper_allowed_group_ids)
+      end
+
+      if !SiteSetting.suppress_secured_categories_from_admin
+        topic_allowed_group_ids << ::Group::AUTO_GROUPS[:admins]
+      end
+
+      shared_group_ids = whisper_allowed_group_ids & topic_allowed_group_ids
+      whisper_only_group_ids = whisper_allowed_group_ids - shared_group_ids
+      topic_only_group_ids = topic_allowed_group_ids - shared_group_ids
+
+      allowed_user_ids =
+        if topic.private_message? && whisper_only_group_ids.present?
+          topic_allowed_user_ids &
+            GroupUser.where(group_id: whisper_only_group_ids).distinct.pluck(:user_id)
+        else
+          []
+        end
+
+      # Presence configs combine groups with OR, so only cross-group members need user entries.
+      if whisper_only_group_ids.present? && topic_only_group_ids.present?
+        allowed_user_ids.concat(
+          GroupUser
+            .where(group_id: whisper_only_group_ids)
+            .where(user_id: GroupUser.where(group_id: topic_only_group_ids).select(:user_id))
+            .distinct
+            .pluck(:user_id),
+        )
+      end
+
+      PresenceChannel::Config.new(
+        allowed_user_ids: allowed_user_ids.uniq.presence,
+        allowed_group_ids: shared_group_ids.presence,
+      )
     elsif post_id = channel_name[%r{/discourse-presence/edit/(\d+)}, 1]
       post = Post.find(post_id)
       topic = Topic.find(post.topic_id)
@@ -44,17 +152,25 @@ after_initialize do
 
       # Whispers posts are for allowed whisper groups
       if post.whisper?
-        config.allowed_group_ids += SiteSetting.whispers_allowed_groups_map
+        if topic.private_message?
+          config.allowed_user_ids = topic.allowed_users.pluck(:id)
+          config.allowed_group_ids += topic.allowed_groups.pluck(:group_id)
+        else
+          whisper_allowed_group_ids = SiteSetting.whispers_allowed_groups_map
+          whisper_allowed_group_ids &= topic.secure_group_ids if topic.secure_group_ids
+          config.allowed_group_ids += whisper_allowed_group_ids
+        end
         next config
       end
 
-      config.allowed_user_ids = [post.user_id]
+      config.allowed_user_ids = [post.user_id] if post.user.guardian.can_see?(topic)
 
       if topic.private_message? && post.wiki
         # Ignore trust level and just publish to all allowed groups since
         # trying to figure out which users in the allowed groups have
         # the necessary trust levels can lead to a large array of user ids
         # if the groups are big.
+        config.allowed_user_ids ||= []
         config.allowed_user_ids += topic.allowed_users.pluck(:id)
         config.allowed_group_ids += topic.allowed_groups.pluck(:id)
       elsif post.wiki
@@ -74,7 +190,9 @@ after_initialize do
       end
 
       if SiteSetting.enable_category_group_moderation? && topic.category
-        config.allowed_group_ids.push(*topic.category.moderating_groups.pluck(:id))
+        category_moderating_group_ids = topic.category.moderating_groups.pluck(:id)
+        category_moderating_group_ids &= topic.secure_group_ids if topic.secure_group_ids
+        config.allowed_group_ids.push(*category_moderating_group_ids)
       end
 
       config.allowed_group_ids.uniq!
@@ -88,19 +206,19 @@ after_initialize do
       config.allowed_group_ids = staff_groups
       config.allowed_user_ids = []
 
-      if SiteSetting.content_localization_enabled
-        config.allowed_group_ids += SiteSetting.content_localization_allowed_groups_map
-      end
-
       if topic.private_message?
         config.allowed_user_ids += topic.allowed_users.pluck(:id)
         config.allowed_group_ids += topic.allowed_groups.pluck(:group_id)
       elsif secure_group_ids = topic.secure_group_ids
         config.allowed_group_ids += secure_group_ids
+      elsif SiteSetting.content_localization_enabled
+        config.allowed_group_ids += SiteSetting.content_localization_allowed_groups_map
       end
 
-      if SiteSetting.content_localization_allow_author_localization
-        config.allowed_user_ids += [post.user_id]
+      if SiteSetting.content_localization_allow_author_localization &&
+           post.user.guardian.can_see?(topic)
+        config.allowed_user_ids ||= []
+        config.allowed_user_ids << post.user_id
       end
 
       config.allowed_group_ids.uniq!

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -31,17 +31,6 @@ after_initialize do
       config
     elsif topic_id = channel_name[%r{/discourse-presence/whisper/(\d+)}, 1]
       topic = Topic.find(topic_id)
-      config = PresenceChannel::Config.new
-
-      if topic.private_message?
-        config.allowed_user_ids = topic.allowed_users.pluck(:id)
-        config.allowed_group_ids = topic.allowed_groups.pluck(:id).presence
-      else
-        config.allowed_group_ids = SiteSetting.whispers_allowed_groups_map
-        config.allowed_group_ids &= topic.secure_group_ids if topic.secure_group_ids
-      end
-
-      config
       whisper_allowed_group_ids = SiteSetting.whispers_allowed_groups_map
 
       if !topic.private_message? && topic.shared_draft?

--- a/plugins/discourse-presence/spec/integration/presence_spec.rb
+++ b/plugins/discourse-presence/spec/integration/presence_spec.rb
@@ -285,6 +285,7 @@ RSpec.describe "discourse-presence" do
   describe "PresenceController#get" do
     fab!(:editor, :trust_level_1)
     fab!(:attacker, :trust_level_1)
+    fab!(:outside_user, :trust_level_1)
 
     fab!(:private_group) { Fabricate(:group).tap { |private_group| private_group.add(editor) } }
 
@@ -320,7 +321,7 @@ RSpec.describe "discourse-presence" do
     it "hides topic-backed presence from capability groups without topic access" do
       capability_group = Fabricate(:group)
       capability_group.add(editor)
-      capability_group.add(attacker)
+      capability_group.add(outside_user)
       whisper_post = Fabricate(:whisper, topic: private_topic, user: editor)
       editable_post = Fabricate(:post, topic: private_topic, user: editor)
       translation_post = Fabricate(:post, topic: private_topic, user: editor)
@@ -342,7 +343,7 @@ RSpec.describe "discourse-presence" do
       SiteSetting.content_localization_allowed_groups = "#{capability_group.id}|#{private_group.id}"
 
       expect(editor.guardian.can_see?(private_topic)).to eq(true)
-      expect(attacker.guardian.can_see?(private_topic)).to eq(false)
+      expect(outside_user.guardian.can_see?(private_topic)).to eq(false)
 
       sign_in(editor)
       post "/presence/update.json",
@@ -353,17 +354,18 @@ RSpec.describe "discourse-presence" do
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, true] })
 
-      sign_in(attacker)
+      sign_in(outside_user)
       get "/presence/get", params: { channels: channel_names }
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, nil] })
     end
 
     it "removes edit and translate presence access when post authors lose topic access" do
-      private_group.add(attacker)
-      private_category_post = Fabricate(:post, topic: private_topic, user: attacker, wiki: true)
-      private_message = Fabricate(:private_message_topic, user: editor, recipient: attacker)
-      private_message_post = Fabricate(:post, topic: private_message, user: attacker, wiki: true)
+      private_group.add(outside_user)
+      private_category_post = Fabricate(:post, topic: private_topic, user: outside_user, wiki: true)
+      private_message = Fabricate(:private_message_topic, user: editor, recipient: outside_user)
+      private_message_post =
+        Fabricate(:post, topic: private_message, user: outside_user, wiki: true)
       channel_names = [
         "/discourse-presence/edit/#{private_category_post.id}",
         "/discourse-presence/translate/#{private_category_post.id}",
@@ -376,10 +378,10 @@ RSpec.describe "discourse-presence" do
       SiteSetting.content_localization_allowed_groups = private_group.id
       SiteSetting.content_localization_allow_author_localization = true
 
-      expect(attacker.guardian.can_see?(private_topic)).to eq(true)
-      expect(attacker.guardian.can_see?(private_message)).to eq(true)
+      expect(outside_user.guardian.can_see?(private_topic)).to eq(true)
+      expect(outside_user.guardian.can_see?(private_message)).to eq(true)
 
-      sign_in(attacker)
+      sign_in(outside_user)
       post "/presence/update.json",
            params: {
              client_id: SecureRandom.hex,
@@ -388,12 +390,12 @@ RSpec.describe "discourse-presence" do
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, true] })
 
-      private_group.remove(attacker)
-      private_message.remove_allowed_user(editor, attacker)
+      private_group.remove(outside_user)
+      private_message.remove_allowed_user(editor, outside_user)
       PresenceChannel.clear_all!
 
-      expect(attacker.guardian.can_see?(private_topic)).to eq(false)
-      expect(attacker.guardian.can_see?(private_message)).to eq(false)
+      expect(outside_user.guardian.can_see?(private_topic)).to eq(false)
+      expect(outside_user.guardian.can_see?(private_message)).to eq(false)
 
       sign_in(editor)
       post "/presence/update.json",
@@ -404,7 +406,7 @@ RSpec.describe "discourse-presence" do
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, true] })
 
-      sign_in(attacker)
+      sign_in(outside_user)
       get "/presence/get", params: { channels: channel_names }
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, nil] })

--- a/plugins/discourse-presence/spec/integration/presence_spec.rb
+++ b/plugins/discourse-presence/spec/integration/presence_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe "discourse-presence" do
     end
 
     it "handles secure category permissions for edit" do
+      group.add(private_topic.user)
       p = Fabricate(:post, topic: private_topic, user: private_topic.user)
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}")
       expect(c.can_view?(user_id: user.id)).to eq(false)
@@ -314,6 +315,109 @@ RSpec.describe "discourse-presence" do
       get "/presence/get", params: { channels: [channel_name] }
       expect(response.status).to eq(200)
       expect(response.parsed_body[channel_name]).to eq(nil)
+    end
+
+    it "hides topic-backed presence from capability groups without topic access" do
+      capability_group = Fabricate(:group)
+      capability_group.add(editor)
+      capability_group.add(attacker)
+      whisper_post = Fabricate(:whisper, topic: private_topic, user: editor)
+      editable_post = Fabricate(:post, topic: private_topic, user: editor)
+      translation_post = Fabricate(:post, topic: private_topic, user: editor)
+      private_message = Fabricate(:private_message_topic, user: editor)
+      private_message_whisper = Fabricate(:whisper, topic: private_message, user: editor)
+      channel_names = [
+        "/discourse-presence/whisper/#{private_topic.id}",
+        "/discourse-presence/edit/#{whisper_post.id}",
+        "/discourse-presence/edit/#{editable_post.id}",
+        "/discourse-presence/translate/#{translation_post.id}",
+        "/discourse-presence/whisper/#{private_message.id}",
+        "/discourse-presence/edit/#{private_message_whisper.id}",
+      ]
+
+      Fabricate(:category_moderation_group, category: private_category, group: capability_group)
+      SiteSetting.enable_category_group_moderation = true
+      SiteSetting.whispers_allowed_groups = "#{capability_group.id}|#{private_group.id}"
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_allowed_groups = "#{capability_group.id}|#{private_group.id}"
+
+      expect(editor.guardian.can_see?(private_topic)).to eq(true)
+      expect(attacker.guardian.can_see?(private_topic)).to eq(false)
+
+      sign_in(editor)
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: channel_names,
+           }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, true] })
+
+      sign_in(attacker)
+      get "/presence/get", params: { channels: channel_names }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, nil] })
+    end
+
+    it "removes edit and translate presence access when post authors lose topic access" do
+      private_group.add(attacker)
+      private_category_post = Fabricate(:post, topic: private_topic, user: attacker, wiki: true)
+      private_message = Fabricate(:private_message_topic, user: editor, recipient: attacker)
+      private_message_post = Fabricate(:post, topic: private_message, user: attacker, wiki: true)
+      channel_names = [
+        "/discourse-presence/edit/#{private_category_post.id}",
+        "/discourse-presence/translate/#{private_category_post.id}",
+        "/discourse-presence/edit/#{private_message_post.id}",
+        "/discourse-presence/translate/#{private_message_post.id}",
+      ]
+
+      SiteSetting.edit_wiki_post_allowed_groups = private_group.id
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_allowed_groups = private_group.id
+      SiteSetting.content_localization_allow_author_localization = true
+
+      expect(attacker.guardian.can_see?(private_topic)).to eq(true)
+      expect(attacker.guardian.can_see?(private_message)).to eq(true)
+
+      sign_in(attacker)
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: channel_names,
+           }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, true] })
+
+      private_group.remove(attacker)
+      private_message.remove_allowed_user(editor, attacker)
+      PresenceChannel.clear_all!
+
+      expect(attacker.guardian.can_see?(private_topic)).to eq(false)
+      expect(attacker.guardian.can_see?(private_message)).to eq(false)
+
+      sign_in(editor)
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: channel_names,
+           }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, true] })
+
+      sign_in(attacker)
+      get "/presence/get", params: { channels: channel_names }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(channel_names.to_h { |channel_name| [channel_name, nil] })
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: channel_names,
+           }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(
+        channel_names.to_h { |channel_name| [channel_name, false] },
+      )
     end
   end
 end

--- a/plugins/discourse-presence/spec/requests/presence_controller_spec.rb
+++ b/plugins/discourse-presence/spec/requests/presence_controller_spec.rb
@@ -1,0 +1,401 @@
+# frozen_string_literal: true
+
+RSpec.describe PresenceController do
+  describe "#get" do
+    fab!(:whisperers_group, :group)
+    fab!(:private_group, :group)
+
+    fab!(:authorized_whisperer) do
+      Fabricate(:user).tap do |user|
+        whisperers_group.add(user)
+        private_group.add(user)
+      end
+    end
+
+    fab!(:unauthorized_whisperer) { Fabricate(:user).tap { |user| whisperers_group.add(user) } }
+    fab!(:private_category_user) { Fabricate(:user).tap { |user| private_group.add(user) } }
+
+    fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+    fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+
+    before do
+      PresenceChannel.clear_all!
+      SiteSetting.whispers_allowed_groups = whisperers_group.id.to_s
+    end
+
+    after { PresenceChannel.clear_all! }
+
+    it "only shows whisper presence to users who can whisper and see the topic" do
+      whisper_channel_name = "/discourse-presence/whisper/#{private_topic.id}"
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: authorized_whisperer.id,
+        client_id: SecureRandom.hex,
+      )
+
+      sign_in(unauthorized_whisperer)
+
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+
+      sign_in(private_category_user)
+
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+
+      sign_in(authorized_whisperer)
+
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      presence = response.parsed_body[whisper_channel_name]
+      expect(presence["count"]).to eq(1)
+      expect(presence["users"].map { |present_user| present_user["id"] }).to contain_exactly(
+        authorized_whisperer.id,
+      )
+      expect(PresenceChannel.new(whisper_channel_name).config.allowed_user_ids).to contain_exactly(
+        authorized_whisperer.id,
+      )
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => true)
+    end
+
+    it "requires shared draft visibility for whisper presence" do
+      shared_drafts_group = Fabricate(:group)
+      shared_draft_viewer =
+        Fabricate(:user).tap do |user|
+          whisperers_group.add(user)
+          private_group.add(user)
+          shared_drafts_group.add(user)
+        end
+      shared_draft_topic = Fabricate(:topic, category: private_category)
+      Fabricate(:shared_draft, topic: shared_draft_topic, category: Fabricate(:category))
+      SiteSetting.shared_drafts_category = private_category.id
+      SiteSetting.shared_drafts_allowed_groups = shared_drafts_group.id.to_s
+      whisper_channel_name = "/discourse-presence/whisper/#{shared_draft_topic.id}"
+
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: shared_draft_viewer.id,
+        client_id: SecureRandom.hex,
+      )
+
+      expect(authorized_whisperer.guardian.can_see?(shared_draft_topic)).to eq(false)
+      expect(shared_draft_viewer.guardian.can_see?(shared_draft_topic)).to eq(true)
+
+      sign_in(authorized_whisperer)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+
+      sign_in(shared_draft_viewer)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body[whisper_channel_name]["count"]).to eq(1)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => true)
+    end
+
+    it "allows whisperers who can see shared drafts through a logged-in user group" do
+      shared_draft_topic = Fabricate(:topic, category: private_category)
+      Fabricate(:shared_draft, topic: shared_draft_topic, category: Fabricate(:category))
+      SiteSetting.shared_drafts_category = private_category.id
+      SiteSetting.shared_drafts_allowed_groups = Group::AUTO_GROUPS[:logged_in_users].to_s
+      whisper_channel_name = "/discourse-presence/whisper/#{shared_draft_topic.id}"
+
+      expect(authorized_whisperer.guardian.can_see?(shared_draft_topic)).to eq(true)
+
+      sign_in(authorized_whisperer)
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => true)
+    end
+
+    it "denies a whisper-enabled moderator outside a private message" do
+      participant = Fabricate(:user)
+      whisperers_group.add(participant)
+      moderator = Fabricate(:moderator)
+      whisperers_group.add(moderator)
+      private_message = Fabricate(:private_message_topic, user: participant)
+      whisper_channel_name = "/discourse-presence/whisper/#{private_message.id}"
+
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: participant.id,
+        client_id: SecureRandom.hex,
+      )
+
+      sign_in(moderator)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+
+      sign_in(participant)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(
+        response.parsed_body[whisper_channel_name]["users"].map { |user| user["id"] },
+      ).to contain_exactly(participant.id)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => true)
+
+      admin = Fabricate(:admin)
+      whisperers_group.add(admin)
+      PresenceChannel.clear_all!
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: participant.id,
+        client_id: SecureRandom.hex,
+      )
+      sign_in(admin)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body[whisper_channel_name]["count"]).to eq(1)
+
+      SiteSetting.suppress_secured_categories_from_admin = true
+      PresenceChannel.clear_all!
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: participant.id,
+        client_id: SecureRandom.hex,
+      )
+
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+    end
+
+    it "allows whisperers who receive private message access through an allowed group" do
+      participant_group = Fabricate(:group)
+      participant = Fabricate(:user)
+      participant_group.add(participant)
+      whisperers_group.add(participant)
+      private_message = Fabricate(:private_message_topic, allowed_groups: [participant_group])
+      whisper_channel_name = "/discourse-presence/whisper/#{private_message.id}"
+
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: participant.id,
+        client_id: SecureRandom.hex,
+      )
+
+      sign_in(participant)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body[whisper_channel_name]["count"]).to eq(1)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => true)
+    end
+
+    it "honors suppressed category visibility for whisper-enabled admins" do
+      admin = Fabricate(:admin)
+      whisperers_group.add(admin)
+      whisper_channel_name = "/discourse-presence/whisper/#{private_topic.id}"
+      SiteSetting.suppress_secured_categories_from_admin = true
+
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: authorized_whisperer.id,
+        client_id: SecureRandom.hex,
+      )
+
+      sign_in(admin)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+    end
+
+    it "allows whisper-enabled moderators to view and enter flagged and official-warning PM channels" do
+      participant = Fabricate(:user)
+      moderator = Fabricate(:moderator)
+      whisperers_group.add(participant)
+      whisperers_group.add(moderator)
+
+      flagged_private_message = Fabricate(:private_message_topic, user: participant)
+      flagged_post = Fabricate(:post, topic: flagged_private_message, user: participant)
+      Fabricate(:reviewable_flagged_post, topic: flagged_private_message, target: flagged_post)
+
+      official_warning_private_message =
+        Fabricate(
+          :private_message_topic,
+          user: participant,
+          subtype: TopicSubtype.moderator_warning,
+        )
+
+      [flagged_private_message, official_warning_private_message].each do |private_message|
+        channel_name = "/discourse-presence/whisper/#{private_message.id}"
+        PresenceChannel.new(channel_name).present(
+          user_id: participant.id,
+          client_id: SecureRandom.hex,
+        )
+
+        expect(moderator.guardian.can_see?(private_message)).to eq(true)
+
+        sign_in(moderator)
+        get "/presence/get", params: { channels: [channel_name] }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body[channel_name]["count"]).to eq(1)
+
+        post "/presence/update.json",
+             params: {
+               client_id: SecureRandom.hex,
+               present_channels: [channel_name],
+             }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq(channel_name => true)
+      end
+    end
+
+    it "keeps public whisper presence available only to whisperers" do
+      public_topic = Fabricate(:topic)
+      outsider = Fabricate(:user)
+      whisper_channel_name = "/discourse-presence/whisper/#{public_topic.id}"
+
+      PresenceChannel.new(whisper_channel_name).present(
+        user_id: authorized_whisperer.id,
+        client_id: SecureRandom.hex,
+      )
+
+      sign_in(authorized_whisperer)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      presence = response.parsed_body[whisper_channel_name]
+      expect(presence["count"]).to eq(1)
+      expect(presence["users"].map { |user| user["id"] }).to contain_exactly(
+        authorized_whisperer.id,
+      )
+
+      sign_in(outsider)
+      get "/presence/get", params: { channels: [whisper_channel_name] }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => nil)
+
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [whisper_channel_name],
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(whisper_channel_name => false)
+    end
+
+    it "uses matching groups without materializing their members for restricted channels" do
+      shared_group = Fabricate(:group)
+      users = Fabricate.times(10, :user)
+      users.each { |user| shared_group.add(user) }
+      topics =
+        Fabricate.times(50, :topic, category: Fabricate(:private_category, group: shared_group))
+      channel_names = topics.map { |topic| "/discourse-presence/whisper/#{topic.id}" }
+      SiteSetting.whispers_allowed_groups = shared_group.id.to_s
+
+      sign_in(users.first)
+      get "/presence/get", params: { channels: channel_names }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.values).to all(be_truthy)
+      expect(
+        channel_names.map { |name| PresenceChannel.new(name).config.allowed_user_ids }.uniq,
+      ).to eq([nil])
+      expect(
+        channel_names.map { |name| PresenceChannel.new(name).config.allowed_group_ids }.uniq,
+      ).to eq([[shared_group.id]])
+    end
+  end
+end

--- a/spec/lib/presence_channel_spec.rb
+++ b/spec/lib/presence_channel_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe PresenceChannel do
         PresenceChannel::Config.new(allowed_user_ids: [user.id])
       when "/test/allowedgroup"
         PresenceChannel::Config.new(allowed_group_ids: [group.id])
+      when "/test/allowedgroupwithoutusers"
+        PresenceChannel::Config.new(allowed_user_ids: [], allowed_group_ids: [group.id])
       when "/test/everyonegroup"
         PresenceChannel::Config.new(allowed_group_ids: [Group::AUTO_GROUPS[:everyone]])
       when "/test/loggedingroup"
@@ -256,6 +258,18 @@ RSpec.describe PresenceChannel do
         channel.present(user_id: user.id, client_id: "a")
       end
     expect(messages.count).to eq(1)
+    expect(messages[0].group_ids).to eq([group.id])
+  end
+
+  it "publishes group-protected messages when allowed users is empty" do
+    channel = PresenceChannel.new("/test/allowedgroupwithoutusers")
+    messages =
+      MessageBus.track_publish(channel.message_bus_channel_name) do
+        channel.present(user_id: user.id, client_id: "a")
+      end
+
+    expect(messages.count).to eq(1)
+    expect(messages[0].user_ids).to eq(nil)
     expect(messages[0].group_ids).to eq([group.id])
   end
 


### PR DESCRIPTION
## Summary

Make topic-backed presence channels follow the current visibility rules of their topics across whispers, private messages, restricted categories, shared drafts, editing, and translation.

The combined implementation preserves the broad audience handling from patch #1139, includes the private-message and restricted-category cases from patch #2450, and refreshes author access for edit and translation channels from patch #2495.

## Patches

- **Require effective topic visibility for whisper presence channels in Discourse** ([patch #1139](https://patch.discourse.org/patch-triage/1139))
  Apply current topic visibility rules to whisper presence channels, including shared drafts, restricted categories, private-message participants and groups, and administrator visibility settings.
- **Scope whisper presence to the topic audience for private messages and restricted categories** ([patch #2450](https://patch.discourse.org/patch-triage/2450))
  Cover private-message recipients and groups as well as restricted-category audiences within the shared whisper-channel implementation. These cases overlap with, and are handled by, the broader implementation from patch #1139.
- **Revoke presence channel access for former authors of private topics** ([patch #2495](https://patch.discourse.org/patch-triage/2495))
  Recalculate edit and translation presence access when a post author’s current topic visibility changes.

## Source

- Patch group: https://patch.discourse.org/patch-triage/groups/6

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
