### PR TITLE
FIX: Keep design wizard welcome action in the footer

### DIFF
--- a/app/assets/stylesheets/common/components/design-wizard.scss
+++ b/app/assets/stylesheets/common/components/design-wizard.scss
@@ -806,6 +806,7 @@ $dw-button-default-border: #d3d3d3;
   &__actions {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: var(--space-2);
     padding-block-start: var(--space-4);
     border-block-start: 1px solid var(--content-border-color);

--- a/frontend/discourse/app/components/design-wizard/controls.gjs
+++ b/frontend/discourse/app/components/design-wizard/controls.gjs
@@ -167,7 +167,7 @@ export default class DesignWizardControls extends Component {
       </header>
 
       {{#if this.designWizard.showIntro}}
-        <IntroSection @onStart={{this.startFlow}} />
+        <IntroSection />
       {{else}}
         <div class="design-wizard__sections">
           {{#if (eq this.currentStep "theme")}}
@@ -232,7 +232,16 @@ export default class DesignWizardControls extends Component {
           {{/if}}
         </div>
 
-        <footer class="design-wizard__actions">
+      {{/if}}
+
+      <footer class="design-wizard__actions">
+        {{#if this.designWizard.showIntro}}
+          <DButton
+            class="btn-primary design-wizard__intro-start"
+            @action={{this.startFlow}}
+            @label="design_wizard.intro.start"
+          />
+        {{else}}
           <div class="design-wizard__step-dots">
             {{#each STEPS as |step index|}}
               <button
@@ -269,8 +278,8 @@ export default class DesignWizardControls extends Component {
               class="btn-primary design-wizard__next"
             />
           {{/if}}
-        </footer>
-      {{/if}}
+        {{/if}}
+      </footer>
     </div>
   </template>
 }

--- a/frontend/discourse/app/components/design-wizard/intro-section.gjs
+++ b/frontend/discourse/app/components/design-wizard/intro-section.gjs
@@ -1,4 +1,3 @@
-import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
@@ -11,11 +10,6 @@ const DesignWizardIntroSection = <template>
       {{dIcon "circle-info" class="design-wizard__intro-note-icon"}}
       <span>{{i18n "design_wizard.intro.autosave"}}</span>
     </p>
-    <DButton
-      @action={{@onStart}}
-      @label="design_wizard.intro.start"
-      class="btn-primary design-wizard__intro-start"
-    />
   </div>
 </template>;
 


### PR DESCRIPTION
**Previously**, the design wizard’s “Get started” button appeared beneath the welcome text instead of in the footer.

**In this update**, the welcome screen uses the shared wizard footer, keeping “Get started” at the bottom and aligned with the other primary actions.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/d9d69ede-2e3a-4b07-9d87-9b0dbebd765b) | ![After](https://github.com/user-attachments/assets/336573fb-aec6-441d-9964-b7a45ee845b4) |
