### PR TITLE
FIX: Render the like reaction as an icon when emojis are disabled

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions.gjs
@@ -36,8 +36,13 @@ export function resetCurrentReaction() {
 }
 
 function buildFakeReaction(reactionId) {
+  const emojiUrl = emojiUrlFor(reactionId);
+  if (!emojiUrl) {
+    return null;
+  }
+
   const img = document.createElement("img");
-  img.src = emojiUrlFor(reactionId);
+  img.src = emojiUrl;
   img.classList.add(
     "btn-toggle-reaction-emoji",
     "reaction-button",
@@ -59,6 +64,10 @@ function moveReactionAnimation(
   }
 
   const fakeReaction = buildFakeReaction(reactionId);
+  if (!fakeReaction) {
+    return run(complete);
+  }
+
   const reactionButton = postContainer.querySelector(".reaction-button");
 
   reactionButton.appendChild(fakeReaction);
@@ -340,7 +349,9 @@ export default class DiscourseReactionsActions extends Component {
       const pickedReaction = this.containerElement?.querySelector(
         `.discourse-reactions-picker .pickable-reaction.${CSS.escape(
           params.reaction
-        )} .emoji`
+        )} .emoji, .discourse-reactions-picker .pickable-reaction.${CSS.escape(
+          params.reaction
+        )} .d-icon`
       );
 
       const scales = [1.0, 1.75];

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
-import dEmoji from "discourse/ui-kit/helpers/d-emoji";
+import discourseReactionsEmoji from "../helpers/discourse-reactions-emoji";
 
 export default class DiscourseReactionsListEmoji extends Component {
   @service siteSettings;
@@ -12,7 +12,7 @@ export default class DiscourseReactionsListEmoji extends Component {
   <template>
     <span class="discourse-reactions-list-emoji" id={{this.elementId}}>
       {{#if @reaction.count}}
-        {{dEmoji
+        {{discourseReactionsEmoji
           @reaction.id
           class=(if
             this.siteSettings.discourse_reactions_desaturated_reaction_panel

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
@@ -6,8 +6,8 @@ import { service } from "@ember/service";
 import EmojiPicker from "discourse/components/emoji-picker";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
-import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 import { i18n } from "discourse-i18n";
+import discourseReactionsEmoji from "../helpers/discourse-reactions-emoji";
 
 export default class DiscourseReactionsPicker extends Component {
   @service capabilities;
@@ -186,7 +186,7 @@ export default class DiscourseReactionsPicker extends Component {
               }}
               @translatedTitle={{reaction.title}}
             >
-              {{dEmoji reaction.id}}
+              {{discourseReactionsEmoji reaction.id}}
             </DButton>
           {{/each}}
           {{#if this.siteSettings.discourse_reactions_allow_any_emoji}}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-emoji.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-emoji.gjs
@@ -1,17 +1,18 @@
 import Component from "@glimmer/component";
-import { emojiUrlFor } from "discourse/lib/text";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
+import discourseReactionsEmoji from "../helpers/discourse-reactions-emoji";
 
 export default class DiscourseReactionsReactionEmoji extends Component {
-  get emojiUrl() {
-    const reactionValue = this.args.reaction.reaction?.reaction_value;
-    return reactionValue ? emojiUrlFor(reactionValue) : null;
+  get reactionValue() {
+    return this.args.reaction.reaction?.reaction_value;
   }
 
   <template>
     {{#if @reaction.reaction.reaction_users_count}}
       <div class="discourse-reactions-my-reaction">
-        <img class="reaction-emoji" src={{this.emojiUrl}} />
+        {{#if this.reactionValue}}
+          {{discourseReactionsEmoji this.reactionValue class="reaction-emoji"}}
+        {{/if}}
         <a
           class="avatar-link"
           data-user-card={{@reaction.user.username}}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -7,9 +7,9 @@ import { service } from "@ember/service";
 import UsersPopup from "discourse/components/user/users-popup";
 import { eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
-import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import discourseReactionsEmoji from "../helpers/discourse-reactions-emoji";
 import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 export default class DiscourseReactionsUsersMenu extends Component {
@@ -150,7 +150,7 @@ export default class DiscourseReactionsUsersMenu extends Component {
                 type="button"
                 {{on "click" (fn this.selectFilter reaction.id)}}
               >
-                {{dEmoji reaction.id}}
+                {{discourseReactionsEmoji reaction.id}}
                 <span>{{reaction.count}}</span>
               </button>
             {{/each}}
@@ -160,7 +160,10 @@ export default class DiscourseReactionsUsersMenu extends Component {
 
       <:reaction as |user|>
         {{#if user.reaction}}
-          {{dEmoji user.reaction class="users-popup__reaction"}}
+          {{discourseReactionsEmoji
+            user.reaction
+            class="users-popup__reaction"
+          }}
         {{else}}
           {{dIcon "d-liked" class="users-popup__reaction"}}
         {{/if}}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/helpers/discourse-reactions-emoji.js
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/helpers/discourse-reactions-emoji.js
@@ -1,0 +1,25 @@
+import Helper from "@ember/component/helper";
+import { service } from "@ember/service";
+import dEmoji from "discourse/ui-kit/helpers/d-emoji";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+
+export default class DiscourseReactionsEmoji extends Helper {
+  @service siteSettings;
+
+  compute([reaction], options) {
+    // The like reaction must stay usable without emoji rendering, so fall
+    // back to the configured like icon when emojis are disabled site-wide.
+    if (
+      !this.siteSettings.enable_emoji &&
+      reaction === this.siteSettings.discourse_reactions_reaction_for_like
+    ) {
+      const icon = this.siteSettings.discourse_reactions_like_icon;
+      return dIcon(icon === "heart" ? "d-liked" : icon, {
+        ...options,
+        "aria-label": reaction,
+      });
+    }
+
+    return dEmoji(reaction, options);
+  }
+}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -15,9 +15,19 @@ replaceIcon("notification.reaction", "bell");
 function initializeDiscourseReactions(api) {
   customizePostMenu(api);
 
-  api.addKeyboardShortcut("l", null, {
-    click: ".topic-post.selected .discourse-reactions-reaction-button",
-  });
+  api.addKeyboardShortcut(
+    "l",
+    () => {
+      document
+        .querySelector(
+          ".topic-post.selected .discourse-reactions-reaction-button"
+        )
+        ?.click();
+    },
+    {
+      context: ".topic-post.selected .discourse-reactions-reaction-button",
+    }
+  );
 
   api.addTrackedPostProperties(
     "current_user_used_main_reaction",

--- a/plugins/discourse-reactions/assets/stylesheets/common/discourse-reactions.scss
+++ b/plugins/discourse-reactions/assets/stylesheets/common/discourse-reactions.scss
@@ -25,7 +25,8 @@ html.discourse-reactions-no-select {
         display: none;
       }
 
-      .emoji {
+      .emoji,
+      .d-icon {
         width: 1em;
         height: 1em;
 
@@ -103,7 +104,8 @@ html.discourse-reactions-no-select {
     cursor: not-allowed;
     border-radius: var(--d-border-radius);
 
-    .emoji {
+    .emoji,
+    .d-icon {
       pointer-events: none;
       height: 1.2em;
       width: 1.2em;

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_button.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_button.rb
@@ -31,6 +31,12 @@ module PageObjects
         has_css?(".pickable-reaction.#{emoji}")
       end
 
+      def has_reaction_icon?(reaction, icon)
+        context_component.has_css?(
+          ".pickable-reaction[data-reaction='#{reaction}'] .d-icon-#{icon}",
+        )
+      end
+
       def pick_reaction(emoji)
         find(".pickable-reaction.#{emoji}").click
       end

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
@@ -27,6 +27,10 @@ module PageObjects
         component.has_css?(reaction_list_emoji_selector(reaction))
       end
 
+      def has_reaction_icon?(reaction, icon)
+        component.has_css?("#{reaction_list_emoji_selector(reaction)} .d-icon-#{icon}")
+      end
+
       def click_reaction(reaction)
         component.find(reaction_list_emoji_selector(reaction)).click
       end

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_popup.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_popup.rb
@@ -24,6 +24,12 @@ module PageObjects
       def has_no_user?(username)
         page.has_no_css?("#{SELECTOR} .users-popup__name[data-user-card=#{username}]")
       end
+
+      def has_user_reaction_icon?(user, icon)
+        page.has_css?(
+          "#{SELECTOR} .users-popup__item:has(.users-popup__name[data-user-card='#{user.username}']) .users-popup__reaction.d-icon-#{icon}",
+        )
+      end
     end
   end
 end

--- a/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
+++ b/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
@@ -12,6 +12,7 @@ describe "Reactions | Post reactions" do
   let(:reactions_list) do
     PageObjects::Components::PostReactionsList.new("#post_#{post_2.post_number}")
   end
+  let(:popup) { PageObjects::Components::PostReactionsPopup.new }
 
   before do
     SiteSetting.discourse_reactions_enabled = true
@@ -69,6 +70,24 @@ describe "Reactions | Post reactions" do
     expect(reactions_list).to have_reaction("laughing")
   end
 
+  it "lets the user like a post and see who liked it with emojis disabled" do
+    SiteSetting.enable_emoji = false
+    SiteSetting.discourse_reactions_enabled_reactions = "heart"
+
+    visit post_2.url
+    reactions_button.hover_like_button(post_2.id)
+    expect(reactions_button).to have_reaction_icon("heart", "d-liked")
+
+    reactions_button.pick_reaction("heart")
+    expect(reactions_list).to have_reaction_icon("heart", "d-liked")
+
+    page.refresh
+    expect(reactions_list).to have_reaction_icon("heart", "d-liked")
+
+    reactions_list.click_counter
+    expect(popup).to have_user_reaction_icon(current_user, "d-liked")
+  end
+
   it "does not show emoji_deny_list emojis for post reactions" do
     SiteSetting.emoji_deny_list = "middle_finger"
     visit post_2.url
@@ -111,7 +130,6 @@ describe "Reactions | Post reactions" do
 
   context "when clicking a reaction whose value contains a URL-reserved character" do
     fab!(:other_user, :user)
-    let(:popup) { PageObjects::Components::PostReactionsPopup.new }
 
     before do
       DiscourseReactions::ReactionManager.new(

--- a/plugins/discourse-reactions/test/javascripts/integration/helpers/discourse-reactions-emoji-test.gjs
+++ b/plugins/discourse-reactions/test/javascripts/integration/helpers/discourse-reactions-emoji-test.gjs
@@ -1,0 +1,88 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { replaceIcon, REPLACEMENTS } from "discourse/lib/icon-library";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import discourseReactionsEmoji from "discourse/plugins/discourse-reactions/discourse/helpers/discourse-reactions-emoji";
+
+module("Integration | Helper | discourse-reactions-emoji", function (hooks) {
+  setupRenderingTest(hooks);
+
+  let originalLikeIcon;
+
+  hooks.beforeEach(function () {
+    this.siteSettings.enable_emoji = false;
+    this.siteSettings.discourse_reactions_reaction_for_like = "heart";
+    this.siteSettings.discourse_reactions_like_icon = "heart";
+    originalLikeIcon = REPLACEMENTS["d-liked"];
+  });
+
+  hooks.afterEach(function () {
+    replaceIcon("d-liked", originalLikeIcon);
+  });
+
+  test("uses the configured reaction and icon for likes", async function (assert) {
+    this.siteSettings.discourse_reactions_reaction_for_like = "+1";
+    this.siteSettings.discourse_reactions_like_icon = "star";
+
+    await render(
+      <template>
+        {{discourseReactionsEmoji "+1" class="users-popup__reaction"}}
+      </template>
+    );
+
+    assert
+      .dom("svg.users-popup__reaction use")
+      .hasAttribute(
+        "href",
+        "#star",
+        "the custom like icon retains the supplied class"
+      );
+    assert
+      .dom("svg")
+      .hasAria("label", "+1", "the reaction has an accessible label");
+  });
+
+  test("respects theme replacements for the like icon", async function (assert) {
+    replaceIcon("d-liked", "thumbs-up");
+
+    await render(<template>{{discourseReactionsEmoji "heart"}}</template>);
+
+    assert
+      .dom("svg use")
+      .hasAttribute("href", "#thumbs-up", "the heart uses the d-liked alias");
+  });
+
+  test("renders likes as emoji when emojis are enabled", async function (assert) {
+    this.siteSettings.enable_emoji = true;
+
+    await render(
+      <template>
+        {{discourseReactionsEmoji "heart" class="users-popup__reaction"}}
+      </template>
+    );
+
+    assert
+      .dom("img.emoji.users-popup__reaction")
+      .hasAttribute("alt", "heart", "the like remains an emoji image");
+    assert
+      .dom("img.emoji")
+      .hasAttribute("title", "heart", "the emoji keeps its tooltip");
+  });
+
+  test("keeps other reactions as text when emojis are disabled", async function (assert) {
+    this.siteSettings.discourse_reactions_reaction_for_like = "+1";
+
+    await render(
+      <template>
+        <span>{{discourseReactionsEmoji "heart"}}</span>
+      </template>
+    );
+
+    assert
+      .dom("span")
+      .hasText(
+        ":heart:",
+        "the fallback only applies to the configured like reaction"
+      );
+  });
+});


### PR DESCRIPTION
With `enable_emoji` disabled, likes were rendered as literal `:heart:` text in the reactions picker, list, and users menu, and as a broken image on the My Reactions page. This was inconsistent with the like button, which already uses an icon.

Since disabling emojis is an intentional site choice, we shouldn't enable them just for likes. Instead, the like reaction should fall back to the configured like icon (`d-liked`) across all surfaces where it is rendered. Other reactions should remain as text.