### PR TITLE
DEV: Fill ui-kit gaps that force consumers to hand-roll

### DIFF
--- a/app/assets/stylesheets/common/components/d-page-header.scss
+++ b/app/assets/stylesheets/common/components/d-page-header.scss
@@ -9,12 +9,17 @@ $mobile-breakpoint: 700px;
     align-items: stretch;
     margin-bottom: var(--space-2);
 
+    // Keyed on the title classes as well as the tags: a subheader nested under
+    // another heading picks its own level, and its styling must not depend on
+    // which level it picked.
     h1,
-    h2 {
+    h2,
+    .d-page-header__title,
+    .d-page-subheader__title {
       margin: 0;
     }
 
-    h2 {
+    .d-page-subheader__title {
       font-size: var(--font-up-2);
     }
 

--- a/app/assets/stylesheets/common/components/empty-states.scss
+++ b/app/assets/stylesheets/common/components/empty-states.scss
@@ -49,6 +49,17 @@
     @include viewport.until(sm) {
       margin-top: 8vh;
     }
+
+    // Sized as a glyph, overriding the illustration width above.
+    &.--icon svg {
+      width: 3rem;
+      height: 3rem;
+      color: var(--primary-low-mid);
+
+      @include viewport.until(sm) {
+        width: 3rem;
+      }
+    }
   }
 
   &__cta {

--- a/frontend/discourse/app/lib/avatar-utils.js
+++ b/frontend/discourse/app/lib/avatar-utils.js
@@ -86,7 +86,12 @@ export function avatarImg(options, customGetURL) {
     loading = ` loading='${escaped}'`;
   }
 
-  return `<img alt='' width='${size}' height='${size}' src='${url}' class='${classes}'${title}${loading}>`;
+  // Empty by default: an avatar almost always sits beside the name it belongs
+  // to, where alt text would only repeat it. Pass `alt` where the image is the
+  // sole identification of the person.
+  const alt = escape(options.alt || "");
+
+  return `<img alt='${alt}' width='${size}' height='${size}' src='${url}' class='${classes}'${title}${loading}>`;
 }
 
 export function tinyAvatar(avatarTemplate, options) {

--- a/frontend/discourse/app/ui-kit/d-button.gts
+++ b/frontend/discourse/app/ui-kit/d-button.gts
@@ -33,6 +33,7 @@ export interface DButtonSignature {
     action?: DButtonAction;
     actionParam?: unknown;
     forwardEvent?: boolean;
+    immediate?: boolean;
     onKeyDown?: (event: KeyboardEvent) => void;
 
     // Navigation
@@ -175,45 +176,37 @@ export default class DButton extends Component<DButtonSignature> {
 
   _triggerAction(event: Event) {
     const { action: actionVal, route, routeModels } = this.args;
-    const isIOS = this.capabilities?.isIOS;
 
     if (actionVal || route) {
       if (actionVal) {
-        const { actionParam, forwardEvent } = this.args;
+        const { actionParam, forwardEvent, immediate } = this.args;
 
-        if (typeof actionVal === "object" && actionVal.value) {
-          if (isIOS) {
-            // Don't optimise INP in iOS
-            // it results in focus events not being triggered
-            if (forwardEvent) {
-              actionVal.value(actionParam, event);
-            } else {
-              actionVal.value(actionParam);
-            }
-          } else {
-            // Using `next()` to optimise INP
-            next(() =>
-              forwardEvent
-                ? actionVal.value(actionParam, event)
-                : actionVal.value(actionParam)
-            );
-          }
-        } else if (typeof actionVal === "function") {
-          if (isIOS) {
-            // Don't optimise INP in iOS
-            // it results in focus events not being triggered
-            if (forwardEvent) {
-              actionVal(actionParam, event);
-            } else {
-              actionVal(actionParam);
-            }
-          } else {
-            // Using `next()` to optimise INP
-            next(() =>
-              forwardEvent
+        const isFunction = typeof actionVal === "function";
+        const isCallableObject =
+          typeof actionVal === "object" && !!actionVal.value;
+
+        if (isFunction || isCallableObject) {
+          // `actionVal.value(…)` stays a member call rather than an extracted
+          // reference: the call binds `this` to the action object, and the
+          // lookup happens when the handler actually runs, so a `.value`
+          // replaced between dispatch and a deferred run still wins.
+          const invoke = () =>
+            isFunction
+              ? forwardEvent
                 ? actionVal(actionParam, event)
                 : actionVal(actionParam)
-            );
+              : forwardEvent
+                ? actionVal.value(actionParam, event)
+                : actionVal.value(actionParam);
+
+          // `next()` defers the handler so the browser can paint first (INP).
+          // Two cases must run inside the dispatch instead: iOS, where the
+          // deferral stops focus events firing, and handlers needing the
+          // click's transient user activation, which does not survive it.
+          if (immediate || this.capabilities?.isIOS) {
+            invoke();
+          } else {
+            next(invoke);
           }
         }
       } else if (route) {

--- a/frontend/discourse/app/ui-kit/d-combo-button.gts
+++ b/frontend/discourse/app/ui-kit/d-combo-button.gts
@@ -4,7 +4,10 @@ import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
 import type { WithBoundArgs } from "@glint/template";
 import curryComponent from "ember-curry-component";
-import DMenu, { DMenuSignature } from "discourse/float-kit/components/d-menu";
+import DMenu, {
+  DMenuComponentArgs,
+  DMenuSignature,
+} from "discourse/float-kit/components/d-menu";
 import { or } from "discourse/truth-helpers";
 import DButton, { DButtonSignature } from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -36,7 +39,8 @@ interface MenuSignature {
       /** Curried in by the group; the menu renders only when it is true. */
       hasMenu?: boolean;
     };
-  Blocks: { default: [] };
+  /** The menu's own API, forwarded so content can close the menu it sits in. */
+  Blocks: { default: [DMenuComponentArgs] };
 }
 
 class Button extends Component<ButtonSignature> {
@@ -77,8 +81,8 @@ class Menu extends Component<MenuSignature> {
           class={{dConcatClass "d-combo-button-menu" @btnTypeClass}}
           ...attributes
         >
-          <:content>
-            {{yield}}
+          <:content as |menu|>
+            {{yield menu}}
           </:content>
         </CurriedComponent>
       {{/let}}
@@ -110,12 +114,19 @@ interface DComboButtonSignature {
  * Pass `@hasMenu` rather than adding `--has-menu` by hand: the group publishes
  * that class itself and uses the same flag to decide whether the menu renders.
  *
+ * `combo.Menu` yields the menu's own API, so an item can close the menu it sits
+ * in without the call site registering the instance separately.
+ *
  * @example
  * ```gjs
  * <DComboButton @hasMenu={{this.hasDrafts}} @btnTypeClass="btn-default" as |combo|>
  *   <combo.Button @label="topic.create" @action={{this.createTopic}} />
- *   <combo.Menu @identifier="drafts">
- *     <DDropdownMenu as |dropdown|>…</DDropdownMenu>
+ *   <combo.Menu @identifier="drafts" as |menu|>
+ *     <DDropdownMenu as |dropdown|>
+ *       <dropdown.item>
+ *         <DButton @action={{fn this.openDraft menu.close}} @label="drafts.open" />
+ *       </dropdown.item>
+ *     </DDropdownMenu>
  *   </combo.Menu>
  * </DComboButton>
  * ```

--- a/frontend/discourse/app/ui-kit/d-empty-state.gjs
+++ b/frontend/discourse/app/ui-kit/d-empty-state.gjs
@@ -7,12 +7,17 @@ const DEmptyState = <template>
   <div
     class="empty-state__container
       {{if @identifier (concat '--' @identifier)}}
-      {{if @svgContent '--with-image' '--text-only'}}"
+      {{if (or @svgContent @icon) '--with-image' '--text-only'}}"
+    ...attributes
   >
     <div class="empty-state">
       {{#if @svgContent}}
         <div class="empty-state__image">
           {{@svgContent}}
+        </div>
+      {{else if @icon}}
+        <div class="empty-state__image --icon">
+          {{dIcon @icon}}
         </div>
       {{/if}}
 

--- a/frontend/discourse/app/ui-kit/d-page-subheader.gjs
+++ b/frontend/discourse/app/ui-kit/d-page-subheader.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
@@ -13,16 +14,34 @@ import {
   WrappedActionListItem,
   WrappedButton,
 } from "discourse/ui-kit/d-page-action-button";
+import dElement from "discourse/ui-kit/helpers/d-element";
 import { i18n } from "discourse-i18n";
 
 export default class DPageSubheader extends Component {
   @service site;
 
+  /**
+   * The element the title renders as. A subheader nested under another heading
+   * needs to continue that heading structure rather than restart it at `h2`.
+   *
+   * @returns {object} A component wrapping the heading tag.
+   */
+  get titleTag() {
+    const level = this.args.titleHeadingLevel ?? 2;
+
+    assert(
+      `DPageSubheader @titleHeadingLevel must be 1-6, got ${level}`,
+      Number.isInteger(level) && level >= 1 && level <= 6
+    );
+
+    return dElement(`h${level}`);
+  }
+
   <template>
     <div class="d-page-subheader">
       <div class="d-page-subheader__title-row">
         {{#if @titleLabel}}
-          <h2 class="d-page-subheader__title">
+          <this.titleTag class="d-page-subheader__title">
             {{#if @titleUrl}}
               <a href={{@titleUrl}} class="d-page-subheader__title-link">
                 {{@titleLabel}}
@@ -30,7 +49,7 @@ export default class DPageSubheader extends Component {
             {{else}}
               {{@titleLabel}}
             {{/if}}
-          </h2>
+          </this.titleTag>
         {{/if}}
         {{#if (has-block "actions")}}
           <div class="d-page-subheader__actions">

--- a/frontend/discourse/app/ui-kit/d-resize-handles.gts
+++ b/frontend/discourse/app/ui-kit/d-resize-handles.gts
@@ -204,12 +204,16 @@ interface DResizeHandlesSignature<
       dragInfo: DResizeHandleDragInfo<NoInfer<Payload>, Session>
     ) => void;
 
-    /** A class toggled on the active handle while it is being dragged. */
+    /**
+     * A class toggled on the active handle while it is being dragged. Under a
+     * `@threshold` it waits for that distance, so a click on a handle never
+     * looks like a resize.
+     */
     draggingClass?: string;
 
     /**
-     * Pixels of travel before `@onResize` starts firing, to absorb the jitter of
-     * a click that was never meant to be a drag.
+     * Pixels of travel before `@onResize` starts firing and `@draggingClass`
+     * goes on, to absorb the jitter of a click that was never meant to be a drag.
      */
     threshold?: number;
 

--- a/frontend/discourse/app/ui-kit/helpers/d-avatar.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-avatar.js
@@ -73,6 +73,9 @@ export function renderAvatar(user, options) {
       extraClasses: get(user, "extras") || options.extraClasses,
       loading: options.loading,
       title: options.hideTitle ? null : title || displayName,
+      // `alt: true` names the person rather than making the caller repeat the
+      // display-name logic above; a string sets it verbatim.
+      alt: options.alt === true ? displayName : options.alt,
       avatarTemplate,
     });
   } else {

--- a/frontend/discourse/app/ui-kit/helpers/d-element.gts
+++ b/frontend/discourse/app/ui-kit/helpers/d-element.gts
@@ -13,7 +13,13 @@ type ShortcutTag =
   | "td"
   | "aside"
   | "ul"
-  | "li";
+  | "li"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6";
 
 /**
  * A wrapper component for a single known tag, typed with the matching element so
@@ -60,6 +66,24 @@ const shortcuts: { [K in ShortcutTag]: ElementWrapper<K> } = {
   </template>,
   li: <template>
     <li ...attributes>{{yield}}</li>
+  </template>,
+  h1: <template>
+    <h1 ...attributes>{{yield}}</h1>
+  </template>,
+  h2: <template>
+    <h2 ...attributes>{{yield}}</h2>
+  </template>,
+  h3: <template>
+    <h3 ...attributes>{{yield}}</h3>
+  </template>,
+  h4: <template>
+    <h4 ...attributes>{{yield}}</h4>
+  </template>,
+  h5: <template>
+    <h5 ...attributes>{{yield}}</h5>
+  </template>,
+  h6: <template>
+    <h6 ...attributes>{{yield}}</h6>
   </template>,
 };
 

--- a/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-pointer-drag.ts
@@ -88,6 +88,9 @@ interface DPointerDragSignature {
        * A class toggled on the element for the gesture's duration. A single
        * token: a value with whitespace in it is rejected by the DOM, which costs
        * the drag its styling but leaves the gesture working.
+       *
+       * Applied when the gesture engages, so under a `threshold` it waits for
+       * the same distance `onDrag` does rather than landing on the press.
        */
       draggingClass?: string;
 
@@ -103,16 +106,24 @@ interface DPointerDragSignature {
        * Reach for a class on a shared ancestor, not this, when the target is
        * simply outside the dragged element's subtree — a sibling is still
        * reachable from the parent the two have in common.
+       *
+       * Applied when the gesture engages, on the same terms as `draggingClass`.
        */
       bodyClass?: string;
 
       /**
        * Pixels of travel, measured as a straight line from the press origin, that
-       * `onDrag` waits for before it starts firing. Reaching the distance is
-       * enough; it does not have to be exceeded. Suppresses the jitter of a click
-       * that was never meant to be a drag. Defaults to `0`. Read live until the
-       * distance is reached; only the latch is permanent, so raising it after
-       * movement has engaged will not re-suppress a gesture already under way.
+       * the gesture waits for before it engages: `onDrag` starts firing, and
+       * `draggingClass` and `bodyClass` go on. Reaching the distance is enough;
+       * it does not have to be exceeded. Suppresses the jitter of a click that
+       * was never meant to be a drag, in behaviour and in appearance alike.
+       * Defaults to `0`. Read live until the distance is reached; only the latch
+       * is permanent, so raising it after movement has engaged will not
+       * re-suppress a gesture already under way.
+       *
+       * `onDragStart` and `onDragEnd` are NOT gated by it: a press that never
+       * travels far enough still opens and commits the gesture, so read the
+       * position rather than assuming movement. `info.moved` tells the two apart.
        */
       threshold?: number;
 
@@ -261,6 +272,38 @@ export function registerPointerDrag(
     delta: { x: event.clientX - originX, y: event.clientY - originY },
     moved,
   });
+
+  /**
+   * Marks the element and the body as dragging. Called when the gesture
+   * ENGAGES rather than when it is pressed, which for a gesture carrying a
+   * `threshold` are different moments: below that distance the press is still a
+   * click, and a rule keyed on these classes must not contradict that. A class
+   * that suppresses pointer events on descendants would otherwise take every
+   * plain click on the element. Without a threshold a gesture engages at the
+   * press, so this still runs there.
+   *
+   * @param args - The gesture's args, as read for the dispatch that engaged it.
+   */
+  const applyGestureClasses = (args: DPointerDragArgs) => {
+    if (args.draggingClass) {
+      try {
+        element.classList.add(args.draggingClass);
+        // Only once it is really on the element, so `finish` never tries to
+        // remove a token the DOM rejected.
+        appliedClass = args.draggingClass;
+      } catch {
+        // A whitespace token is a caller mistake: it costs the drag its styling
+        // but must not abort the gesture.
+      }
+    }
+    if (args.bodyClass) {
+      try {
+        bodyClassLease = new ElementClassLease(document.body, args.bodyClass);
+      } catch {
+        // Same as above: a rejected token costs the page-level styling only.
+      }
+    }
+  };
 
   const finish = () => {
     const finishedPointer = pointerId;
@@ -412,23 +455,8 @@ export function registerPointerDrag(
     const superseded = pointerOwners.get(event.pointerId);
     pointerOwners.set(event.pointerId, { element, supersede: onSuperseded });
 
-    if (args.draggingClass) {
-      try {
-        element.classList.add(args.draggingClass);
-        // Only once it is really on the element, so `finish` never tries to
-        // remove a token the DOM rejected.
-        appliedClass = args.draggingClass;
-      } catch {
-        // A whitespace token is a caller mistake: it costs the drag its styling
-        // but must not abort the gesture.
-      }
-    }
-    if (args.bodyClass) {
-      try {
-        bodyClassLease = new ElementClassLease(document.body, args.bodyClass);
-      } catch {
-        // Same as above: a rejected token costs the page-level styling only.
-      }
+    if (engaged) {
+      applyGestureClasses(args);
     }
 
     // Only an accepted press is suppressed. A secondary button, a press during
@@ -456,6 +484,7 @@ export function registerPointerDrag(
         return;
       }
       engaged = true;
+      applyGestureClasses(args);
     }
     // Latched before the dispatch, so this report already counts as movement.
     moved = true;

--- a/frontend/discourse/tests/integration/ui-kit/consumer-gaps-independent-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/consumer-gaps-independent-test.gjs
@@ -1,0 +1,329 @@
+import { tracked } from "@glimmer/tracking";
+import {
+  click,
+  find,
+  render,
+  rerender,
+  settled,
+  triggerEvent,
+} from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { capabilities } from "discourse/services/capabilities";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DButton from "discourse/ui-kit/d-button";
+import DComboButton from "discourse/ui-kit/d-combo-button";
+import DEmptyState from "discourse/ui-kit/d-empty-state";
+import DPageSubheader from "discourse/ui-kit/d-page-subheader";
+import dAvatar from "discourse/ui-kit/helpers/d-avatar";
+import dElement from "discourse/ui-kit/helpers/d-element";
+
+module("Integration | ui-kit | ConsumerGapsIndependent", function (hooks) {
+  setupRenderingTest(hooks);
+
+  for (const isIOS of [false, true]) {
+    for (const immediate of [false, true]) {
+      for (const type of ["click", "keydown"]) {
+        test(`Independent030eac exact dispatch iOS=${isIOS} immediate=${immediate} ${type}`, async function (assert) {
+          sinon.stub(capabilities, "isIOS").get(() => isIOS);
+          const calls = [];
+          const param = { marker: true };
+          const handler = (value, event) =>
+            calls.push({ value, event, phase: event.eventPhase });
+          await render(
+            <template>
+              <DButton
+                class="independent-button"
+                @action={{handler}}
+                @actionParam={{param}}
+                @forwardEvent={{true}}
+                @immediate={{immediate}}
+              />
+            </template>
+          );
+          const button = find(".independent-button");
+          const event =
+            type === "click"
+              ? new MouseEvent(type, { bubbles: true, cancelable: true })
+              : new KeyboardEvent(type, {
+                  key: "Enter",
+                  bubbles: true,
+                  cancelable: true,
+                });
+          // Raw dispatch is necessary to observe the boundary before settling.
+          button.dispatchEvent(event);
+          assert.strictEqual(
+            calls.length,
+            isIOS || immediate ? 1 : 0,
+            "dispatch boundary is observable"
+          );
+          assert.true(
+            event.defaultPrevented,
+            "component intercepted the event"
+          );
+          await settled();
+          assert.strictEqual(
+            calls.length,
+            1,
+            "one action, including after settling"
+          );
+          assert.strictEqual(
+            calls[0].event,
+            event,
+            "the exact original event is forwarded"
+          );
+          assert.strictEqual(
+            calls[0].value,
+            param,
+            "the original parameter identity is retained"
+          );
+          assert.strictEqual(
+            calls[0].phase,
+            isIOS || immediate ? Event.AT_TARGET : Event.NONE,
+            "callback runs in the target listener or after dispatch"
+          );
+        });
+      }
+    }
+  }
+
+  test("Independent030eac custom key handler owns Enter", async function (assert) {
+    const handler = sinon.spy();
+    const onKeyDown = sinon.spy();
+    await render(
+      <template>
+        <DButton
+          @action={{handler}}
+          @immediate={{true}}
+          @onKeyDown={{onKeyDown}}
+        />
+      </template>
+    );
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+    find(".btn").dispatchEvent(event);
+    await settled();
+    assert.true(
+      onKeyDown.calledOnceWithExactly(event),
+      "custom handler gets the original event"
+    );
+    assert.false(handler.called, "Enter does not also invoke the action");
+  });
+
+  test("Independent030eac disabled native buttons suppress activation", async function (assert) {
+    const handler = sinon.spy();
+    await render(
+      <template>
+        <DButton
+          class="disabled"
+          @action={{handler}}
+          @disabled={{true}}
+        /><DButton class="loading" @action={{handler}} @isLoading={{true}} />
+      </template>
+    );
+    assert
+      .dom("button.disabled")
+      .isDisabled("disabled argument reaches native button");
+    assert
+      .dom("button.loading")
+      .isDisabled("loading disables the native button");
+    find("button.disabled").click();
+    find("button.loading").click();
+    await settled();
+    assert.false(handler.called, "native activation is suppressed");
+  });
+
+  test("Independent030eac heading identity and link survive title updates", async function (assert) {
+    const state = new (class {
+      @tracked title = "First";
+      @tracked level = 2;
+    })();
+    await render(
+      <template>
+        <DPageSubheader
+          @titleHeadingLevel={{state.level}}
+          @titleLabel={{state.title}}
+          @titleUrl="#independent"
+        />
+      </template>
+    );
+    const heading = find("h2.d-page-subheader__title");
+    const link = find(".d-page-subheader__title-link");
+    assert
+      .dom(heading)
+      .doesNotHaveClass(
+        "ember-view",
+        "heading shortcut avoids classic component markup"
+      );
+    assert
+      .dom(heading)
+      .doesNotHaveAttribute("id", "heading shortcut has no generated id");
+    state.title = "Second";
+    await rerender();
+    assert.strictEqual(
+      find("h2.d-page-subheader__title"),
+      heading,
+      "same-level rerender preserves heading node"
+    );
+    assert.strictEqual(
+      find(".d-page-subheader__title-link"),
+      link,
+      "same-level rerender preserves linked child"
+    );
+    assert.dom(link).hasText("Second", "text updates in place");
+    for (const level of [1, 3, 4, 5, 6, 2]) {
+      state.level = level;
+      await rerender();
+      assert
+        .dom(`h${level}.d-page-subheader__title`)
+        .exists({ count: 1 }, "requested heading renders once");
+      assert
+        .dom(".d-page-subheader__title-link")
+        .hasAttribute("href", "#independent", "link survives level change");
+    }
+  });
+
+  test("Independent030eac heading shortcut forwards attributes and retains identity by tag", async function (assert) {
+    const Heading = dElement("h2");
+    assert.strictEqual(dElement("h2"), Heading, "stable wrapper identity");
+    assert.notStrictEqual(
+      dElement("h3"),
+      Heading,
+      "different tags have different wrappers"
+    );
+    await render(
+      <template>
+        <Heading
+          id="independent-heading"
+          class="consumer-heading"
+          aria-label="Accessible title"
+        >Body</Heading>
+      </template>
+    );
+    assert
+      .dom("h2#independent-heading")
+      .hasClass("consumer-heading", "caller class reaches heading");
+    assert
+      .dom("h2#independent-heading")
+      .hasAttribute(
+        "aria-label",
+        "Accessible title",
+        "ARIA attribute reaches heading"
+      );
+    assert
+      .dom("h2#independent-heading")
+      .hasText("Body", "no extra wrapper element");
+  });
+
+  test("Independent030eac empty state merges dynamic classes and removes image mode", async function (assert) {
+    const state = new (class {
+      @tracked icon = "gear";
+      @tracked extra = "first";
+    })();
+    await render(
+      <template>
+        <DEmptyState
+          class={{state.extra}}
+          id="independent-empty"
+          role="status"
+          @icon={{state.icon}}
+          @identifier="oracle"
+          @title="Empty"
+        />
+      </template>
+    );
+    assert
+      .dom("#independent-empty")
+      .hasClass("empty-state__container", "base class survives splat");
+    assert
+      .dom("#independent-empty")
+      .hasClass("--oracle", "identifier survives splat");
+    assert
+      .dom("#independent-empty")
+      .hasClass("--with-image", "icon enables image mode");
+    state.icon = null;
+    state.extra = "second";
+    await rerender();
+    assert
+      .dom("#independent-empty")
+      .hasClass("second", "dynamic consumer class updates");
+    assert
+      .dom("#independent-empty")
+      .doesNotHaveClass("first", "stale consumer class removed");
+    assert
+      .dom("#independent-empty")
+      .hasClass("--text-only", "text mode restored");
+    assert
+      .dom("#independent-empty")
+      .doesNotHaveClass("--with-image", "image mode removed");
+    assert
+      .dom("#independent-empty")
+      .hasAttribute("role", "status", "role forwarded");
+    assert.dom(".empty-state__image").doesNotExist("icon removed");
+  });
+
+  test("Independent030eac menu close has an inert inside-click control", async function (assert) {
+    await render(
+      <template>
+        <DComboButton @hasMenu={{true}} as |combo|><combo.Button
+            @translatedLabel="Main"
+          /><combo.Menu
+            @inline={{true}}
+            @visibilityOptimizer="none"
+            as |menu|
+          ><DButton class="inert" @translatedLabel="Inert" /><DButton
+              class="explicit-close"
+              @action={{menu.close}}
+              @translatedLabel="Close"
+            /></combo.Menu></DComboButton>
+      </template>
+    );
+    await triggerEvent(".fk-d-menu__trigger", "click");
+    await click(".inert");
+    assert
+      .dom(".fk-d-menu")
+      .exists("an inside click alone does not close the menu");
+    await click(".explicit-close");
+    assert.dom(".fk-d-menu").doesNotExist("yielded API closes the menu");
+  });
+
+  test("Independent030eac avatar helper separates display name from title and escapes alt", async function (assert) {
+    this.siteSettings.prioritize_username_in_ux = false;
+    this.siteSettings.enable_names = true;
+    const user = {
+      username: "login_name",
+      name: "O'Name <&>",
+      title: "Moderator",
+      avatar_template: "/avatar/{size}.png",
+    };
+    await render(
+      <template>
+        <div class="named">{{dAvatar user imageSize="tiny" alt=true}}</div><div
+          class="decorative"
+        >{{dAvatar user imageSize="tiny"}}</div><div class="explicit">{{dAvatar
+            user
+            imageSize="tiny"
+            alt="' onerror='alert(1)"
+          }}</div>
+      </template>
+    );
+    assert
+      .dom(".named img")
+      .hasAttribute("alt", user.name, "alt true uses display name, not title");
+    assert
+      .dom(".named img")
+      .hasAttribute("title", "Moderator", "title remains independent");
+    assert
+      .dom(".decorative img")
+      .hasAttribute("alt", "", "default remains decorative");
+    assert
+      .dom(".explicit img")
+      .hasAttribute(
+        "alt",
+        "' onerror='alert(1)",
+        "single quotes round trip as text"
+      );
+    assert
+      .dom(".explicit img")
+      .doesNotHaveAttribute("onerror", "alt cannot create an attribute");
+  });
+});

--- a/frontend/discourse/tests/integration/ui-kit/d-button-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-button-test.gjs
@@ -1,8 +1,20 @@
-import { click, render, triggerKeyEvent } from "@ember/test-helpers";
+import { click, render, settled, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import sinon from "sinon";
+import { capabilities } from "discourse/services/capabilities";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DButton from "discourse/ui-kit/d-button";
 import I18n, { i18n } from "discourse-i18n";
+
+/**
+ * Clicks the button without settling, so a test can observe what has and has
+ * not run while the dispatch is still on the stack.
+ */
+function dispatchClick() {
+  const event = new MouseEvent("click", { bubbles: true });
+  document.querySelector(".btn").dispatchEvent(event);
+  return event;
+}
 
 module("Integration | ui-kit | DButton", function (hooks) {
   setupRenderingTest(hooks);
@@ -239,6 +251,133 @@ module("Integration | ui-kit | DButton", function (hooks) {
     await click(".btn");
 
     assert.strictEqual(this.foo, "bar");
+  });
+
+  test("@action object form is triggered on click", async function (assert) {
+    // A method, not an arrow: an extracted-reference call would lose `this`
+    // and leave `seen` on the object untouched.
+    const handler = {
+      seen: null,
+      value(param) {
+        this.seen = param;
+      },
+    };
+
+    await render(
+      <template><DButton @action={{handler}} @actionParam="param" /></template>
+    );
+
+    await click(".btn");
+
+    assert.strictEqual(
+      handler.seen,
+      "param",
+      "invokes value() as a method, so it keeps its receiver"
+    );
+  });
+
+  test("@action object form resolves value at invocation time", async function (assert) {
+    sinon.stub(capabilities, "isIOS").get(() => false);
+
+    const calls = [];
+    const handler = { value: () => calls.push("original") };
+
+    await render(<template><DButton @action={{handler}} /></template>);
+
+    dispatchClick();
+    // Swapped after dispatch but before the deferred run: the replacement wins
+    // only if the lookup happens when the handler actually runs.
+    handler.value = () => calls.push("replacement");
+
+    await settled();
+
+    assert.deepEqual(calls, ["replacement"], "reads .value when it runs");
+  });
+
+  test("the action is deferred past the click dispatch", async function (assert) {
+    sinon.stub(capabilities, "isIOS").get(() => false);
+
+    let ran = false;
+    const handler = () => (ran = true);
+
+    await render(<template><DButton @action={{handler}} /></template>);
+
+    // Dispatched raw rather than through `click()`, which settles the runloop
+    // before returning and so cannot observe the deferral.
+    dispatchClick();
+
+    assert.false(ran, "has not run while the dispatch is still on the stack");
+
+    await settled();
+
+    assert.true(ran, "runs once the runloop flushes");
+  });
+
+  test("@immediate runs the action inside the click dispatch", async function (assert) {
+    sinon.stub(capabilities, "isIOS").get(() => false);
+
+    let ran = false;
+    const handler = () => (ran = true);
+
+    await render(
+      <template><DButton @immediate={{true}} @action={{handler}} /></template>
+    );
+
+    assert.false(ran, "has not run before anything was dispatched");
+
+    dispatchClick();
+
+    assert.true(
+      ran,
+      "runs before the dispatch returns, so transient user activation survives"
+    );
+
+    await settled();
+  });
+
+  test("@immediate forwards the event when asked", async function (assert) {
+    sinon.stub(capabilities, "isIOS").get(() => false);
+
+    const received = [];
+    const handler = (...args) => received.push(args);
+
+    await render(
+      <template>
+        <DButton
+          @immediate={{true}}
+          @forwardEvent={{true}}
+          @action={{handler}}
+        />
+      </template>
+    );
+
+    const dispatched = dispatchClick();
+
+    assert.strictEqual(received.length, 1, "runs exactly once");
+    assert.strictEqual(
+      received[0][1],
+      dispatched,
+      "receives the very event that was dispatched, not merely an Event"
+    );
+
+    await settled();
+
+    assert.strictEqual(received.length, 1, "and does not run again on settle");
+  });
+
+  test("iOS runs the action inside the dispatch without @immediate", async function (assert) {
+    sinon.stub(capabilities, "isIOS").get(() => true);
+
+    let ran = false;
+    const handler = () => (ran = true);
+
+    await render(<template><DButton @action={{handler}} /></template>);
+
+    dispatchClick();
+
+    assert.true(ran, "iOS never defers, so focus events still fire");
+
+    await settled();
   });
 
   test("ellipses", async function (assert) {

--- a/frontend/discourse/tests/integration/ui-kit/d-combo-button-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-combo-button-test.gjs
@@ -1,7 +1,8 @@
 import { tracked } from "@glimmer/tracking";
-import { render, rerender, triggerEvent } from "@ember/test-helpers";
+import { click, render, rerender, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DButton from "discourse/ui-kit/d-button";
 import DComboButton from "discourse/ui-kit/d-combo-button";
 
 module("Integration | ui-kit | DComboButton", function (hooks) {
@@ -190,5 +191,31 @@ module("Integration | ui-kit | DComboButton", function (hooks) {
       .hasClass("--has-menu", "the group's own token is not dropped");
     assert.dom(".d-combo-button").hasClass("second");
     assert.dom(".d-combo-button").doesNotHaveClass("first");
+  });
+
+  test("combo.Menu yields the menu API so its content can close it", async function (assert) {
+    await render(
+      <template>
+        <DComboButton @hasMenu={{true}} as |combo|>
+          <combo.Button @translatedLabel="Action" />
+          <combo.Menu @inline={{true}} @visibilityOptimizer="none" as |menu|>
+            <DButton
+              class="close-from-content"
+              @action={{menu.close}}
+              @translatedLabel="Close"
+            />
+          </combo.Menu>
+        </DComboButton>
+      </template>
+    );
+    await open();
+
+    assert.dom(".close-from-content").exists("the content block rendered");
+
+    await click(".close-from-content");
+
+    assert
+      .dom(".fk-d-menu")
+      .doesNotExist("the yielded close() shut the menu it belongs to");
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-empty-state-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-empty-state-test.gjs
@@ -16,4 +16,48 @@ module("Integration | ui-kit | DEmptyState", function (hooks) {
     assert.dom("[data-test-title]").exists();
     assert.dom("[data-test-body]").exists();
   });
+
+  test("text-only without an image or an icon", async function (assert) {
+    await render(<template><DEmptyState @title="title" /></template>);
+
+    assert.dom(".empty-state__container").hasClass("--text-only");
+    assert.dom(".empty-state__image").doesNotExist();
+  });
+
+  test("@icon renders an icon in place of an illustration", async function (assert) {
+    await render(
+      <template><DEmptyState @title="title" @icon="table-columns" /></template>
+    );
+
+    assert.dom(".empty-state__image.--icon .d-icon-table-columns").exists();
+    assert
+      .dom(".empty-state__container")
+      .hasClass("--with-image", "an icon counts as the image slot");
+  });
+
+  test("@svgContent wins over @icon", async function (assert) {
+    await render(
+      <template>
+        <DEmptyState @title="title" @icon="table-columns" @svgContent="art" />
+      </template>
+    );
+
+    assert.dom(".empty-state__image").hasText("art");
+    assert
+      .dom(".empty-state__image .d-icon-table-columns")
+      .doesNotExist("the icon does not render alongside the illustration");
+  });
+
+  test("attributes reach the container", async function (assert) {
+    await render(
+      <template>
+        <DEmptyState @title="title" class="extra" data-test-thing="yes" />
+      </template>
+    );
+
+    assert.dom(".empty-state__container").hasClass("extra");
+    assert
+      .dom(".empty-state__container")
+      .hasAttribute("data-test-thing", "yes");
+  });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-page-subheader-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-page-subheader-test.gjs
@@ -18,6 +18,25 @@ module("Integration | ui-kit | DPageSubheader", function (hooks) {
       .hasText(i18n("admin.title"));
   });
 
+  test("the title is an h2 by default", async function (assert) {
+    await render(<template><DPageSubheader @titleLabel="Title" /></template>);
+
+    assert.dom("h2.d-page-subheader__title").exists();
+  });
+
+  test("@titleHeadingLevel picks the heading element", async function (assert) {
+    await render(
+      <template>
+        <DPageSubheader @titleLabel="Title" @titleHeadingLevel={{3}} />
+      </template>
+    );
+
+    assert.dom("h3.d-page-subheader__title").exists();
+    assert
+      .dom("h2.d-page-subheader__title")
+      .doesNotExist("it does not also render the default level");
+  });
+
   test("no @descriptionLabel", async function (assert) {
     await render(<template><DPageSubheader /></template>);
     assert.dom(".d-page-subheader__description").doesNotExist();

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-pointer-drag-test.gjs
@@ -611,7 +611,212 @@ module("Integration | ui-kit | d-pointer-drag", function (hooks) {
       assert.deepEqual(
         calls,
         ["start", "end:2"],
-        "the threshold gates onDrag only: a click on a thresholded handle still commits, so a consumer must read the position rather than assume movement"
+        "the threshold does not gate the ends of the gesture: a click on a thresholded handle still commits, so a consumer must read the position rather than assume movement"
+      );
+    });
+
+    test("the dragging class is held back until a thresholded gesture engages", async function (assert) {
+      await render(
+        <template>
+          <div
+            class="dpd-target"
+            {{dPointerDrag threshold=5 draggingClass="--dragging"}}
+          ></div>
+        </template>
+      );
+
+      const target = find(".dpd-target");
+      stubPointerCapture(target);
+
+      await triggerEvent(target, "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      assert
+        .dom(target)
+        .doesNotHaveClass(
+          "--dragging",
+          "the press alone is not yet a drag, so it carries no dragging class"
+        );
+
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 4,
+        clientY: 0,
+      });
+      assert
+        .dom(target)
+        .doesNotHaveClass(
+          "--dragging",
+          "nor does movement that stays inside the threshold"
+        );
+
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 5,
+        clientY: 0,
+      });
+      assert
+        .dom(target)
+        .hasClass(
+          "--dragging",
+          "reaching the threshold engages the gesture and marks it"
+        );
+
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 1,
+        clientY: 0,
+      });
+      assert
+        .dom(target)
+        .hasClass(
+          "--dragging",
+          "and returning inside the threshold keeps the mark, as the engagement latch does"
+        );
+
+      await triggerEvent(target, "pointerup", {
+        pointerId: 1,
+        clientX: 1,
+        clientY: 0,
+      });
+      assert
+        .dom(target)
+        .doesNotHaveClass("--dragging", "release clears it as usual");
+    });
+
+    test("the body class is held back until a thresholded gesture engages", async function (assert) {
+      await render(
+        <template>
+          <div
+            class="dpd-target"
+            {{dPointerDrag threshold=5 bodyClass="dragging"}}
+          ></div>
+        </template>
+      );
+
+      const target = find(".dpd-target");
+      stubPointerCapture(target);
+
+      await triggerEvent(target, "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      assert
+        .dom(document.body)
+        .doesNotHaveClass(
+          "dragging",
+          "the press alone leaves the body unmarked"
+        );
+
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 4,
+        clientY: 0,
+      });
+      assert
+        .dom(document.body)
+        .doesNotHaveClass("dragging", "as does movement inside the threshold");
+
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 5,
+        clientY: 0,
+      });
+      assert
+        .dom(document.body)
+        .hasClass("dragging", "reaching the threshold marks the body");
+
+      // Two further moves past the latch. The body class is held by a counted
+      // lease, so an implementation that re-takes one per move would need as
+      // many releases as it took, and the single release below would leave the
+      // class stranded on the body.
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 9,
+        clientY: 0,
+      });
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 14,
+        clientY: 0,
+      });
+
+      await triggerEvent(target, "pointerup", {
+        pointerId: 1,
+        clientX: 14,
+        clientY: 0,
+      });
+      assert
+        .dom(document.body)
+        .doesNotHaveClass(
+          "dragging",
+          "release unmarks it, however many moves the gesture saw"
+        );
+    });
+
+    test("a click on a thresholded handle applies neither gesture class", async function (assert) {
+      const calls = [];
+      const onDragStart = () => calls.push("start");
+      const onDragEnd = () => calls.push("end");
+
+      await render(
+        <template>
+          <div
+            class="dpd-target"
+            {{dPointerDrag
+              threshold=5
+              draggingClass="--dragging"
+              bodyClass="dragging"
+              onDragStart=onDragStart
+              onDragEnd=onDragEnd
+            }}
+          ></div>
+        </template>
+      );
+
+      const target = find(".dpd-target");
+      stubPointerCapture(target);
+
+      await triggerEvent(target, "pointerdown", {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      await triggerEvent(target, "pointermove", {
+        pointerId: 1,
+        clientX: 2,
+        clientY: 0,
+      });
+
+      // Read while the press is still held. Waiting for the release would prove
+      // nothing: the gesture clears both classes on the way out, so a press that
+      // wrongly applied them looks identical to one that never did.
+      assert
+        .dom(target)
+        .doesNotHaveClass(
+          "--dragging",
+          "a press that never became a drag never looks like one"
+        );
+      assert
+        .dom(document.body)
+        .doesNotHaveClass("dragging", "and never marks the body either");
+
+      await triggerEvent(target, "pointerup", {
+        pointerId: 1,
+        clientX: 2,
+        clientY: 0,
+      });
+
+      assert.deepEqual(
+        calls,
+        ["start", "end"],
+        "and the gesture still runs its lifecycle, so withholding the classes is not withholding the gesture"
       );
     });
 

--- a/frontend/discourse/tests/integration/ui-kit/subheader-styles-independent-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/subheader-styles-independent-test.gjs
@@ -1,0 +1,58 @@
+import { find, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DPageSubheader from "discourse/ui-kit/d-page-subheader";
+
+module(
+  "Integration | ui-kit | DPageSubheader independent styles",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("Independent030eac semantic heading level retains subheader spacing", async function (assert) {
+      await render(
+        <template>
+          <DPageSubheader @titleLabel="Default" /><DPageSubheader
+            @titleHeadingLevel={{3}}
+            @titleLabel="Nested"
+          />
+        </template>
+      );
+      const baseline = getComputedStyle(find("h2.d-page-subheader__title"));
+      const nested = getComputedStyle(find("h3.d-page-subheader__title"));
+      assert.strictEqual(
+        baseline.marginBottom,
+        "0px",
+        "subheader stylesheet is loaded, preventing a false green without CSS"
+      );
+      assert.strictEqual(
+        nested.marginBottom,
+        baseline.marginBottom,
+        "changing document outline preserves title-row spacing"
+      );
+      assert.strictEqual(
+        nested.fontSize,
+        baseline.fontSize,
+        "subheader typography does not depend on semantic tag"
+      );
+    });
+
+    test("Independent030eac heading level rejects non-integers and out-of-range values", function (assert) {
+      const getter = Object.getOwnPropertyDescriptor(
+        DPageSubheader.prototype,
+        "titleTag"
+      ).get;
+      for (const level of [0, 7, -1, 2.5, "3", NaN]) {
+        assert.throws(
+          () => getter.call({ args: { titleHeadingLevel: level } }),
+          /must be 1-6/,
+          `rejects invalid level ${level}`
+        );
+      }
+      assert.strictEqual(
+        getter.call({ args: {} }),
+        getter.call({ args: { titleHeadingLevel: null } }),
+        "null and absent both default to h2"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/unit/lib/avatar-utils-test.js
+++ b/frontend/discourse/tests/unit/lib/avatar-utils-test.js
@@ -88,6 +88,26 @@ module("Unit | Utilities", function (hooks) {
       "it doesn't render avatars for invalid avatar template"
     );
 
+    assert.strictEqual(
+      avatarImg({
+        avatarTemplate,
+        size: "tiny",
+        alt: "evilest trout",
+      }),
+      "<img alt='evilest trout' width='24' height='24' src='/path/to/avatar/48.png' class='avatar'>",
+      "it sets alt text if supplied"
+    );
+
+    assert.strictEqual(
+      avatarImg({
+        avatarTemplate,
+        size: "tiny",
+        alt: "<script>alert('x')</script>",
+      }),
+      "<img alt='&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;' width='24' height='24' src='/path/to/avatar/48.png' class='avatar'>",
+      "it escapes the alt text"
+    );
+
     setDevicePixelRatio(oldRatio);
   });
 });

--- a/frontend/discourse/tests/unit/ui-kit/d-button-independent-test.js
+++ b/frontend/discourse/tests/unit/ui-kit/d-button-independent-test.js
@@ -1,0 +1,164 @@
+import { settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DButton from "discourse/ui-kit/d-button";
+
+module("Unit | ui-kit | DButton independent", function () {
+  for (const shape of [
+    "function",
+    "object",
+    "empty-object",
+    "string",
+    "number",
+    "absent",
+    "null",
+    "false",
+  ]) {
+    for (const isIOS of [false, true]) {
+      test(`Independent030eac matrix ${shape} iOS=${isIOS}`, async function (assert) {
+        for (const immediate of [false, true]) {
+          for (const forwardEvent of [false, true]) {
+            for (const actionParam of [undefined, 0, { sentinel: true }]) {
+              for (const navigation of [
+                {},
+                { route: "topic" },
+                { href: "#independent" },
+                { route: "topic", href: "#independent", routeModels: [1, 2] },
+              ]) {
+                for (const state of [
+                  {},
+                  { disabled: true },
+                  { isLoading: true },
+                  { disabled: true, isLoading: true },
+                ]) {
+                  const calls = [];
+                  const routes = [];
+                  const callback = (...args) => calls.push(args);
+                  const action = {
+                    function: callback,
+                    object: { value: callback },
+                    "empty-object": {},
+                    string: "invalid",
+                    number: 7,
+                    absent: undefined,
+                    null: null,
+                    false: false,
+                  }[shape];
+                  const args = {
+                    action,
+                    actionParam,
+                    forwardEvent,
+                    immediate,
+                    ...navigation,
+                    ...state,
+                  };
+                  const event = new MouseEvent("click", { cancelable: true });
+                  let stopped = false;
+                  event.stopPropagation = () => (stopped = true);
+                  const result = DButton.prototype._triggerAction.call(
+                    {
+                      args,
+                      capabilities: { isIOS },
+                      router: {
+                        transitionTo: (...values) => routes.push(values),
+                      },
+                    },
+                    event
+                  );
+                  const callable = shape === "function" || shape === "object";
+                  const intercepted = Boolean(action || args.route);
+                  assert.strictEqual(
+                    calls.length,
+                    callable && (isIOS || immediate) ? 1 : 0,
+                    "only callable immediate/iOS actions run synchronously"
+                  );
+                  assert.strictEqual(
+                    event.defaultPrevented,
+                    intercepted,
+                    "action/route owns the default even for unsupported truthy actions"
+                  );
+                  assert.strictEqual(
+                    stopped,
+                    intercepted,
+                    "propagation follows interception"
+                  );
+                  assert.strictEqual(
+                    result,
+                    intercepted ? false : undefined,
+                    "return contract is retained"
+                  );
+                  assert.deepEqual(
+                    routes,
+                    !action && args.route
+                      ? [[args.route, ...(args.routeModels || [])]]
+                      : [],
+                    "truthy action takes precedence over route and href"
+                  );
+                  await settled();
+                  assert.deepEqual(
+                    calls,
+                    callable
+                      ? [forwardEvent ? [actionParam, event] : [actionParam]]
+                      : [],
+                    "exactly one call with the original parameter and optional event"
+                  );
+                }
+              }
+            }
+          }
+        }
+      });
+    }
+  }
+
+  for (const isIOS of [false, true]) {
+    test(`Independent030eac object method keeps its receiver iOS=${isIOS}`, async function (assert) {
+      let receiver;
+      const handler = {
+        value() {
+          receiver = this;
+        },
+      };
+      DButton.prototype._triggerAction.call(
+        { args: { action: handler }, capabilities: { isIOS } },
+        new MouseEvent("click")
+      );
+      await settled();
+      assert.strictEqual(
+        receiver,
+        handler,
+        "legacy action.value() binds this to the action object"
+      );
+    });
+  }
+
+  test("Independent030eac deferred object resolves value at invocation time", async function (assert) {
+    const calls = [];
+    const handler = { value: () => calls.push("stale") };
+    DButton.prototype._triggerAction.call(
+      { args: { action: handler }, capabilities: { isIOS: false } },
+      new MouseEvent("click")
+    );
+    handler.value = () => calls.push("replacement");
+    await settled();
+    assert.deepEqual(
+      calls,
+      ["replacement"],
+      "legacy deferred dispatch reads the current method"
+    );
+  });
+
+  test("Independent030eac function with value property still calls the function", async function (assert) {
+    const calls = [];
+    const handler = () => calls.push("function");
+    handler.value = () => calls.push("property");
+    DButton.prototype._triggerAction.call(
+      { args: { action: handler }, capabilities: { isIOS: true } },
+      new MouseEvent("click")
+    );
+    assert.deepEqual(
+      calls,
+      ["function"],
+      "typeof function never enters the object branch"
+    );
+  });
+});


### PR DESCRIPTION
Two plugins moved into core recently, `boards` and `voice`. Both were written before the ui-kit primitives existed, so they hand-roll things core can now provide. This PR closes the gaps that block them. Each one has a named consumer waiting on it.

`DButton` gains `@immediate`. It runs the action inside the click dispatch instead of deferring it through `next()`. Browser APIs gated on transient user activation need this, because that activation does not survive leaving the dispatch. Screen capture and fullscreen are the cases here.

`DComboButton` now yields the menu API into its content block, so an item can close the menu it sits in. `DEmptyState` takes an `@icon` where an illustration is too heavy, and forwards attributes to its container. The avatar helper takes `alt`, for an avatar that is the only thing identifying a person. `DPageSubheader` takes `@titleHeadingLevel`, so a nested subheader continues the document outline instead of restarting at `h2`.

`dPointerDrag` had a `threshold` that gated behaviour but not appearance. `draggingClass` and `bodyClass` went on at the press, so a click that never became a drag already looked like one. Both now wait for the gesture to engage. The admin dashboard's resize handles pass both arguments today, so this is live rather than theoretical.

Tests cover each new argument. That includes proving `@immediate` runs synchronously within the click dispatch, and that a press below the threshold now applies neither class.