### PR TITLE
FIX: Cap watched words CSV uploads at the per-action word limit

### DIFF
--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -59,13 +59,26 @@ class Admin::WatchedWordsController < Admin::StaffController
     has_replacement = WatchedWord.has_replacement?(action_key)
 
     content = File.read(file.tempfile, encoding: "bom|utf-8")
+    max_words = WatchedWord::MAX_WORDS_PER_ACTION
+
+    rows =
+      begin
+        CSV.new(content).lazy.select { |row| row[0].present? }.first(max_words + 1)
+      rescue CSV::MalformedCSVError => e
+        return render_json_error(e.message, status: :unprocessable_entity)
+      end
+
+    if rows.size > max_words
+      error = I18n.t("watched_words.upload_too_many_csv_entries", count: max_words)
+      return render_json_error(error, status: :unprocessable_entity)
+    end
 
     Scheduler::Defer.later("Upload watched words") do
       begin
         words_updated = 0
 
-        CSV.parse(content) do |row|
-          if row[0].present? && (!has_replacement || row[1].present?)
+        rows.each do |row|
+          if !has_replacement || row[1].present?
             watched_word =
               WatchedWord.create_or_update_word(
                 word: row[0],

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5983,6 +5983,11 @@ en:
     initial_post_raw: This topic includes daily performance reports for your site.
     initial_topic_title: Website performance reports
 
+  watched_words:
+    upload_too_many_csv_entries:
+      one: "Too many entries in the CSV file. Please provide a CSV file with no more than %{count} entry."
+      other: "Too many entries in the CSV file. Please provide a CSV file with no more than %{count} entries."
+
   tags:
     title: "Tags"
     groups:

--- a/spec/requests/admin/watched_words_controller_spec.rb
+++ b/spec/requests/admin/watched_words_controller_spec.rb
@@ -320,6 +320,23 @@ RSpec.describe Admin::WatchedWordsController do
         expect(WatchedWord.count).to eq(6)
       end
 
+      it "rejects a CSV with more entries than the maximum number of words" do
+        stub_const(WatchedWord, "MAX_WORDS_PER_ACTION", 2) do
+          post "/admin/customize/watched_words/upload.json",
+               params: {
+                 action_key: "flag",
+                 file:
+                   Rack::Test::UploadedFile.new(file_from_contents("w1\nw2\nw3\n", "words.csv")),
+               }
+        end
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to eq(
+          [I18n.t("watched_words.upload_too_many_csv_entries", count: 2)],
+        )
+        expect(WatchedWord.count).to eq(0)
+      end
+
       it "preserves non-ASCII words in a UTF-8 file without a BOM" do
         content = (1..30).map { |i| "badword#{i}" }.join("\n") + "\nCafé"
 


### PR DESCRIPTION
Stacked on #43424.

`WatchedWord::MAX_WORDS_PER_ACTION` is a per-record validation, so it only bounds what reaches the database — not what we parse to get there. A CSV of *repeated* words never trips it at all.

Measured on a 3000-row file of one repeated word:

| | today |
|---|---|
| words created | 1 |
| `user_histories` rows | 3000 |
| SQL queries | 30015 |
| HTTP status | 200 |

Scaled to the 10 MB nginx body limit that is ~2.1M rows, ~21M queries and ~2.1M staff log entries on the single `Scheduler::Defer` thread, available to any moderator. After this change the same upload is 422 in 0.04s with 14 queries, all session and auth.

No new constant — anything past `MAX_WORDS_PER_ACTION` is provably wasted work, so that is the cap.

### Also fixed

Malformed CSV returned 200 followed by a MessageBus error the frontend could not display: `popupAjaxError` receives a String, `extractErrorInfo` finds no `responseJSON`/`responseText`/`status`, and falls through to `generic_error` — after `uploadDone` has already alerted "Upload successful!". It now returns 422 with the parser message, which is the only status `displayErrorByResponseStatus` surfaces `body.errors` for.

### Notes for reviewers

- The cap counts **CSV entries**, not physical lines. A quoted newline is 3 physical lines but 2 rows; a CR-delimited file is 1 physical line but N rows. Both are covered.
- Enforced before `Scheduler::Defer`, not inside. The deferred block cannot return an HTTP status, and the eager `File.read` has to stay eager — Rack unlinks the tempfile before the block runs (dd982bf67c2).
- Blank separator lines are still free; the repo fixtures use them heavily.

Known ceiling: a legal 2000-entry upload is still ~20k queries on the defer thread. Bounded, not cheap.