### PR TITLE
FIX: Cap tag CSV uploads at 5000 rows

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,6 +4,8 @@ class TagsController < ::ApplicationController
   include TopicListResponder
   include TopicQueryParams
 
+  MAX_CSV_ROWS = 5_000
+
   before_action :ensure_tags_enabled
 
   def self.show_methods
@@ -304,8 +306,18 @@ class TagsController < ::ApplicationController
     file = params[:file] || params[:files].first
 
     hijack do
+      rows = 0
+
       Tag.transaction do
         CSV.foreach(file.tempfile) do |row|
+          rows += 1
+
+          if rows > MAX_CSV_ROWS
+            raise Discourse::InvalidParameters.new(
+                    I18n.t("tags.upload_too_many_rows", count: MAX_CSV_ROWS),
+                  )
+          end
+
           if row.length > 2
             raise Discourse::InvalidParameters.new(I18n.t("tags.upload_row_too_long"))
           end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6002,6 +6002,9 @@ en:
       one: "You can apply up to %{count} tag to a topic."
       other: "You can apply up to %{count} tags to a topic."
     upload_row_too_long: "The CSV file should have one tag per line. Optionally the tag can be followed by a comma, then the tag group name."
+    upload_too_many_rows:
+      one: "Too many rows in the CSV file. Please upload no more than %{count} row at a time."
+      other: "Too many rows in the CSV file. Please upload no more than %{count} rows at a time."
     bulk_create:
       invalid_params: "Invalid parameters. Please provide an array of tag names."
       invalid_name: "Invalid tag name."

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -2397,6 +2397,21 @@ RSpec.describe TagsController do
           expect(response.status).to eq(422)
         end.not_to change { [Tag.count, TagGroup.count] }
       end
+
+      it "fails if the CSV has too many rows" do
+        sign_in(moderator)
+
+        expect do
+          stub_const(TagsController, "MAX_CSV_ROWS", 2) do
+            post "/tags/upload.json", params: { file: file, name: filename }
+          end
+        end.not_to change { [Tag.count, TagGroup.count] }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          I18n.t("tags.upload_too_many_rows", count: 2),
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Stacked on #43425.

`/tags/upload` streams, so memory is fine — but every row runs inside **one** `Tag.transaction` doing up to two inserts, on the deferred thread. A large file holds that transaction open indefinitely.

Measured at **11.9 queries per row** (distinct tag and distinct group each row). Against `Scheduler::Deferrable::DEFAULT_TIMEOUT = 90` at a 1ms round trip that is ~7570 rows before the watchdog fires, so 5000 leaves roughly 1.5x headroom. At a 3ms round trip a max-size upload is ~180s.

Deliberately lower than the 50000 used for badge awards and bulk invites — those enqueue to Sidekiq, this writes inline while holding a transaction.

### Notes for reviewers

- **The 5000 is the one judgement call in this stack.** It constrains sites importing a vocabulary larger than 5000 tags in a single file. The loop is idempotent (`Tag.find_by_name(...) || Tag.create!`), so splitting into overlapping files is safe, but it is friction. Happy to raise it.
- No new error handling: the existing `rescue Discourse::InvalidParameters => e` renders 422, and the existing spec already asserts the rollback contract.
- A constant rather than a site setting — it is derived from a framework timeout, not something an operator should tune.

Known ceiling: the guard fires mid-transaction, so an oversized upload writes up to `MAX_CSV_ROWS + 1` rows before rolling back. That is the same cost as a legitimate max-size upload, so the bound holds.