### PR TITLE
PERF: Stop parsing event invitees past the bulk invite limit

### DIFF
--- a/plugins/discourse-events/app/services/discourse_events/events/action/parse_invitees_csv.rb
+++ b/plugins/discourse-events/app/services/discourse_events/events/action/parse_invitees_csv.rb
@@ -11,8 +11,10 @@ module DiscourseEvents
         option :file
 
         def call
+          max_invitees = SiteSetting.discourse_post_event_max_bulk_invitees
           invitees = []
           CSV.foreach(file.tempfile) do |identifier, attendance|
+            break if invitees.size >= max_invitees
             next if identifier.blank?
             invitees << { identifier: identifier, attendance: attendance || DEFAULT_ATTENDANCE }
           end

--- a/plugins/discourse-events/app/services/discourse_events/events/bulk_invite.rb
+++ b/plugins/discourse-events/app/services/discourse_events/events/bulk_invite.rb
@@ -9,7 +9,10 @@ module DiscourseEvents
         attribute :event_id, :integer
         attribute :invitees, :array
 
-        before_validation { self.invitees = Array(invitees).reject(&:blank?) }
+        before_validation do
+          max_invitees = SiteSetting.discourse_post_event_max_bulk_invitees
+          self.invitees = Array(invitees).reject(&:blank?).first(max_invitees)
+        end
 
         validates :event_id, presence: true
       end

--- a/plugins/discourse-events/spec/services/discourse_events/events/action/parse_invitees_csv_spec.rb
+++ b/plugins/discourse-events/spec/services/discourse_events/events/action/parse_invitees_csv_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe(DiscourseEvents::Events::Action::ParseInviteesCsv) do
       end
     end
 
+    context "when the file has more rows than the maximum number of bulk invitees" do
+      let(:file) { csv_file("a,going\nb,going\nc,going\n") }
+
+      before { SiteSetting.discourse_post_event_max_bulk_invitees = 2 }
+
+      it "stops parsing at the maximum" do
+        expect(result.size).to eq(2)
+      end
+    end
+
     context "when the file is malformed" do
       let(:file) { csv_file("alice,\"unterminated") }
 

--- a/plugins/discourse-events/spec/services/discourse_events/events/bulk_invite_spec.rb
+++ b/plugins/discourse-events/spec/services/discourse_events/events/bulk_invite_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe(DiscourseEvents::Events::BulkInvite) do
           },
         ) { result }
       end
+
+      context "with more invitees than the maximum" do
+        let(:invitees) do
+          Array.new(3) { |i| { "identifier" => "user#{i}", "attendance" => "going" } }
+        end
+
+        before { SiteSetting.discourse_post_event_max_bulk_invitees = 2 }
+
+        it "enqueues no more invitees than the job will process" do
+          expect_enqueued_with(
+            job: :discourse_post_event_bulk_invite,
+            args: {
+              event_id: event.id,
+              invitees: invitees.first(2),
+              current_user_id: admin.id,
+            },
+          ) { result }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Stacked on #43426.

`Jobs::DiscoursePostEvent::BulkInvite` already stops at `SiteSetting.discourse_post_event_max_bulk_invitees` (500). Both callers were building and enqueueing everything above that for the job to throw away — a 10 MB CSV is 1.3M rows, ~400 MB of heap and ~50 MB of JSON through Redis.

Capped at the source in both places. No new constant, no new setting, no new ceiling: this only stops materialising rows that were already discarded.

### Notes for reviewers

- **Both callers, not just the CSV one.** `POST /discourse-post-event/events/:id/bulk-invite` feeds the same job behind the same policies, and unlike the CSV path it is not inside `hijack`, so it holds a real worker.
- **Truncates rather than rejects**, deliberately. `filter_out_unavailable_groups` runs before the job's own limit check, so rejecting would turn "450 invited" into "0 invited, 422" for any roster containing stale usernames. Core's `/invites/upload_csv` truncates too.
- No `option :limit` on the action — it is a required `Dry::Initializer` option and would break the existing spec. Reading the setting directly costs no plumbing.

Noticed, not fixed here: `discourse_post_event.errors.bulk_invite.max_invitees` exists in `server.en.yml`, is translated into 20+ locales, and is never referenced from Ruby. Wiring it up needs the job to know its input was truncated.