### PR TITLE
DEV: Sort the video node view's attributes

### DIFF
--- a/frontend/discourse/app/static/prosemirror/components/video-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/video-node-view.gjs
@@ -236,17 +236,17 @@ export default class VideoNodeView extends Component {
 
   <template>
     <video
+      aria-label={{@node.attrs.alt}}
       class={{dConcatClass
         "composer-video-node__video"
         (unless this.isActivated "is-inactive")
       }}
-      aria-label={{@node.attrs.alt}}
-      src={{if this.isPlaybackRequested this.source}}
-      poster={{this.poster}}
+      contenteditable="false"
       controls
       playsinline
+      poster={{this.poster}}
       preload="metadata"
-      contenteditable="false"
+      src={{if this.isPlaybackRequested this.source}}
       {{didInsert this.setupVideo}}
       {{on "click" this.selectVideo}}
       {{on "error" this.handlePlaybackError}}


### PR DESCRIPTION
The video playback node view landed alongside the rule that orders a tag's attributes, so its `<video>` was never sorted and `lint:js` has been failing on main since.

Autofix output: the attributes now read alphabetically, with the modifiers left in source order. The tag carries no `...attributes`, so nothing changes at runtime.