### PR TITLE
DEV: Report the drop position the target was painting

### DIFF
--- a/frontend/discourse/app/lib/-internals/drag-and-drop/drop-target-kernel.ts
+++ b/frontend/discourse/app/lib/-internals/drag-and-drop/drop-target-kernel.ts
@@ -431,20 +431,26 @@ export function registerDropTargetKernel<Payload, Source>({
       reportLeave(source, location);
     },
     onDrop: ({ source, location }) => {
-      indicator.clear();
       if (!isDeepestTarget(location, element)) {
+        indicator.clear();
         pairing.reset();
         return;
       }
       // Sampled before the reset clears it, so the drop uses the direction the
       // hover was measured against.
       const rtl = pairing.isRtl();
-      pairing.reset();
       const args = getArgs();
+      // Measured while the indicator is still up. The position comes from the
+      // element's box, and a consumer is free to give the indicator classes a
+      // layout effect, so clearing first would report a position against a box
+      // the reader never saw.
+      const position = positionFor(args, location.current.input, rtl);
+      indicator.clear();
+      pairing.reset();
       consumerMayThrow(() =>
         args.onDrop?.({
           source: decorateSource(source),
-          position: positionFor(args, location.current.input, rtl),
+          position,
           location,
           element,
         })

--- a/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/modifiers/d-drag-and-drop-test.gjs
@@ -3365,4 +3365,95 @@ module("Integration | ui-kit | Modifier | dragAndDrop", function (hooks) {
       );
     });
   });
+
+  // Authored as the independent oracle for the clear-before-measure ordering in
+  // the kernel's `onDrop`. The assertion compares the position the target was
+  // PAINTING at the moment of release against the one the consumer is handed,
+  // so it needs no prediction of which way the mismatch falls.
+  module("drop position layout oracle", function (oracleHooks) {
+    let consumerSheet;
+
+    oracleHooks.afterEach(function () {
+      consumerSheet?.remove();
+      consumerSheet = null;
+    });
+
+    /**
+     * Gives the indicator classes a layout effect, which core's own stylesheet
+     * deliberately avoids. A consumer is free to do this, and it is what makes
+     * the ordering observable: clearing the class resizes the element that the
+     * drop position is then measured against.
+     */
+    function styleIndicatorWithLayout() {
+      consumerSheet = document.createElement("style");
+      consumerSheet.textContent = `
+        .oracle-target { height: 60px; }
+        .oracle-target.--drag-above { padding-block-start: 120px; }
+        .oracle-target.--drag-below { padding-block-end: 120px; }
+      `;
+      document.head.appendChild(consumerSheet);
+    }
+
+    /** The position the target is painting right now, read from its classes. */
+    function paintedPosition() {
+      const target = find("#tgt");
+      if (target.classList.contains("--drag-above")) {
+        return "before";
+      }
+      return target.classList.contains("--drag-below") ? "after" : null;
+    }
+
+    for (const [label, grip] of [
+      ["above its midpoint", 0.25],
+      ["below its midpoint", 0.75],
+    ]) {
+      test(`drop position layout oracle: a release ${label} reports the position it painted`, async function (assert) {
+        styleIndicatorWithLayout();
+
+        const drops = [];
+        const onDrop = ({ position }) => drops.push(position);
+
+        await render(
+          <template>
+            <div id="src" {{dDragAndDropSource type="row"}}>src</div>
+            <div
+              class="oracle-target"
+              id="tgt"
+              {{dDragAndDropTarget accepts="row" onDrop=onDrop}}
+            >tgt</div>
+          </template>
+        );
+
+        const dataTransfer = new DataTransfer();
+        // Taken before anything is painted, and reused for the release, so the
+        // pointer is provably stationary across the hover and the drop.
+        const rect = find("#tgt").getBoundingClientRect();
+        const coordinates = {
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height * grip,
+        };
+
+        await startDrag("#src", {
+          dataTransfer,
+          coordinates: centerOf("#src"),
+        });
+        await dragOver("#tgt", { dataTransfer, coordinates });
+
+        const painted = paintedPosition();
+        assert.notStrictEqual(
+          painted,
+          null,
+          "the target is painting a position before release"
+        );
+
+        await dragEvent("#tgt", "drop", { dataTransfer, ...coordinates });
+
+        assert.deepEqual(
+          drops,
+          [painted],
+          "onDrop receives the position painted immediately before release"
+        );
+      });
+    }
+  });
 });


### PR DESCRIPTION
A drop target's indicator was cleared before the kernel resolved the position it hands to `onDrop`. That position is measured from the element's own box, so a consumer whose CSS gives the indicator classes a layout effect got a position measured against a box that only existed once the indicator was gone. The card landed somewhere other than where the drop was shown.

Core's own stylesheet only sets `position: relative` and a pseudo-element line off those classes, so core never triggers it and nothing caught it. A consumer reaches it today by keying padding or a height off `--drag-above`, and it becomes unavoidable for any indicator that reserves space.

The position is now taken while the indicator is still up. Clearing still happens on both exits, including the one that leaves the drop to a deeper target.

The two new tests read which position the target is actually painting at the moment of release and assert the consumer is handed that one, so they hold whichever way a future mismatch falls rather than pinning today's direction.