### PR TITLE
UX: Allow searching workflows by username

### DIFF
--- a/plugins/discourse-workflows/app/models/discourse_workflows/workflow.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/workflow.rb
@@ -84,6 +84,14 @@ module DiscourseWorkflows
           ->(name) do
             where("discourse_workflows_workflows.name ILIKE ?", "%#{sanitize_sql_like(name)}%")
           end
+    scope :filter_by_name_or_username,
+          ->(filter) do
+            matching_users =
+              User.where("username_lower LIKE ?", "%#{sanitize_sql_like(filter.downcase)}%")
+            filter_by_name(filter).or(where(created_by_id: matching_users.select(:id))).or(
+              where(updated_by_id: matching_users.select(:id)),
+            )
+          end
     scope :filter_by_trigger_type,
           ->(type) do
             where(
@@ -104,9 +112,9 @@ module DiscourseWorkflows
               SQL
           end
 
-    def self.filtered(name: nil, trigger_type: nil, exclude_id: nil, tags: nil)
+    def self.filtered(filter: nil, trigger_type: nil, exclude_id: nil, tags: nil)
       scope = all
-      scope = scope.filter_by_name(name) if name.present?
+      scope = scope.filter_by_name_or_username(filter) if filter.present?
       scope = scope.filter_by_trigger_type(trigger_type) if trigger_type.present?
       scope = scope.filter_by_tags(tags) if tags.present?
       scope = scope.where.not(id: exclude_id) if exclude_id

--- a/plugins/discourse-workflows/app/services/discourse_workflows/workflow/list.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/workflow/list.rb
@@ -53,7 +53,7 @@ module DiscourseWorkflows
       scope =
         DiscourseWorkflows::Workflow
           .filtered(
-            name: params.filter,
+            filter: params.filter,
             trigger_type: params.trigger_type,
             exclude_id: params.exclude_id,
             tags: params.tag_names,
@@ -85,7 +85,7 @@ module DiscourseWorkflows
 
     def fetch_total_rows(params:)
       DiscourseWorkflows::Workflow.filtered(
-        name: params.filter,
+        filter: params.filter,
         trigger_type: params.trigger_type,
         exclude_id: params.exclude_id,
         tags: params.tag_names,

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -129,7 +129,7 @@ en:
       create_first_workflow: "Create your first workflow"
       empty_title: "%{username}, let's set up a workflow"
       empty_description: "Workflows automate tasks by connecting triggers, conditions, and actions into a visual flow"
-      search_placeholder: "Filter by name"
+      search_placeholder: "Filter by name or username"
       no_workflows_found: "No workflows match your filters"
       tags:
         manage: "Manage tags"

--- a/plugins/discourse-workflows/spec/models/discourse_workflows/workflow_spec.rb
+++ b/plugins/discourse-workflows/spec/models/discourse_workflows/workflow_spec.rb
@@ -3,6 +3,51 @@
 RSpec.describe DiscourseWorkflows::Workflow do
   fab!(:user)
 
+  describe ".filtered" do
+    fab!(:author) { Fabricate(:user, username: "Workflow_Author") }
+    fab!(:editor) { Fabricate(:user, username: "Workflow_Editor") }
+    fab!(:workflow) do
+      Fabricate(
+        :discourse_workflows_workflow,
+        name: "Deploy updates",
+        created_by: author,
+        updated_by: editor,
+        tags: %w[ops],
+      )
+    end
+    fab!(:other_workflow) do
+      Fabricate(:discourse_workflows_workflow, name: "Send notification", created_by: user)
+    end
+
+    it "matches partial names and creator or last editor usernames case insensitively" do
+      %w[DEPLOY AUTHOR EDITOR].each do |filter|
+        expect(described_class.filtered(filter:)).to contain_exactly(workflow)
+      end
+    end
+
+    it "returns a workflow only once when both usernames match" do
+      expect(described_class.filtered(filter: "Workflow_")).to contain_exactly(workflow)
+    end
+
+    it "matches names and creators when there is no last editor" do
+      workflow.update!(updated_by: nil)
+
+      %w[deploy author].each do |filter|
+        expect(described_class.filtered(filter:)).to contain_exactly(workflow)
+      end
+    end
+
+    it "treats SQL wildcard characters literally" do
+      %w[% Workflow_Auth_r].each { |filter| expect(described_class.filtered(filter:)).to be_empty }
+    end
+
+    it "combines username matching with tag and exclusion filters" do
+      expect(described_class.filtered(filter: "editor", tags: ["ops"])).to contain_exactly(workflow)
+      expect(described_class.filtered(filter: "editor", tags: ["missing"])).to be_empty
+      expect(described_class.filtered(filter: "author", exclude_id: workflow.id)).to be_empty
+    end
+  end
+
   describe "defaults" do
     it "uses a connection map by default" do
       expect(described_class.new.connections).to eq({})


### PR DESCRIPTION
Now the workflow list can be filtered by the username of the
workflow creator, which is handy for big lists of workflows

<img width="1036" height="226" alt="image" src="https://github.com/user-attachments/assets/91fbceac-4370-4b0b-81fe-cda5e078ca67" />
