### PR TITLE
FIX: Fork vips operations on all platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       simpleidn (~> 0.2)
     jwt (2.10.3)
       base64
-    landlock (0.5)
+    landlock (0.5.1)
     language_server-protocol (3.17.0.6)
     libv8-node (24.12.0.1-aarch64-linux)
     libv8-node (24.12.0.1-aarch64-linux-musl)
@@ -1112,7 +1112,7 @@ CHECKSUMS
   json_completer (1.2.0) sha256=4665749172634eccb208c562eb59ea81dd7a612a1fa9a36df441ac473ff177b1
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   jwt (2.10.3) sha256=e4d9352fbc7309b1a7448c7dd713dfe4d8c47077af80759cdbed8f878ea0b484
-  landlock (0.5) sha256=fbe450a0f73be398a7dd75e7b731bcf3764442228c8a259b6fa651affb431d33
+  landlock (0.5.1) sha256=4c66c5ea238ce0fb4dbf0ea8697da3af01f396f86b34f1f5c323969bc524eba0
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   libv8-node (24.12.0.1-aarch64-linux) sha256=22bd0246cde85d70c88cf772727ac3677a20ac1d169105f82efe5f1f7c39f755
   libv8-node (24.12.0.1-aarch64-linux-musl) sha256=791b5960f79525e87d1bd1e5f2bf3715ef2a38bac6c97f297853e98a8411ba89

--- a/script/discourse_vips_worker
+++ b/script/discourse_vips_worker
@@ -203,11 +203,7 @@ class DiscourseVipsWorker
       break if ready_ios.include?(@owner_reader)
 
       connection = @server.accept
-      if LINUX_PLATFORM
-        fork_connection_process(connection)
-      else
-        handle_connection(connection)
-      end
+      fork_connection_process(connection)
     end
   ensure
     @server.close unless @server.closed?
@@ -242,12 +238,7 @@ class DiscourseVipsWorker
   def handle_connection(connection)
     request = MessagePack.unpack(connection.read)
     operation = Operations.build(request.fetch("command"))
-    response =
-      if LINUX_PLATFORM
-        run_sandboxed(request:, operation:)
-      else
-        run_direct(operation)
-      end
+    response = run_sandboxed(request:, operation:)
     write_response(connection, response)
   rescue StandardError => error
     write_response(connection, "status" => "error", "message" => error.message.byteslice(0, 4096))
@@ -272,7 +263,7 @@ class DiscourseVipsWorker
           env: child_environment(scratch),
           unsetenv_others: true,
           rlimits: RLIMITS,
-          seccomp_deny_network: true,
+          seccomp_deny_network: LINUX_PLATFORM,
           on_unsupported: :run_without_landlock,
         ) do |stdout, _stderr|
           apply_nice(request)
@@ -287,10 +278,6 @@ class DiscourseVipsWorker
         { "status" => "error", "message" => "libvips operation failed" }
       end
     end
-  end
-
-  def run_direct(operation)
-    operation_response(operation)
   end
 
   def remove_socket_directory

--- a/spec/lib/discourse_vips_spec.rb
+++ b/spec/lib/discourse_vips_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe DiscourseVips do
     end
 
     it "recovers after an operation times out" do
-      skip "per-operation timeouts require fork isolation" if RUBY_PLATFORM.include?("darwin")
-
       Dir.mktmpdir do |directory|
         input_path = File.join(directory, "blocked.png")
         File.mkfifo(input_path)


### PR DESCRIPTION
This commit updates ruby-landlock to 0.5.1, which fixes `on_unsupported: :run_without_landlock` when the Landlock support check fails and adds the fallback on non-Linux systems.

With that fix, non-Linux environments no longer run vips operations directly inside the worker process; every environment uses the forked operation path.
