### PR TITLE
DEV: Move permission checks into PostMover

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -987,10 +987,7 @@ class TopicsController < ApplicationController
     topic = Topic.find_by(id: topic_id)
     guardian.ensure_can_move_posts!(topic)
 
-    destination_topic = Topic.find_by(id: destination_topic_id)
-    guardian.ensure_can_create_post_on_topic!(destination_topic)
-
-    args = {}
+    args = { guardian: guardian }
     args[:destination_topic_id] = destination_topic_id.to_i
     args[:chronological_order] = params[:chronological_order] == "true"
     args[:freeze_original] = params[:freeze_original] == "true"
@@ -1005,6 +1002,8 @@ class TopicsController < ApplicationController
     hijack(info: "merging topic #{topic_id.inspect} into #{destination_topic_id.inspect}") do
       destination_topic = topic.move_posts(acting_user, topic.posts.pluck(:id), args)
       render_topic_changes(destination_topic)
+    rescue Discourse::InvalidAccess => ex
+      rescue_with_handler(ex)
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => ex
       render_json_error(ex)
     end
@@ -1040,14 +1039,12 @@ class TopicsController < ApplicationController
       end
     end
 
-    if params[:destination_topic_id].present?
-      destination_topic = Topic.find_by(id: params[:destination_topic_id])
-      guardian.ensure_can_create_post_on_topic!(destination_topic)
-    end
-
+    request_guardian = guardian
     hijack do
-      destination_topic = move_posts_to_destination(topic)
+      destination_topic = move_posts_to_destination(topic, guardian: request_guardian)
       render_topic_changes(destination_topic)
+    rescue Discourse::InvalidAccess => ex
+      rescue_with_handler(ex)
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => ex
       render_json_error(ex)
     end
@@ -1620,8 +1617,8 @@ class TopicsController < ApplicationController
     end
   end
 
-  def move_posts_to_destination(topic)
-    args = {}
+  def move_posts_to_destination(topic, guardian:)
+    args = { guardian: guardian }
     args[:title] = params[:title] if params[:title].present?
     args[:destination_topic_id] = params[:destination_topic_id].to_i if params[
       :destination_topic_id

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -9,10 +9,18 @@ class PostMover
 
   # options:
   # freeze_original: :boolean  - if true, the original topic will be frozen but not deleted and posts will be "copied" to topic
-  def initialize(original_topic, user, post_ids, move_to_pm: false, options: {})
+  def initialize(
+    original_topic,
+    user,
+    post_ids,
+    guardian: user.guardian,
+    move_to_pm: false,
+    options: {}
+  )
     @original_topic = original_topic
     @original_topic_title = original_topic.title
     @user = user
+    @guardian = guardian
     @post_ids = post_ids
     # For now we store a copy of post_ids. If `freeze_original` is present, we will have new post_ids.
     # When we create the new posts, we will pluck out post_ids out of this and replace with updated ids.
@@ -22,11 +30,14 @@ class PostMover
   end
 
   def to_topic(id, participants: nil, chronological_order: false)
+    @guardian.ensure_can_move_posts!(original_topic)
+    topic = Topic.find_by_id(id)
+    @guardian.ensure_can_create_post_on_topic!(topic)
+
     @move_type = PostMover.move_types[:existing_topic]
     @creating_new_topic = false
     @chronological_order = chronological_order
 
-    topic = Topic.find_by_id(id)
     if topic.archetype != @original_topic.archetype &&
          [@original_topic.archetype, topic.archetype].include?(Archetype.private_message)
       raise Discourse::InvalidParameters
@@ -39,6 +50,9 @@ class PostMover
   end
 
   def to_new_topic(title, category_id = nil, tag_ids: nil, tags: nil)
+    @guardian.ensure_can_move_posts!(original_topic)
+    @guardian.ensure_can_create_topic_on_category!(category_id) if category_id.present?
+
     @move_type = PostMover.move_types[:new_topic]
     @creating_new_topic = true
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1409,6 +1409,7 @@ class Topic < ActiveRecord::Base
         self,
         moved_by,
         post_ids,
+        guardian: opts.fetch(:guardian) { moved_by.guardian },
         move_to_pm: opts[:archetype].present? && opts[:archetype] == "private_message",
         options: {
           freeze_original: opts[:freeze_original],

--- a/plugins/discourse-ai/lib/agents/tools/move_posts.rb
+++ b/plugins/discourse-ai/lib/agents/tools/move_posts.rb
@@ -89,7 +89,8 @@ module DiscourseAi
             opts[:category_id] = parameters[:category_id] if parameters[:category_id].present?
           end
 
-          destination_topic = topic.move_posts(acting_user, post_ids, opts)
+          destination_topic =
+            topic.move_posts(acting_user, post_ids, opts.merge(guardian: guardian))
 
           if destination_topic.present?
             {

--- a/plugins/discourse-ai/spec/lib/agents/tools/move_posts_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/move_posts_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DiscourseAi::Agents::Tools::MovePosts do
     fab!(:user, :trust_level_4)
     let(:context) { DiscourseAi::Agents::BotContext.new(user: user) }
 
-    it "uses the context user's category permissions when creating a topic" do
+    it "rejects moving posts to a category where the user cannot create topics" do
       category = Fabricate(:category)
       category.set_permissions(everyone: :reply)
       category.save!

--- a/plugins/discourse-ai/spec/lib/agents/tools/move_posts_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/move_posts_spec.rb
@@ -21,6 +21,29 @@ RSpec.describe DiscourseAi::Agents::Tools::MovePosts do
 
   let(:context) { DiscourseAi::Agents::BotContext.new }
 
+  describe "#invoke" do
+    fab!(:user, :trust_level_4)
+    let(:context) { DiscourseAi::Agents::BotContext.new(user: user) }
+
+    it "uses the context user's category permissions when creating a topic" do
+      category = Fabricate(:category)
+      category.set_permissions(everyone: :reply)
+      category.save!
+
+      expect do
+        expect do
+          tool(
+            topic_id: topic.id,
+            post_ids: [post2.id],
+            new_title: "A separate discussion",
+            category_id: category.id,
+            reason: "Organizing the discussion",
+          ).invoke
+        end.to raise_error(Discourse::InvalidAccess)
+      end.not_to change { [Topic.count, Post.count, post2.reload.topic_id] }
+    end
+  end
+
   it "moves posts to an existing topic" do
     result =
       tool(

--- a/plugins/discourse-ai/spec/lib/agents/tools/move_posts_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/move_posts_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DiscourseAi::Agents::Tools::MovePosts do
     fab!(:user, :trust_level_4)
     let(:context) { DiscourseAi::Agents::BotContext.new(user: user) }
 
-    it "rejects moving posts to a category where the user cannot create topics" do
+    it "leaves posts unchanged when the user can only reply in the destination category" do
       category = Fabricate(:category)
       category.set_permissions(everyone: :reply)
       category.save!

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -4,6 +4,107 @@ RSpec.describe PostMover do
   fab!(:admin)
   fab!(:evil_trout) { Fabricate(:evil_trout, refresh_auto_groups: true) }
 
+  describe "#to_topic" do
+    fab!(:topic)
+    fab!(:first_post) { Fabricate(:post, topic: topic) }
+    fab!(:reply) { Fabricate(:post, topic: topic) }
+    fab!(:destination_topic, :topic)
+    fab!(:user)
+
+    it "requires permission to move posts from the source topic" do
+      mover = described_class.new(topic, user, [reply.id])
+
+      expect do
+        expect { mover.to_topic(destination_topic.id) }.to raise_error(Discourse::InvalidAccess)
+      end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
+    end
+
+    it "uses the supplied guardian instead of the attribution user's permissions" do
+      expect do
+        expect do
+          topic.move_posts(
+            admin,
+            [reply.id],
+            destination_topic_id: destination_topic.id,
+            guardian: user.guardian,
+          )
+        end.to raise_error(Discourse::InvalidAccess)
+      end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
+    end
+
+    it "requires permission to create posts in the destination topic" do
+      mover_user = Fabricate(:trust_level_4)
+      category = Fabricate(:category)
+      category.set_permissions(everyone: :readonly)
+      category.save!
+      destination_topic.update!(category: category)
+      mover = described_class.new(topic, mover_user, [reply.id])
+
+      expect do
+        expect { mover.to_topic(destination_topic.id) }.to raise_error(Discourse::InvalidAccess)
+      end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
+    end
+
+    it "rejects a missing destination before dereferencing it" do
+      mover = described_class.new(topic, admin, [reply.id])
+
+      expect { mover.to_topic(nil) }.to raise_error(Discourse::InvalidAccess)
+      expect(reply.reload.topic_id).to eq(topic.id)
+    end
+
+    it "preserves attribution when a separate guardian authorizes the move" do
+      topic.move_posts(
+        user,
+        [reply.id],
+        destination_topic_id: destination_topic.id,
+        guardian: admin.guardian,
+      )
+
+      expect(reply.reload.topic_id).to eq(destination_topic.id)
+      expect(topic.posts.find_by(action_code: "split_topic").user_id).to eq(user.id)
+    end
+  end
+
+  describe "#to_new_topic" do
+    fab!(:topic)
+    fab!(:first_post) { Fabricate(:post, topic: topic) }
+    fab!(:reply) { Fabricate(:post, topic: topic) }
+
+    it "requires source permissions before creating a topic" do
+      mover = described_class.new(topic, Fabricate(:user), [reply.id])
+
+      expect do
+        expect { mover.to_new_topic("A separate discussion") }.to raise_error(
+          Discourse::InvalidAccess,
+        )
+      end.not_to change { [Topic.count, Post.count, reply.reload.topic_id] }
+    end
+
+    it "requires permission to create a topic in an explicitly selected category" do
+      user = Fabricate(:trust_level_4)
+      category = Fabricate(:category)
+      category.set_permissions(everyone: :reply)
+      category.save!
+      mover = described_class.new(topic, user, [reply.id])
+
+      expect do
+        expect { mover.to_new_topic("A separate discussion", category.id) }.to raise_error(
+          Discourse::InvalidAccess,
+        )
+      end.not_to change { [Topic.count, Post.count, reply.reload.topic_id] }
+    end
+
+    it "creates a topic in a category allowed by the supplied guardian" do
+      category = Fabricate(:category)
+      mover = described_class.new(topic, admin, [reply.id], guardian: admin.guardian)
+
+      destination = mover.to_new_topic("A separate discussion", category.id)
+
+      expect(destination.category_id).to eq(category.id)
+      expect(reply.reload.topic_id).to eq(destination.id)
+    end
+  end
+
   describe "#move_types" do
     context "when verifying enum sequence" do
       it "'new_topic' should be at 1st position" do
@@ -2995,7 +3096,7 @@ RSpec.describe PostMover do
       fab!(:topic_1, :topic)
       fab!(:topic_2, :topic)
       fab!(:post_1) { Fabricate(:post, topic: topic_1) }
-      fab!(:user)
+      fab!(:user, :trust_level_4)
 
       before { SiteSetting.delete_merged_stub_topics_after_days = 0 }
 
@@ -3023,7 +3124,7 @@ RSpec.describe PostMover do
       end
 
       it "allows specific user to merge topics" do
-        special_user = Fabricate(:user)
+        special_user = Fabricate(:trust_level_4)
         plugin_instance = Plugin::Instance.new
 
         plugin_instance.register_modifier(:is_allowed_to_delete_after_merge, &modifier_block)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -19,19 +19,6 @@ RSpec.describe PostMover do
       end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
     end
 
-    it "uses the supplied guardian instead of the attribution user's permissions" do
-      expect do
-        expect do
-          topic.move_posts(
-            admin,
-            [reply.id],
-            destination_topic_id: destination_topic.id,
-            guardian: user.guardian,
-          )
-        end.to raise_error(Discourse::InvalidAccess)
-      end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
-    end
-
     it "requires permission to create posts in the destination topic" do
       mover_user = Fabricate(:trust_level_4)
       category = Fabricate(:category)
@@ -45,23 +32,11 @@ RSpec.describe PostMover do
       end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
     end
 
-    it "rejects a missing destination before dereferencing it" do
+    it "rejects a missing destination" do
       mover = described_class.new(topic, admin, [reply.id])
 
       expect { mover.to_topic(nil) }.to raise_error(Discourse::InvalidAccess)
       expect(reply.reload.topic_id).to eq(topic.id)
-    end
-
-    it "preserves attribution when a separate guardian authorizes the move" do
-      topic.move_posts(
-        user,
-        [reply.id],
-        destination_topic_id: destination_topic.id,
-        guardian: admin.guardian,
-      )
-
-      expect(reply.reload.topic_id).to eq(destination_topic.id)
-      expect(topic.posts.find_by(action_code: "split_topic").user_id).to eq(user.id)
     end
   end
 
@@ -94,9 +69,12 @@ RSpec.describe PostMover do
       end.not_to change { [Topic.count, Post.count, reply.reload.topic_id] }
     end
 
-    it "creates a topic in a category allowed by the supplied guardian" do
+    it "creates a topic on behalf of a user who can only reply in the category" do
+      user = Fabricate(:trust_level_4)
       category = Fabricate(:category)
-      mover = described_class.new(topic, admin, [reply.id], guardian: admin.guardian)
+      category.set_permissions(everyone: :reply)
+      category.save!
+      mover = described_class.new(topic, user, [reply.id], guardian: admin.guardian)
 
       destination = mover.to_new_topic("A separate discussion", category.id)
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe PostMover do
     fab!(:first_post) { Fabricate(:post, topic: topic) }
     fab!(:reply) { Fabricate(:post, topic: topic) }
 
-    it "rejects the split when the user cannot move posts from the source topic" do
+    it "does not create a topic when the user cannot move posts from the source topic" do
       mover = described_class.new(topic, Fabricate(:user), [reply.id])
 
       expect do
@@ -55,7 +55,7 @@ RSpec.describe PostMover do
       end.not_to change { [Topic.count, Post.count, reply.reload.topic_id] }
     end
 
-    it "rejects the split when the user can only reply in the destination category" do
+    it "does not create a topic when the user can only reply in the destination category" do
       user = Fabricate(:trust_level_4)
       category = Fabricate(:category)
       category.set_permissions(everyone: :reply)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PostMover do
     fab!(:destination_topic, :topic)
     fab!(:user)
 
-    it "requires permission to move posts from the source topic" do
+    it "rejects the move when the user cannot move posts from the source topic" do
       mover = described_class.new(topic, user, [reply.id])
 
       expect do
@@ -19,7 +19,7 @@ RSpec.describe PostMover do
       end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
     end
 
-    it "requires permission to create posts in the destination topic" do
+    it "rejects the move when the destination category is read-only for the user" do
       mover_user = Fabricate(:trust_level_4)
       category = Fabricate(:category)
       category.set_permissions(everyone: :readonly)
@@ -32,7 +32,7 @@ RSpec.describe PostMover do
       end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
     end
 
-    it "rejects a missing destination" do
+    it "rejects the move when no destination is given" do
       mover = described_class.new(topic, admin, [reply.id])
 
       expect { mover.to_topic(nil) }.to raise_error(Discourse::InvalidAccess)
@@ -45,7 +45,7 @@ RSpec.describe PostMover do
     fab!(:first_post) { Fabricate(:post, topic: topic) }
     fab!(:reply) { Fabricate(:post, topic: topic) }
 
-    it "requires source permissions before creating a topic" do
+    it "rejects the split when the user cannot move posts from the source topic" do
       mover = described_class.new(topic, Fabricate(:user), [reply.id])
 
       expect do
@@ -55,7 +55,7 @@ RSpec.describe PostMover do
       end.not_to change { [Topic.count, Post.count, reply.reload.topic_id] }
     end
 
-    it "requires permission to create a topic in an explicitly selected category" do
+    it "rejects the split when the user can only reply in the destination category" do
       user = Fabricate(:trust_level_4)
       category = Fabricate(:category)
       category.set_permissions(everyone: :reply)
@@ -69,7 +69,7 @@ RSpec.describe PostMover do
       end.not_to change { [Topic.count, Post.count, reply.reload.topic_id] }
     end
 
-    it "creates a topic on behalf of a user who can only reply in the category" do
+    it "allows an admin to split posts on behalf of a user with reply-only access" do
       user = Fabricate(:trust_level_4)
       category = Fabricate(:category)
       category.set_permissions(everyone: :reply)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Topic do
     fab!(:reply) { Fabricate(:post, topic: topic) }
     fab!(:destination_topic, :topic)
 
-    it "rejects an unauthorized move even when attributed to an admin" do
+    it "rejects the move when only the credited user has permission" do
       expect do
         expect do
           topic.move_posts(
@@ -35,7 +35,7 @@ RSpec.describe Topic do
       end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
     end
 
-    it "attributes the move to the specified user when authorized by an admin" do
+    it "credits the specified user for a move authorized by an admin" do
       topic.move_posts(
         user,
         [reply.id],

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,6 +16,38 @@ RSpec.describe Topic do
 
   it_behaves_like "it has custom fields"
 
+  describe "#move_posts" do
+    fab!(:topic)
+    fab!(:first_post) { Fabricate(:post, topic: topic) }
+    fab!(:reply) { Fabricate(:post, topic: topic) }
+    fab!(:destination_topic, :topic)
+
+    it "rejects an unauthorized move even when attributed to an admin" do
+      expect do
+        expect do
+          topic.move_posts(
+            admin,
+            [reply.id],
+            destination_topic_id: destination_topic.id,
+            guardian: user.guardian,
+          )
+        end.to raise_error(Discourse::InvalidAccess)
+      end.not_to change { [Post.count, reply.reload.topic_id, topic.reload.closed] }
+    end
+
+    it "attributes the move to the specified user when authorized by an admin" do
+      topic.move_posts(
+        user,
+        [reply.id],
+        destination_topic_id: destination_topic.id,
+        guardian: admin.guardian,
+      )
+
+      expect(reply.reload.topic_id).to eq(destination_topic.id)
+      expect(topic.posts.find_by(action_code: "split_topic").user_id).to eq(user.id)
+    end
+  end
+
   describe "Validations" do
     let(:topic) { Fabricate.build(:topic) }
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -625,39 +625,28 @@ RSpec.describe TopicsController do
       end
 
       it "moves the posts" do
-        io = StringIO.new
-
         post "/t/#{topic.id}/move-posts.json",
              params: {
                post_ids: [p2.id],
                destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
              }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
-        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq("success" => true, "url" => dest_topic.relative_url)
         expect(p2.reload.topic_id).to eq(dest_topic.id)
       end
 
       it "does not allow posts to be moved to a private category" do
         dest_topic.update!(category: staff_category)
-        io = StringIO.new
 
         post "/t/#{topic.id}/move-posts.json",
              params: {
                post_ids: [p2.id],
                destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
              }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
-        expect(JSON.parse(body)["errors"]).to be_present
+        expect(response).to be_forbidden
+        expect(response.parsed_body["errors"]).to be_present
         expect(p2.reload.topic_id).to eq(topic.id)
         expect(topic.reload.deleted_at).to be_nil
       end
@@ -962,37 +951,20 @@ RSpec.describe TopicsController do
       end
 
       it "moves the posts" do
-        io = StringIO.new
+        post "/t/#{topic.id}/merge-topic.json", params: { destination_topic_id: dest_topic.id }
 
-        post "/t/#{topic.id}/merge-topic.json",
-             params: {
-               destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
-             }
-
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
-        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq("success" => true, "url" => dest_topic.relative_url)
         expect(p2.reload.topic_id).to eq(dest_topic.id)
       end
 
       it "does not allow posts to be moved to a private category" do
         dest_topic.update!(category: staff_category)
-        io = StringIO.new
 
-        post "/t/#{topic.id}/merge-topic.json",
-             params: {
-               destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
-             }
+        post "/t/#{topic.id}/merge-topic.json", params: { destination_topic_id: dest_topic.id }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
-        expect(JSON.parse(body)["errors"]).to be_present
+        expect(response).to be_forbidden
+        expect(response.parsed_body["errors"]).to be_present
         expect(p2.reload.topic_id).to eq(topic.id)
         expect(topic.reload.deleted_at).to be_nil
       end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
-      it "rejects a forbidden category even when a destination topic or archetype is supplied" do
+      it "returns 403 for a restricted category even when other destination options are supplied" do
         [
           { destination_topic_id: dest_topic.id },
           { archetype: Archetype.default },
@@ -649,42 +649,44 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
-      it "returns JSON success through a hijacked response" do
-        io = StringIO.new
+      context "when the request is hijacked" do
+        it "returns 200 with the destination URL after moving the posts" do
+          io = StringIO.new
 
-        post "/t/#{topic.id}/move-posts.json",
-             params: {
-               post_ids: [p2.id],
-               destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
-             }
+          post "/t/#{topic.id}/move-posts.json",
+               params: {
+                 post_ids: [p2.id],
+                 destination_topic_id: dest_topic.id,
+               },
+               env: {
+                 "rack.hijack" => -> { io },
+               }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
-        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
-        expect(p2.reload.topic_id).to eq(dest_topic.id)
-      end
+          headers, body = io.string.split("\r\n\r\n", 2)
+          expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
+          expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+          expect(p2.reload.topic_id).to eq(dest_topic.id)
+        end
 
-      it "returns JSON permission errors through a hijacked response without moving posts" do
-        dest_topic.update!(category: staff_category)
-        io = StringIO.new
+        it "returns 403 with JSON errors when the destination category is inaccessible" do
+          dest_topic.update!(category: staff_category)
+          io = StringIO.new
 
-        post "/t/#{topic.id}/move-posts.json",
-             params: {
-               post_ids: [p2.id],
-               destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
-             }
+          post "/t/#{topic.id}/move-posts.json",
+               params: {
+                 post_ids: [p2.id],
+                 destination_topic_id: dest_topic.id,
+               },
+               env: {
+                 "rack.hijack" => -> { io },
+               }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
-        expect(JSON.parse(body)["errors"]).to be_present
-        expect(p2.reload.topic_id).to eq(topic.id)
-        expect(topic.reload.deleted_at).to be_nil
+          headers, body = io.string.split("\r\n\r\n", 2)
+          expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
+          expect(JSON.parse(body)["errors"]).to be_present
+          expect(p2.reload.topic_id).to eq(topic.id)
+          expect(topic.reload.deleted_at).to be_nil
+        end
       end
 
       it "does not allow posts outside of the category to be moved" do
@@ -1003,40 +1005,42 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
-      it "returns JSON success through a hijacked response" do
-        io = StringIO.new
+      context "when the request is hijacked" do
+        it "returns 200 with the destination URL after merging the topics" do
+          io = StringIO.new
 
-        post "/t/#{topic.id}/merge-topic.json",
-             params: {
-               destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
-             }
+          post "/t/#{topic.id}/merge-topic.json",
+               params: {
+                 destination_topic_id: dest_topic.id,
+               },
+               env: {
+                 "rack.hijack" => -> { io },
+               }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
-        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
-        expect(p2.reload.topic_id).to eq(dest_topic.id)
-      end
+          headers, body = io.string.split("\r\n\r\n", 2)
+          expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
+          expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+          expect(p2.reload.topic_id).to eq(dest_topic.id)
+        end
 
-      it "returns JSON permission errors through a hijacked response without moving posts" do
-        dest_topic.update!(category: staff_category)
-        io = StringIO.new
+        it "returns 403 with JSON errors when the destination category is inaccessible" do
+          dest_topic.update!(category: staff_category)
+          io = StringIO.new
 
-        post "/t/#{topic.id}/merge-topic.json",
-             params: {
-               destination_topic_id: dest_topic.id,
-             },
-             env: {
-               "rack.hijack" => -> { io },
-             }
+          post "/t/#{topic.id}/merge-topic.json",
+               params: {
+                 destination_topic_id: dest_topic.id,
+               },
+               env: {
+                 "rack.hijack" => -> { io },
+               }
 
-        headers, body = io.string.split("\r\n\r\n", 2)
-        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
-        expect(JSON.parse(body)["errors"]).to be_present
-        expect(p2.reload.topic_id).to eq(topic.id)
-        expect(topic.reload.deleted_at).to be_nil
+          headers, body = io.string.split("\r\n\r\n", 2)
+          expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
+          expect(JSON.parse(body)["errors"]).to be_present
+          expect(p2.reload.topic_id).to eq(topic.id)
+          expect(topic.reload.deleted_at).to be_nil
+        end
       end
 
       it "does not allow posts outside of the category to be moved" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -342,6 +342,24 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
+      it "checks the category when combined options select another destination" do
+        [
+          { destination_topic_id: dest_topic.id },
+          { archetype: Archetype.default },
+        ].each do |options|
+          post "/t/#{topic.id}/move-posts.json",
+               params: {
+                 title: "Logan is a good movie",
+                 post_ids: [p2.id],
+                 category_id: staff_category.id,
+               }.merge(options)
+
+          expect(response).to be_forbidden
+          expect(response.parsed_body["errors"]).to be_present
+          expect(p2.reload.topic_id).to eq(topic.id)
+        end
+      end
+
       it "ignores unrelated post IDs without exposing their reviewables" do
         restricted_category = Fabricate(:private_category, group: Fabricate(:group))
         restricted_topic = Fabricate(:topic, category: restricted_category)
@@ -629,6 +647,44 @@ RSpec.describe TopicsController do
              }
 
         expect(response).to be_forbidden
+      end
+
+      it "returns JSON success through a hijacked response" do
+        io = StringIO.new
+
+        post "/t/#{topic.id}/move-posts.json",
+             params: {
+               post_ids: [p2.id],
+               destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
+             }
+
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
+        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+        expect(p2.reload.topic_id).to eq(dest_topic.id)
+      end
+
+      it "returns JSON permission errors through a hijacked response without moving posts" do
+        dest_topic.update!(category: staff_category)
+        io = StringIO.new
+
+        post "/t/#{topic.id}/move-posts.json",
+             params: {
+               post_ids: [p2.id],
+               destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
+             }
+
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
+        expect(JSON.parse(body)["errors"]).to be_present
+        expect(p2.reload.topic_id).to eq(topic.id)
+        expect(topic.reload.deleted_at).to be_nil
       end
 
       it "does not allow posts outside of the category to be moved" do
@@ -945,6 +1001,42 @@ RSpec.describe TopicsController do
         post "/t/#{topic.id}/merge-topic.json", params: { destination_topic_id: dest_topic.id }
 
         expect(response).to be_forbidden
+      end
+
+      it "returns JSON success through a hijacked response" do
+        io = StringIO.new
+
+        post "/t/#{topic.id}/merge-topic.json",
+             params: {
+               destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
+             }
+
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
+        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+        expect(p2.reload.topic_id).to eq(dest_topic.id)
+      end
+
+      it "returns JSON permission errors through a hijacked response without moving posts" do
+        dest_topic.update!(category: staff_category)
+        io = StringIO.new
+
+        post "/t/#{topic.id}/merge-topic.json",
+             params: {
+               destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
+             }
+
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
+        expect(JSON.parse(body)["errors"]).to be_present
+        expect(p2.reload.topic_id).to eq(topic.id)
+        expect(topic.reload.deleted_at).to be_nil
       end
 
       it "does not allow posts outside of the category to be moved" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -342,22 +342,32 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
-      it "does not allow posts to be moved to a private category when other destination options are supplied" do
-        [
-          { destination_topic_id: dest_topic.id },
-          { archetype: Archetype.default },
-        ].each do |options|
-          post "/t/#{topic.id}/move-posts.json",
-               params: {
-                 title: "Logan is a good movie",
-                 post_ids: [p2.id],
-                 category_id: staff_category.id,
-               }.merge(options)
+      it "does not allow posts to be moved to a private category when a destination topic is supplied" do
+        post "/t/#{topic.id}/move-posts.json",
+             params: {
+               title: "Logan is a good movie",
+               post_ids: [p2.id],
+               category_id: staff_category.id,
+               destination_topic_id: dest_topic.id,
+             }
 
-          expect(response).to be_forbidden
-          expect(response.parsed_body["errors"]).to be_present
-          expect(p2.reload.topic_id).to eq(topic.id)
-        end
+        expect(response).to be_forbidden
+        expect(response.parsed_body["errors"]).to be_present
+        expect(p2.reload.topic_id).to eq(topic.id)
+      end
+
+      it "does not allow posts to be moved to a private category when an archetype is supplied" do
+        post "/t/#{topic.id}/move-posts.json",
+             params: {
+               title: "Logan is a good movie",
+               post_ids: [p2.id],
+               category_id: staff_category.id,
+               archetype: Archetype.default,
+             }
+
+        expect(response).to be_forbidden
+        expect(response.parsed_body["errors"]).to be_present
+        expect(p2.reload.topic_id).to eq(topic.id)
       end
 
       it "ignores unrelated post IDs without exposing their reviewables" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
-      it "checks the category when combined options select another destination" do
+      it "rejects a forbidden category even when a destination topic or archetype is supplied" do
         [
           { destination_topic_id: dest_topic.id },
           { archetype: Archetype.default },

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe TopicsController do
         expect(response).to be_forbidden
       end
 
-      it "returns 403 for a restricted category even when other destination options are supplied" do
+      it "does not allow posts to be moved to a private category when other destination options are supplied" do
         [
           { destination_topic_id: dest_topic.id },
           { archetype: Archetype.default },
@@ -625,68 +625,41 @@ RSpec.describe TopicsController do
       end
 
       it "moves the posts" do
+        io = StringIO.new
+
         post "/t/#{topic.id}/move-posts.json",
              params: {
                post_ids: [p2.id],
                destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
              }
 
-        expect(response.status).to eq(200)
-        result = response.parsed_body
-        expect(result["success"]).to eq(true)
-        expect(result["url"]).to be_present
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
+        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+        expect(p2.reload.topic_id).to eq(dest_topic.id)
       end
 
       it "does not allow posts to be moved to a private category" do
         dest_topic.update!(category: staff_category)
+        io = StringIO.new
 
         post "/t/#{topic.id}/move-posts.json",
              params: {
                post_ids: [p2.id],
                destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
              }
 
-        expect(response).to be_forbidden
-      end
-
-      context "when the request is hijacked" do
-        it "returns 200 with the destination URL after moving the posts" do
-          io = StringIO.new
-
-          post "/t/#{topic.id}/move-posts.json",
-               params: {
-                 post_ids: [p2.id],
-                 destination_topic_id: dest_topic.id,
-               },
-               env: {
-                 "rack.hijack" => -> { io },
-               }
-
-          headers, body = io.string.split("\r\n\r\n", 2)
-          expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
-          expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
-          expect(p2.reload.topic_id).to eq(dest_topic.id)
-        end
-
-        it "returns 403 with JSON errors when the destination category is inaccessible" do
-          dest_topic.update!(category: staff_category)
-          io = StringIO.new
-
-          post "/t/#{topic.id}/move-posts.json",
-               params: {
-                 post_ids: [p2.id],
-                 destination_topic_id: dest_topic.id,
-               },
-               env: {
-                 "rack.hijack" => -> { io },
-               }
-
-          headers, body = io.string.split("\r\n\r\n", 2)
-          expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
-          expect(JSON.parse(body)["errors"]).to be_present
-          expect(p2.reload.topic_id).to eq(topic.id)
-          expect(topic.reload.deleted_at).to be_nil
-        end
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
+        expect(JSON.parse(body)["errors"]).to be_present
+        expect(p2.reload.topic_id).to eq(topic.id)
+        expect(topic.reload.deleted_at).to be_nil
       end
 
       it "does not allow posts outside of the category to be moved" do
@@ -989,58 +962,39 @@ RSpec.describe TopicsController do
       end
 
       it "moves the posts" do
-        post "/t/#{topic.id}/merge-topic.json", params: { destination_topic_id: dest_topic.id }
+        io = StringIO.new
 
-        expect(response.status).to eq(200)
-        result = response.parsed_body
-        expect(result["success"]).to eq(true)
-        expect(result["url"]).to be_present
+        post "/t/#{topic.id}/merge-topic.json",
+             params: {
+               destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
+             }
+
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
+        expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
+        expect(p2.reload.topic_id).to eq(dest_topic.id)
       end
 
       it "does not allow posts to be moved to a private category" do
         dest_topic.update!(category: staff_category)
+        io = StringIO.new
 
-        post "/t/#{topic.id}/merge-topic.json", params: { destination_topic_id: dest_topic.id }
+        post "/t/#{topic.id}/merge-topic.json",
+             params: {
+               destination_topic_id: dest_topic.id,
+             },
+             env: {
+               "rack.hijack" => -> { io },
+             }
 
-        expect(response).to be_forbidden
-      end
-
-      context "when the request is hijacked" do
-        it "returns 200 with the destination URL after merging the topics" do
-          io = StringIO.new
-
-          post "/t/#{topic.id}/merge-topic.json",
-               params: {
-                 destination_topic_id: dest_topic.id,
-               },
-               env: {
-                 "rack.hijack" => -> { io },
-               }
-
-          headers, body = io.string.split("\r\n\r\n", 2)
-          expect(headers).to start_with("HTTP/1.1 200 OK\r\n")
-          expect(JSON.parse(body)).to eq("success" => true, "url" => dest_topic.relative_url)
-          expect(p2.reload.topic_id).to eq(dest_topic.id)
-        end
-
-        it "returns 403 with JSON errors when the destination category is inaccessible" do
-          dest_topic.update!(category: staff_category)
-          io = StringIO.new
-
-          post "/t/#{topic.id}/merge-topic.json",
-               params: {
-                 destination_topic_id: dest_topic.id,
-               },
-               env: {
-                 "rack.hijack" => -> { io },
-               }
-
-          headers, body = io.string.split("\r\n\r\n", 2)
-          expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
-          expect(JSON.parse(body)["errors"]).to be_present
-          expect(p2.reload.topic_id).to eq(topic.id)
-          expect(topic.reload.deleted_at).to be_nil
-        end
+        headers, body = io.string.split("\r\n\r\n", 2)
+        expect(headers).to start_with("HTTP/1.1 403 Forbidden\r\n")
+        expect(JSON.parse(body)["errors"]).to be_present
+        expect(p2.reload.topic_id).to eq(topic.id)
+        expect(topic.reload.deleted_at).to be_nil
       end
 
       it "does not allow posts outside of the category to be moved" do


### PR DESCRIPTION
Move permission checks into `PostMover` so callers no longer need to remember to enforce them.