### PR TITLE
SECURITY: Prevent posts with active policy markup from being made wiki posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -725,6 +725,8 @@ class PostsController < ApplicationController
 
     post.revise(current_user, wiki: params[:wiki])
 
+    return render_json_error(post) if post.errors.present?
+
     render body: nil
   end
 

--- a/plugins/discourse-policy/config/locales/server.en.yml
+++ b/plugins/discourse-policy/config/locales/server.en.yml
@@ -11,6 +11,7 @@ en:
       no_policy: "No policy exists for post"
       staff_only: "Policies may only apply to staff posts"
       policy_group_inaccessible: "This policy cannot be accepted at this time. Please contact a site administrator."
+      policy_cannot_be_wiki: "Posts with policies cannot be wiki posts."
       no_policy_permission: "You do not have permission to modify policies in this post."
     error:
       no_permission: "Not authorized"

--- a/plugins/discourse-policy/lib/post_validator.rb
+++ b/plugins/discourse-policy/lib/post_validator.rb
@@ -15,6 +15,11 @@ module DiscoursePolicy
       old_policies = extract_policies(@post.cooked)
       new_policies = extract_policies(PrettyText.cook(new_raw, {}))
 
+      if @post.wiki? && new_policies.present?
+        @post.errors.add(:base, I18n.t("discourse_policy.errors.policy_cannot_be_wiki"))
+        return false
+      end
+
       return true if old_policies == new_policies
 
       if !user_allowed?(@post.acting_user) || !user_allowed?(@post.user) ||

--- a/plugins/discourse-policy/plugin.rb
+++ b/plugins/discourse-policy/plugin.rb
@@ -60,7 +60,7 @@ after_initialize do
   TopicView.default_post_custom_fields << DiscoursePolicy::HAS_POLICY
 
   validate(:post, :validate_policy) do
-    return unless raw_changed?
+    return unless raw_changed? || wiki_changed?
 
     validator = DiscoursePolicy::PostValidator.new(self)
     return unless validator.validate_post

--- a/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
+++ b/plugins/discourse-policy/spec/requests/policy_controller_spec.rb
@@ -328,111 +328,36 @@ describe DiscoursePolicy::PolicyController do
     end
   end
 
-  describe "wiki policy edits" do
+  describe "wiki policy posts" do
     fab!(:admin)
-    fab!(:editor, :user)
-    fab!(:policy_group, :group)
-    fab!(:policy_creator_group, :group)
-    fab!(:target_group, :group)
-    fab!(:private_category) { Fabricate(:private_category, group: target_group) }
-    fab!(:private_topic) { Fabricate(:topic, category: private_category, user: admin) }
-    fab!(:private_post) do
-      Fabricate(:post, topic: private_topic, user: admin, raw: "Restricted group content")
-    end
-    let(:policy_post) { create_post(user: admin, raw: <<~MD) }
-          [policy group=#{policy_group.name}]
-          Accept this policy
-          [/policy]
-        MD
-    let(:policy_post_with_target_group) { create_post(user: admin, raw: <<~MD) }
-          [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
-          Accept this policy
-          [/policy]
-        MD
 
-    before do
-      policy_group.add(editor)
-      policy_creator_group.add(editor)
-      SiteSetting.policy_enabled = true
-      SiteSetting.create_policy_allowed_groups = "1|2|#{policy_creator_group.id}"
-      editor.change_trust_level!(TrustLevel[1])
-      SiteSetting.edit_wiki_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
-      policy_post.update!(wiki: true)
-    end
+    let(:policy_post) { create_post(user: admin, raw: raw) }
 
-    it "prevents wiki editors from granting themselves access through a policy target group" do
-      sign_in(editor)
-      get "/posts/#{private_post.id}.json"
-      inaccessible_status = response.status
-      inaccessible_body = response.body
+    it "rejects making a policy post a wiki while allowing quoted policy markup" do
+      sign_in(admin)
 
-      put "/posts/#{policy_post.id}.json", params: { post: { raw: <<~MD } }
-                [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
-                Accept this policy
-                [/policy]
-              MD
-
-      edit_status = response.status
-      edit_errors = response.parsed_body["errors"]
-
-      put "/policy/accept.json", params: { post_id: policy_post.id }
-      accept_status = response.status
-      accept_body = response.body
-
-      get "/posts/#{private_post.id}.json"
-      restricted_status = response.status
-      restricted_body = response.body
+      put "/posts/#{policy_post.id}/wiki.json", params: { wiki: "true" }
 
       aggregate_failures do
-        expect(inaccessible_status).to eq(403)
-        expect(inaccessible_body).not_to include(private_post.raw)
-        expect(edit_status).to eq(422)
-        expect(edit_errors).to include(I18n.t("discourse_policy.errors.no_policy_permission"))
-        expect(accept_status).to eq(200), accept_body
-        expect(target_group.user_ids).not_to include(editor.id)
-        expect(restricted_status).to eq(403)
-        expect(restricted_body).not_to include(private_post.raw)
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          I18n.t("discourse_policy.errors.policy_cannot_be_wiki"),
+        )
+        expect(policy_post.reload).not_to be_wiki
       end
-    end
 
-    it "does not grant wiki editors access through a blockquoted policy" do
-      sign_in(editor)
-      put "/posts/#{policy_post.id}.json", params: { post: { raw: <<~MD } }
-                [quote="someone, post:1, topic:1"]
-                [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
-                Accept this policy
-                [/policy]
-                [/quote]
-              MD
+      quoted_policy_post = create_post(user: admin, raw: <<~MD)
+        [quote="someone, post:1, topic:1"]
+        #{raw}
+        [/quote]
+      MD
 
-      expect(response.status).to eq(200)
-
-      put "/policy/accept.json", params: { post_id: policy_post.id }
-      accept_status = response.status
-
-      get "/posts/#{private_post.id}.json"
-      restricted_status = response.status
-
-      aggregate_failures do
-        expect(target_group.user_ids).not_to include(editor.id)
-        expect(accept_status).not_to eq(200)
-        expect(restricted_status).to eq(403)
-      end
-    end
-
-    it "allows wiki editors to modify policy text without changing an inaccessible target group" do
-      policy_post_with_target_group.update!(wiki: true)
-      sign_in(editor)
-
-      put "/posts/#{policy_post_with_target_group.id}.json", params: { post: { raw: <<~MD } }
-                [policy group=#{policy_group.name} add-users-to-group=#{target_group.name}]
-                Updated policy text
-                [/policy]
-              MD
+      put "/posts/#{quoted_policy_post.id}/wiki.json", params: { wiki: "true" }
 
       aggregate_failures do
         expect(response.status).to eq(200)
-        expect(response.parsed_body["post"]["raw"]).to include("Updated policy text")
+        expect(response.body).to be_blank
+        expect(quoted_policy_post.reload).to be_wiki
       end
     end
   end


### PR DESCRIPTION
## Summary

Prevent the wiki editing boundary from being combined with active discourse-policy markup. The patch rejects any save that would result in a wiki post containing an active policy block, and surfaces a 422 with a clear error from the wiki endpoint instead of silently succeeding.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/2508

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>