### PR TITLE
DEV: Bind subscription API calls to Stripe clients

### DIFF
--- a/plugins/discourse-subscriptions/app/controllers/concerns/stripe.rb
+++ b/plugins/discourse-subscriptions/app/controllers/concerns/stripe.rb
@@ -4,8 +4,10 @@ module DiscourseSubscriptions
   module Stripe
     extend ActiveSupport::Concern
 
-    def self.request_opts
-      { api_key: SiteSetting.discourse_subscriptions_secret_key }
+    def self.client(api_key: SiteSetting.discourse_subscriptions_secret_key)
+      raise ::Stripe::AuthenticationError, "Stripe secret key is not configured" if api_key.blank?
+
+      ::Stripe::StripeClient.new(api_key, stripe_version: "2024-04-10")
     end
 
     def self.configured?
@@ -13,12 +15,14 @@ module DiscourseSubscriptions
         SiteSetting.discourse_subscriptions_secret_key.present?
     end
 
-    def stripe_request_opts
-      DiscourseSubscriptions::Stripe.request_opts
-    end
-
     def is_stripe_configured?
       DiscourseSubscriptions::Stripe.configured?
+    end
+
+    private
+
+    def stripe_client
+      @stripe_client ||= DiscourseSubscriptions::Stripe.client
     end
   end
 end

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/coupons_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/coupons_controller.rb
@@ -13,9 +13,9 @@ module DiscourseSubscriptions
 
         if is_stripe_configured?
           promo_codes =
-            ::Stripe::PromotionCode.list({ limit: 100 }, stripe_request_opts)[
-              :data
-            ].select { |code| code[:coupon][:valid] == true }
+            stripe_client.v1.promotion_codes.list({ limit: 100 })[:data].select do |code|
+              code[:coupon][:valid] == true
+            end
         end
 
         render_json_dump promo_codes
@@ -36,12 +36,11 @@ module DiscourseSubscriptions
             coupon_params[:percent_off] = params[:discount]
           end
 
-          coupon = ::Stripe::Coupon.create(coupon_params, stripe_request_opts)
+          coupon = stripe_client.v1.coupons.create(coupon_params)
 
           promo_code =
-            ::Stripe::PromotionCode.create(
+            stripe_client.v1.promotion_codes.create(
               { coupon: coupon[:id], code: params[:promo] },
-              stripe_request_opts,
             ) if coupon.present?
 
           render_json_dump promo_code
@@ -54,11 +53,7 @@ module DiscourseSubscriptions
         params.require(%i[id active])
         begin
           promo_code =
-            ::Stripe::PromotionCode.update(
-              params[:id],
-              { active: params[:active] },
-              stripe_request_opts,
-            )
+            stripe_client.v1.promotion_codes.update(params[:id], { active: params[:active] })
 
           render_json_dump promo_code
         rescue ::Stripe::InvalidRequestError => e
@@ -69,7 +64,7 @@ module DiscourseSubscriptions
       def destroy
         params.require(:coupon_id)
         begin
-          coupon = ::Stripe::Coupon.delete(params[:coupon_id], {}, stripe_request_opts)
+          coupon = stripe_client.v1.coupons.delete(params[:coupon_id], {})
           render_json_dump coupon
         rescue ::Stripe::InvalidRequestError => e
           render_json_error e.message

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/plans_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/plans_controller.rb
@@ -8,7 +8,7 @@ module DiscourseSubscriptions
       requires_plugin PLUGIN_NAME
 
       def index
-        plans = ::Stripe::Price.list(product_params, stripe_request_opts)
+        plans = stripe_client.v1.prices.list(product_params)
 
         render_json_dump plans.data
       rescue ::Stripe::InvalidRequestError => e
@@ -30,7 +30,7 @@ module DiscourseSubscriptions
 
         price_object[:recurring] = { interval: params[:interval] } if params[:type] == "recurring"
 
-        plan = ::Stripe::Price.create(price_object, stripe_request_opts)
+        plan = stripe_client.v1.prices.create(price_object)
 
         render_json_dump plan
       rescue ::Stripe::InvalidRequestError => e
@@ -38,7 +38,7 @@ module DiscourseSubscriptions
       end
 
       def show
-        plan = ::Stripe::Price.retrieve(params[:id], stripe_request_opts)
+        plan = stripe_client.v1.prices.retrieve(params[:id])
 
         if plan[:metadata] && plan[:metadata][:trial_period_days]
           trial_days = plan[:metadata][:trial_period_days]
@@ -63,7 +63,7 @@ module DiscourseSubscriptions
 
       def update
         plan =
-          ::Stripe::Price.update(
+          stripe_client.v1.prices.update(
             params[:id],
             {
               nickname: params[:nickname],
@@ -73,7 +73,6 @@ module DiscourseSubscriptions
                 trial_period_days: params[:trial_period_days],
               },
             },
-            stripe_request_opts,
           )
 
         render_json_dump plan

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/products_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/products_controller.rb
@@ -12,7 +12,7 @@ module DiscourseSubscriptions
         products = []
 
         if product_ids.present? && is_stripe_configured?
-          products = ::Stripe::Product.list({ ids: product_ids, limit: 100 }, stripe_request_opts)
+          products = stripe_client.v1.products.list({ ids: product_ids, limit: 100 })
           products = products[:data]
         elsif !is_stripe_configured?
           products = nil
@@ -28,7 +28,7 @@ module DiscourseSubscriptions
 
         create_params.except!(:statement_descriptor) if params[:statement_descriptor].blank?
 
-        product = ::Stripe::Product.create(create_params, stripe_request_opts)
+        product = stripe_client.v1.products.create(create_params)
 
         Product.create(external_id: product[:id])
 
@@ -38,7 +38,7 @@ module DiscourseSubscriptions
       end
 
       def show
-        product = ::Stripe::Product.retrieve(params[:id], stripe_request_opts)
+        product = stripe_client.v1.products.retrieve(params[:id])
 
         render_json_dump product
       rescue ::Stripe::InvalidRequestError => e
@@ -46,7 +46,7 @@ module DiscourseSubscriptions
       end
 
       def update
-        product = ::Stripe::Product.update(params[:id], product_params, stripe_request_opts)
+        product = stripe_client.v1.products.update(params[:id], product_params)
 
         render_json_dump product
       rescue ::Stripe::InvalidRequestError => e
@@ -54,7 +54,7 @@ module DiscourseSubscriptions
       end
 
       def destroy
-        product = ::Stripe::Product.delete(params[:id], {}, stripe_request_opts)
+        product = stripe_client.v1.products.delete(params[:id], {})
 
         Product.delete_by(external_id: params[:id])
 

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
@@ -45,7 +45,7 @@ module DiscourseSubscriptions
         params.require(:id)
         begin
           refund_subscription(params[:id]) if ActiveModel::Type::Boolean.new.cast(params[:refund])
-          subscription = ::Stripe::Subscription.cancel(params[:id], {}, stripe_request_opts)
+          subscription = stripe_client.v1.subscriptions.cancel(params[:id], {})
 
           customer =
             Customer.find_by(
@@ -68,14 +68,13 @@ module DiscourseSubscriptions
       private
 
       def get_subscriptions(start)
-        ::Stripe::Subscription.list(
+        stripe_client.v1.subscriptions.list(
           {
             expand: ["data.plan.product"],
             limit: PAGE_LIMIT,
             starting_after: start,
             status: "all",
           },
-          stripe_request_opts,
         )
       end
 
@@ -86,15 +85,13 @@ module DiscourseSubscriptions
 
       # this will only refund the most recent subscription payment
       def refund_subscription(subscription_id)
-        subscription = ::Stripe::Subscription.retrieve(subscription_id, stripe_request_opts)
-        invoice =
-          ::Stripe::Invoice.retrieve(
-            subscription[:latest_invoice],
-            stripe_request_opts,
-          ) if subscription[:latest_invoice]
+        subscription = stripe_client.v1.subscriptions.retrieve(subscription_id)
+        invoice = stripe_client.v1.invoices.retrieve(subscription[:latest_invoice]) if subscription[
+          :latest_invoice
+        ]
         payment_intent = invoice[:payment_intent] if invoice[:payment_intent]
 
-        ::Stripe::Refund.create({ payment_intent: payment_intent }, stripe_request_opts)
+        stripe_client.v1.refunds.create({ payment_intent: payment_intent })
       end
     end
   end

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -51,7 +51,7 @@ module DiscourseSubscriptions
         end
 
         if checkout_session[:customer].nil?
-          customer = ::Stripe::Customer.create({ email: user.email }, stripe_request_opts)
+          customer = stripe_client.v1.customers.create({ email: user.email })
           customer_id = customer[:id]
         else
           customer_id = checkout_session[:customer]
@@ -70,11 +70,7 @@ module DiscourseSubscriptions
         end
 
         line_items =
-          ::Stripe::Checkout::Session.list_line_items(
-            checkout_session[:id],
-            { limit: 1 },
-            stripe_request_opts,
-          )
+          stripe_client.v1.checkout.sessions.line_items.list(checkout_session[:id], { limit: 1 })
         item = line_items[:data].first
 
         group = plan_group(item[:price])
@@ -93,10 +89,9 @@ module DiscourseSubscriptions
         discourse_customer.save!
 
         if !subscription.nil?
-          ::Stripe::Subscription.update(
+          stripe_client.v1.subscriptions.update(
             subscription,
             { metadata: { user_id: user.id, username: user.username } },
-            stripe_request_opts,
           )
         end
       when "customer.subscription.created"

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -14,11 +14,7 @@ module DiscourseSubscriptions
       products = []
 
       if product_ids.present? && is_stripe_configured?
-        response =
-          ::Stripe::Product.list(
-            { ids: product_ids, active: true, limit: 100 },
-            stripe_request_opts,
-          )
+        response = stripe_client.v1.products.list({ ids: product_ids, active: true, limit: 100 })
 
         products = response[:data].map { |p| serialize_product(p) }
       end
@@ -53,8 +49,8 @@ module DiscourseSubscriptions
       ensure_published_product!(params[:id])
 
       begin
-        product = ::Stripe::Product.retrieve(params[:id], stripe_request_opts)
-        plans = ::Stripe::Price.list({ active: true, product: params[:id] }, stripe_request_opts)
+        product = stripe_client.v1.products.retrieve(params[:id])
+        plans = stripe_client.v1.prices.list({ active: true, product: params[:id] })
 
         response = { product: serialize_product(product), plans: serialize_plans(plans) }
 
@@ -77,7 +73,7 @@ module DiscourseSubscriptions
           )
 
         if params[:promo].present?
-          promo_code = ::Stripe::PromotionCode.list({ code: params[:promo] }, stripe_request_opts)
+          promo_code = stripe_client.v1.promotion_codes.list({ code: params[:promo] })
           promo_code = promo_code[:data][0] # we assume promo codes have a unique name
 
           if promo_code.blank?
@@ -105,7 +101,7 @@ module DiscourseSubscriptions
             subscription_params[:automatic_tax] = { enabled: true }
           end
 
-          transaction = ::Stripe::Subscription.create(subscription_params, stripe_request_opts)
+          transaction = stripe_client.v1.subscriptions.create(subscription_params)
 
           payment_intent = retrieve_payment_intent(transaction[:latest_invoice]) if transaction[
             :status
@@ -118,19 +114,18 @@ module DiscourseSubscriptions
           if SiteSetting.discourse_subscriptions_enable_automatic_tax
             invoice_params[:automatic_tax] = { enabled: true }
           end
-          invoice = ::Stripe::Invoice.create(invoice_params, stripe_request_opts)
+          invoice = stripe_client.v1.invoices.create(invoice_params)
 
-          ::Stripe::InvoiceItem.create(
+          stripe_client.v1.invoice_items.create(
             {
               customer: customer[:id],
               price: params[:plan],
               discounts: [{ coupon: coupon_id }],
               invoice: invoice[:id],
             },
-            stripe_request_opts,
           )
 
-          transaction = ::Stripe::Invoice.finalize_invoice(invoice[:id], {}, stripe_request_opts)
+          transaction = stripe_client.v1.invoices.finalize_invoice(invoice[:id], {})
           payment_intent = retrieve_payment_intent(transaction[:id]) if transaction[:status] ==
             "open"
           if payment_intent.nil?
@@ -138,8 +133,7 @@ module DiscourseSubscriptions
               render_json_error I18n.t("js.discourse_subscriptions.subscribe.transaction_error")
             )
           end
-          transaction =
-            ::Stripe::Invoice.pay(invoice[:id], {}, stripe_request_opts) if payment_intent[
+          transaction = stripe_client.v1.invoices.pay(invoice[:id], {}) if payment_intent[
             :status
           ] == "successful"
         end
@@ -253,31 +247,30 @@ module DiscourseSubscriptions
         )
 
       if customer.present?
-        ::Stripe::Customer.retrieve(customer.customer_id, stripe_request_opts)
+        stripe_client.v1.customers.retrieve(customer.customer_id)
       else
-        ::Stripe::Customer.create(
+        stripe_client.v1.customers.create(
           {
             email: current_user.email,
             source: source,
             name: cardholder_name,
             address: cardholder_address,
           },
-          stripe_request_opts,
         )
       end
     end
 
     def retrieve_payment_intent(invoice_id)
-      invoice = ::Stripe::Invoice.retrieve(invoice_id, stripe_request_opts)
-      ::Stripe::PaymentIntent.retrieve(invoice[:payment_intent], stripe_request_opts)
+      invoice = stripe_client.v1.invoices.retrieve(invoice_id)
+      stripe_client.v1.payment_intents.retrieve(invoice[:payment_intent])
     end
 
     def retrieve_transaction(transaction)
       case transaction
       when /^sub_/
-        ::Stripe::Subscription.retrieve(transaction, stripe_request_opts)
+        stripe_client.v1.subscriptions.retrieve(transaction)
       when /^in_/
-        ::Stripe::Invoice.retrieve(transaction, stripe_request_opts)
+        stripe_client.v1.invoices.retrieve(transaction)
       end
     rescue ::Stripe::InvalidRequestError => e
       e.message
@@ -288,7 +281,7 @@ module DiscourseSubscriptions
     end
 
     def fetch_published_plan(plan_id)
-      plan = ::Stripe::Price.retrieve(plan_id, stripe_request_opts)
+      plan = stripe_client.v1.prices.retrieve(plan_id)
       ensure_published_product!(price_product_id(plan))
       plan
     end

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -19,10 +19,10 @@ module DiscourseSubscriptions
         if customer_ids.present? && product_ids.present?
           customer_ids.each do |customer_id|
             # lots of matching because the Stripe API doesn't make it easy to match products => payments except from invoices
-            all_invoices = ::Stripe::Invoice.list({ customer: customer_id }, stripe_request_opts)
+            all_invoices = stripe_client.v1.invoices.list({ customer: customer_id })
             invoices_with_products = parse_invoices(all_invoices, product_ids)
             invoice_ids = invoices_with_products.map { |invoice| invoice[:id] }
-            payments = ::Stripe::PaymentIntent.list({ customer: customer_id }, stripe_request_opts)
+            payments = stripe_client.v1.payment_intents.list({ customer: customer_id })
             payments_from_invoices =
               payments[:data].select { |payment| invoice_ids.include?(payment[:invoice]) }
 
@@ -84,9 +84,8 @@ module DiscourseSubscriptions
           loop do
             # Fetch charges in batches of 100, using pagination with starting_after
             charges =
-              ::Stripe::Charge.list(
+              stripe_client.v1.charges.list(
                 { limit: 100, starting_after: starting_after, expand: ["data.payment_intent"] },
-                stripe_request_opts,
               )
 
             charges[:data].each do |charge|

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/user/subscriptions_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/user/subscriptions_controller.rb
@@ -24,7 +24,7 @@ module DiscourseSubscriptions
           prices = []
           price_params = { limit: 100, expand: ["data.product"] }
           loop do
-            response = ::Stripe::Price.list(price_params, stripe_request_opts)
+            response = stripe_client.v1.prices.list(price_params)
             prices.concat(response[:data])
             break unless response[:has_more]
             price_params[:starting_after] = response[:data].last.id
@@ -33,10 +33,7 @@ module DiscourseSubscriptions
 
           stripe_customer_ids.each do |stripe_customer_id|
             customer_subscriptions =
-              ::Stripe::Subscription.list(
-                { customer: stripe_customer_id, status: "all" },
-                stripe_request_opts,
-              )
+              stripe_client.v1.subscriptions.list({ customer: stripe_customer_id, status: "all" })
             all_subscriptions.concat(customer_subscriptions[:data])
           end
 
@@ -58,11 +55,7 @@ module DiscourseSubscriptions
         # full removal is done via webhooks
 
         subscription =
-          ::Stripe::Subscription.update(
-            params[:id],
-            { cancel_at_period_end: true },
-            stripe_request_opts,
-          )
+          stripe_client.v1.subscriptions.update(params[:id], { cancel_at_period_end: true })
 
         if subscription
           render_json_dump subscription
@@ -78,10 +71,9 @@ module DiscourseSubscriptions
 
         begin
           attach_method_to_customer(@subscription.customer_id, params[:payment_method])
-          ::Stripe::Subscription.update(
+          stripe_client.v1.subscriptions.update(
             params[:id],
             { default_payment_method: params[:payment_method] },
-            stripe_request_opts,
           )
           render json: success_json
         rescue ::Stripe::InvalidRequestError
@@ -93,11 +85,7 @@ module DiscourseSubscriptions
 
       def attach_method_to_customer(customer_id, method)
         customer = Customer.find(customer_id)
-        ::Stripe::PaymentMethod.attach(
-          method,
-          { customer: customer.customer_id },
-          stripe_request_opts,
-        )
+        stripe_client.v1.payment_methods.attach(method, { customer: customer.customer_id })
       end
 
       def find_subscription

--- a/plugins/discourse-subscriptions/app/services/discourse_subscriptions/campaign.rb
+++ b/plugins/discourse-subscriptions/app/services/discourse_subscriptions/campaign.rb
@@ -2,9 +2,8 @@
 
 module DiscourseSubscriptions
   class Campaign
-    include DiscourseSubscriptions::Stripe
-
     def refresh_data
+      stripe_client = DiscourseSubscriptions::Stripe.client
       product_ids = Set.new(Product.all.pluck(:external_id))
 
       # if a product id is set for the campaign, we only want to return those results.
@@ -15,11 +14,12 @@ module DiscourseSubscriptions
       end
 
       amount = 0.00
-      subscriptions = get_subscription_data
+      subscriptions = get_subscription_data(stripe_client)
       subscriptions = filter_to_subscriptions_products(subscriptions, product_ids)
 
       # Fetch product purchases
-      one_time_payments = get_one_time_payments(product_ids)
+      one_time_payments =
+        get_one_time_payments(product_ids: product_ids, stripe_client: stripe_client)
       one_time_payments.each { |c| amount += c[:price].to_f / 100.00 }
 
       # get number of subscribers
@@ -37,9 +37,10 @@ module DiscourseSubscriptions
     end
 
     def create_campaign
+      stripe_client = DiscourseSubscriptions::Stripe.client
       group = create_campaign_group
-      product = create_campaign_product
-      create_campaign_prices(product, group)
+      product = create_campaign_product(stripe_client)
+      create_campaign_prices(product: product, group: group, stripe_client: stripe_client)
 
       SiteSetting.discourse_subscriptions_campaign_enabled = true
       SiteSetting.discourse_subscriptions_campaign_product = product[:id]
@@ -95,7 +96,7 @@ module DiscourseSubscriptions
       group[:name]
     end
 
-    def create_campaign_product
+    def create_campaign_product(stripe_client)
       product_params = {
         name: I18n.t("js.discourse_subscriptions.campaign.title"),
         active: true,
@@ -104,24 +105,40 @@ module DiscourseSubscriptions
         },
       }
 
-      product = ::Stripe::Product.create(product_params, stripe_request_opts)
+      product = stripe_client.v1.products.create(product_params)
 
       Product.create(external_id: product[:id])
 
       product
     end
 
-    def create_campaign_prices(product, group)
+    def create_campaign_prices(product:, group:, stripe_client:)
       # hard coded defaults to make setting this up as simple as possible
       monthly_prices = [3, 5, 10, 25]
       yearly_prices = [50, 100]
 
-      monthly_prices.each { |price| create_price(product[:id], group, price, "month") }
+      monthly_prices.each do |price|
+        create_price(
+          product_id: product[:id],
+          group_name: group,
+          amount: price,
+          recurrence: "month",
+          stripe_client: stripe_client,
+        )
+      end
 
-      yearly_prices.each { |price| create_price(product[:id], group, price, "year") }
+      yearly_prices.each do |price|
+        create_price(
+          product_id: product[:id],
+          group_name: group,
+          amount: price,
+          recurrence: "year",
+          stripe_client: stripe_client,
+        )
+      end
     end
 
-    def create_price(product_id, group_name, amount, recurrence)
+    def create_price(product_id:, group_name:, amount:, recurrence:, stripe_client:)
       price_object = {
         nickname: "#{amount}/#{recurrence}",
         unit_amount: amount * 100,
@@ -136,10 +153,10 @@ module DiscourseSubscriptions
         },
       }
 
-      ::Stripe::Price.create(price_object, stripe_request_opts)
+      stripe_client.v1.prices.create(price_object)
     end
 
-    def get_one_time_payments(product_ids)
+    def get_one_time_payments(product_ids:, stripe_client:)
       one_time_payments = []
       current_set = { has_more: true, last_record: nil }
 
@@ -147,9 +164,8 @@ module DiscourseSubscriptions
         # lots of matching because the Stripe API doesn't make it easy to match products => payments except from invoices
         until current_set[:has_more] == false
           all_invoices =
-            ::Stripe::Invoice.list(
+            stripe_client.v1.invoices.list(
               { limit: 100, starting_after: current_set[:last_record] },
-              stripe_request_opts,
             )
 
           if all_invoices[:data].present?
@@ -183,19 +199,18 @@ module DiscourseSubscriptions
       one_time_payments
     end
 
-    def get_subscription_data
+    def get_subscription_data(stripe_client)
       subscriptions = []
       current_set = { has_more: true, last_record: nil }
 
       until current_set[:has_more] == false
         current_set =
-          ::Stripe::Subscription.list(
+          stripe_client.v1.subscriptions.list(
             {
               expand: ["data.plan.product"],
               limit: 100,
               starting_after: current_set[:last_record],
             },
-            stripe_request_opts,
           )
 
         current_set[:last_record] = current_set[:data].last[:id] if current_set[:data].present?

--- a/plugins/discourse-subscriptions/lib/tasks/subscriptions_import.rake
+++ b/plugins/discourse-subscriptions/lib/tasks/subscriptions_import.rake
@@ -5,8 +5,10 @@ require "highline/import"
 
 desc "Import subscriptions from Stripe"
 task "subscriptions:subscriptions_import" => :environment do
-  setup_api
-  products = get_stripe_products
+  api_key =
+    SiteSetting.discourse_subscriptions_secret_key.presence || ask("Input Stripe secret key")
+  stripe_client = DiscourseSubscriptions::Stripe.client(api_key: api_key)
+  products = get_stripe_products(stripe_client: stripe_client)
   strip_products_to_import = []
 
   procourse_import = false
@@ -22,17 +24,19 @@ task "subscriptions:subscriptions_import" => :environment do
   end
 
   import_products(strip_products_to_import)
-  import_subscriptions(procourse_import)
+  import_subscriptions(procourse_import: procourse_import, stripe_client: stripe_client)
 end
 
-def get_stripe_products(starting_after: nil)
+def get_stripe_products(stripe_client:, starting_after: nil)
   puts "Getting products from Stripe API"
 
   all_products = []
 
   loop do
     products =
-      Stripe::Product.list({ type: "service", starting_after: starting_after, active: true })
+      stripe_client.v1.products.list(
+        { type: "service", starting_after: starting_after, active: true },
+      )
     all_products += products[:data]
     break if products[:has_more] == false
     starting_after = products[:data].last["id"]
@@ -41,13 +45,14 @@ def get_stripe_products(starting_after: nil)
   all_products
 end
 
-def get_stripe_subscriptions(starting_after: nil)
+def get_stripe_subscriptions(stripe_client:, starting_after: nil)
   puts "Getting Subscriptions from Stripe API"
 
   all_subscriptions = []
 
   loop do
-    subscriptions = Stripe::Subscription.list({ starting_after: starting_after, status: "active" })
+    subscriptions =
+      stripe_client.v1.subscriptions.list({ starting_after: starting_after, status: "active" })
     all_subscriptions += subscriptions[:data]
     break if subscriptions[:has_more] == false
     starting_after = subscriptions[:data].last["id"]
@@ -56,13 +61,13 @@ def get_stripe_subscriptions(starting_after: nil)
   all_subscriptions
 end
 
-def get_stripe_customers(starting_after: nil)
+def get_stripe_customers(stripe_client:, starting_after: nil)
   puts "Getting Customers from Stripe API"
 
   all_customers = []
 
   loop do
-    customers = Stripe::Customer.list({ starting_after: starting_after })
+    customers = stripe_client.v1.customers.list({ starting_after: starting_after })
     all_customers += customers[:data]
     break if customers[:has_more] == false
     starting_after = customers[:data].last["id"]
@@ -85,14 +90,14 @@ def import_products(products)
   end
 end
 
-def import_subscriptions(procourse_import)
+def import_subscriptions(procourse_import:, stripe_client:)
   puts "Importing subscriptions"
   product_ids = DiscourseSubscriptions::Product.all.pluck(:external_id)
 
-  all_customers = get_stripe_customers
+  all_customers = get_stripe_customers(stripe_client: stripe_client)
   puts "Total available Stripe Customers: #{all_customers.length}, the first of which is customer id: #{all_customers[0][:description]}"
 
-  subscriptions = get_stripe_subscriptions
+  subscriptions = get_stripe_subscriptions(stripe_client: stripe_client)
   puts "Total Active Subscriptions available: #{subscriptions.length}"
 
   subscriptions_for_products =
@@ -158,23 +163,17 @@ def import_subscriptions(procourse_import)
           puts "Discourse User: #{discourse_user.username_lower} found for Strip metadata update ..."
 
           updated_subscription =
-            Stripe::Subscription.update(
+            stripe_client.v1.subscriptions.update(
               subscription_id,
               { metadata: { user_id: user_id, username: discourse_user.username_lower } },
             )
           puts "Stripe Subscription: #{updated_subscription[:id]}, metadata: #{updated_subscription[:metadata]} UPDATED"
 
-          updated_customer = Stripe::Customer.update(customer_id, { email: discourse_user.email })
+          updated_customer =
+            stripe_client.v1.customers.update(customer_id, { email: discourse_user.email })
           puts "Stripe Customer: #{updated_customer[:id]}, email: #{updated_customer[:email]} UPDATED"
         end
       end
     end
   end
-end
-
-private
-
-def setup_api
-  api_key = SiteSetting.discourse_subscriptions_secret_key || ask("Input Stripe secret key")
-  Stripe.api_key = api_key
 end

--- a/plugins/discourse-subscriptions/plugin.rb
+++ b/plugins/discourse-subscriptions/plugin.rb
@@ -65,8 +65,6 @@ require_relative "app/controllers/concerns/stripe"
 require_relative "app/controllers/concerns/group"
 
 after_initialize do
-  ::Stripe.api_version = "2024-04-10"
-
   ::Stripe.set_app_info(
     "Discourse Subscriptions",
     version: "2.8.2",

--- a/plugins/discourse-subscriptions/spec/lib/stripe_spec.rb
+++ b/plugins/discourse-subscriptions/spec/lib/stripe_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseSubscriptions::Stripe do
+  describe ".client" do
+    it "binds credentials and API version to each client across interleaved requests" do
+      original_key = ::Stripe.api_key
+      original_version = ::Stripe.api_version
+      SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_first"
+      first_client = described_class.client
+      SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_second"
+      second_client = described_class.client
+      requests = []
+      stub_request(:get, "https://api.stripe.com/v1/products/prod_fictional").to_return do |request|
+        requests << request.headers.slice("Authorization", "Stripe-Version")
+        {
+          status: 200,
+          body: { id: "prod_fictional", object: "product" }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        }
+      end
+
+      first_client.v1.products.retrieve("prod_fictional")
+      second_client.v1.products.retrieve("prod_fictional")
+      first_client.v1.products.retrieve("prod_fictional")
+
+      expect(requests).to eq(
+        %w[sk_test_fictional_first sk_test_fictional_second sk_test_fictional_first].map do |key|
+          { "Authorization" => "Bearer #{key}", "Stripe-Version" => "2024-04-10" }
+        end,
+      )
+      expect(::Stripe.api_key).to eq(original_key)
+      expect(::Stripe.api_version).to eq(original_version)
+    end
+
+    it "uses an explicitly supplied import key" do
+      SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_site"
+      request =
+        stub_request(:get, "https://api.stripe.com/v1/products").with(
+          headers: {
+            "Authorization" => "Bearer sk_test_fictional_import",
+            "Stripe-Version" => "2024-04-10",
+          },
+        ).to_return(
+          status: 200,
+          body: { object: "list", data: [], has_more: false }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+
+      result = described_class.client(api_key: "sk_test_fictional_import").v1.products.list
+
+      expect(result.data).to eq([])
+      expect(request).to have_been_requested
+    end
+
+    it "rejects missing credentials even when Stripe has a global key" do
+      ::Stripe.stubs(:api_key).returns("sk_test_fictional_global")
+      SiteSetting.discourse_subscriptions_secret_key = ""
+
+      expect { described_class.client }.to raise_error(
+        ::Stripe::AuthenticationError,
+        "Stripe secret key is not configured",
+      )
+      [nil, "", " "].each do |key|
+        expect { described_class.client(api_key: key) }.to raise_error(
+          ::Stripe::AuthenticationError,
+        )
+      end
+    end
+  end
+end

--- a/plugins/discourse-subscriptions/spec/requests/admin/coupons_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/admin/coupons_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DiscourseSubscriptions::Admin::CouponsController do
 
   context "when unauthenticated" do
     it "does nothing" do
-      ::Stripe::PromotionCode.expects(:list).never
+      ::Stripe::PromotionCodeService.any_instance.expects(:list).never
       get "/s/admin/coupons.json"
       expect(response.status).to eq(404)
     end
@@ -36,9 +36,10 @@ RSpec.describe DiscourseSubscriptions::Admin::CouponsController do
       end
 
       it "returns a list of promo codes" do
-        ::Stripe::PromotionCode
+        ::Stripe::PromotionCodeService
+          .any_instance
           .expects(:list)
-          .with({ limit: 100 }, DiscourseSubscriptions::Stripe.request_opts)
+          .with({ limit: 100 })
           .returns({ data: [{ id: "promo_123", coupon: { valid: true } }] })
 
         get "/s/admin/coupons.json"
@@ -47,9 +48,10 @@ RSpec.describe DiscourseSubscriptions::Admin::CouponsController do
       end
 
       it "only returns valid promo codes" do
-        ::Stripe::PromotionCode
+        ::Stripe::PromotionCodeService
+          .any_instance
           .expects(:list)
-          .with({ limit: 100 }, DiscourseSubscriptions::Stripe.request_opts)
+          .with({ limit: 100 })
           .returns({ data: [{ id: "promo_123", coupon: { valid: false } }] })
 
         get "/s/admin/coupons.json"
@@ -60,13 +62,11 @@ RSpec.describe DiscourseSubscriptions::Admin::CouponsController do
 
     describe "#create" do
       it "creates a coupon with an amount off" do
-        ::Stripe::Coupon
+        ::Stripe::CouponService.any_instance.expects(:create).with(anything).returns(id: "coup_123")
+        ::Stripe::PromotionCodeService
+          .any_instance
           .expects(:create)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-          .returns(id: "coup_123")
-        ::Stripe::PromotionCode
-          .expects(:create)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with(anything)
           .returns({ code: "p123", coupon: { amount_off: 2000 } })
 
         post "/s/admin/coupons.json",
@@ -82,13 +82,11 @@ RSpec.describe DiscourseSubscriptions::Admin::CouponsController do
       end
 
       it "creates a coupon with a percent off" do
-        ::Stripe::Coupon
+        ::Stripe::CouponService.any_instance.expects(:create).with(anything).returns(id: "coup_123")
+        ::Stripe::PromotionCodeService
+          .any_instance
           .expects(:create)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-          .returns(id: "coup_123")
-        ::Stripe::PromotionCode
-          .expects(:create)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with(anything)
           .returns({ code: "p123", coupon: { percent_off: 20 } })
 
         post "/s/admin/coupons.json",

--- a/plugins/discourse-subscriptions/spec/requests/admin/plans_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/admin/plans_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
   context "when not authenticated" do
     describe "index" do
       it "does not get the plans" do
-        ::Stripe::Price.expects(:list).never
+        ::Stripe::PriceService.any_instance.expects(:list).never
         get "/s/admin/plans.json"
       end
 
@@ -22,7 +22,7 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
 
     describe "create" do
       it "does not create a plan" do
-        ::Stripe::Price.expects(:create).never
+        ::Stripe::PriceService.any_instance.expects(:create).never
         post "/s/admin/plans.json", params: { name: "Rick Astley", amount: 1, interval: "week" }
       end
 
@@ -34,7 +34,7 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
 
     describe "show" do
       it "does not show the plan" do
-        ::Stripe::Price.expects(:retrieve).never
+        ::Stripe::PriceService.any_instance.expects(:retrieve).never
         get "/s/admin/plans/plan_12345.json"
       end
 
@@ -46,7 +46,7 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
 
     describe "update" do
       it "does not update a plan" do
-        ::Stripe::Price.expects(:update).never
+        ::Stripe::PriceService.any_instance.expects(:update).never
         delete "/s/admin/plans/plan_12345.json"
       end
     end
@@ -62,33 +62,32 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
 
     describe "index" do
       it "lists the plans" do
-        ::Stripe::Price.expects(:list).with(nil, DiscourseSubscriptions::Stripe.request_opts)
+        ::Stripe::PriceService.any_instance.expects(:list).with(nil)
         get "/s/admin/plans.json"
       end
 
       it "lists the plans for the product" do
-        ::Stripe::Price.expects(:list).with(
-          { product: "prod_id123" },
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:list).with({ product: "prod_id123" })
         get "/s/admin/plans.json", params: { product_id: "prod_id123" }
       end
     end
 
     describe "show" do
       it "shows a plan" do
-        ::Stripe::Price
+        ::Stripe::PriceService
+          .any_instance
           .expects(:retrieve)
-          .with("plan_12345", DiscourseSubscriptions::Stripe.request_opts)
+          .with("plan_12345")
           .returns(currency: "aud")
         get "/s/admin/plans/plan_12345.json"
         expect(response.status).to eq 200
       end
 
       it "upcases the currency" do
-        ::Stripe::Price
+        ::Stripe::PriceService
+          .any_instance
           .expects(:retrieve)
-          .with("plan_12345", DiscourseSubscriptions::Stripe.request_opts)
+          .with("plan_12345")
           .returns(currency: "aud", recurring: { interval: "year" })
         get "/s/admin/plans/plan_12345.json"
 
@@ -100,26 +99,20 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
 
     describe "create" do
       it "creates a plan with a nickname" do
-        ::Stripe::Price.expects(:create).with(
-          has_entry(:nickname, "Veg"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:create).with(has_entry(:nickname, "Veg"))
         post "/s/admin/plans.json", params: { nickname: "Veg", metadata: { group_name: "" } }
       end
 
       it "creates a plan with a currency" do
-        ::Stripe::Price.expects(:create).with(
-          has_entry(:currency, "AUD"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:create).with(has_entry(:currency, "AUD"))
         post "/s/admin/plans.json", params: { currency: "AUD", metadata: { group_name: "" } }
       end
 
       it "creates a plan with an interval" do
-        ::Stripe::Price.expects(:create).with(
-          has_entry(recurring: { interval: "week" }),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService
+          .any_instance
+          .expects(:create)
+          .with(has_entry(recurring: { interval: "week" }))
         post "/s/admin/plans.json",
              params: {
                type: "recurring",
@@ -131,26 +124,20 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
       end
 
       it "creates a plan as a one-time purchase" do
-        ::Stripe::Price.expects(:create).with(
-          Not(has_key(:recurring)),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:create).with(Not(has_key(:recurring)))
         post "/s/admin/plans.json", params: { metadata: { group_name: "" } }
       end
 
       it "creates a plan with an amount" do
-        ::Stripe::Price.expects(:create).with(
-          has_entry(:unit_amount, "102"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:create).with(has_entry(:unit_amount, "102"))
         post "/s/admin/plans.json", params: { amount: "102", metadata: { group_name: "" } }
       end
 
       it "creates a plan with a product" do
-        ::Stripe::Price.expects(:create).with(
-          has_entry(product: "prod_walterwhite"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService
+          .any_instance
+          .expects(:create)
+          .with(has_entry(product: "prod_walterwhite"))
         post "/s/admin/plans.json",
              params: {
                product: "prod_walterwhite",
@@ -161,10 +148,7 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
       end
 
       it "creates a plan with an active status" do
-        ::Stripe::Price.expects(:create).with(
-          has_entry(:active, "false"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:create).with(has_entry(:active, "false"))
         post "/s/admin/plans.json", params: { active: "false", metadata: { group_name: "" } }
       end
 
@@ -172,23 +156,19 @@ RSpec.describe DiscourseSubscriptions::Admin::PlansController do
       # I think mocha has issues with the metadata fields here.
 
       #it 'has metadata' do
-      #  ::Stripe::Price.expects(:create).with(has_entry(:group_name, "discourse-user-group-name"))
+      #  ::Stripe::PriceService.any_instance.expects(:create).with(has_entry(:group_name, "discourse-user-group-name"))
       #  post "/s/admin/plans.json", params: { amount: "100", metadata: { group_name: 'discourse-user-group-name' } }
       #end
 
       #it "creates a plan with a trial period" do
-      #  ::Stripe::Price.expects(:create).with(has_entry(trial_period_days: '14'))
+      #  ::Stripe::PriceService.any_instance.expects(:create).with(has_entry(trial_period_days: '14'))
       #  post "/s/admin/plans.json", params: { trial_period_days: '14' }
       #end
     end
 
     describe "update" do
       it "updates a plan" do
-        ::Stripe::Price.expects(:update).with(
-          "plan_12345",
-          anything,
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::PriceService.any_instance.expects(:update).with("plan_12345", anything)
         patch "/s/admin/plans/plan_12345.json",
               params: {
                 trial_period_days: "14",

--- a/plugins/discourse-subscriptions/spec/requests/admin/products_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/admin/products_controller_spec.rb
@@ -1,155 +1,198 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseSubscriptions::Admin::ProductsController do
-  before { SiteSetting.discourse_subscriptions_enabled = true }
+  fab!(:admin)
 
-  it "is a subclass of AdminController" do
-    expect(DiscourseSubscriptions::Admin::ProductsController < ::Admin::AdminController).to eq(true)
+  before do
+    SiteSetting.discourse_subscriptions_enabled = true
+    SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_products"
+    SiteSetting.discourse_subscriptions_public_key = "pk_test_fictional_products"
   end
 
-  context "when unauthenticated" do
-    it "does not list the products" do
-      ::Stripe::Product.expects(:list).never
+  let(:stripe_headers) do
+    { "Authorization" => "Bearer sk_test_fictional_products", "Stripe-Version" => "2024-04-10" }
+  end
+  let(:product_response) do
+    {
+      status: 200,
+      body: { id: "prod_fictional", object: "product", name: "Support the community" }.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    }
+  end
+
+  describe "#index" do
+    it "requires an administrator" do
       get "/s/admin/products.json"
+
       expect(response.status).to eq(404)
     end
 
-    it "does not create the product" do
-      ::Stripe::Product.expects(:create).never
-      post "/s/admin/products.json"
-      expect(response.status).to eq(404)
+    it "returns published products using the current site's credentials" do
+      Fabricate(:product, external_id: "prod_fictional")
+      sign_in(admin)
+      request =
+        stub_request(:get, "https://api.stripe.com/v1/products").with(
+          headers: stripe_headers,
+          query: {
+            "ids" => ["prod_fictional"],
+            "limit" => "100",
+          },
+        ).to_return(
+          status: 200,
+          body: { object: "list", data: [{ id: "prod_fictional", object: "product" }] }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+
+      get "/s/admin/products.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.pluck("id")).to eq(["prod_fictional"])
+      expect(request).to have_been_requested
     end
 
-    it "does not show the product" do
-      ::Stripe::Product.expects(:retrieve).never
-      get "/s/admin/products/prod_qwerty123.json"
-      expect(response.status).to eq(404)
-    end
+    it "returns an empty list without published products" do
+      sign_in(admin)
 
-    it "does not update the product" do
-      ::Stripe::Product.expects(:update).never
-      put "/s/admin/products/prod_qwerty123.json"
-      expect(response.status).to eq(404)
-    end
+      get "/s/admin/products.json"
 
-    it "does not delete the product" do
-      ::Stripe::Product.expects(:delete).never
-      delete "/s/admin/products/u2.json"
-      expect(response.status).to eq(404)
+      expect(response.parsed_body).to eq([])
     end
   end
 
-  context "when authenticated" do
-    let(:admin) { Fabricate(:admin) }
+  describe "#create" do
+    it "requires an administrator" do
+      post "/s/admin/products.json"
 
-    before do
-      SiteSetting.discourse_subscriptions_secret_key = "secret-key"
+      expect(response.status).to eq(404)
+    end
+
+    it "creates a service product with its name, status, descriptor, and metadata" do
       sign_in(admin)
-    end
-
-    describe "index" do
-      it "gets the empty products" do
-        SiteSetting.discourse_subscriptions_public_key = "public-key"
-        get "/s/admin/products.json"
-        expect(response.parsed_body).to be_empty
-      end
-    end
-
-    describe "create" do
-      it "is of product type service" do
-        ::Stripe::Product.expects(:create).with(
-          has_entry(:type, "service"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        post "/s/admin/products.json", params: {}
-      end
-
-      it "has a name" do
-        ::Stripe::Product.expects(:create).with(
-          has_entry(:name, "Jesse Pinkman"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        post "/s/admin/products.json", params: { name: "Jesse Pinkman" }
-      end
-
-      it "has an active attribute" do
-        ::Stripe::Product.expects(:create).with(
-          has_entry(active: "false"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        post "/s/admin/products.json", params: { active: "false" }
-      end
-
-      it "has a statement descriptor" do
-        ::Stripe::Product.expects(:create).with(
-          has_entry(statement_descriptor: "Blessed are the cheesemakers"),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        post "/s/admin/products.json",
-             params: {
-               statement_descriptor: "Blessed are the cheesemakers",
-             }
-      end
-
-      it "has no statement descriptor if empty" do
-        ::Stripe::Product
-          .expects(:create)
-          .with(has_key(:statement_descriptor), DiscourseSubscriptions::Stripe.request_opts)
-          .never
-        post "/s/admin/products.json", params: { statement_descriptor: "" }
-      end
-
-      it "has metadata" do
-        ::Stripe::Product.expects(:create).with(
-          has_entry(
-            metadata: {
-              description: "Oi, I think he just said bless be all the bignoses!",
-              repurchaseable: "false",
+      request =
+        stub_request(:post, "https://api.stripe.com/v1/products").with(
+          headers: stripe_headers,
+          body: {
+            "type" => "service",
+            "name" => "Support the community",
+            "active" => "false",
+            "statement_descriptor" => "COMMUNITY",
+            "metadata" => {
+              "description" => "Monthly support",
+              "repurchaseable" => "false",
             },
-          ),
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+          },
+        ).to_return(product_response)
 
-        post "/s/admin/products.json",
-             params: {
-               metadata: {
-                 description: "Oi, I think he just said bless be all the bignoses!",
-                 repurchaseable: "false",
-               },
-             }
-      end
+      post "/s/admin/products.json",
+           params: {
+             name: "Support the community",
+             active: false,
+             statement_descriptor: "COMMUNITY",
+             metadata: {
+               description: "Monthly support",
+               repurchaseable: false,
+             },
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["id"]).to eq("prod_fictional")
+      expect(DiscourseSubscriptions::Product.exists?(external_id: "prod_fictional")).to eq(true)
+      expect(request).to have_been_requested
     end
 
-    describe "show" do
-      it "retrieves the product" do
-        ::Stripe::Product.expects(:retrieve).with(
-          "prod_walterwhite",
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        get "/s/admin/products/prod_walterwhite.json"
-      end
+    it "omits an empty statement descriptor" do
+      sign_in(admin)
+      request =
+        stub_request(:post, "https://api.stripe.com/v1/products")
+          .with do |stripe_request|
+            !Rack::Utils.parse_nested_query(stripe_request.body).key?("statement_descriptor")
+          end
+          .to_return(product_response)
+
+      post "/s/admin/products.json", params: { name: "Support", statement_descriptor: "" }
+
+      expect(response.status).to eq(200)
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#show" do
+    it "requires an administrator" do
+      get "/s/admin/products/prod_fictional.json"
+
+      expect(response.status).to eq(404)
     end
 
-    describe "update" do
-      it "updates the product" do
-        ::Stripe::Product.expects(:update).with(
-          "prod_walterwhite",
-          anything,
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        patch "/s/admin/products/prod_walterwhite.json", params: {}
-      end
+    it "uses a newly configured key on the next request" do
+      sign_in(admin)
+      first_request =
+        stub_request(:get, "https://api.stripe.com/v1/products/prod_fictional").with(
+          headers: stripe_headers,
+        ).to_return(product_response)
+      second_request =
+        stub_request(:get, "https://api.stripe.com/v1/products/prod_fictional").with(
+          headers: stripe_headers.merge("Authorization" => "Bearer sk_test_fictional_replacement"),
+        ).to_return(product_response)
+
+      get "/s/admin/products/prod_fictional.json"
+      expect(response.status).to eq(200)
+      SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_replacement"
+      get "/s/admin/products/prod_fictional.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["id"]).to eq("prod_fictional")
+      expect(first_request).to have_been_requested.once
+      expect(second_request).to have_been_requested.once
+    end
+  end
+
+  describe "#update" do
+    it "requires an administrator" do
+      patch "/s/admin/products/prod_fictional.json"
+
+      expect(response.status).to eq(404)
     end
 
-    describe "delete" do
-      it "deletes the product" do
-        ::Stripe::Product.expects(:delete).with(
-          "prod_walterwhite",
-          anything,
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
-        delete "/s/admin/products/prod_walterwhite.json"
-      end
+    it "updates the product" do
+      sign_in(admin)
+      request =
+        stub_request(:post, "https://api.stripe.com/v1/products/prod_fictional").with(
+          headers: stripe_headers,
+          body: hash_including("name" => "Support the community"),
+        ).to_return(product_response)
+
+      patch "/s/admin/products/prod_fictional.json", params: { name: "Support the community" }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["name"]).to eq("Support the community")
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#destroy" do
+    it "requires an administrator" do
+      delete "/s/admin/products/prod_fictional.json"
+
+      expect(response.status).to eq(404)
+    end
+
+    it "deletes the product remotely and locally" do
+      Fabricate(:product, external_id: "prod_fictional")
+      sign_in(admin)
+      request =
+        stub_request(:delete, "https://api.stripe.com/v1/products/prod_fictional").with(
+          headers: stripe_headers,
+        ).to_return(product_response)
+
+      delete "/s/admin/products/prod_fictional.json"
+
+      expect(response.status).to eq(200)
+      expect(DiscourseSubscriptions::Product.exists?(external_id: "prod_fictional")).to eq(false)
+      expect(request).to have_been_requested
     end
   end
 end

--- a/plugins/discourse-subscriptions/spec/requests/admin/subscriptions_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/admin/subscriptions_controller_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
 
   context "when unauthenticated" do
     it "does nothing" do
-      ::Stripe::Subscription.expects(:list).never
+      ::Stripe::SubscriptionService.any_instance.expects(:list).never
       get "/s/admin/subscriptions.json"
       expect(response.status).to eq(404)
     end
 
     it "does not destroy a subscription" do
-      ::Stripe::Subscription.expects(:delete).never
+      ::Stripe::SubscriptionService.any_instance.expects(:cancel).never
       patch "/s/admin/subscriptions/sub_12345.json"
     end
   end
@@ -44,12 +44,10 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
       before { SiteSetting.discourse_subscriptions_public_key = "public-key" }
 
       it "gets the subscriptions and products" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:list)
-          .with(
-            { expand: ["data.plan.product"], limit: 10, starting_after: nil, status: "all" },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with({ expand: ["data.plan.product"], limit: 10, starting_after: nil, status: "all" })
           .returns(has_more: false, data: [{ id: "sub_12345" }, { id: "sub_nope" }])
         get "/s/admin/subscriptions.json"
         subscriptions = response.parsed_body["data"][0]["id"]
@@ -59,11 +57,11 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
       end
 
       it "handles starting at a different point in the set" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:list)
           .with(
             { expand: ["data.plan.product"], limit: 10, starting_after: "sub_nope", status: "all" },
-            DiscourseSubscriptions::Stripe.request_opts,
           )
           .returns(has_more: false, data: [{ id: "sub_77777" }, { id: "sub_yepnoep" }])
         get "/s/admin/subscriptions.json", params: { last_record: "sub_nope" }
@@ -80,9 +78,10 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
       before { group.add(user) }
 
       it "deletes a customer" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:cancel)
-          .with("sub_12345", anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with("sub_12345", anything)
           .returns(plan: { product: "pr_34578" }, customer: "c_123")
 
         # We don't want to delete the customer record. The webhook hook will update the status instead.
@@ -92,9 +91,10 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
       end
 
       it "removes the user from the group" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:cancel)
-          .with("sub_12345", anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with("sub_12345", anything)
           .returns(
             plan: {
               product: "pr_34578",
@@ -111,9 +111,10 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
       end
 
       it "does not remove the user from the group" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:cancel)
-          .with("sub_12345", anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with("sub_12345", anything)
           .returns(
             plan: {
               product: "pr_34578",
@@ -130,36 +131,34 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
       end
 
       it "does not refund when refund param is the string 'false'" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:cancel)
-          .with("sub_12345", anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with("sub_12345", anything)
           .returns(plan: { product: "pr_34578" }, customer: "c_123")
-        ::Stripe::Subscription
-          .expects(:retrieve)
-          .with("sub_12345", DiscourseSubscriptions::Stripe.request_opts)
-          .never
-        ::Stripe::Refund.expects(:create).never
+        ::Stripe::SubscriptionService.any_instance.expects(:retrieve).with("sub_12345").never
+        ::Stripe::RefundService.any_instance.expects(:create).never
 
         delete "/s/admin/subscriptions/sub_12345.json", params: { refund: "false" }
       end
 
       it "refunds if params[:refund] present" do
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:cancel)
-          .with("sub_12345", anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with("sub_12345", anything)
           .returns(plan: { product: "pr_34578" }, customer: "c_123")
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .expects(:retrieve)
-          .with("sub_12345", DiscourseSubscriptions::Stripe.request_opts)
+          .with("sub_12345")
           .returns(latest_invoice: "in_123")
-        ::Stripe::Invoice
+        ::Stripe::InvoiceService
+          .any_instance
           .expects(:retrieve)
-          .with("in_123", DiscourseSubscriptions::Stripe.request_opts)
+          .with("in_123")
           .returns(payment_intent: "pi_123")
-        ::Stripe::Refund.expects(:create).with(
-          { payment_intent: "pi_123" },
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        ::Stripe::RefundService.any_instance.expects(:create).with({ payment_intent: "pi_123" })
 
         delete "/s/admin/subscriptions/sub_12345.json", params: { refund: true }
       end

--- a/plugins/discourse-subscriptions/spec/requests/hooks_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/hooks_controller_spec.rb
@@ -163,21 +163,18 @@ RSpec.describe DiscourseSubscriptions::HooksController do
     describe "checkout.session.completed" do
       before do
         event = { type: "checkout.session.completed", data: checkout_session_completed_data }
-        ::Stripe::Checkout::Session
-          .stubs(:list_line_items)
-          .with(
-            checkout_session_completed_data[:object][:id],
-            { limit: 1 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+        ::Stripe::Checkout::SessionLineItemService
+          .any_instance
+          .stubs(:list)
+          .with(checkout_session_completed_data[:object][:id], { limit: 1 })
           .returns(list_line_items_data)
 
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .stubs(:update)
           .with(
             checkout_session_completed_data[:object][:subscription],
             { metadata: { user_id: user.id, username: user.username } },
-            DiscourseSubscriptions::Stripe.request_opts,
           )
           .returns(
             {
@@ -244,16 +241,13 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:metadata] = { user_id: other_user.id }
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session
-          .stubs(:list_line_items)
-          .with(
-            checkout_session_completed_data[:object][:id],
-            { limit: 1 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+        ::Stripe::Checkout::SessionLineItemService
+          .any_instance
+          .stubs(:list)
+          .with(checkout_session_completed_data[:object][:id], { limit: 1 })
           .returns(list_line_items_data)
 
-        ::Stripe::Subscription.stubs(:update).returns({})
+        ::Stripe::SubscriptionService.any_instance.stubs(:update).returns({})
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -276,8 +270,8 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:customer_email] = other_user.email
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -299,9 +293,9 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:customer_email] = other_user.email
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Customer.expects(:create).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::CustomerService.any_instance.expects(:create).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -321,8 +315,8 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object].delete(:client_reference_id)
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -342,8 +336,8 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:client_reference_id] = "tampered-reference"
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -363,8 +357,8 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:customer_email] = nil
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -384,9 +378,9 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:client_reference_id] = client_reference_id
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Customer.expects(:create).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::CustomerService.any_instance.expects(:create).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -402,19 +396,17 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           type: "checkout.session.completed",
           data: checkout_session_completed_data_one_off,
         }
-        ::Stripe::Checkout::Session
-          .stubs(:list_line_items)
-          .with(
-            checkout_session_completed_data[:object][:id],
-            { limit: 1 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+        ::Stripe::Checkout::SessionLineItemService
+          .any_instance
+          .stubs(:list)
+          .with(checkout_session_completed_data[:object][:id], { limit: 1 })
           .returns(list_line_items_data)
 
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
-        ::Stripe::Customer
+        ::Stripe::CustomerService
+          .any_instance
           .stubs(:create)
-          .with({ email: user.email }, DiscourseSubscriptions::Stripe.request_opts)
+          .with({ email: user.email })
           .returns(id: "cus_1234")
       end
 
@@ -431,9 +423,9 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:client_reference_id] = client_reference_id
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Customer.expects(:create).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::CustomerService.any_instance.expects(:create).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -450,9 +442,9 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         data[:object][:client_reference_id] = client_reference_id
         event = { type: "checkout.session.completed", data: data }
 
-        ::Stripe::Checkout::Session.expects(:list_line_items).never
-        ::Stripe::Customer.expects(:create).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::Checkout::SessionLineItemService.any_instance.expects(:list).never
+        ::Stripe::CustomerService.any_instance.expects(:create).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
       end
 
@@ -543,20 +535,17 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           data: checkout_session_completed_data,
         }
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
-        ::Stripe::Checkout::Session
-          .stubs(:list_line_items)
-          .with(
-            checkout_session_completed_data[:object][:id],
-            { limit: 1 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+        ::Stripe::Checkout::SessionLineItemService
+          .any_instance
+          .stubs(:list)
+          .with(checkout_session_completed_data[:object][:id], { limit: 1 })
           .returns(list_line_items_data)
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .stubs(:update)
           .with(
             checkout_session_completed_data[:object][:subscription],
             { metadata: { user_id: user.id, username: user.username } },
-            DiscourseSubscriptions::Stripe.request_opts,
           )
           .returns(
             {

--- a/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
@@ -74,12 +74,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
       end
 
       it "gets products" do
-        ::Stripe::Product
+        ::Stripe::ProductService
+          .any_instance
           .expects(:list)
-          .with(
-            { ids: product_ids, active: true, limit: 100 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with({ ids: product_ids, active: true, limit: 100 })
           .returns(data: [product])
 
         get "/s.json"
@@ -103,12 +101,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
       it "is subscribed" do
         Fabricate(:subscription, external_id: "sub_12345", customer_id: customer.id, status: nil)
 
-        ::Stripe::Product
+        ::Stripe::ProductService
+          .any_instance
           .expects(:list)
-          .with(
-            { ids: product_ids, active: true, limit: 100 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with({ ids: product_ids, active: true, limit: 100 })
           .returns(data: [product])
 
         get "/s.json"
@@ -118,12 +114,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
       it "is not subscribed" do
         DiscourseSubscriptions::Customer.delete_all
-        ::Stripe::Product
+        ::Stripe::ProductService
+          .any_instance
           .expects(:list)
-          .with(
-            { ids: product_ids, active: true, limit: 100 },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with({ ids: product_ids, active: true, limit: 100 })
           .returns(data: [product])
 
         get "/s.json"
@@ -184,16 +178,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
       it "retrieves the product" do
         Fabricate(:product, external_id: "prod_walterwhite")
 
-        ::Stripe::Product
+        ::Stripe::ProductService
+          .any_instance
           .expects(:retrieve)
-          .with("prod_walterwhite", DiscourseSubscriptions::Stripe.request_opts)
+          .with("prod_walterwhite")
           .returns(product)
-        ::Stripe::Price
+        ::Stripe::PriceService
+          .any_instance
           .expects(:list)
-          .with(
-            { active: true, product: "prod_walterwhite" },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with({ active: true, product: "prod_walterwhite" })
           .returns(prices)
         get "/s/prod_walterwhite.json"
 
@@ -240,8 +233,8 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
       end
 
       it "returns 404 for a product outside the allowlist" do
-        ::Stripe::Product.expects(:retrieve).never
-        ::Stripe::Price.expects(:list).never
+        ::Stripe::ProductService.any_instance.expects(:retrieve).never
+        ::Stripe::PriceService.any_instance.expects(:list).never
 
         get "/s/prod_hidden.json"
 
@@ -290,9 +283,9 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
   context "when creating subscriptions" do
     context "when unauthenticated" do
       it "does not create a subscription" do
-        ::Stripe::Customer.expects(:create).never
-        ::Stripe::Price.expects(:retrieve).never
-        ::Stripe::Subscription.expects(:create).never
+        ::Stripe::CustomerService.any_instance.expects(:create).never
+        ::Stripe::PriceService.any_instance.expects(:retrieve).never
+        ::Stripe::SubscriptionService.any_instance.expects(:create).never
         post "/s/create.json", params: { plan: "plan_1234", source: "tok_1234" }
       end
     end
@@ -304,17 +297,19 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
       describe "#create" do
         before do
-          ::Stripe::Customer
+          ::Stripe::CustomerService
+            .any_instance
             .stubs(:create)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(id: "cus_1234")
         end
 
         it "creates a subscription without automatic_tax param" do
           SiteSetting.discourse_subscriptions_enable_automatic_tax = false
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(
               type: "recurring",
               product: "product_12345",
@@ -335,11 +330,11 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             promotion_code: nil,
           }
 
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:create)
-            .with do |params, opts|
-              params == expected_subscription_params && !params.key?(:automatic_tax) &&
-                opts == DiscourseSubscriptions::Stripe.request_opts
+            .with do |params|
+              params == expected_subscription_params && !params.key?(:automatic_tax)
             end
             .returns(status: "active", customer: "cus_1234")
 
@@ -350,9 +345,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         it "creates a subscription with automatic tax" do
           SiteSetting.discourse_subscriptions_enable_automatic_tax = true
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(
               type: "recurring",
               product: "product_12345",
@@ -376,9 +372,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             },
           }
 
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:create)
-            .with(expected_subscription_params, DiscourseSubscriptions::Stripe.request_opts)
+            .with(expected_subscription_params)
             .returns(status: "active", customer: "cus_1234")
 
           expect {
@@ -387,9 +384,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
         end
 
         it "rejects a plan outside the allowlist" do
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with("price_hidden", DiscourseSubscriptions::Stripe.request_opts)
+            .with("price_hidden")
             .returns(
               type: "recurring",
               product: "prod_hidden",
@@ -398,8 +396,8 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
                 trial_period_days: 0,
               },
             )
-          ::Stripe::Customer.expects(:create).never
-          ::Stripe::Subscription.expects(:create).never
+          ::Stripe::CustomerService.any_instance.expects(:create).never
+          ::Stripe::SubscriptionService.any_instance.expects(:create).never
 
           expect {
             post "/s/create.json", params: { plan: "price_hidden", source: "tok_1234" }
@@ -412,9 +410,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           # It's possible that the invoice item doesn't get attached
           # to the invoice. This means the invoice is paid, but for $0.00 with
           # a pending invoice item.
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(
               type: "one_time",
               product: "product_12345",
@@ -423,19 +422,18 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
               },
             )
 
-          ::Stripe::InvoiceItem.expects(:create).with(
-            anything,
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          ::Stripe::InvoiceItemService.any_instance.expects(:create).with(anything)
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:create)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(status: "open", id: "in_123")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:finalize_invoice)
-            .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything, anything)
             .returns(id: "in_123", status: "paid", payment_intent: "pi_123")
 
           expect {
@@ -447,9 +445,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         it "creates a one time payment subscription without automatic tax" do
           SiteSetting.discourse_subscriptions_enable_automatic_tax = false
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(
               type: "one_time",
               product: "product_12345",
@@ -458,39 +457,38 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
               },
             )
 
-          ::Stripe::InvoiceItem.expects(:create).with(
-            anything,
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          ::Stripe::InvoiceItemService.any_instance.expects(:create).with(anything)
 
           expected_one_time_params = { customer: "cus_1234" }
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:create)
-            .with do |params, opts|
-              params == expected_one_time_params && !params.key?(:automatic_tax) &&
-                opts == DiscourseSubscriptions::Stripe.request_opts
-            end
+            .with { |params| params == expected_one_time_params && !params.key?(:automatic_tax) }
             .returns(status: "open", id: "in_123")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:finalize_invoice)
-            .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything, anything)
             .returns(id: "in_123", status: "open", payment_intent: "pi_123")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(id: "in_123", status: "open", payment_intent: "pi_123")
 
-          ::Stripe::PaymentIntent
+          ::Stripe::PaymentIntentService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(status: "successful")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:pay)
-            .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything, anything)
             .returns(status: "paid", customer: "cus_1234")
 
           expect {
@@ -500,9 +498,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         it "creates a one time payment subscription" do
           SiteSetting.discourse_subscriptions_enable_automatic_tax = true
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(
               type: "one_time",
               product: "product_12345",
@@ -511,36 +510,38 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
               },
             )
 
-          ::Stripe::InvoiceItem.expects(:create).with(
-            anything,
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          ::Stripe::InvoiceItemService.any_instance.expects(:create).with(anything)
 
           expected_one_time_params = { customer: "cus_1234", automatic_tax: { enabled: true } }
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:create)
-            .with(expected_one_time_params, DiscourseSubscriptions::Stripe.request_opts)
+            .with(expected_one_time_params)
             .returns(status: "open", id: "in_123")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:finalize_invoice)
-            .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything, anything)
             .returns(id: "in_123", status: "open", payment_intent: "pi_123")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(id: "in_123", status: "open", payment_intent: "pi_123")
 
-          ::Stripe::PaymentIntent
+          ::Stripe::PaymentIntentService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(status: "successful")
 
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:pay)
-            .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything, anything)
             .returns(status: "paid", customer: "cus_1234")
 
           expect {
@@ -549,24 +550,23 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
         end
 
         it "creates a customer model" do
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(type: "recurring", product: "product_12345", metadata: {})
             .twice
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:create)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(status: "active", customer: "cus_1234")
 
           expect {
             post "/s/create.json", params: { plan: "plan_1234", source: "tok_1234" }
           }.to change { DiscourseSubscriptions::Customer.count }
 
-          ::Stripe::Customer.expects(:retrieve).with(
-            "cus_1234",
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          ::Stripe::CustomerService.any_instance.expects(:retrieve).with("cus_1234")
 
           expect {
             post "/s/create.json", params: { plan: "plan_5678", source: "tok_5678" }
@@ -575,13 +575,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         context "with customer name & address" do
           it "creates a customer & subscription when a customer address is provided" do
-            ::Stripe::Price
+            ::Stripe::PriceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(type: "recurring", product: "product_12345", metadata: {})
-            ::Stripe::Subscription
+            ::Stripe::SubscriptionService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(status: "active", customer: "cus_1234")
             expect {
               post "/s/create.json",
@@ -604,9 +606,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
         context "with promo code" do
           context "with invalid code" do
             it "prevents use of invalid coupon codes" do
-              ::Stripe::Price
+              ::Stripe::PriceService
+                .any_instance
                 .expects(:retrieve)
-                .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything)
                 .returns(
                   type: "recurring",
                   product: "product_12345",
@@ -616,9 +619,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
                   },
                 )
 
-              ::Stripe::PromotionCode
+              ::Stripe::PromotionCodeService
+                .any_instance
                 .expects(:list)
-                .with({ code: "invalid" }, DiscourseSubscriptions::Stripe.request_opts)
+                .with({ code: "invalid" })
                 .returns(data: [])
 
               post "/s/create.json",
@@ -635,16 +639,18 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
           context "with valid code" do
             before do
-              ::Stripe::PromotionCode
+              ::Stripe::PromotionCodeService
+                .any_instance
                 .expects(:list)
-                .with({ code: "123" }, DiscourseSubscriptions::Stripe.request_opts)
+                .with({ code: "123" })
                 .returns(data: [{ id: "promo123", coupon: { id: "c123" } }])
             end
 
             it "applies promo code to recurring subscription" do
-              ::Stripe::Price
+              ::Stripe::PriceService
+                .any_instance
                 .expects(:retrieve)
-                .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything)
                 .returns(
                   type: "recurring",
                   product: "product_12345",
@@ -665,9 +671,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
                 promotion_code: "promo123",
               }
 
-              ::Stripe::Subscription
+              ::Stripe::SubscriptionService
+                .any_instance
                 .expects(:create)
-                .with(expected_subscription_params, DiscourseSubscriptions::Stripe.request_opts)
+                .with(expected_subscription_params)
                 .returns(status: "active", customer: "cus_1234")
 
               expect {
@@ -681,9 +688,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             end
 
             it "applies promo code to one time purchase" do
-              ::Stripe::Price
+              ::Stripe::PriceService
+                .any_instance
                 .expects(:retrieve)
-                .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything)
                 .returns(
                   type: "one_time",
                   product: "product_12345",
@@ -692,39 +700,46 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
                   },
                 )
 
-              ::Stripe::Invoice
+              ::Stripe::InvoiceService
+                .any_instance
                 .expects(:create)
-                .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything)
                 .returns(status: "open", id: "in_123")
 
-              ::Stripe::InvoiceItem.expects(:create).with(
-                {
-                  customer: "cus_1234",
-                  price: "plan_1234",
-                  discounts: [{ coupon: "c123" }],
-                  invoice: "in_123",
-                },
-                DiscourseSubscriptions::Stripe.request_opts,
-              )
+              ::Stripe::InvoiceItemService
+                .any_instance
+                .expects(:create)
+                .with(
+                  {
+                    customer: "cus_1234",
+                    price: "plan_1234",
+                    discounts: [{ coupon: "c123" }],
+                    invoice: "in_123",
+                  },
+                )
 
-              ::Stripe::Invoice
+              ::Stripe::InvoiceService
+                .any_instance
                 .expects(:finalize_invoice)
-                .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything, anything)
                 .returns(id: "in_123", status: "open", payment_intent: "pi_123")
 
-              ::Stripe::Invoice
+              ::Stripe::InvoiceService
+                .any_instance
                 .expects(:retrieve)
-                .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything)
                 .returns(id: "in_123", status: "open", payment_intent: "pi_123")
 
-              ::Stripe::PaymentIntent
+              ::Stripe::PaymentIntentService
+                .any_instance
                 .expects(:retrieve)
-                .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything)
                 .returns(status: "successful")
 
-              ::Stripe::Invoice
+              ::Stripe::InvoiceService
+                .any_instance
                 .expects(:pay)
-                .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
+                .with(anything, anything)
                 .returns(status: "paid", customer: "cus_1234")
 
               expect {
@@ -747,13 +762,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
               transaction_id: "sub_1234",
               plan_id: "plan_1234",
             }
-            ::Stripe::Price
+            ::Stripe::PriceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(id: "plan_1234", product: "product_12345", metadata: {})
-            ::Stripe::Subscription
+            ::Stripe::SubscriptionService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(id: "sub_123", customer: "cus_1234", status: "active")
 
             expect { post "/s/finalize.json" }.to change { DiscourseSubscriptions::Customer.count }
@@ -766,13 +783,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
               transaction_id: "in_1234",
               plan_id: "plan_1234",
             }
-            ::Stripe::Price
+            ::Stripe::PriceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(id: "plan_1234", product: "product_12345", metadata: {})
-            ::Stripe::Invoice
+            ::Stripe::InvoiceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(id: "in_123", customer: "cus_1234", status: "paid")
 
             expect { post "/s/finalize.json" }.to change { DiscourseSubscriptions::Customer.count }
@@ -789,13 +808,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             transaction_id: "sub_123",
             plan_id: "plan_1234",
           }
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(id: "plan_1234", product: "product_12345", metadata: {})
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:retrieve)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(id: "sub_123", customer: "cus_1234", status: "active")
 
           post "/s/finalize.json"
@@ -810,11 +831,12 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             transaction_id: "sub_123",
             plan_id: "price_hidden",
           }
-          ::Stripe::Price
+          ::Stripe::PriceService
+            .any_instance
             .expects(:retrieve)
-            .with("price_hidden", DiscourseSubscriptions::Stripe.request_opts)
+            .with("price_hidden")
             .returns(id: "price_hidden", product: "prod_hidden", metadata: {})
-          ::Stripe::Subscription.expects(:retrieve).never
+          ::Stripe::SubscriptionService.any_instance.expects(:retrieve).never
 
           expect { post "/s/finalize.json" }.not_to change {
             DiscourseSubscriptions::Customer.count
@@ -830,20 +852,23 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         context "with unauthorized group" do
           before do
-            ::Stripe::Customer
+            ::Stripe::CustomerService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(id: "cus_1234")
-            ::Stripe::Subscription
+            ::Stripe::SubscriptionService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(status: "active")
           end
 
           it "does not add the user to the admins group" do
-            ::Stripe::Price
+            ::Stripe::PriceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(
                 type: "recurring",
                 product: "product_12345",
@@ -856,9 +881,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           end
 
           it "does not add the user to other group" do
-            ::Stripe::Price
+            ::Stripe::PriceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(
                 type: "recurring",
                 product: "product_12345",
@@ -873,13 +899,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         context "when plan has group in metadata" do
           before do
-            ::Stripe::Customer
+            ::Stripe::CustomerService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(id: "cus_1234")
-            ::Stripe::Price
+            ::Stripe::PriceService
+              .any_instance
               .expects(:retrieve)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(
                 type: "recurring",
                 product: "product_12345",
@@ -890,9 +918,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           end
 
           it "does not add the user to the group when subscription fails" do
-            ::Stripe::Subscription
+            ::Stripe::SubscriptionService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(status: "failed")
 
             expect {
@@ -903,9 +932,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           end
 
           it "adds the user to the group when the subscription is active" do
-            ::Stripe::Subscription
+            ::Stripe::SubscriptionService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(status: "active")
 
             expect {
@@ -916,9 +946,10 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           end
 
           it "adds the user to the group when the subscription is trialing" do
-            ::Stripe::Subscription
+            ::Stripe::SubscriptionService
+              .any_instance
               .expects(:create)
-              .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+              .with(anything)
               .returns(status: "trialing")
 
             expect {

--- a/plugins/discourse-subscriptions/spec/requests/user/payments_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/user/payments_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
 
   context "when not authenticated" do
     it "does not get the payment intents" do
-      ::Stripe::PaymentIntent.expects(:list).never
+      ::Stripe::PaymentIntentService.any_instance.expects(:list).never
       get "/s/user/payments.json"
       expect(response.status).to eq(403)
     end
@@ -30,9 +30,10 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
 
     it "gets payment intents" do
       created_time = Time.now
-      ::Stripe::Invoice
+      ::Stripe::InvoiceService
+        .any_instance
         .expects(:list)
-        .with({ customer: "c_345678" }, DiscourseSubscriptions::Stripe.request_opts)
+        .with({ customer: "c_345678" })
         .returns(
           data: [
             { id: "inv_900007", lines: { data: [plan: { product: "prod_8675309" }] } },
@@ -41,9 +42,10 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
           ],
         )
 
-      ::Stripe::PaymentIntent
+      ::Stripe::PaymentIntentService
+        .any_instance
         .expects(:list)
-        .with({ customer: "c_345678" }, DiscourseSubscriptions::Stripe.request_opts)
+        .with({ customer: "c_345678" })
         .returns(
           data: [
             { id: "pi_900008", invoice: "inv_900008", created: created_time },
@@ -63,14 +65,16 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
     end
 
     it "gets pricing table one-off purchases" do
-      ::Stripe::Invoice
+      ::Stripe::InvoiceService
+        .any_instance
         .expects(:list)
-        .with({ customer: "c_345678" }, DiscourseSubscriptions::Stripe.request_opts)
+        .with({ customer: "c_345678" })
         .returns(data: [])
 
-      ::Stripe::PaymentIntent
+      ::Stripe::PaymentIntentService
+        .any_instance
         .expects(:list)
-        .with({ customer: "c_345678" }, DiscourseSubscriptions::Stripe.request_opts)
+        .with({ customer: "c_345678" })
         .returns(data: [{ id: "pi_900010", invoice: nil, created: Time.now }])
 
       get "/s/user/payments.json"
@@ -82,22 +86,22 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
 
     it "gets pricing table one-off purchases that show up as related guest payments" do
       SiteSetting.discourse_subscriptions_pricing_table_enabled = true
-      ::Stripe::Invoice
+      ::Stripe::InvoiceService
+        .any_instance
         .expects(:list)
-        .with({ customer: "c_345678" }, DiscourseSubscriptions::Stripe.request_opts)
+        .with({ customer: "c_345678" })
         .returns(data: [])
 
-      ::Stripe::PaymentIntent
+      ::Stripe::PaymentIntentService
+        .any_instance
         .expects(:list)
-        .with({ customer: "c_345678" }, DiscourseSubscriptions::Stripe.request_opts)
+        .with({ customer: "c_345678" })
         .returns(data: [])
 
-      ::Stripe::Charge
+      ::Stripe::ChargeService
+        .any_instance
         .expects(:list)
-        .with(
-          { limit: 100, starting_after: nil, expand: ["data.payment_intent"] },
-          DiscourseSubscriptions::Stripe.request_opts,
-        )
+        .with({ limit: 100, starting_after: nil, expand: ["data.payment_intent"] })
         .returns(
           data: [
             {

--- a/plugins/discourse-subscriptions/spec/requests/user/subscriptions_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/user/subscriptions_controller_spec.rb
@@ -14,18 +14,18 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
 
   context "when not authenticated" do
     it "does not get the subscriptions" do
-      ::Stripe::Customer.expects(:list).never
+      ::Stripe::CustomerService.any_instance.expects(:list).never
       get "/s/user/subscriptions.json"
     end
 
     it "does not destroy a subscription" do
-      ::Stripe::Subscription.expects(:delete).never
+      ::Stripe::SubscriptionService.any_instance.expects(:cancel).never
       patch "/s/user/subscriptions/sub_12345.json"
     end
 
     it "doesn't update payment method for subscription" do
-      ::Stripe::Subscription.expects(:update).never
-      ::Stripe::PaymentMethod.expects(:attach).never
+      ::Stripe::SubscriptionService.any_instance.expects(:update).never
+      ::Stripe::PaymentMethodService.any_instance.expects(:attach).never
       put "/s/user/subscriptions/sub_12345.json", params: { payment_method: "pm_abc123abc" }
     end
   end
@@ -50,9 +50,10 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
         )
 
       it "gets subscriptions" do
-        ::Stripe::Price
+        ::Stripe::PriceService
+          .any_instance
           .stubs(:list)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with(anything)
           .returns(JSON.parse(plans_json, symbolize_names: true))
 
         subscriptions_json =
@@ -62,9 +63,10 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
             ),
           )
 
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .stubs(:list)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with(anything)
           .returns(JSON.parse(subscriptions_json, symbolize_names: true))
 
         get "/s/user/subscriptions.json"
@@ -78,12 +80,10 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
 
       it "aggregates prices from multiple pages using pagination logic" do
         subscription_data = { id: "sub_10z", items: { data: [{ price: { id: "price_200" } }] } }
-        ::Stripe::Subscription
+        ::Stripe::SubscriptionService
+          .any_instance
           .stubs(:list)
-          .with(
-            { customer: "cus_23456", status: "all" },
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with({ customer: "cus_23456", status: "all" })
           .returns({ data: [subscription_data] })
 
         # Build the first page of 100 prices that do NOT include the desired price.
@@ -109,20 +109,16 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
           ),
         ]
 
-        ::Stripe::Price
+        ::Stripe::PriceService
+          .any_instance
           .expects(:list)
-          .with(
-            has_entries(limit: 100, expand: ["data.product"]),
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with(has_entries(limit: 100, expand: ["data.product"]))
           .returns({ data: prices_page_1, has_more: true })
 
-        ::Stripe::Price
+        ::Stripe::PriceService
+          .any_instance
           .expects(:list)
-          .with(
-            has_entries(limit: 100, expand: ["data.product"], starting_after: "price_100"),
-            DiscourseSubscriptions::Stripe.request_opts,
-          )
+          .with(has_entries(limit: 100, expand: ["data.product"], starting_after: "price_100"))
           .returns({ data: prices_page_2, has_more: false })
 
         get "/s/user/subscriptions.json"
@@ -138,14 +134,8 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
 
     describe "update" do
       it "updates the payment method for subscription" do
-        ::Stripe::Subscription
-          .expects(:update)
-          .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
-          .once
-        ::Stripe::PaymentMethod
-          .expects(:attach)
-          .with(anything, anything, DiscourseSubscriptions::Stripe.request_opts)
-          .once
+        ::Stripe::SubscriptionService.any_instance.expects(:update).with(anything, anything).once
+        ::Stripe::PaymentMethodService.any_instance.expects(:attach).with(anything, anything).once
         put "/s/user/subscriptions/sub_10z.json", params: { payment_method: "pm_abc123abc" }
       end
     end
@@ -161,7 +151,7 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
 
     describe "destroy" do
       it "does not allow user to cancel a subscription that is not theirs" do
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
 
         delete "/s/user/subscriptions/abc.json"
 
@@ -171,8 +161,8 @@ RSpec.describe DiscourseSubscriptions::User::SubscriptionsController do
 
     describe "update" do
       it "does not allow user to update a subscription that is not theirs" do
-        ::Stripe::PaymentMethod.expects(:attach).never
-        ::Stripe::Subscription.expects(:update).never
+        ::Stripe::PaymentMethodService.any_instance.expects(:attach).never
+        ::Stripe::SubscriptionService.any_instance.expects(:update).never
 
         put "/s/user/subscriptions/abc.json", params: { payment_method: "x" }
 

--- a/plugins/discourse-subscriptions/spec/services/campaign_spec.rb
+++ b/plugins/discourse-subscriptions/spec/services/campaign_spec.rb
@@ -1,6 +1,43 @@
 # frozen_string_literal: true
 
 describe DiscourseSubscriptions::Campaign do
+  describe "#refresh_data" do
+    it "uses one client per refresh and reads the current credentials on the next refresh" do
+      Fabricate(:product, external_id: "prod_fictional")
+      SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_first"
+      campaign = described_class.new
+      requests = []
+      stub_request(
+        :get,
+        %r{\Ahttps://api\.stripe\.com/v1/(subscriptions|invoices)},
+      ).to_return do |request|
+        requests << request.headers["Authorization"]
+        SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_second"
+        {
+          status: 200,
+          body: { object: "list", data: [], has_more: false }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        }
+      end
+
+      campaign.refresh_data
+      campaign.refresh_data
+
+      expect(requests).to eq(
+        [
+          "Bearer sk_test_fictional_first",
+          "Bearer sk_test_fictional_first",
+          "Bearer sk_test_fictional_second",
+          "Bearer sk_test_fictional_second",
+        ],
+      )
+      expect(SiteSetting.discourse_subscriptions_campaign_subscribers).to eq(0)
+      expect(SiteSetting.discourse_subscriptions_campaign_amount_raised).to eq(0)
+    end
+  end
+
   describe "campaign data is refreshed" do
     let(:user) { Fabricate(:user) }
     let(:user2) { Fabricate(:user) }
@@ -79,13 +116,15 @@ describe DiscourseSubscriptions::Campaign do
     describe "refresh_data" do
       context "for all subscription purchases" do
         it "refreshes the campaign data properly" do
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [subscription], has_more: false)
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [invoice, invoice2], has_more: false)
 
           DiscourseSubscriptions::Campaign.new.refresh_data
@@ -96,13 +135,15 @@ describe DiscourseSubscriptions::Campaign do
 
         it "checks if the goal is completed or not" do
           SiteSetting.discourse_subscriptions_campaign_goal = 5
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [subscription], has_more: false)
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [invoice], has_more: false)
 
           DiscourseSubscriptions::Campaign.new.refresh_data
@@ -112,13 +153,15 @@ describe DiscourseSubscriptions::Campaign do
         it "checks if goal is < 90% met after being met" do
           SiteSetting.discourse_subscriptions_campaign_goal = 25
           Discourse.redis.set("subscriptions_goal_met_date", 10.days.ago)
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [subscription], has_more: false)
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [invoice], has_more: false)
 
           DiscourseSubscriptions::Campaign.new.refresh_data
@@ -126,26 +169,30 @@ describe DiscourseSubscriptions::Campaign do
         end
 
         it "handles invoices with nil lines gracefully" do
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [subscription], has_more: false)
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [invoice_with_nil_lines], has_more: false)
 
           expect { DiscourseSubscriptions::Campaign.new.refresh_data }.not_to raise_error
         end
 
         it "handles invoices with nil price gracefully" do
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [subscription], has_more: false)
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [invoice_with_nil_price], has_more: false)
 
           expect { DiscourseSubscriptions::Campaign.new.refresh_data }.not_to raise_error
@@ -180,13 +227,15 @@ describe DiscourseSubscriptions::Campaign do
         end
 
         it "refreshes campaign data with only the campaign product/subscriptions" do
-          ::Stripe::Subscription
+          ::Stripe::SubscriptionService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [subscription, campaign_subscription], has_more: false)
-          ::Stripe::Invoice
+          ::Stripe::InvoiceService
+            .any_instance
             .expects(:list)
-            .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+            .with(anything)
             .returns(data: [invoice], has_more: false)
 
           DiscourseSubscriptions::Campaign.new.refresh_data
@@ -203,14 +252,12 @@ describe DiscourseSubscriptions::Campaign do
 
     describe "create_campaign" do
       it "successfully creates the campaign group, product, and prices" do
-        ::Stripe::Product
+        ::Stripe::ProductService
+          .any_instance
           .expects(:create)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
+          .with(anything)
           .returns(id: "prod_campaign")
-        ::Stripe::Price
-          .expects(:create)
-          .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-          .times(6)
+        ::Stripe::PriceService.any_instance.expects(:create).with(anything).times(6)
 
         DiscourseSubscriptions::Campaign.new.create_campaign
 

--- a/plugins/discourse-subscriptions/spec/system/campaign_banner_spec.rb
+++ b/plugins/discourse-subscriptions/spec/system/campaign_banner_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "Campaign Banner", allow_network: ["js.stripe.com"] do
   fab!(:contributor) { Fabricate(:user, username: "contributor1") }
 
   before do
-    ::Stripe::Product.stubs(:list).returns({ data: [] })
-    ::Stripe::Price.stubs(:list).returns({ data: [] })
+    ::Stripe::ProductService.any_instance.stubs(:list).returns({ data: [] })
+    ::Stripe::PriceService.any_instance.stubs(:list).returns({ data: [] })
 
     SiteSetting.discourse_subscriptions_campaign_enabled = true
     SiteSetting.discourse_subscriptions_campaign_show_contributors = true

--- a/plugins/discourse-subscriptions/spec/system/configure_subscriptions_plugin_spec.rb
+++ b/plugins/discourse-subscriptions/spec/system/configure_subscriptions_plugin_spec.rb
@@ -15,7 +15,7 @@ describe "Configure subscriptions plugin", allow_network: ["js.stripe.com"] do
   it "takes the admin to the products tab, alongside the other tabs, once Stripe keys are set" do
     SiteSetting.discourse_subscriptions_secret_key = "sk_test_51xuu"
     SiteSetting.discourse_subscriptions_public_key = "pk_test_51xuu"
-    ::Stripe::Product.stubs(:list).returns({ data: [] })
+    ::Stripe::ProductService.any_instance.stubs(:list).returns({ data: [] })
 
     config_page.visit
 

--- a/plugins/discourse-subscriptions/spec/system/pricing_table_spec.rb
+++ b/plugins/discourse-subscriptions/spec/system/pricing_table_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe "Pricing Table", allow_network: ["js.stripe.com"] do
         repurchaseable: true,
       },
     }
-    ::Stripe::Product.stubs(:list).returns({ data: [one_product] })
-    ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
-    ::Stripe::Product.stubs(:retrieve).returns(one_product)
-    ::Stripe::Price.stubs(:list).returns({ data: [] })
+    ::Stripe::ProductService.any_instance.stubs(:list).returns({ data: [one_product] })
+    ::Stripe::ProductService.any_instance.stubs(:delete).returns({ id: "prod_OiK" })
+    ::Stripe::ProductService.any_instance.stubs(:retrieve).returns(one_product)
+    ::Stripe::PriceService.any_instance.stubs(:list).returns({ data: [] })
   end
 
   it "Links to the pricing table page" do

--- a/plugins/discourse-subscriptions/spec/system/subscription_product_spec.rb
+++ b/plugins/discourse-subscriptions/spec/system/subscription_product_spec.rb
@@ -22,10 +22,10 @@ describe "Subscription products", allow_network: ["js.stripe.com"] do
         repurchaseable: true,
       },
     }
-    ::Stripe::Product.stubs(:list).returns({ data: [one_product] })
-    ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
-    ::Stripe::Product.stubs(:retrieve).returns(one_product)
-    ::Stripe::Price.stubs(:list).returns({ data: [] })
+    ::Stripe::ProductService.any_instance.stubs(:list).returns({ data: [one_product] })
+    ::Stripe::ProductService.any_instance.stubs(:delete).returns({ id: "prod_OiK" })
+    ::Stripe::ProductService.any_instance.stubs(:retrieve).returns(one_product)
+    ::Stripe::PriceService.any_instance.stubs(:list).returns({ data: [] })
   end
 
   it "shows the login screen" do

--- a/plugins/discourse-subscriptions/spec/system/subscription_subscription_spec.rb
+++ b/plugins/discourse-subscriptions/spec/system/subscription_subscription_spec.rb
@@ -52,13 +52,17 @@ describe "Subscription products" do
         ),
       )
 
-    ::Stripe::Product.stubs(:list).returns({ data: [one_product] })
-    ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
-    ::Stripe::Product.stubs(:retrieve).returns(one_product)
-    ::Stripe::Price.stubs(:list).returns(JSON.parse(plans_json, symbolize_names: true))
-    ::Stripe::Subscription.stubs(:list).returns(
-      JSON.parse(subscriptions_json, symbolize_names: true),
-    )
+    ::Stripe::ProductService.any_instance.stubs(:list).returns({ data: [one_product] })
+    ::Stripe::ProductService.any_instance.stubs(:delete).returns({ id: "prod_OiK" })
+    ::Stripe::ProductService.any_instance.stubs(:retrieve).returns(one_product)
+    ::Stripe::PriceService
+      .any_instance
+      .stubs(:list)
+      .returns(JSON.parse(plans_json, symbolize_names: true))
+    ::Stripe::SubscriptionService
+      .any_instance
+      .stubs(:list)
+      .returns(JSON.parse(subscriptions_json, symbolize_names: true))
   end
 
   it "shows active and canceled subscriptions for admins" do

--- a/plugins/discourse-subscriptions/spec/tasks/subscriptions_import_spec.rb
+++ b/plugins/discourse-subscriptions/spec/tasks/subscriptions_import_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "highline/import"
+
+RSpec.describe "subscriptions:subscriptions_import" do
+  fab!(:user)
+
+  describe "invoke" do
+    before do
+      HighLine.stubs(:ask).returns("y")
+      stub_request(:get, "https://api.stripe.com/v1/products").with(
+        query: {
+          "type" => "service",
+          "active" => "true",
+        },
+      ).to_return(
+        status: 200,
+        body: {
+          object: "list",
+          data: [{ id: "prod_fictional", object: "product", name: "Community support" }],
+          has_more: false,
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+      stub_request(:get, "https://api.stripe.com/v1/customers").to_return(
+        status: 200,
+        body: {
+          object: "list",
+          data: [{ id: "cus_fictional", object: "customer", description: user.id.to_s }],
+          has_more: false,
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+      stub_request(:get, "https://api.stripe.com/v1/subscriptions").with(
+        query: {
+          "status" => "active",
+        },
+      ).to_return(
+        status: 200,
+        body: {
+          object: "list",
+          data: [
+            {
+              id: "sub_fictional",
+              object: "subscription",
+              customer: "cus_fictional",
+              items: {
+                data: [
+                  { price: { product: "prod_fictional" }, plan: { product: "prod_fictional" } },
+                ],
+              },
+            },
+          ],
+          has_more: false,
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+      stub_request(:post, "https://api.stripe.com/v1/subscriptions/sub_fictional").with(
+        body: {
+          "metadata" => {
+            "user_id" => user.id.to_s,
+            "username" => user.username_lower,
+          },
+        },
+      ).to_return(
+        status: 200,
+        body: { id: "sub_fictional", object: "subscription", metadata: {} }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+      stub_request(:post, "https://api.stripe.com/v1/customers/cus_fictional").with(
+        body: {
+          "email" => user.email,
+        },
+      ).to_return(
+        status: 200,
+        body: { id: "cus_fictional", object: "customer", email: user.email }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it "uses the configured key for every import request without changing global credentials" do
+      SiteSetting.discourse_subscriptions_secret_key = "sk_test_fictional_import"
+      original_key = ::Stripe.api_key
+      original_version = ::Stripe.api_version
+
+      capture_stdout { invoke_rake_task("subscriptions:subscriptions_import") }
+
+      expect(DiscourseSubscriptions::Product.exists?(external_id: "prod_fictional")).to eq(true)
+      expect(DiscourseSubscriptions::Customer.find_by(customer_id: "cus_fictional").user_id).to eq(
+        user.id,
+      )
+      expect(DiscourseSubscriptions::Subscription.exists?(external_id: "sub_fictional")).to eq(true)
+      expect(
+        a_request(:any, %r{\Ahttps://api\.stripe\.com/v1/}).with(
+          headers: {
+            "Authorization" => "Bearer sk_test_fictional_import",
+            "Stripe-Version" => "2024-04-10",
+          },
+        ),
+      ).to have_been_made.times(5)
+      expect(::Stripe.api_key).to eq(original_key)
+      expect(::Stripe.api_version).to eq(original_version)
+    end
+
+    it "uses the prompted key when the site key is blank" do
+      SiteSetting.discourse_subscriptions_secret_key = ""
+      HighLine.stubs(:ask).with("Input Stripe secret key").returns("sk_test_fictional_prompt")
+
+      capture_stdout { invoke_rake_task("subscriptions:subscriptions_import") }
+
+      expect(
+        a_request(:any, %r{\Ahttps://api\.stripe\.com/v1/}).with(
+          headers: {
+            "Authorization" => "Bearer sk_test_fictional_prompt",
+            "Stripe-Version" => "2024-04-10",
+          },
+        ),
+      ).to have_been_made.times(5)
+      expect(SiteSetting.discourse_subscriptions_secret_key).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
Subscription controllers, campaign operations, and imports pass credentials separately for each Stripe call. Keeping the API context at each call site makes consistent credential handling a caller responsibility.

This commit uses the SDK's `StripeClient` with an explicit key and pinned API version. Controllers reuse a client for one request, campaign operations create one client per operation, and imports pass one client through their helpers. Missing credentials fail before SDK fallback, and plugin-wide API key/version mutation is removed. Stripe application metadata remains configured as before.

Reviewer notes: This is a draft architectural proposal inspired by CVE-2026-33073. It removes repeated credential plumbing within subscriptions rather than introducing a general integration framework.

Validation: subscriptions request, campaign, import, client transport, and affected system specs. Transport checks cover interleaved client credentials, configuration changes, API version, missing keys, and unchanged global credentials. Local verification used one isolated worktree containing this and the other independent draft proposals.