### PR TITLE
DEV: Render shared AI oneboxes with autoescaping templates

### DIFF
--- a/plugins/discourse-ai/app/models/shared_ai_conversation.rb
+++ b/plugins/discourse-ai/app/models/shared_ai_conversation.rb
@@ -119,38 +119,21 @@ class SharedAiConversation < ActiveRecord::Base
   end
 
   def html_excerpt
-    html = +""
-    populated_context.each do |post|
-      text = PrettyText.excerpt(post.cooked, 400, strip_links: true, strip_details: true)
-      username = ERB::Util.html_escape(post.user.username)
-
-      html << "<p><b>#{username}</b>: #{text}</p>"
-      if html.length > 1000
-        html << "<p>...</p>"
-        break
-      end
-    end
-    html << "<a href='#{url}'>#{I18n.t("discourse_ai.share_ai.read_more")}</a>"
-    html
+    ApplicationController.render(
+      partial: "discourse_ai/ai_bot/shared_ai_conversations/excerpt",
+      locals: {
+        conversation: self,
+      },
+    )
   end
 
   def onebox
-    escaped_title = ERB::Util.html_escape(title)
-    <<~HTML
-    <div>
-      <aside class="onebox allowlistedgeneric" data-onebox-src="#{url}">
-      <header class="source">
-        <span class="onebox-ai-llm-title">#{I18n.t("discourse_ai.share_ai.onebox_title", llm_name: llm_name)}</span>
-        <a href="#{url}" target="_blank" rel="nofollow ugc noopener" tabindex="-1">#{Discourse.base_uri}</a>
-      </header>
-      <article class="onebox-body">
-      <h3><a href="#{url}" rel="nofollow ugc noopener" tabindex="-1">#{escaped_title}</a></h3>
-    #{html_excerpt}
-    </article>
-    <div style="clear: both"></div>
-    </aside>
-    </div>
-    HTML
+    ApplicationController.render(
+      partial: "discourse_ai/ai_bot/shared_ai_conversations/onebox",
+      locals: {
+        conversation: self,
+      },
+    )
   end
 
   def self.excerpt(posts)

--- a/plugins/discourse-ai/app/views/discourse_ai/ai_bot/shared_ai_conversations/_excerpt.html.erb
+++ b/plugins/discourse-ai/app/views/discourse_ai/ai_bot/shared_ai_conversations/_excerpt.html.erb
@@ -1,0 +1,11 @@
+<% excerpt_length = 0 %>
+<% conversation.populated_context.each do |post| %>
+  <% paragraph = capture do %><p><b><%= post.user.username %></b>: <%= PrettyText.excerpt(post.cooked, 400, strip_links: true, strip_details: true).html_safe %></p><% end %>
+  <%= paragraph %>
+  <% excerpt_length += paragraph.length %>
+  <% if excerpt_length > 1000 %>
+    <p>...</p>
+    <% break %>
+  <% end %>
+<% end %>
+<a href="<%= conversation.url %>"><%= I18n.t("discourse_ai.share_ai.read_more") %></a>

--- a/plugins/discourse-ai/app/views/discourse_ai/ai_bot/shared_ai_conversations/_onebox.html.erb
+++ b/plugins/discourse-ai/app/views/discourse_ai/ai_bot/shared_ai_conversations/_onebox.html.erb
@@ -1,0 +1,13 @@
+<div>
+  <aside class="onebox allowlistedgeneric" data-onebox-src="<%= conversation.url %>">
+    <header class="source">
+      <span class="onebox-ai-llm-title"><%= I18n.t("discourse_ai.share_ai.onebox_title", llm_name: conversation.llm_name) %></span>
+      <a href="<%= conversation.url %>" target="_blank" rel="nofollow ugc noopener" tabindex="-1"><%= Discourse.base_uri %></a>
+    </header>
+    <article class="onebox-body">
+      <h3><a href="<%= conversation.url %>" rel="nofollow ugc noopener" tabindex="-1"><%= conversation.title %></a></h3>
+      <%= render partial: "discourse_ai/ai_bot/shared_ai_conversations/excerpt", locals: { conversation: conversation } %>
+    </article>
+    <div style="clear: both"></div>
+  </aside>
+</div>

--- a/plugins/discourse-ai/spec/models/shared_ai_conversation_spec.rb
+++ b/plugins/discourse-ai/spec/models/shared_ai_conversation_spec.rb
@@ -160,6 +160,30 @@ RSpec.describe SharedAiConversation, type: :model do
   end
 
   describe "#onebox" do
+    it "renders punctuation and Unicode as text while preserving the onebox structure" do
+      conversation = described_class.share_conversation(user, topic)
+      conversation.update!(title: %(A < B & "東京"), llm_name: "Research & <édition>")
+      conversation.share_key = %(review "A&B")
+      read_more = "Continue & <次へ>"
+      TranslationOverride.upsert!(I18n.locale, "discourse_ai.share_ai.read_more", read_more)
+
+      onebox = Nokogiri::HTML5.fragment(conversation.onebox)
+
+      expect(onebox.css("div > aside.onebox.allowlistedgeneric").size).to eq(1)
+      expect(onebox.at_css("aside")["data-onebox-src"]).to eq(conversation.url)
+      expect(onebox.at_css("header.source > .onebox-ai-llm-title").text).to eq(
+        I18n.t("discourse_ai.share_ai.onebox_title", llm_name: conversation.llm_name),
+      )
+      expect(onebox.at_css(".onebox-ai-llm-title").element_children).to be_empty
+      expect(onebox.at_css("article.onebox-body > h3 > a").text).to eq(conversation.title)
+      expect(onebox.at_css("h3 > a").element_children).to be_empty
+      expect(onebox.css("a").map { |link| link["href"] }).to eq([conversation.url] * 3)
+      expect(onebox.at_css("header.source > a")["rel"]).to eq("nofollow ugc noopener")
+      expect(onebox.at_css("header.source > a")["target"]).to eq("_blank")
+      expect(onebox.at_css("article > a").text).to eq(read_more)
+      expect(onebox.at_css("article > a").element_children).to be_empty
+    end
+
     it "escapes title and username" do
       malicious_username = %(user"><img src=x onerror=alert(1)>)
       malicious_title = %(title</a><script>alert("x")</script>)
@@ -177,6 +201,69 @@ RSpec.describe SharedAiConversation, type: :model do
 
       expect(onebox).not_to include("<img src=x onerror=alert(1)>")
       expect(onebox).not_to include(%(<script>alert("x")</script>))
+    end
+  end
+
+  describe "#html_excerpt" do
+    it "renders usernames as text and preserves cooked excerpt content" do
+      username = %(Renée & <reader> "東京")
+      user.update_columns(username: username, username_lower: username.downcase)
+      cooked = <<~HTML
+        <p><strong>Research &amp; development</strong> with <em>care</em>
+        <a href="https://example.com/guide">guide</a>
+        <span class="hashtag-icon-placeholder">tag</span></p>
+        <details><summary>Notes</summary><p>Internal notes</p></details>
+      HTML
+      post1.update_columns(user_id: user.id, cooked: cooked)
+      conversation = described_class.share_conversation(user, topic, max_posts: 1)
+
+      html = conversation.html_excerpt
+      excerpt = Nokogiri::HTML5.fragment(html)
+
+      expect(html).to be_a(String)
+      expect(excerpt.at_css("p > b").text).to eq(username)
+      expect(excerpt.at_css("p > b").element_children).to be_empty
+      expect(excerpt.at_css("p").text).to include("Research & development", "care", "guide")
+      expect(excerpt.at_css("p > span.hashtag-icon-placeholder").text).to eq("tag")
+      expect(excerpt.css("p a, details")).to be_empty
+      expect(excerpt.css("a").map { |link| link["href"] }).to eq([conversation.url])
+    end
+
+    it "limits each cooked excerpt to 400 characters" do
+      post1.update_column(:cooked, "<p>#{"a" * 450}</p>")
+      conversation = described_class.share_conversation(user, topic, max_posts: 1)
+
+      excerpt = Nokogiri::HTML5.fragment(conversation.html_excerpt)
+
+      expect(excerpt.at_css("p").text).to eq("#{post1.user.username}: #{"a" * 400}…")
+    end
+
+    it "includes the paragraph crossing 1000 HTML characters before stopping" do
+      user.update_columns(username: "reader", username_lower: "reader")
+      conversation = described_class.share_conversation(user, topic)
+      conversation.context =
+        ["a" * 399, "b" * 399, "c" * 136, "fourth", "fifth"].map.with_index do |text, index|
+          {
+            id: index + 1,
+            user_id: user.id,
+            created_at: Time.current.iso8601,
+            cooked: "<p>#{text}</p>",
+          }
+        end
+
+      excerpt = Nokogiri::HTML5.fragment(conversation.html_excerpt)
+
+      expect(excerpt.css("p").map(&:text)).to eq(
+        [
+          "reader: #{"a" * 399}",
+          "reader: #{"b" * 399}",
+          "reader: #{"c" * 136}",
+          "reader: fourth",
+          "...",
+        ],
+      )
+      expect(excerpt.element_children.last.name).to eq("a")
+      expect(excerpt.element_children.last["href"]).to eq(conversation.url)
     end
   end
 end


### PR DESCRIPTION
Shared AI conversation oneboxes construct HTML by interpolating strings and selectively escaping fields. Each additional text field requires its author to remember the correct escaping boundary.

This commit renders the onebox and excerpt through Rails templates, so ordinary values use framework escaping. Only the existing `PrettyText.excerpt` output is explicitly treated as rich HTML. Excerpt options, ordering, per-post limits, and the aggregate cutoff remain intact.

Reviewer notes: This is a draft architectural proposal inspired by the shared-conversation title fixes associated with CVE-2026-27570 and CVE-2026-32243. It replaces manual text escaping at this rendering boundary without claiming a new vulnerability or universal rendering safety.

Validation: shared-conversation model output and existing sharing system coverage. Added examples use ordinary punctuation, Unicode, retained excerpt markup, and length boundaries. Local verification used one isolated worktree containing this and the other independent draft proposals.