### PR TITLE
DEV: Enable the no-unused-expressions ESLint rule

### DIFF
--- a/frontend/discourse/app/components/modal/grant-badge.gjs
+++ b/frontend/discourse/app/components/modal/grant-badge.gjs
@@ -30,7 +30,7 @@ export default class GrantBadgeModal extends Component {
   @autoTrackedArray userBadges = [];
 
   get noAvailableBadges() {
-    !this.availableBadges.length;
+    return !this.availableBadges.length;
   }
 
   get badgeOptions() {

--- a/frontend/discourse/app/components/post/load-more-accessible.gjs
+++ b/frontend/discourse/app/components/post/load-more-accessible.gjs
@@ -24,9 +24,11 @@ export default class PostLoadMoreAccessible extends Component {
 
   get label() {
     if (this.loading) {
-      this.direction === "above"
-        ? "post.loading_more_posts_above"
-        : "post.loading_more_posts_below";
+      return i18n(
+        this.direction === "above"
+          ? "post.loading_more_posts_above"
+          : "post.loading_more_posts_below"
+      );
     }
 
     return i18n(

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -32,6 +32,7 @@ import optionalService from "discourse/lib/optional-service";
 import { showAlert } from "discourse/lib/post-action-feedback";
 import { survivingPenalty } from "discourse/lib/reviewable-penalty";
 import { resolveReviewableComponent } from "discourse/lib/reviewable-registry";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import { clipboardCopy } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
@@ -127,7 +128,7 @@ export default class ReviewableItem extends Component {
   @cached
   get state() {
     // reading the argument is what ties this cache to a single reviewable
-    this.args.reviewable;
+    manuallyTrack(this.args.reviewable);
 
     return trackedObject({
       activeTab: "timeline",

--- a/frontend/discourse/app/lib/blocks/-internals/components/block-outlet-root-container.gts
+++ b/frontend/discourse/app/lib/blocks/-internals/components/block-outlet-root-container.gts
@@ -23,6 +23,7 @@ import type {
   BlockEntry,
   ChildBlockResult,
 } from "discourse/lib/blocks/-internals/types";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import type Blocks from "discourse/services/blocks";
 
 interface BlockOutletRootContainerSignature {
@@ -119,9 +120,7 @@ export default class BlockOutletRootContainer extends Component<BlockOutletRootC
       createChildBlockFn,
     } = this.args;
 
-    // force tracking the value
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    this.args.showVisualOverlay;
+    manuallyTrack(this.args.showVisualOverlay);
 
     if (!rawChildren?.length) {
       return [];

--- a/frontend/discourse/app/lib/composer-video-thumbnail-uppy.js
+++ b/frontend/discourse/app/lib/composer-video-thumbnail-uppy.js
@@ -23,7 +23,7 @@ export default class ComposerVideoThumbnailUppy {
   }
 
   get uploading() {
-    this._uppyUpload.uploading;
+    return this._uppyUpload.uploading;
   }
 
   generateVideoThumbnail(videoFile, uploadUrl, callback) {

--- a/frontend/discourse/app/lib/textarea-text-manipulation.ts
+++ b/frontend/discourse/app/lib/textarea-text-manipulation.ts
@@ -474,7 +474,6 @@ export default class TextareaTextManipulation implements TextManipulation {
       plainText = plainText.replace(/\r/g, "");
       const table = this.extractTable(plainText);
       if (table) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         this.eventPrefix
           ? this.appEvents.trigger(`${this.eventPrefix}:insert-text`, table)
           : this.insertText(table);
@@ -531,7 +530,6 @@ export default class TextareaTextManipulation implements TextManipulation {
         }
 
         if (isComposer) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           this.eventPrefix
             ? this.appEvents.trigger(
                 `${this.eventPrefix}:insert-text`,
@@ -541,7 +539,6 @@ export default class TextareaTextManipulation implements TextManipulation {
           handled = true;
         }
       } else if (plainText && isComposer) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         this.eventPrefix
           ? this.appEvents.trigger(`${this.eventPrefix}:insert-text`, plainText)
           : this.insertText(plainText);

--- a/frontend/discourse/app/lib/tracked-tools.js
+++ b/frontend/discourse/app/lib/tracked-tools.js
@@ -423,3 +423,16 @@ export function enumerateTrackedEntries(obj) {
   const keys = enumerateTrackedKeys(obj);
   return keys.map((key) => [key, obj[key]]);
 }
+
+/**
+ * A no-op function which is used to signal the intent of consuming a getter
+ * for autotracking purposes. The actual autotracking happens when you call
+ * the getter, but would trip the `no-unused-expressions` line rule without this
+ * wrapper.
+ *
+ * Consuming state you do not use is generally a violation of Ember's declarative
+ * patterns, so reach for this only when absolutely necessary.
+ *
+ * @type {(value: unknown) => void}
+ */
+export function manuallyTrack() {}

--- a/frontend/discourse/app/ui-kit/d-decorated-html.gjs
+++ b/frontend/discourse/app/ui-kit/d-decorated-html.gjs
@@ -10,6 +10,7 @@ import {
   isRailsTesting,
   isTesting,
 } from "discourse/lib/environment";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 
 const detachedDocument = document.implementation.createHTMLDocument("detached");
 
@@ -115,7 +116,7 @@ export default class DDecoratedHtml extends Component {
   renderGlimmerInfos = trackedArray();
   decoratedContent = helperFn(({ decorateArgs }) => {
     // Releasing a deferred render must consume the latest arguments.
-    this._pointerRevision;
+    manuallyTrack(this._pointerRevision);
     if (this.#pressedElement) {
       this.#renderDeferred = true;
       return this.#pressedElement;

--- a/frontend/discourse/select-kit/components/select-kit.js
+++ b/frontend/discourse/select-kit/components/select-kit.js
@@ -1312,7 +1312,7 @@ export default class SelectKit extends Component {
           `The \`${from}\` attribute is deprecated. Use \`${to}\` instead`
         );
 
-        resolvedDeprecations[(to, this.get(from))];
+        resolvedDeprecations[to] = this.get(from);
       }
     });
 

--- a/frontend/discourse/tests/acceptance/user-preferences-tracking-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-tracking-test.js
@@ -204,7 +204,9 @@ acceptance("User Preferences - Tracking", function (needs) {
       ".tracking-controls__muted-tags .tag-chooser"
     );
 
-    assert.dom(".user-preferences__watched-precedence-over-muted").doesNotExist;
+    assert
+      .dom(".user-preferences__watched-precedence-over-muted")
+      .doesNotExist();
     await mutedTagsSelector.expand();
     await mutedTagsSelector.selectRowByName("dog");
 

--- a/frontend/discourse/tests/integration/components/nested/post-test.gjs
+++ b/frontend/discourse/tests/integration/components/nested/post-test.gjs
@@ -186,7 +186,6 @@ module("Integration | Component | Nested | Post", function (hooks) {
     });
     let registered = false;
     const register = (post) => {
-      post.topic;
       post.topic = updatedTopic;
       registered = true;
     };

--- a/frontend/discourse/tests/unit/lib/transformer-test.js
+++ b/frontend/discourse/tests/unit/lib/transformer-test.js
@@ -400,9 +400,7 @@ module("Unit | Utility | transformers", function (hooks) {
       });
 
       assert.throws(
-        function () {
-          testObject1.value1;
-        },
+        () => testObject1.value1,
         function (error) {
           return error.message === "sabotaged";
         },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Discourse",
   "license": "GPL-2.0-only",
   "devDependencies": {
-    "@discourse/lint-configs": "^3.6.0",
+    "@discourse/lint-configs": "^3.7.0",
     "@discourse/moment-timezone-names-translations": "^1.0.0",
     "@fortawesome/fontawesome-free": "7.3.1",
     "@glint/ember-tsc": "^1.11.4",

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-members.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-members.gjs
@@ -10,6 +10,7 @@ import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
@@ -85,7 +86,7 @@ export default class ChatRouteChannelInfoMembers extends Component {
     if (this.filter?.length) {
       params.username = this.filter;
     }
-    this.updatedAt;
+    manuallyTrack(this.updatedAt);
 
     return this.chatApi.listChannelMemberships(this.args.channel.id, params);
   }

--- a/plugins/chat/test/javascripts/components/chat-message-collapser-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-collapser-test.gjs
@@ -106,7 +106,6 @@ module("Component | chat message collapser youtube", function (hooks) {
   });
 
   test("shows all user written text", async function (assert) {
-    youtubeCooked.youtubeid;
     this.set("cooked", youtubeCooked);
 
     await render(

--- a/plugins/discourse-assign/assets/javascripts/discourse/services/task-actions.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/services/task-actions.js
@@ -3,6 +3,7 @@ import Service, { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import AssignUser from "../components/modal/assign-user";
 import assignmentPayload from "../lib/assignment-payload";
 
@@ -28,7 +29,7 @@ export default class TaskActions extends Service {
   }
 
   suggestionsFor(targetId, targetType = "Topic") {
-    this.suggestionsRevision;
+    manuallyTrack(this.suggestionsRevision);
     this.#ensureSuggestions(targetId, targetType);
 
     return (
@@ -39,7 +40,7 @@ export default class TaskActions extends Service {
   }
 
   allowedGroupsFor(targetId, targetType = "Topic") {
-    this.suggestionsRevision;
+    manuallyTrack(this.suggestionsRevision);
     this.#ensureSuggestions(targetId, targetType);
 
     return (
@@ -50,7 +51,7 @@ export default class TaskActions extends Service {
   }
 
   allowedGroupsForAssignmentFor(targetId, targetType = "Topic") {
-    this.suggestionsRevision;
+    manuallyTrack(this.suggestionsRevision);
     this.#ensureSuggestions(targetId, targetType);
 
     return (

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/index.gjs
@@ -11,6 +11,7 @@ import DMenu from "discourse/float-kit/components/d-menu";
 import dContextMenu from "discourse/float-kit/modifiers/d-context-menu";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import { clipboardCopy } from "discourse/lib/utilities";
 import DButton from "discourse/ui-kit/d-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
@@ -169,7 +170,7 @@ export default class WorkflowCanvas extends Component {
 
   @action
   isStickyNoteSelected(clientId) {
-    this.selectionVersion;
+    manuallyTrack(this.selectionVersion);
     return this.rete.isStickyNoteSelected(clientId);
   }
 

--- a/plugins/voice/assets/javascripts/discourse/app/services/voice-webrtc.js
+++ b/plugins/voice/assets/javascripts/discourse/app/services/voice-webrtc.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import Service, { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import Draft from "discourse/models/draft";
 import { i18n } from "discourse-i18n";
 import { confirmMeshPrivacy } from "../../components/modal/voice-mesh-privacy-warning";
@@ -537,12 +538,12 @@ export default class VoiceWebrtcService extends Service {
   }
 
   get remoteStreams() {
-    this.remoteStreamsRevision;
+    manuallyTrack(this.remoteStreamsRevision);
     return this.#remoteStreamRegistry.allStreams();
   }
 
   get remoteScreenAudioStreams() {
-    this.remoteStreamsRevision;
+    manuallyTrack(this.remoteStreamsRevision);
     return this.#remoteStreamRegistry.allScreenAudioStreams();
   }
 
@@ -641,7 +642,7 @@ export default class VoiceWebrtcService extends Service {
   }
 
   remoteStreamsFor(roomId) {
-    this.remoteStreamsRevision;
+    manuallyTrack(this.remoteStreamsRevision);
     return this.#remoteStreamRegistry.streamsFor(roomId);
   }
 
@@ -652,12 +653,12 @@ export default class VoiceWebrtcService extends Service {
   }
 
   remoteStreamFor(roomId, userId) {
-    this.remoteStreamsRevision;
+    manuallyTrack(this.remoteStreamsRevision);
     return this.#remoteStreamRegistry.streamFor(roomId, userId);
   }
 
   connectionStateFor(roomId) {
-    this.connectionRevision;
+    manuallyTrack(this.connectionRevision);
     if (this.#connectingRoomIds.has(roomId)) {
       return "connecting";
     }

--- a/plugins/voice/assets/javascripts/discourse/lib/voice/transcription-coordinator.js
+++ b/plugins/voice/assets/javascripts/discourse/lib/voice/transcription-coordinator.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { ajax } from "discourse/lib/ajax";
+import { manuallyTrack } from "discourse/lib/tracked-tools";
 import Composer from "discourse/models/composer";
 import Draft from "discourse/models/draft";
 import { i18n } from "discourse-i18n";
@@ -121,27 +122,27 @@ export default class TranscriptionCoordinator {
   }
 
   get recording() {
-    this.revision;
+    manuallyTrack(this.revision);
     return this.#transcript.recording;
   }
 
   get roomId() {
-    this.revision;
+    manuallyTrack(this.revision);
     return this.#transcript.roomId;
   }
 
   get entries() {
-    this.revision;
+    manuallyTrack(this.revision);
     return this.#transcript.entries;
   }
 
   get entriesRoomId() {
-    this.revision;
+    manuallyTrack(this.revision);
     return this.#transcript.entriesRoomId;
   }
 
   get startedAt() {
-    this.revision;
+    manuallyTrack(this.revision);
     return this.#transcript.startedAt;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
   .:
     devDependencies:
       '@discourse/lint-configs':
-        specifier: ^3.6.0
-        version: 3.6.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(postcss@8.5.26)(prettier@3.8.1)(stylelint@17.5.0(typescript@6.0.3))
+        specifier: ^3.7.0
+        version: 3.7.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(postcss@8.5.26)(prettier@3.8.1)(stylelint@17.5.0(typescript@6.0.3))
       '@discourse/moment-timezone-names-translations':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1879,8 +1879,8 @@ packages:
       prettier: 3.8.1
       stylelint: 17.5.0
 
-  '@discourse/lint-configs@3.6.0':
-    resolution: {integrity: sha512-nXV9Svx0E4a6zFs+G9paO9e3cwSl7TjrYw7yDb0Q2ih7GaBAHRGPNl89GAmMikLNq5ZIp3Lv2j2jK14KPAOHzg==}
+  '@discourse/lint-configs@3.7.0':
+    resolution: {integrity: sha512-neUanixZ9MfPscEElger0BNx05/wAw3BZXlBmGfUHscZ+iKBVygko6nDiZZHDBPGZYeZ53JxQXysknSunQpDQQ==}
     peerDependencies:
       eslint: 10.6.0
       prettier: 3.8.1
@@ -9614,7 +9614,7 @@ snapshots:
       - postcss
       - supports-color
 
-  '@discourse/lint-configs@3.6.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(postcss@8.5.26)(prettier@3.8.1)(stylelint@17.5.0(typescript@6.0.3))':
+  '@discourse/lint-configs@3.7.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(postcss@8.5.26)(prettier@3.8.1)(stylelint@17.5.0(typescript@6.0.3))':
     dependencies:
       '@babel/core': 8.0.1
       '@babel/eslint-parser': 8.0.1(@babel/core@8.0.1)(eslint@10.6.0(jiti@2.7.0))


### PR DESCRIPTION
This rule helps us catch mistakes like missing `return`. A noop `manuallyTrack()` helper is introduced so that deliberate calls of getters (to workaround ember autotracking) can be done without adding an ignore comment.