### PR TITLE
FIX: Accept `-latest` builds in theme version constraints

### DIFF
--- a/lib/version_compatibility.rb
+++ b/lib/version_compatibility.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Discourse
-  VERSION_REGEXP = /\A\d+\.\d+\.\d+(\.beta\d+)?\z/
+  VERSION_REGEXP = /\A\d+\.\d+\.\d+(\.beta\d+|-latest(\.\d+)?)?\z/
   VERSION_COMPATIBILITY_FILENAME = ".discourse-compatibility"
 
   class InvalidVersionListError < StandardError

--- a/spec/lib/version_compatibility_spec.rb
+++ b/spec/lib/version_compatibility_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe Discourse do
       expect(Discourse.has_needed_version?("1.3.0.beta4", "1.3.0.beta3")).to eq(true)
       expect(Discourse.has_needed_version?("1.3.0", "1.3.0.beta3")).to eq(true)
     end
+
+    it "treats -latest builds as pre-releases of the same version" do
+      expect(Discourse.has_needed_version?("2026.8.0-latest", "2026.7.2")).to eq(true)
+      expect(Discourse.has_needed_version?("2026.8.0-latest.1", "2026.8.0-latest")).to eq(true)
+      expect(Discourse.has_needed_version?("2026.8.0", "2026.8.0-latest.1")).to eq(true)
+      expect(Discourse.has_needed_version?("2026.8.0-latest", "2026.8.0-latest.1")).to eq(false)
+      expect(Discourse.has_needed_version?("2026.8.0-latest.1", "2026.8.0")).to eq(false)
+    end
+  end
+
+  describe "VERSION_REGEXP" do
+    it "matches release, beta and -latest versions" do
+      %w[2026.8.0 1.3.0.beta3 2026.8.0-latest 2026.8.0-latest.1].each do |v|
+        expect(v).to match(Discourse::VERSION_REGEXP)
+      end
+    end
+
+    it "rejects other suffixes" do
+      %w[2026.8 2026.8.0-beta 2026.8.0-latest. 2026.8.0-latest.1.2 2026.8.0latest].each do |v|
+        expect(v).not_to match(Discourse::VERSION_REGEXP)
+      end
+    end
   end
 
   describe ".find_compatible_resource" do

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -700,6 +700,24 @@ RSpec.describe RemoteTheme do
     end
   end
 
+  describe "version validations" do
+    it "accepts -latest versions" do
+      remote = RemoteTheme.new(minimum_discourse_version: "2026.8.0-latest")
+      remote.validate
+      expect(remote.errors[:minimum_discourse_version]).to be_empty
+
+      remote = RemoteTheme.new(maximum_discourse_version: "2026.8.0-latest.1")
+      remote.validate
+      expect(remote.errors[:maximum_discourse_version]).to be_empty
+    end
+
+    it "rejects malformed versions" do
+      remote = RemoteTheme.new(minimum_discourse_version: "2026.8.0-nightly")
+      remote.validate
+      expect(remote.errors[:minimum_discourse_version]).to be_present
+    end
+  end
+
   describe ".extract_theme_info" do
     let(:importer) { mock }
 


### PR DESCRIPTION
Discourse builds are versioned as `2026.8.0-latest` and `2026.8.0-latest.1` between releases, but the `about.json` validation for `minimum_discourse_version` and `maximum_discourse_version` only accepted `X.Y.Z` and `X.Y.Z.betaN`. Gem::Version treats `-latest` as a pre-release, so a theme that needs `2026.8.0` was disabled on `2026.8.0-latest.1`, and authors could not express the intended constraint `2026.8.0-latest` because the import rejected it.

- `Discourse::VERSION_REGEXP` now allows `-latest` and `-latest.N` suffixes.
- Add specs for the regexp, for `has_needed_version?` ordering of `-latest` builds, and for the `RemoteTheme` validation.

See https://meta.discourse.org/t/411985