### PR TITLE
UX: <modifier>+enter submits assign modal

### DIFF
--- a/plugins/discourse-assign/assets/javascripts/discourse/components/assignment.gjs
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/assignment.gjs
@@ -62,8 +62,10 @@ export default class Assignment extends Component {
   }
 
   @action
-  handleTextAreaKeydown(event) {
+  handleKeydown(event) {
     if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
       this.args.onSubmit();
     }
   }
@@ -117,6 +119,7 @@ export default class Assignment extends Component {
         }}
         @showUserStatus={{true}}
         @value={{this.assignee}}
+        {{on "keydown" this.handleKeydown capture=true}}
       />
 
       {{#if this.showAssigneeIeEmptyError}}
@@ -135,6 +138,7 @@ export default class Assignment extends Component {
           @id="assign-status"
           @onChange={{this.setStatus}}
           @value={{this.status}}
+          {{on "keydown" this.handleKeydown capture=true}}
         />
       </div>
     {{/if}}
@@ -149,7 +153,7 @@ export default class Assignment extends Component {
       <DTextarea
         id="assign-modal-note"
         @value={{@assignment.note}}
-        {{on "keydown" this.handleTextAreaKeydown}}
+        {{on "keydown" this.handleKeydown}}
         {{on "input" this.markAsEdited}}
       />
     </div>

--- a/plugins/discourse-assign/test/javascripts/integration/components/assign-user-form-test.gjs
+++ b/plugins/discourse-assign/test/javascripts/integration/components/assign-user-form-test.gjs
@@ -1,0 +1,100 @@
+import { trackedObject } from "@ember/reactive/collections";
+import { focus, render, triggerKeyEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import { i18n } from "discourse-i18n";
+import AssignUserForm from "discourse/plugins/discourse-assign/discourse/components/assign-user-form";
+
+module("Integration | Component | AssignUserForm", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    pretender.get("/assign/suggestions", () =>
+      response({
+        suggestions: [],
+        assign_allowed_on_groups: [],
+        assign_allowed_for_groups: [],
+      })
+    );
+  });
+
+  for (const modifier of ["metaKey", "ctrlKey"]) {
+    test(`${modifier}+Enter submits from the assignee picker and note`, async function (assert) {
+      const model = trackedObject({
+        username: "eviltrout",
+        targetType: "Post",
+      });
+      const formApi = {};
+      let submissions = 0;
+      const onSubmit = () => submissions++;
+
+      await render(
+        <template>
+          <AssignUserForm
+            @formApi={{formApi}}
+            @model={{model}}
+            @onSubmit={{onSubmit}}
+          />
+        </template>
+      );
+
+      await focus("#assignee-chooser-header");
+      await triggerKeyEvent("#assignee-chooser-header", "keydown", "Enter", {
+        [modifier]: true,
+      });
+      assert.strictEqual(
+        submissions,
+        1,
+        "submits once from the assignee picker"
+      );
+
+      await focus("#assign-modal-note");
+      await triggerKeyEvent("#assign-modal-note", "keydown", "Enter");
+      assert.strictEqual(
+        submissions,
+        1,
+        "plain Enter in the note does not submit"
+      );
+
+      await triggerKeyEvent("#assign-modal-note", "keydown", "Enter", {
+        [modifier]: true,
+      });
+      assert.strictEqual(submissions, 2, "submits once from the note");
+    });
+
+    test(`${modifier}+Enter requires an assignee`, async function (assert) {
+      const model = trackedObject({ targetType: "Post" });
+      const formApi = {};
+      let submitted = false;
+      const onSubmit = () => (submitted = true);
+
+      await render(
+        <template>
+          <AssignUserForm
+            @formApi={{formApi}}
+            @model={{model}}
+            @onSubmit={{onSubmit}}
+          />
+        </template>
+      );
+
+      await triggerKeyEvent(
+        "#assignee-chooser .filter-input",
+        "keydown",
+        "Enter",
+        {
+          [modifier]: true,
+        }
+      );
+
+      assert.false(submitted, "does not submit without an assignee");
+      assert
+        .dom(".assignee-error .error-label")
+        .hasText(
+          i18n("discourse_assign.assign_modal.choose_assignee"),
+          "shows the assignee validation error"
+        );
+    });
+  }
+});


### PR DESCRIPTION
This submission currently doesn't work if the user is not in the "note" textbox.

This PR makes is such that when the focus is in the user selector, submission will still work.

https://github.com/user-attachments/assets/aa2fe5da-1241-47cc-959a-6128c4579317

