### PR TITLE
FEATURE: Basic metrics for Ask AI usage on the dashboard

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/admin/components/dashboard/ask-ai.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/admin/components/dashboard/ask-ai.gjs
@@ -1,0 +1,173 @@
+import Component from "@glimmer/component";
+import AdminReportChart from "discourse/admin/components/admin-report-chart";
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import Report from "discourse/admin/models/report";
+import DTooltip from "discourse/float-kit/components/d-tooltip";
+import { or } from "discourse/truth-helpers";
+import I18n, { i18n } from "discourse-i18n";
+
+const copy = (key) => i18n(`admin.dashboard.ask_ai.${key}`);
+const count = (value) => I18n.toNumber(value, { precision: 0 });
+const outcomeLabel = (value) => copy(`outcomes.${value}`);
+
+export default class AskAiDashboard extends Component {
+  get averageFirstAnswer() {
+    const value = this.args.data?.average_first_answer_ms;
+    return value == null
+      ? copy("not_available")
+      : i18n("admin.dashboard.ask_ai.seconds", {
+          seconds: I18n.toNumber(value / 1000, { precision: 1 }),
+        });
+  }
+
+  get chartModel() {
+    return {
+      start_date: this.args.data.start_date,
+      end_date: this.args.data.end_date,
+      data: this.args.data.daily_asks ?? [],
+    };
+  }
+
+  get chartOptions() {
+    return {
+      chartGrouping: Report.groupingForDatapoints(
+        this.args.data.daily_asks?.length ?? 0
+      ),
+    };
+  }
+
+  get outcomes() {
+    return (this.args.data.outcomes ?? [])
+      .filter((outcome) => outcome.count > 0)
+      .map((outcome) => ({
+        ...outcome,
+        percentage: I18n.toNumber(
+          (outcome.count / this.args.data.questions) * 100,
+          { precision: 1 }
+        ),
+      }));
+  }
+
+  <template>
+    {{#if (or @data @fetchError)}}
+      <DashboardSection
+        class="ask-ai-dashboard"
+        ...attributes
+        @title={{copy "title"}}
+      >
+        {{#if @fetchError}}
+          <p class="db-section__error" role="alert">{{copy "fetch_error"}}</p>
+        {{else}}
+          <div class="db-section__subheader">
+            <div class="db-section__subintro">
+              <h3>
+                {{#if @data.questions}}
+                  {{i18n
+                    "admin.dashboard.ask_ai.summary"
+                    count=@data.questions
+                  }}
+                {{else}}
+                  {{copy "empty"}}
+                {{/if}}
+              </h3>
+            </div>
+            <dl
+              aria-busy={{@loading}}
+              class="db-section__metrics ask-ai-dashboard__metrics"
+            >
+              <div
+                class="db-section__metric ask-ai-dashboard__metric"
+                data-metric="questions"
+              >
+                <dt class="db-section__metric-label">{{copy "questions"}}</dt>
+                <dd class="db-section__metric-number">{{count
+                    @data.questions
+                  }}</dd>
+              </div>
+              <div
+                class="db-section__metric ask-ai-dashboard__metric"
+                data-metric="askers"
+              >
+                <dt class="db-section__metric-label">{{copy "askers"}}</dt>
+                <dd class="db-section__metric-number">{{count
+                    @data.askers
+                  }}</dd>
+              </div>
+              <div
+                class="db-section__metric ask-ai-dashboard__metric"
+                data-metric="latency"
+              >
+                <dt class="db-section__metric-label">
+                  {{copy "latency"}}
+                  <DTooltip
+                    class="db-section__info"
+                    @icon="far-circle-question"
+                    @identifier="ask-ai-answer-time-tooltip"
+                  >
+                    <:content>{{copy "latency_tooltip"}}</:content>
+                  </DTooltip>
+                </dt>
+                <dd
+                  class="db-section__metric-number"
+                >{{this.averageFirstAnswer}}</dd>
+              </div>
+            </dl>
+          </div>
+          {{#if @data.questions}}
+            <div class="db-section__row ask-ai-dashboard__activity">
+              <section
+                aria-label={{copy "activity"}}
+                class="db-section__row-block ask-ai-dashboard__chart"
+              >
+                <h3 class="db-section__row-block-title">{{copy "activity"}}</h3>
+                <AdminReportChart
+                  @model={{this.chartModel}}
+                  @options={{this.chartOptions}}
+                />
+                <table class="sr-only">
+                  <caption>{{copy "activity"}}</caption>
+                  <thead><tr><th scope="col">{{copy "date"}}</th><th
+                        scope="col"
+                      >{{copy "questions"}}</th></tr></thead>
+                  <tbody>
+                    {{#each @data.daily_asks as |day|}}
+                      <tr><th scope="row">{{day.x}}</th><td>{{count
+                            day.y
+                          }}</td></tr>
+                    {{/each}}
+                  </tbody>
+                </table>
+              </section>
+              <section class="db-section__row-block ask-ai-dashboard__outcomes">
+                <h3 class="db-section__row-block-title">
+                  {{copy "outcomes_title"}}
+                  <DTooltip
+                    class="db-section__info"
+                    @icon="far-circle-question"
+                    @identifier="ask-ai-outcomes-tooltip"
+                  >
+                    <:content>{{copy "outcome_note"}}</:content>
+                  </DTooltip>
+                </h3>
+                <dl class="ask-ai-dashboard__list">
+                  {{#each this.outcomes as |outcome|}}
+                    <div data-outcome={{outcome.outcome}}>
+                      <dt>{{outcomeLabel outcome.outcome}}</dt>
+                      <dd>
+                        {{count outcome.count}}
+                        <span class="ask-ai-dashboard__percentage">{{i18n
+                            "admin.dashboard.ask_ai.percentage"
+                            value=outcome.percentage
+                          }}</span>
+                      </dd>
+                    </div>
+                  {{/each}}
+                </dl>
+              </section>
+            </div>
+          {{/if}}
+        {{/if}}
+      </DashboardSection>
+    {{/if}}
+  </template>
+}

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/initializers/ask-ai-dashboard.js
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/initializers/ask-ai-dashboard.js
@@ -1,0 +1,12 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import AskAiDashboard from "discourse/plugins/discourse-ai/admin/components/dashboard/ask-ai";
+
+export default {
+  name: "ask-ai-dashboard",
+
+  initialize() {
+    withPluginApi((api) => {
+      api.registerAdminDashboardSection("ask_ai", AskAiDashboard);
+    });
+  },
+};

--- a/plugins/discourse-ai/assets/stylesheets/modules/admin-dashboard/common/admin-dashboard-highlight.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/admin-dashboard/common/admin-dashboard-highlight.scss
@@ -1,3 +1,5 @@
+@import "ask-ai-dashboard";
+
 .ai-admin-dashboard-highlight {
   margin-bottom: 1em;
   max-width: 54em;

--- a/plugins/discourse-ai/assets/stylesheets/modules/admin-dashboard/common/ask-ai-dashboard.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/admin-dashboard/common/ask-ai-dashboard.scss
@@ -1,0 +1,48 @@
+.ask-ai-dashboard {
+  &__metrics {
+    margin: 0;
+  }
+
+  &__metric {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: flex-end;
+
+    dd {
+      margin: 0;
+    }
+  }
+
+  &__chart {
+    .chart-canvas-container {
+      height: 15em;
+    }
+  }
+
+  &__list {
+    margin: 0;
+    font-size: var(--font-down-1);
+
+    > div {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: var(--space-3);
+      padding-block: var(--space-3);
+      border-block-end: 1px solid var(--primary-low);
+    }
+
+    dd {
+      display: flex;
+      gap: var(--space-3);
+      margin: 0;
+      font-variant-numeric: tabular-nums;
+    }
+  }
+
+  &__percentage {
+    min-inline-size: 5ch;
+    color: var(--primary-high);
+    text-align: end;
+  }
+}

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -14,6 +14,33 @@ en:
         categories:
           discourse_ai: "Discourse AI"
       dashboard:
+        sections:
+          ask_ai:
+            title: "Ask AI"
+        ask_ai:
+          title: "Ask AI"
+          questions: "Questions asked"
+          askers: "Users asking"
+          latency: "Answer latency"
+          latency_tooltip: "Average time from when the server accepts a query until it sends the first answer update, including queue time. This excludes network delivery time to the user."
+          seconds: "%{seconds} s"
+          not_available: "—"
+          activity: "Asks over time"
+          date: "Date"
+          percentage: "%{value}%"
+          outcomes_title: "Ask outcomes"
+          outcomes:
+            answered: "Answer provided"
+            no_answer: "No answer provided"
+            failed: "Failed"
+            cancelled: "Cancelled"
+            pending: "Not completed"
+          outcome_note: "An answer being provided does not tell us whether it helped. User success is not yet measured."
+          summary:
+            one: "%{count} question asked in this period"
+            other: "%{count} questions asked in this period"
+          empty: "No asks were logged in this period."
+          fetch_error: "Ask AI metrics could not be loaded."
         emotion:
           title: "Emotion"
           description: "The table lists a count of posts classified with a determined emotion. Depending on the selected emotion classification method, posts are classified with either the configured emotion classification model ('SamLowe/roberta-base-go_emotions') or the configured emotion classification agent."

--- a/plugins/discourse-ai/lib/admin_dashboard/ask_ai.rb
+++ b/plugins/discourse-ai/lib/admin_dashboard/ask_ai.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module AdminDashboard
+    class AskAi
+      def self.build(start_date:, end_date:, current_user:)
+        return unless Guardian.new(current_user).is_admin?
+
+        new(start_date:, end_date:).build
+      end
+
+      def initialize(start_date:, end_date:)
+        @start_date = parse_date(start_date) || 29.days.ago.beginning_of_day
+        @end_date = parse_date(end_date)&.end_of_day || Time.current.end_of_day
+        if @start_date > @end_date
+          @start_date = 29.days.ago.beginning_of_day
+          @end_date = Time.current.end_of_day
+        end
+      end
+
+      def build
+        logs = AskAiLog.where(asked_at: @start_date..@end_date)
+        questions, askers, average_ms =
+          logs.pick(
+            Arel.sql("COUNT(*)"),
+            Arel.sql("COUNT(DISTINCT user_id)"),
+            Arel.sql("AVG(time_to_first_answer_ms)"),
+          )
+        outcomes = logs.group(:ask_outcome).count
+        daily_counts = logs.group("DATE(asked_at)").count
+
+        {
+          start_date: @start_date.to_date,
+          end_date: @end_date.to_date,
+          daily_asks:
+            (@start_date.to_date..@end_date.to_date).map do |date|
+              { x: date.iso8601, y: daily_counts.fetch(date, 0) }
+            end,
+          questions:,
+          askers:,
+          average_first_answer_ms: average_ms,
+          outcomes:
+            %w[answered no_answer failed cancelled].map do |outcome|
+              { outcome:, count: outcomes.fetch(outcome, 0) }
+            end + [{ outcome: "pending", count: outcomes.fetch(nil, 0) }],
+        }
+      end
+
+      private
+
+      def parse_date(value)
+        Time.zone.parse(value.to_s)&.beginning_of_day if value.present?
+      rescue ArgumentError, TypeError
+        nil
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -90,6 +90,13 @@ DiscourseAi::Configuration::Module::NAMES.each do |module_name|
 end
 
 after_initialize do
+  register_admin_dashboard_section(
+    id: "ask_ai",
+    enabled: -> { SiteSetting.ai_ask_ai_enabled },
+  ) do |start_date:, end_date:, current_user:|
+    DiscourseAi::AdminDashboard::AskAi.build(start_date:, end_date:, current_user:)
+  end
+
   register_modifier(:site_setting_result) do |setting_result|
     if setting_result[:setting] == :ai_discover_enabled && !SiteSetting.ai_discover_enabled
       setting_result[:disabled] = true

--- a/plugins/discourse-ai/spec/lib/admin_dashboard/ask_ai_spec.rb
+++ b/plugins/discourse-ai/spec/lib/admin_dashboard/ask_ai_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::AdminDashboard::AskAi do
+  fab!(:admin)
+  fab!(:user)
+  fab!(:moderator)
+
+  before { enable_current_plugin }
+
+  it "counts outcomes, distinct askers, and observed answer latency in the selected period" do
+    AskAiLog.create!(user:, query: "Earlier", asked_at: "2026-08-31 23:59:59")
+    [
+      [:answered, 1000],
+      [:failed, 3000],
+      [:no_answer, nil],
+      [:cancelled, nil],
+      [nil, nil],
+    ].each do |outcome, latency|
+      AskAiLog.create!(
+        user:,
+        query: "猫",
+        asked_at: "2026-09-01 12:00:00",
+        ask_outcome: outcome,
+        time_to_first_answer_ms: latency,
+      )
+    end
+    AskAiLog.create!(
+      user: admin,
+      query: "Last day",
+      asked_at: "2026-09-02 23:59:59",
+      ask_outcome: :answered,
+      time_to_first_answer_ms: 8000,
+    )
+    AskAiLog.create!(
+      user: admin,
+      query: "Outside",
+      asked_at: "2026-09-03 00:00:00",
+      ask_outcome: :answered,
+      time_to_first_answer_ms: 9000,
+    )
+
+    result =
+      described_class.build(start_date: "2026-09-01", end_date: "2026-09-02", current_user: admin)
+
+    expect(result).to include(questions: 6, askers: 2, average_first_answer_ms: 4000)
+    expect(result[:daily_asks]).to eq([{ x: "2026-09-01", y: 5 }, { x: "2026-09-02", y: 1 }])
+    expect(result[:outcomes]).to eq(
+      [
+        { outcome: "answered", count: 2 },
+        { outcome: "no_answer", count: 1 },
+        { outcome: "failed", count: 1 },
+        { outcome: "cancelled", count: 1 },
+        { outcome: "pending", count: 1 },
+      ],
+    )
+  end
+
+  it "returns zero counts and no latency for an empty period" do
+    result =
+      described_class.build(start_date: "2026-09-01", end_date: "2026-09-02", current_user: admin)
+
+    expect(result).to include(questions: 0, askers: 0, average_first_answer_ms: nil)
+    expect(result[:outcomes].pluck(:count)).to eq([0, 0, 0, 0, 0])
+    expect(result[:daily_asks]).to eq([{ x: "2026-09-01", y: 0 }, { x: "2026-09-02", y: 0 }])
+  end
+
+  it "includes days without asks between active days" do
+    %w[2026-09-01 2026-09-03].each { |date| AskAiLog.create!(user:, query: "猫", asked_at: date) }
+
+    result =
+      described_class.build(start_date: "2026-09-01", end_date: "2026-09-03", current_user: admin)
+
+    expect(result[:daily_asks]).to eq(
+      [{ x: "2026-09-01", y: 1 }, { x: "2026-09-02", y: 0 }, { x: "2026-09-03", y: 1 }],
+    )
+  end
+
+  it "does not expose metrics to moderators or anonymous users" do
+    [moderator, nil].each do |viewer|
+      expect(described_class.build(start_date: nil, end_date: nil, current_user: viewer)).to be_nil
+    end
+  end
+
+  it "uses the default window for invalid or reversed dates" do
+    freeze_time Time.zone.parse("2026-09-08 12:00:00")
+    AskAiLog.create!(user:, query: "Today", asked_at: Time.current)
+
+    [%w[invalid invalid], %w[2026-09-09 2026-09-01]].each do |start_date, end_date|
+      expect(described_class.build(start_date:, end_date:, current_user: admin)[:questions]).to eq(
+        1,
+      )
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/requests/admin/ask_ai_dashboard_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ask_ai_dashboard_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+describe Admin::DashboardController do
+  fab!(:admin)
+  fab!(:moderator)
+
+  before do
+    enable_current_plugin
+    SiteSetting.dashboard_improvements = true
+    SiteSetting.ai_ask_ai_enabled = true
+    AdminDashboardSectionConfiguration.all_known_section_ids.each_with_index do |id, index|
+      AdminDashboardSection.find_or_initialize_by(section_id: id).update!(
+        position: index,
+        visible: id == "ask_ai",
+      )
+    end
+  end
+
+  it "serves Ask metrics through the dashboard date range" do
+    AskAiLog.create!(
+      user: admin,
+      query: "Private question",
+      asked_at: "2026-09-01 12:00:00",
+      ask_outcome: :answered,
+    )
+    sign_in(admin)
+
+    get "/admin/dashboard.json", params: { start_date: "2026-09-01", end_date: "2026-09-01" }
+
+    expect(response.status).to eq(200)
+    section = response.parsed_body["sections"].find { |item| item["id"] == "ask_ai" }
+    expect(section["data"]).to include("questions" => 1, "askers" => 1)
+    expect(section["data"]).not_to have_key("query")
+  end
+
+  it "withholds Ask metrics from moderators" do
+    sign_in(moderator)
+
+    get "/admin/dashboard.json"
+
+    expect(response.status).to eq(200)
+    section = response.parsed_body["sections"].find { |item| item["id"] == "ask_ai" }
+    expect(section["data"]).to be_nil
+  end
+
+  it "omits the section and configuration entry when Ask AI is disabled" do
+    sign_in(admin)
+    SiteSetting.ai_ask_ai_enabled = false
+
+    get "/admin/dashboard.json"
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["sections"].pluck("id")).not_to include("ask_ai")
+    expect(response.parsed_body.dig("configuration", "sections").pluck("id")).not_to include(
+      "ask_ai",
+    )
+  end
+end

--- a/plugins/discourse-ai/test/javascripts/integration/components/ask-ai-dashboard-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ask-ai-dashboard-test.gjs
@@ -1,0 +1,117 @@
+import { render, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+import AskAiDashboard from "discourse/plugins/discourse-ai/admin/components/dashboard/ask-ai";
+
+module("Integration | Component | AskAiDashboard", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders metrics, activity, and outcomes", async function (assert) {
+    const data = {
+      start_date: "2026-09-01",
+      end_date: "2026-09-03",
+      daily_asks: [
+        { x: "2026-09-01", y: 8 },
+        { x: "2026-09-02", y: 0 },
+        { x: "2026-09-03", y: 4 },
+      ],
+      questions: 12,
+      askers: 4,
+      average_first_answer_ms: 1500,
+      outcomes: [
+        { outcome: "answered", count: 8 },
+        { outcome: "no_answer", count: 3 },
+        { outcome: "failed", count: 1 },
+        { outcome: "cancelled", count: 0 },
+        { outcome: "pending", count: 0 },
+      ],
+    };
+    await render(<template><AskAiDashboard @data={{data}} /></template>);
+
+    assert.dom(".ask-ai-dashboard__metric").exists({ count: 3 });
+    assert
+      .dom(".ask-ai-dashboard .db-section__subheader")
+      .exists("uses the shared summary header");
+    assert
+      .dom(".ask-ai-dashboard .db-section__row")
+      .exists({ count: 1 }, "groups content in a shared dashboard row");
+    assert
+      .dom(".ask-ai-dashboard .db-section__row > .db-section__row-block")
+      .exists({ count: 2 }, "uses shared blocks for the chart and outcomes");
+    assert
+      .dom(".ask-ai-dashboard .db-section__row-block-title")
+      .exists({ count: 2 }, "uses consistent block headings");
+    assert
+      .dom("[data-outcome]")
+      .exists({ count: 3 }, "only shows outcomes that occurred");
+    assert
+      .dom('[data-outcome="cancelled"]')
+      .doesNotExist("hides zero cancellations");
+    assert
+      .dom('[data-outcome="pending"]')
+      .doesNotExist("hides zero incomplete asks");
+    assert
+      .dom('[data-outcome="answered"] dd')
+      .hasText("8 66.7%", "shows the count and share of all asks");
+    assert
+      .dom(".ask-ai-dashboard__chart canvas")
+      .exists("renders the activity chart");
+    assert
+      .dom(".ask-ai-dashboard__chart tbody tr")
+      .exists(
+        { count: 3 },
+        "provides accessible daily values including zero days"
+      );
+    await triggerEvent(
+      '[data-metric="latency"] .fk-d-tooltip__trigger',
+      "pointermove"
+    );
+    assert
+      .dom(".fk-d-tooltip__content")
+      .hasText(i18n("admin.dashboard.ask_ai.latency_tooltip"));
+    await triggerEvent(
+      '[data-metric="latency"] .fk-d-tooltip__trigger',
+      "pointerleave"
+    );
+    assert
+      .dom(".db-section__subintro h3")
+      .hasText(i18n("admin.dashboard.ask_ai.summary", { count: 12 }));
+    assert
+      .dom('[data-metric="questions"] dd')
+      .hasText("12", "uses the supplied Ask count");
+    assert
+      .dom('[data-metric="latency"] dd')
+      .hasText("1.5 s", "converts milliseconds to seconds");
+  });
+
+  test("distinguishes missing latency from zero latency", async function (assert) {
+    const data = {
+      questions: 0,
+      askers: 0,
+      average_first_answer_ms: null,
+      outcomes: [],
+    };
+    await render(<template><AskAiDashboard @data={{data}} /></template>);
+    assert
+      .dom('[data-metric="latency"] dd')
+      .hasText("—", "no answer timing is available");
+    assert
+      .dom(".ask-ai-dashboard__activity")
+      .doesNotExist("hides the chart and zero outcomes");
+    assert
+      .dom(".db-section__subheader .db-section__subintro h3")
+      .hasText(
+        i18n("admin.dashboard.ask_ai.empty"),
+        "explains the empty period"
+      );
+  });
+
+  test("shows a loading failure instead of zero metrics", async function (assert) {
+    await render(<template><AskAiDashboard @fetchError={{true}} /></template>);
+    assert.dom('[role="alert"]').exists("reports the failure");
+    assert
+      .dom('[data-metric="questions"]')
+      .doesNotExist("does not present a failed request as zero activity");
+  });
+});


### PR DESCRIPTION
Some basic metrics on Asks on a site:
<img width="1086" height="494" alt="Screenshot 2026-09-09 at 9 06 13 PM" src="https://github.com/user-attachments/assets/1cb9a7de-52e3-4e4b-a82f-84afb6d18cee" />

Note: The dashboard hides outcomes with zero asks. “Answer provided”
doesn’t mean the answer was helpful or correct.
- Answer provided (`answered`) - an answer was produced
- No answer provided (`no_answer`) - the ask completed without an answer
- Failed (`failed`) - processing failed
- Cancelled (`cancelled`) - processing was cancelled or superseded by another ask
- Not completed (`NULL`, displayed as `pending`) - no final outcome has been recorded yet


Show questions asked, unique users, average answer latency, activity over
time, and outcomes from Ask AI logs.

The section follows the dashboard date range and skips loading metrics
when hidden. It is only available when Ask AI is enabled. The dashboard 
uses the existing `asked_at` index to filter logs by date range. No new
indexes are needed.

In a subsequent PR we will show "what users are asking".