### PR TITLE
FIX: Render every row when a Data Explorer relation is missing

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
@@ -3,11 +3,9 @@ import { cached, tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
-import { capitalize } from "@ember/string";
 import moment from "moment";
 import DSegmentedControl from "discourse/components/d-segmented-control";
 import Badge from "discourse/models/badge";
-import Category from "discourse/models/category";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
@@ -236,21 +234,21 @@ export default class QueryResult extends Component {
     });
   }
 
+  @cached
   get columnComponents() {
     if (!this.columns) {
       return [];
     }
-    return this.columns.map((_, idx) => {
-      let type = "text";
-      if (this.colRender[idx]) {
-        type = this.colRender[idx];
-      }
-      return { name: type, component: VIEW_COMPONENTS[type] };
-    });
-  }
 
-  get colCount() {
-    return this.columns.length;
+    return this.columns.map((_, idx) => {
+      const type = this.colRender[idx] || "text";
+
+      return {
+        name: type,
+        component: VIEW_COMPONENTS[type],
+        table: this._relationTables[type],
+      };
+    });
   }
 
   get resultCount() {
@@ -277,64 +275,34 @@ export default class QueryResult extends Component {
     });
   }
 
-  get parameterAry() {
-    let arr = [];
-    for (let key in this.params) {
-      if (this.params.hasOwnProperty(key)) {
-        arr.push({ key, value: this.params[key] });
+  @cached
+  get _relationTables() {
+    const { relations = {} } = this.args.content;
+    const tables = {
+      group: this.site.groupsById,
+      category: transformedRelTable(this.site.categories),
+    };
+
+    for (const [type, table] of Object.entries(relations)) {
+      if (tables[type]) {
+        continue;
       }
+
+      tables[type] = transformedRelTable(
+        table,
+        type === "badge" ? Badge : undefined
+      );
     }
-    return arr;
-  }
 
-  get transformedUserTable() {
-    return transformedRelTable(this.args.content.relations.user);
-  }
-
-  get transformedBadgeTable() {
-    return transformedRelTable(this.args.content.relations.badge, Badge);
-  }
-
-  get transformedPostTable() {
-    return transformedRelTable(this.args.content.relations.post);
-  }
-
-  get transformedTopicTable() {
-    return transformedRelTable(this.args.content.relations.topic);
-  }
-
-  get transformedTagGroupTable() {
-    return transformedRelTable(this.args.content.relations.tag_group);
-  }
-
-  get transformedGroupTable() {
-    return transformedRelTable(this.site.groups);
+    return tables;
   }
 
   get chartLabels() {
-    const labelSelectors = {
-      user: (user) => user.username,
-      badge: (badge) => badge.name,
-      topic: (topic) => topic.title,
-      group: (group) => group.name,
-      category: (category) => category.name,
-    };
+    const table = this._relationTables[this.colRender[0]];
 
-    const relationName = this.colRender[0];
-    if (relationName) {
-      const lookupFunc = this[`lookup${capitalize(relationName)}`];
-      const labelSelector = labelSelectors[relationName];
-
-      if (lookupFunc && labelSelector) {
-        return this.rows.map((r) => {
-          const relation = lookupFunc.call(this, r[0]);
-          const label = labelSelector(relation);
-          return this._cutChartLabel(label);
-        });
-      }
-    }
-
-    return this.rows.map((r) => this._cutChartLabel(r[0]));
+    return this.rows.map((r) =>
+      this._cutChartLabel(relationLabel(table?.[r[0]]) ?? r[0])
+    );
   }
 
   @action
@@ -372,34 +340,6 @@ export default class QueryResult extends Component {
   @action
   expandTable() {
     this.tableExpanded = true;
-  }
-
-  lookupUser(id) {
-    return this.transformedUserTable[id];
-  }
-
-  lookupBadge(id) {
-    return this.transformedBadgeTable[id];
-  }
-
-  lookupPost(id) {
-    return this.transformedPostTable[id];
-  }
-
-  lookupTopic(id) {
-    return this.transformedTopicTable[id];
-  }
-
-  lookupTagGroup(id) {
-    return this.transformedTagGroupTable[id];
-  }
-
-  lookupGroup(id) {
-    return this.transformedGroupTable[id];
-  }
-
-  lookupCategory(id) {
-    return Category.findById(id);
   }
 
   _cutChartLabel(label) {
@@ -520,21 +460,7 @@ export default class QueryResult extends Component {
                 {{#each this.rows as |row|}}
                   <QueryRowContent
                     @columnComponents={{this.columnComponents}}
-                    @lookupBadge={{this.lookupBadge}}
-                    @lookupCategory={{this.lookupCategory}}
-                    @lookupGroup={{this.lookupGroup}}
-                    @lookupPost={{this.lookupPost}}
-                    @lookupTagGroup={{this.lookupTagGroup}}
-                    @lookupTopic={{this.lookupTopic}}
-                    @lookupUser={{this.lookupUser}}
                     @row={{row}}
-                    @site={{this.site}}
-                    @transformedBadgeTable={{this.transformedBadgeTable}}
-                    @transformedGroupTable={{this.transformedGroupTable}}
-                    @transformedPostTable={{this.transformedPostTable}}
-                    @transformedTagGroupTable={{this.transformedTagGroupTable}}
-                    @transformedTopicTable={{this.transformedTopicTable}}
-                    @transformedUserTable={{this.transformedUserTable}}
                   />
                 {{/each}}
               </tbody>
@@ -556,13 +482,14 @@ export default class QueryResult extends Component {
 }
 
 function transformedRelTable(table, modelClass) {
-  const result = {};
-  table?.forEach((item) => {
-    if (modelClass) {
-      result[item.id] = modelClass.create(item);
-    } else {
-      result[item.id] = item;
-    }
-  });
-  return result;
+  return Object.fromEntries(
+    (table ?? []).map((item) => [
+      item.id,
+      modelClass ? modelClass.create(item) : item,
+    ])
+  );
+}
+
+function relationLabel(relation) {
+  return relation?.username ?? relation?.title ?? relation?.name;
 }

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-row-content.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-row-content.gjs
@@ -1,54 +1,43 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
-import { classify } from "@ember/string";
 import getURL from "discourse/lib/get-url";
 import TextViewComponent from "./result-types/text";
+
+const BASE_URI = getURL("");
 
 export default class QueryRowContent extends Component {
   @cached
   get results() {
     return this.args.columnComponents.map((componentDefinition, idx) => {
-      const value = this.args.row[idx],
-        id = parseInt(value, 10);
+      const value = this.args.row[idx];
 
-      const ctx = {
-        value,
-        id,
-        baseuri: getURL(""),
-      };
-
-      if (this.args.row[idx] === null) {
-        return {
-          component: TextViewComponent,
-          textValue: "NULL",
-        };
-      } else if (componentDefinition.name === "text") {
-        return {
-          component: TextViewComponent,
-          textValue: this.args.row[idx].toString(),
-        };
+      if (value === null) {
+        return { component: TextViewComponent, textValue: "NULL" };
       }
 
-      const lookupFunc =
-        this.args[`lookup${classify(componentDefinition.name)}`];
-      if (lookupFunc) {
-        ctx[componentDefinition.name] = lookupFunc.call(this.args, id);
+      if (componentDefinition.name === "text") {
+        return { component: TextViewComponent, textValue: value.toString() };
+      }
+
+      const id = parseInt(value, 10);
+      const ctx = { value, id, baseuri: BASE_URI };
+
+      if (componentDefinition.table) {
+        ctx[componentDefinition.name] = componentDefinition.table[id];
+
+        if (!ctx[componentDefinition.name]) {
+          return { component: TextViewComponent, textValue: value.toString() };
+        }
       }
 
       if (componentDefinition.name === "url") {
-        let [url, name] = guessUrl(value);
-        ctx["href"] = url;
-        ctx["target"] = name;
+        [ctx.href, ctx.target] = guessUrl(value);
       }
 
-      try {
-        return {
-          component: componentDefinition.component || TextViewComponent,
-          ctx,
-        };
-      } catch {
-        return "error";
-      }
+      return {
+        component: componentDefinition.component || TextViewComponent,
+        ctx,
+      };
     });
   }
 
@@ -58,7 +47,6 @@ export default class QueryRowContent extends Component {
         <td class="query-result-cell">
           <result.component
             @ctx={{result.ctx}}
-            @params={{result.params}}
             @textValue={{result.textValue}}
           />
         </td>
@@ -68,14 +56,7 @@ export default class QueryRowContent extends Component {
 }
 
 function guessUrl(columnValue) {
-  let [dest, name] = [columnValue, columnValue];
-
-  const split = columnValue.split(/,(.+)/);
-
-  if (split.length > 1) {
-    name = split[0];
-    dest = split[1];
-  }
+  const [name, dest = columnValue] = String(columnValue).split(/,(.+)/);
 
   return [dest, name];
 }

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/badge.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/badge.gjs
@@ -1,31 +1,15 @@
-import Component from "@glimmer/component";
-import { trustHTML } from "@ember/template";
-import { isEmpty } from "@ember/utils";
-import { convertIconClass, iconHTML } from "discourse/lib/icon-library";
+import dIconOrImage from "discourse/ui-kit/helpers/d-icon-or-image";
 
-export default class Badge extends Component {
-  get iconOrImageReplacement() {
-    if (isEmpty(this.args.ctx.badge.icon)) {
-      return "";
-    }
+const Badge = <template>
+  <a
+    class="user-badge {{@ctx.badge.badgeTypeClassName}}"
+    data-badge-name={{@ctx.badge.name}}
+    href="{{@ctx.baseuri}}/badges/{{@ctx.badge.id}}/{{@ctx.badge.name}}"
+    title={{@ctx.badge.display_name}}
+  >
+    {{dIconOrImage @ctx.badge}}
+    <span class="badge-display-name">{{@ctx.badge.display_name}}</span>
+  </a>
+</template>;
 
-    if (this.args.ctx.badge.icon.indexOf("fa-") > -1) {
-      const icon = iconHTML(convertIconClass(this.args.ctx.badge.icon));
-      return trustHTML(icon);
-    } else {
-      return trustHTML("<img src='" + this.args.ctx.badge.icon + "'>");
-    }
-  }
-
-  <template>
-    <a
-      class="user-badge {{@ctx.badge.badgeTypeClassName}}"
-      data-badge-name={{@ctx.badge.name}}
-      href="{{@ctx.baseuri}}/badges/{{@ctx.badge.id}}/{{@ctx.badge.name}}"
-      title={{@ctx.badge.display_name}}
-    >
-      {{this.iconOrImageReplacement}}
-      <span class="badge-display-name">{{@ctx.badge.display_name}}</span>
-    </a>
-  </template>
-}
+export default Badge;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/category.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/category.gjs
@@ -1,18 +1,7 @@
-import Component from "@glimmer/component";
-import { categoryLinkHTML } from "discourse/ui-kit/helpers/d-category-link";
+import dCategoryLink from "discourse/ui-kit/helpers/d-category-link";
 
-export default class Category extends Component {
-  get categoryBadgeReplacement() {
-    return categoryLinkHTML(this.args.ctx.category, {
-      allowUncategorized: true,
-    });
-  }
+const Category = <template>
+  {{dCategoryLink @ctx.category allowUncategorized=true}}
+</template>;
 
-  <template>
-    {{#if @ctx.category}}
-      {{this.categoryBadgeReplacement}}
-    {{else}}
-      <a href="{{@ctx.baseuri}}/t/{{@ctx.id}}">{{@ctx.id}}</a>
-    {{/if}}
-  </template>
-}
+export default Category;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/group.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/group.gjs
@@ -1,11 +1,5 @@
 const Group = <template>
-  {{#if @ctx.group}}
-    <a
-      href="{{@ctx.baseuri}}/groups/{{@ctx.group.name}}"
-    >{{@ctx.group.name}}</a>
-  {{else}}
-    {{@ctx.id}}
-  {{/if}}
+  <a href="{{@ctx.baseuri}}/groups/{{@ctx.group.name}}">{{@ctx.group.name}}</a>
 </template>;
 
 export default Group;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/post.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/post.gjs
@@ -2,40 +2,36 @@ import { trustHTML } from "@ember/template";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 
 const Post = <template>
-  {{#if @ctx.post}}
-    <aside
-      class="quote"
-      data-post={{@ctx.post.post_number}}
-      data-topic={{@ctx.post.topic_id}}
-    >
-      <div class="title">
-        <div class="quote-controls">
-          {{! eslint-disable ember/template-no-invalid-link-text }}
-          <a
-            class="quote-other-topic"
-            href="{{@ctx.baseuri}}/t/via-quote/{{@ctx.post.topic_id}}/{{@ctx.post.post_number}}"
-            title="go to the quoted post"
-          >
-          </a>
-        </div>
-
+  <aside
+    class="quote"
+    data-post={{@ctx.post.post_number}}
+    data-topic={{@ctx.post.topic_id}}
+  >
+    <div class="title">
+      <div class="quote-controls">
+        {{! eslint-disable ember/template-no-invalid-link-text }}
         <a
-          class="result-post-link"
-          href="{{@ctx.baseuri}}/t/{{@ctx.post.topic_id}}/{{@ctx.post.post_number}}"
+          class="quote-other-topic"
+          href="{{@ctx.baseuri}}/t/via-quote/{{@ctx.post.topic_id}}/{{@ctx.post.post_number}}"
+          title="go to the quoted post"
         >
-          {{dAvatar @ctx.post imageSize="tiny"}}{{@ctx.post.username}}:
         </a>
       </div>
 
-      <blockquote>
-        <p>
-          {{trustHTML @ctx.post.excerpt}}
-        </p>
-      </blockquote>
-    </aside>
-  {{else}}
-    {{@ctx.id}}
-  {{/if}}
+      <a
+        class="result-post-link"
+        href="{{@ctx.baseuri}}/t/{{@ctx.post.topic_id}}/{{@ctx.post.post_number}}"
+      >
+        {{dAvatar @ctx.post imageSize="tiny"}}{{@ctx.post.username}}:
+      </a>
+    </div>
+
+    <blockquote>
+      <p>
+        {{trustHTML @ctx.post.excerpt}}
+      </p>
+    </blockquote>
+  </aside>
 </template>;
 
 export default Post;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/tag-group.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/tag-group.gjs
@@ -1,11 +1,5 @@
 const Group = <template>
-  {{#if @ctx.tag_group}}
-    <a
-      href="{{@ctx.baseuri}}/tag_groups/{{@ctx.id}}"
-    >{{@ctx.tag_group.name}}</a>
-  {{else}}
-    {{@ctx.id}}
-  {{/if}}
+  <a href="{{@ctx.baseuri}}/tag_groups/{{@ctx.id}}">{{@ctx.tag_group.name}}</a>
 </template>;
 
 export default Group;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/topic.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/topic.gjs
@@ -1,14 +1,10 @@
 import { trustHTML } from "@ember/template";
 
 const Topic = <template>
-  {{#if @ctx.topic}}
-    <a href="{{@ctx.baseuri}}/t/{{@ctx.topic.slug}}/{{@ctx.topic.id}}">
-      {{trustHTML @ctx.topic.fancy_title}}
-    </a>
-    ({{@ctx.topic.posts_count}})
-  {{else}}
-    <a href="{{@ctx.baseuri}}/t/{{@ctx.id}}">{{@ctx.id}}</a>
-  {{/if}}
+  <a href="{{@ctx.baseuri}}/t/{{@ctx.topic.slug}}/{{@ctx.topic.id}}">
+    {{trustHTML @ctx.topic.fancy_title}}
+  </a>
+  ({{@ctx.topic.posts_count}})
 </template>;
 
 export default Topic;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/user.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/user.gjs
@@ -1,17 +1,13 @@
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 
 const User = <template>
-  {{#if @ctx.user}}
-    <a
-      data-user-card={{@ctx.user.username}}
-      href="{{@ctx.baseuri}}/u/{{@ctx.user.username}}/activity"
-    >
-      {{dAvatar @ctx.user imageSize="tiny"}}
-      {{@ctx.user.username}}
-    </a>
-  {{else}}
-    {{@ctx.id}}
-  {{/if}}
+  <a
+    data-user-card={{@ctx.user.username}}
+    href="{{@ctx.baseuri}}/u/{{@ctx.user.username}}/activity"
+  >
+    {{dAvatar @ctx.user imageSize="tiny"}}
+    {{@ctx.user.username}}
+  </a>
 </template>;
 
 export default User;

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
@@ -1,8 +1,18 @@
-import { click, render } from "@ember/test-helpers";
+import { click, find, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import loadChartJS from "discourse/lib/load-chart-js";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import QueryResult from "../../discourse/components/query-result";
+
+function cell(row, col) {
+  return `table tbody tr:nth-child(${row}) td:nth-child(${col})`;
+}
+
+async function chartData() {
+  const Chart = await loadChartJS();
+  return Chart.getChart(find("canvas")).data;
+}
 
 module("Integration | Component | QueryResult", function (hooks) {
   setupRenderingTest(hooks);
@@ -43,10 +53,10 @@ module("Integration | Component | QueryResult", function (hooks) {
 
     assert.dom("table thead tr th:nth-child(1)").hasText("user_name");
     assert.dom("table thead tr th:nth-child(2)").hasText("like_count");
-    assert.dom("table tbody tr:nth-child(1) td:nth-child(1)").hasText("user1");
-    assert.dom("table tbody tr:nth-child(1) td:nth-child(2)").hasText("10");
-    assert.dom("table tbody tr:nth-child(2) td:nth-child(1)").hasText("user2");
-    assert.dom("table tbody tr:nth-child(2) td:nth-child(2)").hasText("20");
+    assert.dom(cell(1, 1)).hasText("user1");
+    assert.dom(cell(1, 2)).hasText("10");
+    assert.dom(cell(2, 1)).hasText("user2");
+    assert.dom(cell(2, 2)).hasText("20");
   });
 
   test("renders JSON columns as escaped text with a viewer action", async function (assert) {
@@ -60,16 +70,16 @@ module("Integration | Component | QueryResult", function (hooks) {
     await render(<template><QueryResult @content={{content}} /></template>);
 
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(2) .result-json-value")
+      .dom(`${cell(1, 2)} .result-json-value`)
       .hasText(
         '[{"key":"<img src=x onerror=alert(1)>"}]',
         "renders JSON as readable text without HTML entities"
       );
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(2) img")
+      .dom(`${cell(1, 2)} img`)
       .doesNotExist("does not render HTML from JSON values");
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(2) .result-json-button")
+      .dom(`${cell(1, 2)} .result-json-button`)
       .exists("renders a JSON viewer action");
   });
 
@@ -84,10 +94,10 @@ module("Integration | Component | QueryResult", function (hooks) {
     await render(<template><QueryResult @content={{content}} /></template>);
 
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(1)")
+      .dom(cell(1, 1))
       .hasText('{"key":"<script>alert(1)</script>"}', "renders readable text");
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(1) script")
+      .dom(`${cell(1, 1)} script`)
       .doesNotExist("does not render HTML from text values");
   });
 
@@ -112,9 +122,62 @@ module("Integration | Component | QueryResult", function (hooks) {
 
     await render(<template><QueryResult @content={{content}} /></template>);
 
+    assert.dom(`${cell(1, 1)} span`).hasText("badge display name");
+    assert.dom(`${cell(1, 1)} svg`).exists("renders the icon as an svg");
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(1) span")
-      .hasText("badge display name");
+      .dom(`${cell(1, 1)} img`)
+      .doesNotExist("does not treat the icon name as an image url");
+  });
+
+  test("renders chart labels when a badge cannot be resolved", async function (assert) {
+    const content = {
+      colrender: { 0: "badge" },
+      relations: {
+        badge: [
+          { id: 1, name: "badge name", display_name: "badge display name" },
+        ],
+      },
+      result_count: 2,
+      columns: ["user_badge_id", "count"],
+      rows: [
+        [1, 10],
+        [999, 20],
+      ],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
+    assert.deepEqual(
+      (await chartData()).labels,
+      ["badge name", "999"],
+      "falls back to the raw id for an unresolved badge"
+    );
+  });
+
+  test("renders the raw cell when a relation cannot be resolved", async function (assert) {
+    const content = {
+      colrender: { 0: "topic", 1: "user", 2: "badge", 3: "url" },
+      relations: { topic: [], user: [], badge: [] },
+      result_count: 1,
+      columns: ["topic_id", "user_id", "user_badge_id", "some_url"],
+      rows: [[42, "abc", 999, 1]],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
+    assert
+      .dom(cell(1, 1))
+      .hasText("42", "renders the unresolved topic id as text");
+    assert
+      .dom(`${cell(1, 1)} a`)
+      .doesNotExist("does not link to a topic that cannot be resolved");
+    assert.dom(cell(1, 2)).hasText("abc", "renders a non-numeric id verbatim");
+    assert
+      .dom(cell(1, 3))
+      .hasText("999", "renders the unresolved badge id as text");
+    assert
+      .dom(`${cell(1, 4)} a`)
+      .hasAttribute("href", "1", "renders a numeric url cell as a link");
   });
 
   test("renders a post in query results", async function (assert) {
@@ -140,12 +203,27 @@ module("Integration | Component | QueryResult", function (hooks) {
 
     await render(<template><QueryResult @content={{content}} /></template>);
 
+    assert.dom(`${cell(1, 1)} aside`).hasAttribute("data-post", "1");
+    assert.dom(`${cell(1, 1)} aside`).hasAttribute("data-topic", "1");
+  });
+
+  test("resolves groups and categories the server did not send", async function (assert) {
+    const content = {
+      colrender: { 0: "group", 1: "category" },
+      relations: { group: [], category: [] },
+      result_count: 1,
+      columns: ["group_id", "category_id"],
+      rows: [[1, 3]],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(1) aside")
-      .hasAttribute("data-post", "1");
+      .dom(`${cell(1, 1)} a`)
+      .hasText("admins", "resolves the group from the site");
     assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(1) aside")
-      .hasAttribute("data-topic", "1");
+      .dom(`${cell(1, 2)} .badge-category__name`)
+      .hasText("meta", "resolves the category from the site");
   });
 
   test("renders a category_id in query results", async function (assert) {
@@ -171,9 +249,7 @@ module("Integration | Component | QueryResult", function (hooks) {
 
     await render(<template><QueryResult @content={{content}} /></template>);
 
-    assert
-      .dom("table tbody tr:nth-child(1) td:nth-child(1) .badge-category__name")
-      .exists();
+    assert.dom(`${cell(1, 1)} .badge-category__name`).exists();
   });
 });
 


### PR DESCRIPTION
Reported internally that [Data Explorer results table stops rendering rows when a badge lookup returns undefined](https://dev.discourse.org/t/191413).

Previously, a relation-backed cell whose id resolved to nothing was handled by each cell type separately, and the badge cell read the icon off the result without checking, so one unresolved badge threw during render and the results table stopped at the first affected row.

This change resolves the lookup once in `QueryRowContent` and falls back to the raw cell there, so every relation type degrades the same way, a non-numeric id no longer renders as `NaN`, and a numeric or boolean `*_url` cell no longer throws.