### PR TITLE
PERF: Stop rewriting `fancy_title` when serializing topic relations

### DIFF
--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -314,7 +314,7 @@ module DiscourseDataExplorer
         },
         topic: {
           class: Topic,
-          fields: %i[id title slug posts_count locale],
+          fields: %i[id title fancy_title slug posts_count locale],
           serializer: BasicTopicSerializer,
         },
         tag_group: {

--- a/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
+++ b/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
@@ -410,6 +410,20 @@ describe DiscourseDataExplorer::DataExplorer do
         expect(relations[:topic].as_json.size).to eq(2)
       end
 
+      it "does not rewrite fancy_title when serializing topic relations" do
+        Topic.where(id: topic.id).update_all(fancy_title: "sentinel")
+        query = Fabricate(:query, sql: "SELECT #{topic.id} AS topic_id")
+
+        relations, _ =
+          described_class.add_extra_data(
+            described_class.run_query(query)[:pg_result],
+            guardian: nil,
+          )
+        relations[:topic].as_json
+
+        expect(Topic.where(id: topic.id).pick(:fancy_title)).to eq("sentinel")
+      end
+
       it "classifies id columns" do
         query = Fabricate(:query, sql: <<~SQL)
           SELECT


### PR DESCRIPTION
Stacked on #43470.

Previously, topic relations were plucked without `fancy_title`, so `Topic#fancy_title` found the attribute missing, recomputed it and wrote it back, issuing an UPDATE for every topic in every result on every run.

This change selects the column, which removes the writes.