### PR TITLE
FIX: Chart Data Explorer results without inventing zeros

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/admin-dashboard-card.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/admin-dashboard-card.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
 import { i18n } from "discourse-i18n";
-import { chartability, looksLikeDate } from "../lib/chart-helpers";
+import { chartability, chartDatasets, hasDates } from "../lib/chart-helpers";
 import DataExplorerChart from "./data-explorer-chart";
 
 export default class DataExplorerAdminDashboardCard extends Component {
@@ -16,6 +17,7 @@ export default class DataExplorerAdminDashboardCard extends Component {
     return this.columns.map((col) => col.replaceAll("_", " "));
   }
 
+  @cached
   get chartability() {
     return chartability(this.args.payload);
   }
@@ -24,8 +26,9 @@ export default class DataExplorerAdminDashboardCard extends Component {
     return this.columns.length === 2 && this.chartability.chartable;
   }
 
+  @cached
   get hasDates() {
-    return this.rows.length > 0 && looksLikeDate(String(this.rows[0][0]));
+    return hasDates(this.rows);
   }
 
   get chartType() {
@@ -44,10 +47,11 @@ export default class DataExplorerAdminDashboardCard extends Component {
   }
 
   get chartDatasets() {
-    return this.chartability.numericIndices.map((colIdx) => ({
-      label: this.columnLabels[colIdx],
-      values: this.rows.map((row) => Number(row[colIdx])),
-    }));
+    return chartDatasets(
+      this.rows,
+      this.chartability.numericIndices,
+      this.columnLabels
+    );
   }
 
   <template>

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-chart.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-chart.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { buildLegendIcon, dimColor } from "discourse/lib/chart-legend-icon";
@@ -12,6 +11,8 @@ import themeColor from "../lib/themeColor";
 
 export default class DataExplorerChart extends Component {
   chart;
+
+  #latestInit;
 
   willDestroy() {
     super.willDestroy(...arguments);
@@ -31,17 +32,15 @@ export default class DataExplorerChart extends Component {
 
   @bind
   async initChart(canvas) {
+    const call = (this.#latestInit = {});
     const Chart = await loadChartJS();
-    const context = canvas.getContext("2d");
-    this.chart = new Chart(context, this.config);
-  }
 
-  @action
-  updateChartData(canvas) {
-    if (this.chart) {
-      this.chart.destroy();
+    if (call !== this.#latestInit || this.isDestroying) {
+      return;
     }
-    this.initChart(canvas);
+
+    this.chart?.destroy();
+    this.chart = new Chart(canvas.getContext("2d"), this.config);
   }
 
   _buildSingleSeriesConfig(gridColor, labelColor) {
@@ -254,7 +253,7 @@ export default class DataExplorerChart extends Component {
     <canvas
       {{didInsert this.initChart}}
       {{didUpdate
-        this.updateChartData
+        this.initChart
         @labels
         @datasets
         @chartType

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
@@ -9,7 +9,12 @@ import Badge from "discourse/models/badge";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
-import { chartability, defaultView, looksLikeDate } from "../lib/chart-helpers";
+import {
+  chartability,
+  chartDatasets,
+  defaultView,
+  hasDates,
+} from "../lib/chart-helpers";
 import { dataExplorerStore } from "../lib/data-explorer-store";
 import DataExplorerChart from "./data-explorer-chart";
 import QueryChartEmptyState from "./query-chart-empty-state";
@@ -111,14 +116,6 @@ export default class QueryResult extends Component {
     return this.chartability.numericIndices;
   }
 
-  get ignoredColumnNames() {
-    return this.chartability.ignoredColumns;
-  }
-
-  get ignoredColumnsText() {
-    return this.ignoredColumnNames.join(", ");
-  }
-
   get viewItems() {
     return [
       { value: "chart", icon: "signal" },
@@ -177,8 +174,9 @@ export default class QueryResult extends Component {
     return this.hasDates && this.numericColumnIndices.length === 2;
   }
 
+  @cached
   get hasDates() {
-    return this.rows?.length > 0 && looksLikeDate(String(this.rows[0][0]));
+    return hasDates(this.rows);
   }
 
   get defaultChartForm() {
@@ -211,11 +209,13 @@ export default class QueryResult extends Component {
     return this.chartForm === "dual-axis";
   }
 
+  @cached
   get chartDatasets() {
-    return this.numericColumnIndices.map((colIdx) => ({
-      label: this.columnNames[colIdx],
-      values: this.rows.map((r) => Number(r[colIdx])),
-    }));
+    return chartDatasets(
+      this.rows,
+      this.numericColumnIndices,
+      this.columnNames
+    );
   }
 
   get columnNames() {
@@ -297,6 +297,7 @@ export default class QueryResult extends Component {
     return tables;
   }
 
+  @cached
   get chartLabels() {
     const table = this._relationTables[this.colRender[0]];
 
@@ -423,11 +424,11 @@ export default class QueryResult extends Component {
               @labels={{this.chartLabels}}
               @stacked={{this.isStacked}}
             />
-            {{#if this.ignoredColumnNames.length}}
+            {{#if this.chartability.ignoredColumns.length}}
               <p class="query-results-chart__footnote">
                 {{i18n
                   "explorer.chart_footnote.ignored"
-                  columns=this.ignoredColumnsText
+                  columns=(joinNames this.chartability.ignoredColumns)
                 }}
               </p>
             {{/if}}
@@ -488,6 +489,10 @@ function transformedRelTable(table, modelClass) {
       modelClass ? modelClass.create(item) : item,
     ])
   );
+}
+
+function joinNames(names) {
+  return names.join(", ");
 }
 
 function relationLabel(relation) {

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/chart-helpers.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/chart-helpers.js
@@ -1,3 +1,4 @@
+import { isEmpty } from "@ember/utils";
 import moment from "moment";
 
 export const SERIES_COLORS = [
@@ -12,41 +13,63 @@ export const SERIES_COLORS = [
 const DATE_LABEL_FORMATS = ["MMM D", "MMM DD", "MMM YY", "MMM YYYY"];
 const MONTH_DAY_LABEL_FORMATS = ["MMM D", "MMM DD"];
 
-export function looksLikeDate(value) {
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+
+function normalizedLabel(value) {
   if (!value || typeof value !== "string") {
+    return null;
+  }
+
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function looksLikeDate(value) {
+  const label = normalizedLabel(value);
+  if (!label) {
     return false;
   }
 
-  const normalizedValue = value.trim().replace(/\s+/g, " ");
-  if (/^\d{4}-\d{2}-\d{2}/.test(normalizedValue)) {
-    return true;
-  }
-
-  return moment(normalizedValue, DATE_LABEL_FORMATS, true).isValid();
+  return (
+    ISO_DATE.test(label) || moment(label, DATE_LABEL_FORMATS, true).isValid()
+  );
 }
 
 export function formatChartDateLabel(value) {
-  if (!value || typeof value !== "string") {
+  const label = normalizedLabel(value);
+  if (!label) {
     return value;
   }
 
-  const normalizedValue = value.trim().replace(/\s+/g, " ");
-  if (/^\d{4}-\d{2}-\d{2}/.test(normalizedValue)) {
-    return moment(normalizedValue).format("LL");
+  if (ISO_DATE.test(label)) {
+    return moment(label).format("LL");
   }
 
-  const monthDay = moment(normalizedValue, MONTH_DAY_LABEL_FORMATS, true);
+  const monthDay = moment(label, MONTH_DAY_LABEL_FORMATS, true);
   if (monthDay.isValid()) {
     return monthDay.format("MMM D");
   }
 
-  return normalizedValue;
+  return label;
+}
+
+export function hasDates(rows) {
+  return rows?.length > 0 && looksLikeDate(String(rows[0][0]));
+}
+
+export function chartDatasets(rows, numericIndices, labels) {
+  return numericIndices.map((colIdx) => ({
+    label: labels[colIdx],
+    values: rows.map((row) => {
+      const cell = row[colIdx];
+      return isEmpty(cell) ? null : Number(cell);
+    }),
+  }));
 }
 
 export function isNumericColumn(rows, colIndex) {
   for (const row of rows) {
     const val = row[colIndex];
-    if (val !== null && val !== undefined && val !== "") {
+    if (!isEmpty(val)) {
       return Number.isFinite(Number(val));
     }
   }
@@ -110,11 +133,7 @@ function numericDensity(rows, numericIndices) {
   let presentCells = 0;
   for (const row of rows) {
     for (const index of numericIndices) {
-      if (
-        row[index] !== null &&
-        row[index] !== undefined &&
-        row[index] !== ""
-      ) {
+      if (!isEmpty(row[index])) {
         presentCells++;
       }
     }

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/data-explorer-chart-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/data-explorer-chart-test.gjs
@@ -1,7 +1,16 @@
-import { render } from "@ember/test-helpers";
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { schedule } from "@ember/runloop";
+import { find, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import loadChartJS from "discourse/lib/load-chart-js";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DataExplorerChart from "../../discourse/components/data-explorer-chart";
+
+const AfterRender = <template>
+  <div {{didInsert (fn schedule "afterRender" @run)}}></div>
+</template>;
 
 module("Integration | Component | DataExplorerChart", function (hooks) {
   setupRenderingTest(hooks);
@@ -104,5 +113,75 @@ module("Integration | Component | DataExplorerChart", function (hooks) {
     );
 
     assert.dom("canvas").exists("renders a canvas for dual-axis chart");
+  });
+
+  test("re-rendering before the chart library loads creates a single chart", async function (assert) {
+    class State {
+      @tracked labels = ["a", "b"];
+    }
+
+    const state = new State();
+    const datasets = [{ label: "count", values: [1, 2] }];
+    const relabel = () => (state.labels = ["c", "d"]);
+    const Chart = await loadChartJS();
+
+    await render(
+      <template>
+        <DataExplorerChart
+          @chartType="bar"
+          @datasets={{datasets}}
+          @labels={{state.labels}}
+          @stacked={{false}}
+        />
+        <AfterRender @run={{relabel}} />
+      </template>
+    );
+
+    const canvas = find("canvas");
+
+    assert.deepEqual(
+      Chart.getChart(canvas).data.labels,
+      ["c", "d"],
+      "the chart reflects the latest labels"
+    );
+    assert.strictEqual(
+      Object.values(Chart.instances).filter((chart) => chart.canvas === canvas)
+        .length,
+      1,
+      "a single chart is bound to the canvas"
+    );
+  });
+
+  test("does not build a chart when destroyed before the chart library loads", async function (assert) {
+    class State {
+      @tracked shown = true;
+    }
+
+    const state = new State();
+    const datasets = [{ label: "count", values: [1, 2] }];
+    const labels = ["a", "b"];
+    const hide = () => (state.shown = false);
+    const Chart = await loadChartJS();
+    const before = Object.keys(Chart.instances).length;
+
+    await render(
+      <template>
+        {{#if state.shown}}
+          <DataExplorerChart
+            @chartType="bar"
+            @datasets={{datasets}}
+            @labels={{labels}}
+            @stacked={{false}}
+          />
+        {{/if}}
+        <AfterRender @run={{hide}} />
+      </template>
+    );
+
+    assert.strictEqual(
+      Object.keys(Chart.instances).length,
+      before,
+      "no chart survives the destroyed component"
+    );
   });
 });

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
@@ -518,6 +518,26 @@ module("Integration | Component | QueryResult | Chart", function (hooks) {
     assert.dom("canvas").exists("renders a chart canvas");
   });
 
+  test("charts NULL cells as gaps", async function (assert) {
+    const content = {
+      colrender: [],
+      result_count: 2,
+      columns: ["name", "count"],
+      rows: [
+        ["a", 1],
+        ["b", null],
+      ],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
+    assert.deepEqual(
+      (await chartData()).datasets[0].data,
+      [1, null],
+      "NULL is a gap rather than NaN"
+    );
+  });
+
   test("renders a multi-series chart", async function (assert) {
     const content = {
       colrender: [],


### PR DESCRIPTION
Stacked on #43471.

Previously, chart cells went through `Number()`, so a NULL or empty cell was drawn as a real zero rather than a gap, and changing a chart option before the lazily imported chart bundle had loaded constructed a second chart against the same canvas and threw "Canvas is already in use".

This change maps empty cells to `null`, guards construction with a token so only the newest call builds, and caches the getters feeding the chart so an unchanged result stops tearing the chart down on every render.