### PR TITLE
FIX: Scope cached Data Explorer results to the viewer

### DIFF
--- a/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
+++ b/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
@@ -91,7 +91,7 @@ module DiscourseDataExplorer
       json = serialize_data(@query, QueryDetailsSerializer, root: nil)
 
       unless params[:export]
-        cached = QueryRunner.cached_result(@query, params[:params])
+        cached = QueryRunner.cached_result(@query, params[:params], current_user:)
         json[:cached_result] = cached if cached
       end
 

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/admin_dashboard_report_provider.rb
@@ -43,15 +43,16 @@ module DiscourseDataExplorer
     end
 
     def self.fetch_many(identifiers, guardian:, filters: {})
-      return {} if guardian&.user.nil?
+      user = guardian&.user
+      return {} if user.nil?
 
       params = filters.with_indifferent_access
 
       load_queries(identifiers).each_with_object({}) do |query, hash|
         next if !guardian.user_can_access_query?(query) || !mountable?(query)
         result =
-          QueryRunner.cached_result(query, params, max_age: CACHE_MAX_AGE) ||
-            QueryRunner.run(query, params, current_user: guardian.user)
+          QueryRunner.cached_result(query, params, current_user: user, max_age: CACHE_MAX_AGE) ||
+            QueryRunner.run(query, params, current_user: user)
         result = result.merge(empty: Array(result[:rows]).empty?) if result.is_a?(Hash)
         hash[query.id.to_s] = result
       end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_result_cache.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_result_cache.rb
@@ -6,17 +6,19 @@ module DiscourseDataExplorer
     MAX_CACHE_SIZE = 200.kilobytes
     MAX_CACHE_ENTRIES = 50
 
-    def self.cache_key(query_id, params_hash)
-      h = params_hash || {}
-      h = h.to_unsafe_h if h.respond_to?(:to_unsafe_h)
-      normalized = h.sort.to_h.to_json
-      digest = Digest::SHA256.hexdigest(normalized)
-      "data_explorer:result:#{query_id}:#{digest}"
+    def self.visibility_scope(user)
+      return "admin" if user.admin? && !SiteSetting.suppress_secured_categories_from_admin
+
+      user.id
     end
 
-    def self.read(query_id, params_hash, max_age: nil)
-      key = cache_key(query_id, params_hash)
-      raw = Discourse.redis.get(key)
+    def self.cache_key(query_id, user, params_hash)
+      digest = Digest::SHA256.hexdigest((params_hash || {}).sort.to_h.to_json)
+      "data_explorer:result:#{query_id}:#{visibility_scope(user)}:#{digest}"
+    end
+
+    def self.read(query_id, user, params_hash, max_age: nil)
+      raw = Discourse.redis.get(cache_key(query_id, user, params_hash))
       return nil if raw.nil?
 
       result = MultiJson.load(raw)
@@ -32,19 +34,30 @@ module DiscourseDataExplorer
     end
     private_class_method :within_max_age?
 
-    def self.write(query_id, params_hash, result_json)
+    def self.write(query_id, user, params_hash, result_json)
       payload = result_json.merge("cached_at" => Time.now.utc.iso8601)
       serialized = MultiJson.dump(payload)
       return false if serialized.bytesize > MAX_CACHE_SIZE
 
-      key = cache_key(query_id, params_hash)
+      key = cache_key(query_id, user, params_hash)
       index_key = cache_index_key(query_id)
       now = Time.now.to_f
-      prune_stale_entries(index_key, now)
-      return false if limit_reached?(index_key, key)
 
-      Discourse.redis.setex(key, CACHE_TTL, serialized)
+      _pruned, score, oldest =
+        Discourse.redis.pipelined do |redis|
+          redis.zremrangebyscore(index_key, "-inf", now - CACHE_TTL)
+          redis.zscore(index_key, key)
+          redis.zrange(index_key, 0, -MAX_CACHE_ENTRIES)
+        end
+      evicted = score.nil? ? Array(oldest) : []
+
       Discourse.redis.multi do |redis|
+        if evicted.present?
+          redis.del(evicted)
+          redis.zrem(index_key, evicted)
+        end
+
+        redis.setex(key, CACHE_TTL, serialized)
         redis.zadd(index_key, now, key)
         redis.expire(index_key, CACHE_TTL)
       end
@@ -52,25 +65,13 @@ module DiscourseDataExplorer
     end
 
     def self.invalidate(query_id)
-      keys = Discourse.redis.scan_each(match: "data_explorer:result:#{query_id}:*").to_a
+      keys =
+        Discourse.redis.scan_each(match: "data_explorer:result:#{query_id}:*", count: 1000).to_a
       Discourse.redis.del(*keys) if keys.present?
-      Discourse.redis.del(cache_index_key(query_id))
     end
 
     def self.cache_index_key(query_id)
       "data_explorer:result:#{query_id}:keys"
     end
-
-    def self.limit_reached?(index_key, key)
-      return false if Discourse.redis.zscore(index_key, key)
-
-      Discourse.redis.zcard(index_key) >= MAX_CACHE_ENTRIES
-    end
-
-    def self.prune_stale_entries(index_key, now)
-      Discourse.redis.zremrangebyscore(index_key, "-inf", now - CACHE_TTL)
-    end
-
-    private_class_method :limit_reached?, :prune_stale_entries
   end
 end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_runner.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_runner.rb
@@ -16,17 +16,17 @@ module DiscourseDataExplorer
         ResultFormatConverter.convert(:json, result, query_params:, explain:, current_user:)
 
       if query.id.present? && cacheable?(query, explain:) && default_limit?(limit)
-        cache_key_params = resolve_params(query, raw_params)
-        QueryResultCache.write(query.id, cache_key_params, result_json)
+        cache_key_params = resolve_params(query, query_params)
+        QueryResultCache.write(query.id, current_user, cache_key_params, result_json)
       end
 
       result_json
     end
 
-    def self.cached_result(query, raw_params, max_age: nil)
+    def self.cached_result(query, raw_params, current_user:, max_age: nil)
       return nil unless cacheable?(query)
-      params_hash = resolve_params(query, raw_params)
-      QueryResultCache.read(query.id, params_hash, max_age:)&.deep_symbolize_keys
+      params_hash = resolve_params(query, parse_params(raw_params))
+      QueryResultCache.read(query.id, current_user, params_hash, max_age:)&.deep_symbolize_keys
     rescue MultiJson::ParseError
       nil
     end
@@ -43,8 +43,7 @@ module DiscourseDataExplorer
       limit.nil? || limit == SiteSetting.data_explorer_query_result_limit
     end
 
-    def self.resolve_params(query, raw_params)
-      parsed = parse_params(raw_params)
+    def self.resolve_params(query, parsed)
       if parsed.present?
         user_param_ids = query.params.reject(&:internal?).map(&:identifier)
         parsed.slice(*user_param_ids)

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_format_converter.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_format_converter.rb
@@ -36,7 +36,7 @@ module DiscourseDataExplorer
         success: true,
         errors: [],
         duration: (result[:duration_secs].to_f * 1000).round(1),
-        result_count: pg_result.values.length || 0,
+        result_count: pg_result.ntuples,
         params: opts[:query_params],
         columns: cols,
         default_limit: SiteSetting.data_explorer_query_result_limit,

--- a/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/admin_dashboard_report_provider_spec.rb
@@ -295,6 +295,24 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
       expect(payload[:empty]).to eq(false)
     end
 
+    it "does not serve relations cached under another user's guardian" do
+      pm = Fabricate(:private_message_topic)
+      moderator = Fabricate(:moderator)
+      group.add(moderator)
+      query = Fabricate(:query, sql: "SELECT #{pm.id} AS topic_id", user: admin)
+      DiscourseDataExplorer::QueryGroup.create!(query: query, group: group)
+      query_ids_to_invalidate << query.id
+      DiscourseDataExplorer::QueryRunner.run(query, {}, current_user: admin)
+
+      payload =
+        described_class.fetch_many([query.id.to_s], guardian: moderator.guardian).fetch(
+          query.id.to_s,
+        )
+
+      expect(payload[:rows]).to eq([[pm.id]])
+      expect(payload[:relations][:topic].as_json).to be_blank
+    end
+
     it "runs queries when their cached results are over an hour old" do
       now = Time.now
       freeze_time(now)
@@ -366,7 +384,8 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
         },
       )
 
-      cached = DiscourseDataExplorer::QueryRunner.cached_result(visible_query, {})
+      cached =
+        DiscourseDataExplorer::QueryRunner.cached_result(visible_query, {}, current_user: admin)
       expect(cached).to be_present
     end
 
@@ -378,7 +397,8 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
       freeze_time(now + 30.minutes)
       described_class.prewarm([visible_query.id.to_s], guardian: admin_guardian)
 
-      cached = DiscourseDataExplorer::QueryRunner.cached_result(visible_query, {})
+      cached =
+        DiscourseDataExplorer::QueryRunner.cached_result(visible_query, {}, current_user: admin)
       expect(cached[:cached_at]).to eq((now + 30.minutes).utc.iso8601)
     end
 
@@ -409,7 +429,9 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
 
       described_class.prewarm([visible_query.id.to_s], guardian: admin_guardian)
 
-      expect(DiscourseDataExplorer::QueryRunner.cached_result(visible_query, {})).to be_nil
+      expect(
+        DiscourseDataExplorer::QueryRunner.cached_result(visible_query, {}, current_user: admin),
+      ).to be_nil
     end
 
     it "skips queries with required parameters outside the dashboard filters" do
@@ -429,7 +451,9 @@ RSpec.describe DiscourseDataExplorer::AdminDashboardReportProvider do
         },
       )
 
-      expect(DiscourseDataExplorer::QueryRunner.cached_result(query, {})).to be_nil
+      expect(
+        DiscourseDataExplorer::QueryRunner.cached_result(query, {}, current_user: admin),
+      ).to be_nil
     end
   end
 

--- a/plugins/discourse-data-explorer/spec/lib/query_result_cache_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/query_result_cache_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe DiscourseDataExplorer::QueryResultCache do
+  fab!(:user)
+  fab!(:admin)
   fab!(:query) { Fabricate(:query, sql: "SELECT 1") }
 
   let(:params_hash) { { "limit" => "10", "name" => "test" } }
@@ -24,8 +26,8 @@ describe DiscourseDataExplorer::QueryResultCache do
 
   describe ".write and .read" do
     it "stores and retrieves results" do
-      described_class.write(query.id, params_hash, result_json)
-      cached = described_class.read(query.id, params_hash)
+      described_class.write(query.id, user, params_hash, result_json)
+      cached = described_class.read(query.id, user, params_hash)
 
       expect(cached["success"]).to eq(true)
       expect(cached["rows"]).to eq([[1], [2]])
@@ -33,112 +35,97 @@ describe DiscourseDataExplorer::QueryResultCache do
     end
 
     it "returns nil on cache miss" do
-      expect(described_class.read(query.id, params_hash)).to be_nil
+      expect(described_class.read(query.id, user, params_hash)).to be_nil
     end
 
     it "returns nil when the cached result exceeds the maximum age" do
       now = Time.now
       freeze_time(now)
-      described_class.write(query.id, params_hash, result_json)
+      described_class.write(query.id, user, params_hash, result_json)
 
       freeze_time(now + 1.hour + 1.second)
-      expect(described_class.read(query.id, params_hash, max_age: 1.hour)).to be_nil
+      expect(described_class.read(query.id, user, params_hash, max_age: 1.hour)).to be_nil
     end
 
     it "skips write when result exceeds max size" do
       large_result = result_json.merge("rows" => [["x" * (described_class::MAX_CACHE_SIZE + 1)]])
 
-      expect(described_class.write(query.id, params_hash, large_result)).to eq(false)
-      expect(described_class.read(query.id, params_hash)).to be_nil
+      expect(described_class.write(query.id, user, params_hash, large_result)).to eq(false)
+      expect(described_class.read(query.id, user, params_hash)).to be_nil
     end
 
     it "sets a TTL on the cache key" do
-      described_class.write(query.id, params_hash, result_json)
-      key = described_class.cache_key(query.id, params_hash)
+      described_class.write(query.id, user, params_hash, result_json)
+      key = described_class.cache_key(query.id, user, params_hash)
       ttl = Discourse.redis.ttl(key)
 
       expect(ttl).to be > 0
       expect(ttl).to be <= described_class::CACHE_TTL
     end
 
-    it "does not add new cache entries once the per-query limit is reached" do
-      (described_class::MAX_CACHE_ENTRIES + 1).times do |i|
-        described_class.write(query.id, { "value" => i.to_s }, result_json)
+    it "evicts the oldest entry once the per-query limit is reached" do
+      stub_const(described_class, :MAX_CACHE_ENTRIES, 2) do
+        described_class.write(query.id, user, { "value" => "0" }, result_json)
+        described_class.write(query.id, user, { "value" => "1" }, result_json)
+
+        expect(described_class.write(query.id, admin, params_hash, result_json)).to eq(true)
+        expect(described_class.read(query.id, user, { "value" => "0" })).to be_nil
+        expect(described_class.read(query.id, admin, params_hash)).to be_present
+        expect(Discourse.redis.zcard(described_class.cache_index_key(query.id))).to eq(2)
       end
-
-      oldest_key = described_class.cache_key(query.id, { "value" => "0" })
-      overflow_key =
-        described_class.cache_key(query.id, { "value" => described_class::MAX_CACHE_ENTRIES.to_s })
-
-      expect(Discourse.redis.get(oldest_key)).to be_present
-      expect(Discourse.redis.get(overflow_key)).to be_nil
-      expect(Discourse.redis.zcard(described_class.cache_index_key(query.id))).to eq(
-        described_class::MAX_CACHE_ENTRIES,
-      )
     end
 
     it "caches new entries after old index members expire" do
-      index_key = described_class.cache_index_key(query.id)
-      stale_score = Time.now.to_f - described_class::CACHE_TTL - 1
-      stale_keys =
-        described_class::MAX_CACHE_ENTRIES.times.map do |i|
-          params = { "value" => i.to_s }
-          described_class.write(query.id, params, result_json)
-          described_class.cache_key(query.id, params)
-        end
+      stub_const(described_class, :MAX_CACHE_ENTRIES, 2) do
+        stale_score = Time.now.to_f - described_class::CACHE_TTL - 1
+        Discourse.redis.zadd(
+          described_class.cache_index_key(query.id),
+          [[stale_score, "stale:0"], [stale_score, "stale:1"]],
+        )
 
-      Discourse.redis.del(*stale_keys)
-      stale_keys.each { |stale_key| Discourse.redis.zadd(index_key, stale_score, stale_key) }
-
-      fresh_params = { "value" => "fresh" }
-
-      expect(described_class.write(query.id, fresh_params, result_json)).to eq(true)
-      expect(described_class.read(query.id, fresh_params)).to be_present
+        expect(described_class.write(query.id, user, params_hash, result_json)).to eq(true)
+        expect(described_class.read(query.id, user, params_hash)).to be_present
+      end
     end
   end
 
   describe ".cache_key" do
     it "produces the same key regardless of param order" do
-      key_a = described_class.cache_key(query.id, { "b" => "2", "a" => "1" })
-      key_b = described_class.cache_key(query.id, { "a" => "1", "b" => "2" })
+      key_a = described_class.cache_key(query.id, user, { "b" => "2", "a" => "1" })
+      key_b = described_class.cache_key(query.id, user, { "a" => "1", "b" => "2" })
 
       expect(key_a).to eq(key_b)
     end
 
     it "produces different keys for different params" do
-      key_a = described_class.cache_key(query.id, { "a" => "1" })
-      key_b = described_class.cache_key(query.id, { "a" => "2" })
+      key_a = described_class.cache_key(query.id, user, { "a" => "1" })
+      key_b = described_class.cache_key(query.id, user, { "a" => "2" })
 
       expect(key_a).not_to eq(key_b)
-    end
-
-    it "handles nil params" do
-      key = described_class.cache_key(query.id, nil)
-      expect(key).to include("data_explorer:result:#{query.id}:")
     end
   end
 
   describe ".invalidate" do
     it "removes all cached results for a query" do
-      described_class.write(query.id, { "a" => "1" }, result_json)
-      described_class.write(query.id, { "b" => "2" }, result_json)
+      described_class.write(query.id, user, params_hash, result_json)
+      described_class.write(query.id, admin, params_hash, result_json)
 
       described_class.invalidate(query.id)
 
-      expect(described_class.read(query.id, { "a" => "1" })).to be_nil
-      expect(described_class.read(query.id, { "b" => "2" })).to be_nil
+      expect(described_class.read(query.id, user, params_hash)).to be_nil
+      expect(described_class.read(query.id, admin, params_hash)).to be_nil
     end
 
     it "does not affect other queries" do
       other_query = Fabricate(:query, sql: "SELECT 2")
 
-      described_class.write(query.id, params_hash, result_json)
-      described_class.write(other_query.id, params_hash, result_json)
+      described_class.write(query.id, user, params_hash, result_json)
+      described_class.write(other_query.id, user, params_hash, result_json)
 
       described_class.invalidate(query.id)
 
-      expect(described_class.read(query.id, params_hash)).to be_nil
-      expect(described_class.read(other_query.id, params_hash)).to be_present
+      expect(described_class.read(query.id, user, params_hash)).to be_nil
+      expect(described_class.read(other_query.id, user, params_hash)).to be_present
     end
   end
 end

--- a/plugins/discourse-data-explorer/spec/lib/query_runner_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/query_runner_spec.rb
@@ -39,7 +39,7 @@ describe DiscourseDataExplorer::QueryRunner do
     it "caches the result after execution" do
       described_class.run(query, nil, current_user: admin)
 
-      cached = described_class.cached_result(query, nil)
+      cached = described_class.cached_result(query, nil, current_user: admin)
       expect(cached).to be_present
       expect(cached[:success]).to eq(true)
     end
@@ -47,13 +47,15 @@ describe DiscourseDataExplorer::QueryRunner do
     it "does not cache when explain is true" do
       described_class.run(query, nil, current_user: admin, explain: true)
 
-      expect(described_class.cached_result(query, nil)).to be_nil
+      expect(described_class.cached_result(query, nil, current_user: admin)).to be_nil
     end
 
     it "does not cache queries with internal params" do
       described_class.run(query_with_internal_params, nil, current_user: admin)
 
-      expect(described_class.cached_result(query_with_internal_params, nil)).to be_nil
+      expect(
+        described_class.cached_result(query_with_internal_params, nil, current_user: admin),
+      ).to be_nil
     end
 
     it "returns error info when query fails" do
@@ -66,47 +68,50 @@ describe DiscourseDataExplorer::QueryRunner do
 
   describe ".cached_result" do
     it "returns nil when no cache exists" do
-      expect(described_class.cached_result(query, nil)).to be_nil
+      expect(described_class.cached_result(query, nil, current_user: admin)).to be_nil
     end
 
     it "returns cached result after execute" do
       described_class.run(query, nil, current_user: admin)
-      cached = described_class.cached_result(query, nil)
+      cached = described_class.cached_result(query, nil, current_user: admin)
 
       expect(cached[:cached_at]).to be_present
       expect(cached[:rows]).to be_present
     end
 
     it "returns nil for queries with internal params" do
-      expect(described_class.cached_result(query_with_internal_params, nil)).to be_nil
+      expect(
+        described_class.cached_result(query_with_internal_params, nil, current_user: admin),
+      ).to be_nil
     end
 
     it "resolves URL params when present" do
       described_class.run(query_with_params, '{"limit":"5"}', current_user: admin)
 
-      cached = described_class.cached_result(query_with_params, '{"limit":"5"}')
+      cached =
+        described_class.cached_result(query_with_params, '{"limit":"5"}', current_user: admin)
       expect(cached).to be_present
 
-      cached_default = described_class.cached_result(query_with_params, nil)
+      cached_default = described_class.cached_result(query_with_params, nil, current_user: admin)
       expect(cached_default).to be_nil
     end
 
     it "falls back to default params when no URL params" do
       described_class.run(query_with_params, '{"limit":"10"}', current_user: admin)
 
-      cached = described_class.cached_result(query_with_params, nil)
+      cached = described_class.cached_result(query_with_params, nil, current_user: admin)
       expect(cached).to be_present
     end
 
     it "returns cached result when run was called with null params" do
       described_class.run(query_with_params, "null", current_user: admin)
 
-      cached = described_class.cached_result(query_with_params, nil)
+      cached = described_class.cached_result(query_with_params, nil, current_user: admin)
       expect(cached).to be_present
     end
 
     it "handles malformed JSON params gracefully" do
-      expect(described_class.cached_result(query, "not-json")).to be_nil
+      expect(described_class.cached_result(query, "not-json", current_user: admin)).to be_nil
     end
   end
 
@@ -114,7 +119,7 @@ describe DiscourseDataExplorer::QueryRunner do
     it "does not cache when a non-default limit is used" do
       described_class.run(query, nil, current_user: admin, limit: 1)
 
-      expect(described_class.cached_result(query, nil)).to be_nil
+      expect(described_class.cached_result(query, nil, current_user: admin)).to be_nil
     end
 
     it "caches when using the default limit" do
@@ -125,17 +130,38 @@ describe DiscourseDataExplorer::QueryRunner do
         limit: SiteSetting.data_explorer_query_result_limit,
       )
 
-      expect(described_class.cached_result(query, nil)).to be_present
+      expect(described_class.cached_result(query, nil, current_user: admin)).to be_present
+    end
+  end
+
+  describe "per-user caching" do
+    fab!(:moderator)
+    fab!(:pm, :private_message_topic)
+    fab!(:pm_query) { Fabricate(:query, sql: "SELECT #{pm.id} AS topic_id", user: admin) }
+
+    it "does not serve relations resolved under another user's guardian" do
+      described_class.run(pm_query, nil, current_user: admin)
+
+      admin_cached = described_class.cached_result(pm_query, nil, current_user: admin)
+      expect(admin_cached[:relations][:topic]).to include(include(id: pm.id))
+      expect(described_class.cached_result(pm_query, nil, current_user: moderator)).to be_nil
+    end
+
+    it "does not share entries between admins when secured categories are suppressed" do
+      SiteSetting.suppress_secured_categories_from_admin = true
+      described_class.run(query, nil, current_user: admin)
+
+      expect(described_class.cached_result(query, nil, current_user: Fabricate(:admin))).to be_nil
     end
   end
 
   describe ".invalidate" do
     it "removes all cached results for a query" do
       described_class.run(query, nil, current_user: admin)
-      expect(described_class.cached_result(query, nil)).to be_present
+      expect(described_class.cached_result(query, nil, current_user: admin)).to be_present
 
       described_class.invalidate(query.id)
-      expect(described_class.cached_result(query, nil)).to be_nil
+      expect(described_class.cached_result(query, nil, current_user: admin)).to be_nil
     end
   end
 end

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -24,6 +24,15 @@ describe DiscourseDataExplorer::QueryController do
 
     before { sign_in(admin) }
 
+    def run_query(id, params = {}, explain = false)
+      params = params.transform_values(&:to_s)
+      post "/admin/plugins/discourse-data-explorer/queries/#{id}/run.json",
+           params: {
+             params: params.to_json,
+             explain: explain,
+           }
+    end
+
     describe "when disabled" do
       before { SiteSetting.data_explorer_enabled = false }
 
@@ -206,15 +215,6 @@ describe DiscourseDataExplorer::QueryController do
     end
 
     describe "#run" do
-      def run_query(id, params = {}, explain = false)
-        params = Hash[params.map { |a| [a[0], a[1].to_s] }]
-        post "/admin/plugins/discourse-data-explorer/queries/#{id}/run.json",
-             params: {
-               params: params.to_json,
-               explain: explain,
-             }
-      end
-
       it "can run queries" do
         query = make_query("SELECT 23 as my_value")
         run_query query.id
@@ -610,21 +610,13 @@ describe DiscourseDataExplorer::QueryController do
     end
 
     describe "result caching" do
-      def run_query(id, params = {})
-        params = Hash[params.map { |a| [a[0], a[1].to_s] }]
-        post "/admin/plugins/discourse-data-explorer/queries/#{id}/run.json",
-             params: {
-               params: params.to_json,
-             }
-      end
-
       it "caches results after running a query" do
         query = make_query("SELECT 23 as my_value")
 
         run_query query.id
         expect(response.status).to eq(200)
 
-        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil)
+        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin)
         expect(cached).to be_present
         expect(cached[:rows]).to eq([[23]])
       end
@@ -638,6 +630,15 @@ describe DiscourseDataExplorer::QueryController do
         expect(response_json["query"]["cached_result"]).to be_present
         expect(response_json["query"]["cached_result"]["rows"]).to eq([[23]])
         expect(response_json["query"]["cached_result"]["cached_at"]).to be_present
+      end
+
+      it "does not return results cached for another user" do
+        query = make_query("SELECT 23 as my_value")
+        DiscourseDataExplorer::QueryRunner.run(query, nil, current_user: Fabricate(:user))
+
+        get "/admin/plugins/discourse-data-explorer/queries/#{query.id}.json"
+        expect(response.status).to eq(200)
+        expect(response_json["query"]["cached_result"]).to be_nil
       end
 
       it "returns no cached_result on cache miss" do
@@ -674,7 +675,7 @@ describe DiscourseDataExplorer::QueryController do
              }
         expect(response.status).to eq(200)
 
-        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil)
+        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin)
         expect(cached).to be_nil
       end
 
@@ -684,7 +685,7 @@ describe DiscourseDataExplorer::QueryController do
         run_query query.id
         expect(response.status).to eq(200)
 
-        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil)
+        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin)
         expect(cached).to be_nil
       end
 
@@ -692,7 +693,9 @@ describe DiscourseDataExplorer::QueryController do
         query = make_query("SELECT 1 as old_value")
         run_query query.id
 
-        expect(DiscourseDataExplorer::QueryRunner.cached_result(query, nil)).to be_present
+        expect(
+          DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin),
+        ).to be_present
 
         put "/admin/plugins/discourse-data-explorer/queries/#{query.id}.json",
             params: {
@@ -704,7 +707,9 @@ describe DiscourseDataExplorer::QueryController do
             }
         expect(response.status).to eq(200)
 
-        expect(DiscourseDataExplorer::QueryRunner.cached_result(query, nil)).to be_nil
+        expect(
+          DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin),
+        ).to be_nil
       end
 
       it "does not invalidate cache when only name changes" do
@@ -721,7 +726,9 @@ describe DiscourseDataExplorer::QueryController do
             }
         expect(response.status).to eq(200)
 
-        expect(DiscourseDataExplorer::QueryRunner.cached_result(query, nil)).to be_present
+        expect(
+          DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin),
+        ).to be_present
       end
 
       it "returns cached result on reload when run with no explicit params" do
@@ -742,7 +749,7 @@ describe DiscourseDataExplorer::QueryController do
              }
         expect(response.status).to eq(200)
 
-        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil)
+        cached = DiscourseDataExplorer::QueryRunner.cached_result(query, nil, current_user: admin)
         expect(cached).to be_nil
       end
 


### PR DESCRIPTION
Stacked on #43473.

Previously, a cached query result was keyed by query id and parameters only, but the payload carries relations resolved under the guardian of whoever ran the query, so the last runner decided what every later viewer received.

This change keys the cache by a visibility scope, so admins share one bucket and everyone else gets their own, and makes the entry cap evict the oldest entry rather than refusing to write, which otherwise let unread entries starve the one the dashboard reads.