### PR TITLE
FEATURE: Mark Data Explorer relations the viewer cannot see

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
@@ -240,6 +240,8 @@ export default class QueryResult extends Component {
       return [];
     }
 
+    const hiddenRelations = this.args.content.hidden_relations ?? {};
+
     return this.columns.map((_, idx) => {
       const type = this.colRender[idx] || "text";
 
@@ -247,6 +249,7 @@ export default class QueryResult extends Component {
         name: type,
         component: VIEW_COMPONENTS[type],
         table: this._relationTables[type],
+        hidden: hiddenRelations[type],
       };
     });
   }

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-row-content.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-row-content.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import getURL from "discourse/lib/get-url";
+import HiddenViewComponent from "./result-types/hidden";
 import TextViewComponent from "./result-types/text";
 
 const BASE_URI = getURL("");
@@ -26,7 +27,12 @@ export default class QueryRowContent extends Component {
         ctx[componentDefinition.name] = componentDefinition.table[id];
 
         if (!ctx[componentDefinition.name]) {
-          return { component: TextViewComponent, textValue: value.toString() };
+          return {
+            component: componentDefinition.hidden?.includes(id)
+              ? HiddenViewComponent
+              : TextViewComponent,
+            textValue: value.toString(),
+          };
         }
       }
 

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/hidden.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/result-types/hidden.gjs
@@ -1,0 +1,11 @@
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+const Hidden = <template>
+  <span class="query-result-hidden" title={{i18n "explorer.hidden_relation"}}>
+    {{dIcon "lock"}}
+    {{@textValue}}
+  </span>
+</template>;
+
+export default Hidden;

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -1058,6 +1058,10 @@ table.group-reports {
   display: flex;
 }
 
+.query-result-hidden {
+  color: var(--primary-medium);
+}
+
 .result-json-value {
   flex: 1;
   margin-right: 0.5em;

--- a/plugins/discourse-data-explorer/config/locales/client.en.yml
+++ b/plugins/discourse-data-explorer/config/locales/client.en.yml
@@ -33,6 +33,7 @@ en:
         ai: "Generate with AI"
       or: "or"
       admins_only: "The data explorer is only available to admins."
+      hidden_relation: "You do not have access to this content."
       allow_groups: "Allow groups to access this query"
       title: "Data Explorer"
       create: "Create"

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -357,10 +357,11 @@ module DiscourseDataExplorer
       column_regexes.find { |rgx, _| rgx.match?(col) }&.last
     end
 
-    def self.add_extra_data(pg_result, guardian: nil)
+    def self.add_extra_data(pg_result, guardian:)
       needed_classes = {}
       ret = {}
       col_map = {}
+      hidden = {}
       pg_result.fields.each_with_index do |col, idx|
         if (cls = relation_for(col))
           (needed_classes[cls] ||= []) << idx
@@ -396,16 +397,30 @@ module DiscourseDataExplorer
             .order(:id)
 
         if guardian
-          all_objs =
-            case cls
-            when :post
-              all_objs.select { |post| guardian.can_see_post?(post) }
-            when :topic
-              allowed_topic_ids = guardian.can_see_topic_ids(topic_ids: ids)
-              all_objs.where(id: allowed_topic_ids)
-            else
-              all_objs
-            end
+          case cls
+          when :post
+            allowed = guardian.can_see_topic_ids(topic_ids: all_objs.map(&:topic_id)).to_set
+            visible_post_types = Topic.visible_post_types(guardian.user)
+
+            all_objs, denied =
+              all_objs.partition do |post|
+                next true if guardian.is_admin?
+                next false if !allowed.include?(post.topic_id)
+                next false if visible_post_types.exclude?(post.post_type)
+                if guardian.is_moderator? ||
+                     guardian.is_category_group_moderator?(post.topic.category)
+                  next true
+                end
+
+                (!post.trashed? || guardian.can_see_deleted_post?(post)) &&
+                  (!post.hidden? || guardian.can_see_hidden_post?(post))
+              end
+          when :topic
+            allowed = guardian.can_see_topic_ids(topic_ids: ids).to_set
+            all_objs, denied = all_objs.partition { |topic| allowed.include?(topic.id) }
+          end
+
+          hidden[cls] = denied.map(&:id) if denied.present? && SiteSetting.detailed_404
         end
 
         opts = { each_serializer: support_info[:serializer] }
@@ -413,7 +428,7 @@ module DiscourseDataExplorer
         opts[:scope] = guardian if guardian
         ret[cls] = ActiveModel::ArraySerializer.new(all_objs, **opts)
       end
-      [ret, col_map]
+      [ret, col_map, hidden]
     end
 
     def self.sensitive_column_names

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_format_converter.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_format_converter.rb
@@ -45,9 +45,10 @@ module DiscourseDataExplorer
 
       if !opts[:download]
         guardian = Guardian.new(opts[:current_user])
-        relations, colrender = DataExplorer.add_extra_data(pg_result, guardian:)
+        relations, colrender, hidden = DataExplorer.add_extra_data(pg_result, guardian:)
         json[:relations] = relations
         json[:colrender] = colrender
+        json[:hidden_relations] = hidden
       end
 
       json[:rows] = pg_result.values

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_to_markdown.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_to_markdown.rb
@@ -8,7 +8,7 @@ module DiscourseDataExplorer
     SANITIZABLE_REGEX = /[<>&%]/
 
     def self.convert(pg_result, render_url_columns: false)
-      relations, colrender = DataExplorer.add_extra_data(pg_result)
+      relations, colrender = DataExplorer.add_extra_data(pg_result, guardian: nil)
       relations.transform_values! { |related| related.object.index_by(&:id) }
 
       column_renders =

--- a/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
+++ b/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
@@ -474,6 +474,64 @@ describe DiscourseDataExplorer::DataExplorer do
         expect(relations.keys).not_to include(:group, :category)
       end
 
+      it "reports relations hidden by the guardian" do
+        SiteSetting.detailed_404 = true
+        pm_post = Fabricate(:private_message_post)
+        pm = pm_post.topic
+        query =
+          Fabricate(
+            :query,
+            sql:
+              "SELECT #{pm.id} AS topic_id, #{pm_post.id} AS post_id, #{topic.id} AS other_topic_id",
+          )
+
+        relations, _, hidden =
+          described_class.add_extra_data(
+            described_class.run_query(query)[:pg_result],
+            guardian: Fabricate(:user).guardian,
+          )
+
+        expect(hidden).to eq({ topic: [pm.id], post: [pm_post.id] })
+        expect(relations[:topic].as_json.map { |t| t[:id] }).to eq([topic.id])
+      end
+
+      it "does not report hidden relations when detailed 404s are disabled" do
+        SiteSetting.detailed_404 = false
+        pm_post = Fabricate(:private_message_post)
+        query =
+          Fabricate(:query, sql: "SELECT #{pm_post.topic_id} AS topic_id, #{pm_post.id} AS post_id")
+
+        relations, _, hidden =
+          described_class.add_extra_data(
+            described_class.run_query(query)[:pg_result],
+            guardian: Fabricate(:user).guardian,
+          )
+
+        expect(hidden).to eq({})
+        expect(relations[:post].as_json).to be_empty
+      end
+
+      it "resolves post visibility without a query per post" do
+        query_counts =
+          [2, 8].map do |post_count|
+            posts = Fabricate.times(post_count, :private_message_post)
+            query = Fabricate(:query, sql: "SELECT unnest(ARRAY#{posts.map(&:id)}) AS post_id")
+            pg_result = described_class.run_query(query)[:pg_result]
+            guardian = Fabricate(:user).guardian
+            relations = nil
+
+            queries =
+              track_sql_queries do
+                relations, _ = described_class.add_extra_data(pg_result, guardian:)
+              end
+
+            expect(relations[:post].as_json).to be_empty
+            queries.size
+          end
+
+        expect(query_counts.first).to eq(query_counts.last)
+      end
+
       describe "serializing models to serializer" do
         it "serializes correctly to BasicTopicSerializer for topic relations" do
           topic = Fabricate(:topic, locale: "ja")

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
@@ -180,6 +180,24 @@ module("Integration | Component | QueryResult", function (hooks) {
       .hasAttribute("href", "1", "renders a numeric url cell as a link");
   });
 
+  test("marks relations hidden from the current user", async function (assert) {
+    const content = {
+      colrender: { 0: "topic" },
+      relations: { topic: [] },
+      hidden_relations: { topic: [42] },
+      result_count: 2,
+      columns: ["topic_id"],
+      rows: [[42], [43]],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
+    assert
+      .dom(`${cell(1, 1)} .query-result-hidden`)
+      .hasText("42", "keeps the id");
+    assert.dom(`${cell(2, 1)} svg`).doesNotExist("unresolved ids stay plain");
+  });
+
   test("renders a post in query results", async function (assert) {
     const content = {
       colrender: { 0: "post" },


### PR DESCRIPTION
Stacked on #43474.

Previously, an id that resolved to nothing always rendered as a bare number, so a reader of a shared report could not tell a deleted record from one they simply are not allowed to see.

This change reports the ids the guardian denied alongside the relations it resolved and renders those cells with a lock and a tooltip, gated behind `detailed_404` because distinguishing "exists but hidden" from "does not exist" is the signal that setting suppresses. Post visibility is now resolved in bulk rather than one query per post.