### PR TITLE
FIX: Show the admins-only message instead of a blank Data Explorer page

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -40,216 +40,86 @@ export default class QueriesEdit extends Component {
 
   <template>
     <div class="admin-detail">
-      {{#if @controller.disallow}}
-        <h1>{{i18n "explorer.admins_only"}}</h1>
-      {{else}}
-        <div class="query-edit__top-bar">
-          <BackButton
-            @label="explorer.queries"
-            @route="adminPlugins.show.explorer.index"
+      <div class="query-edit__top-bar">
+        <BackButton
+          @label="explorer.queries"
+          @route="adminPlugins.show.explorer.index"
+        />
+
+        {{#if @controller.aiQueriesEnabled}}
+          <QueryModeSwitch
+            @editDisabled={{@controller.editDisabled}}
+            @onChange={{@controller.setMode}}
+            @value={{@controller.mode}}
           />
+        {{/if}}
+      </div>
 
-          {{#if @controller.aiQueriesEnabled}}
-            <QueryModeSwitch
-              @editDisabled={{@controller.editDisabled}}
-              @onChange={{@controller.setMode}}
-              @value={{@controller.mode}}
+      <div class="query-edit {{if @controller.editingName 'editing'}}">
+        {{#if @controller.editingName}}
+          <div class="name">
+            <DButton
+              class="btn-default previous"
+              @action={{@controller.exitEdit}}
+              @icon="xmark"
             />
-          {{/if}}
-        </div>
+            <div class="name-text-field">
+              <DTextField
+                @onChange={{@controller.setDirty}}
+                @value={{@controller.model.name}}
+              />
+            </div>
+          </div>
 
-        <div class="query-edit {{if @controller.editingName 'editing'}}">
-          {{#if @controller.editingName}}
-            <div class="name">
+          <div class="desc">
+            <DTextarea
+              @input={{@controller.setDirty}}
+              @placeholder={{i18n "explorer.description_placeholder"}}
+              @value={{@controller.model.description}}
+            />
+          </div>
+        {{else}}
+          <div class="name">
+            <h1 class="query-name-display">
+              <span>{{@controller.model.name}}</span>
+            </h1>
+            {{#unless @controller.editDisabled}}
               <DButton
-                class="btn-default previous"
-                @action={{@controller.exitEdit}}
-                @icon="xmark"
+                class="edit-query-name btn-transparent"
+                @action={{@controller.editName}}
+                @icon="pencil"
               />
-              <div class="name-text-field">
-                <DTextField
-                  @onChange={{@controller.setDirty}}
-                  @value={{@controller.model.name}}
-                />
-              </div>
-            </div>
+            {{/unless}}
+          </div>
 
-            <div class="desc">
-              <DTextarea
-                @input={{@controller.setDirty}}
-                @placeholder={{i18n "explorer.description_placeholder"}}
-                @value={{@controller.model.description}}
-              />
-            </div>
-          {{else}}
-            <div class="name">
-              <h1 class="query-name-display">
-                <span>{{@controller.model.name}}</span>
-              </h1>
-              {{#unless @controller.editDisabled}}
-                <DButton
-                  class="edit-query-name btn-transparent"
-                  @action={{@controller.editName}}
-                  @icon="pencil"
-                />
-              {{/unless}}
-            </div>
-
-            <div class="desc">{{@controller.model.description}}</div>
-          {{/if}}
-
-          {{#unless @controller.model.destroyed}}
-            <div class="groups">
-              <span class="label">{{i18n "explorer.allow_groups"}}</span>
-              <span>
-                <GroupChooser
-                  @content={{@controller.groupOptions}}
-                  @onChange={{@controller.updateGroupIds}}
-                  @value={{@controller.model.group_ids}}
-                />
-              </span>
-            </div>
-          {{/unless}}
-
-          <div class="clear"></div>
-
-          {{#if (eq @controller.mode "ai")}}
-            <QueryAiPrompt
-              @disabled={{@controller.aiGenerating}}
-              @generating={{@controller.aiGenerating}}
-              @onChange={{@controller.updateAiPrompt}}
-              @onRegenerate={{@controller.regenerate}}
-              @regenerateDisabled={{@controller.regenerateDisabled}}
-              @value={{@controller.aiPrompt}}
-            />
-          {{else}}
-            <div class="query-editor {{if @controller.hideSchema 'no-schema'}}">
-              <div class="query-editor__header">
-                <h3 class="query-editor__label">{{i18n
-                    "explorer.sql_label"
-                  }}</h3>
-              </div>
-
-              {{#if @controller.editingQuery}}
-                <div class="panels-flex query-editor__panes">
-                  <div class="editor-panel">
-                    <AceEditor
-                      @content={{@controller.model.sql}}
-                      @disabled={{@controller.editorDisabled}}
-                      @mode="sql"
-                      @onChange={{@controller.updateSql}}
-                      @save={{@controller.save}}
-                      @submit={{@controller.run}}
-                    />
-                  </div>
-
-                  <div class="right-panel">
-                    <ExplorerSchema
-                      @hideSchema={{@controller.hideSchema}}
-                      @schema={{@controller.schema}}
-                      @updateHideSchema={{@controller.updateHideSchema}}
-                    />
-                  </div>
-                </div>
-
-                <PaneSeparator @controller={{@controller}} />
-
-                <div class="clear"></div>
-              {{else}}
-                <div class="sql">
-                  <CodeView
-                    @codeClass="sql"
-                    @setDirty={{@controller.setDirty}}
-                    @value={{@controller.model.sql}}
-                  />
-                </div>
-              {{/if}}
-            </div>
-          {{/if}}
-
-          {{#if @controller.model.is_default}}
-            <div class="default-query-notice alert alert-info">{{i18n
-                "explorer.default_query_notice"
-              }}</div>
-          {{/if}}
-        </div>
-
-        {{#if @controller.model.hasParams}}
-          <form class="query-params-block" {{on "submit" @controller.run}}>
-            <ParamInputForm
-              @initialValues={{@controller.parsedParams}}
-              @onRegisterApi={{@controller.onRegisterApi}}
-              @paramInfo={{@controller.model.param_info}}
-            />
-          </form>
+          <div class="desc">{{@controller.model.description}}</div>
         {{/if}}
 
-        <div class="query-action-bar">
-          <div class="query-action-bar__left">
-            <QueryRunSplitButton
-              @disabled={{@controller.runDisabled}}
-              @label={{@controller.runButtonLabel}}
-              @onRun={{@controller.run}}
-            />
-            {{#if @controller.editingQuery}}
-              <DButton
-                class="btn-discard-query"
-                @action={{@controller.discard}}
-                @disabled={{@controller.saveDisabled}}
-                @icon="arrow-rotate-left"
-                @label="explorer.undo"
+        {{#unless @controller.model.destroyed}}
+          <div class="groups">
+            <span class="label">{{i18n "explorer.allow_groups"}}</span>
+            <span>
+              <GroupChooser
+                @content={{@controller.groupOptions}}
+                @onChange={{@controller.updateGroupIds}}
+                @value={{@controller.model.group_ids}}
               />
-              <DButton
-                class="btn-transparent query-action-bar__help"
-                @action={{@controller.showHelpModal}}
-                @disabled={{@controller.actionsBusy}}
-                @icon="circle-question"
-                @label="explorer.help.label"
-              />
-            {{/if}}
+            </span>
           </div>
+        {{/unless}}
 
-          <div class="query-action-bar__right">
-            {{#if (or @controller.hasResults (eq @controller.mode "ai"))}}
-              <DSegmentedControl
-                class="query-results-modes"
-                @items={{@controller.viewItems}}
-                @name="query-result-view"
-                @onSelect={{@controller.setView}}
-                @translatedLabel={{i18n "explorer.view.label"}}
-                @value={{@controller.view}}
-              />
-            {{/if}}
-            <QueryResultDownloadButtons
-              @content={{@controller.results}}
-              @includeQueryExport={{true}}
-              @query={{@controller.model}}
-            />
+        <div class="clear"></div>
 
-            {{#if @controller.model.destroyed}}
-              <DButton
-                @action={{@controller.recover}}
-                @disabled={{@controller.actionsBusy}}
-                @icon="arrow-rotate-left"
-                @label="explorer.recover"
-              />
-            {{else if this.showDestroyQuery}}
-              <DButton
-                class="btn-danger"
-                @action={{@controller.destroyQuery}}
-                @disabled={{@controller.actionsBusy}}
-                @icon="trash-can"
-                @label="explorer.delete"
-              />
-            {{/if}}
-          </div>
-        </div>
-
-        <div hidden {{didInsert @controller.runOnLoad}}></div>
-
-        <DConditionalLoadingSpinner @condition={{@controller.loading}} />
-
-        {{#if (and (eq @controller.mode "ai") (eq @controller.view "sql"))}}
+        {{#if (eq @controller.mode "ai")}}
+          <QueryAiPrompt
+            @disabled={{@controller.aiGenerating}}
+            @generating={{@controller.aiGenerating}}
+            @onChange={{@controller.updateAiPrompt}}
+            @onRegenerate={{@controller.regenerate}}
+            @regenerateDisabled={{@controller.regenerateDisabled}}
+            @value={{@controller.aiPrompt}}
+          />
+        {{else}}
           <div class="query-editor {{if @controller.hideSchema 'no-schema'}}">
             <div class="query-editor__header">
               <h3 class="query-editor__label">{{i18n "explorer.sql_label"}}</h3>
@@ -292,19 +162,142 @@ export default class QueriesEdit extends Component {
           </div>
         {{/if}}
 
-        {{#if (notEq @controller.view "sql")}}
-          <QueryResultsWrapper
-            @cachedAt={{@controller.cachedAt}}
-            @content={{@controller.results}}
-            @hideHeaderActions={{true}}
-            @onSetView={{@controller.setView}}
-            @query={{@controller.model}}
-            @results={{@controller.results}}
-            @showResults={{@controller.showResults}}
-            @view={{@controller.view}}
-          />
+        {{#if @controller.model.is_default}}
+          <div class="default-query-notice alert alert-info">{{i18n
+              "explorer.default_query_notice"
+            }}</div>
         {{/if}}
+      </div>
 
+      {{#if @controller.model.hasParams}}
+        <form class="query-params-block" {{on "submit" @controller.run}}>
+          <ParamInputForm
+            @initialValues={{@controller.parsedParams}}
+            @onRegisterApi={{@controller.onRegisterApi}}
+            @paramInfo={{@controller.model.param_info}}
+          />
+        </form>
+      {{/if}}
+
+      <div class="query-action-bar">
+        <div class="query-action-bar__left">
+          <QueryRunSplitButton
+            @disabled={{@controller.runDisabled}}
+            @label={{@controller.runButtonLabel}}
+            @onRun={{@controller.run}}
+          />
+          {{#if @controller.editingQuery}}
+            <DButton
+              class="btn-discard-query"
+              @action={{@controller.discard}}
+              @disabled={{@controller.saveDisabled}}
+              @icon="arrow-rotate-left"
+              @label="explorer.undo"
+            />
+            <DButton
+              class="btn-transparent query-action-bar__help"
+              @action={{@controller.showHelpModal}}
+              @disabled={{@controller.actionsBusy}}
+              @icon="circle-question"
+              @label="explorer.help.label"
+            />
+          {{/if}}
+        </div>
+
+        <div class="query-action-bar__right">
+          {{#if (or @controller.hasResults (eq @controller.mode "ai"))}}
+            <DSegmentedControl
+              class="query-results-modes"
+              @items={{@controller.viewItems}}
+              @name="query-result-view"
+              @onSelect={{@controller.setView}}
+              @translatedLabel={{i18n "explorer.view.label"}}
+              @value={{@controller.view}}
+            />
+          {{/if}}
+          <QueryResultDownloadButtons
+            @content={{@controller.results}}
+            @includeQueryExport={{true}}
+            @query={{@controller.model}}
+          />
+
+          {{#if @controller.model.destroyed}}
+            <DButton
+              @action={{@controller.recover}}
+              @disabled={{@controller.actionsBusy}}
+              @icon="arrow-rotate-left"
+              @label="explorer.recover"
+            />
+          {{else if this.showDestroyQuery}}
+            <DButton
+              class="btn-danger"
+              @action={{@controller.destroyQuery}}
+              @disabled={{@controller.actionsBusy}}
+              @icon="trash-can"
+              @label="explorer.delete"
+            />
+          {{/if}}
+        </div>
+      </div>
+
+      <div hidden {{didInsert @controller.runOnLoad}}></div>
+
+      <DConditionalLoadingSpinner @condition={{@controller.loading}} />
+
+      {{#if (and (eq @controller.mode "ai") (eq @controller.view "sql"))}}
+        <div class="query-editor {{if @controller.hideSchema 'no-schema'}}">
+          <div class="query-editor__header">
+            <h3 class="query-editor__label">{{i18n "explorer.sql_label"}}</h3>
+          </div>
+
+          {{#if @controller.editingQuery}}
+            <div class="panels-flex query-editor__panes">
+              <div class="editor-panel">
+                <AceEditor
+                  @content={{@controller.model.sql}}
+                  @disabled={{@controller.editorDisabled}}
+                  @mode="sql"
+                  @onChange={{@controller.updateSql}}
+                  @save={{@controller.save}}
+                  @submit={{@controller.run}}
+                />
+              </div>
+
+              <div class="right-panel">
+                <ExplorerSchema
+                  @hideSchema={{@controller.hideSchema}}
+                  @schema={{@controller.schema}}
+                  @updateHideSchema={{@controller.updateHideSchema}}
+                />
+              </div>
+            </div>
+
+            <PaneSeparator @controller={{@controller}} />
+
+            <div class="clear"></div>
+          {{else}}
+            <div class="sql">
+              <CodeView
+                @codeClass="sql"
+                @setDirty={{@controller.setDirty}}
+                @value={{@controller.model.sql}}
+              />
+            </div>
+          {{/if}}
+        </div>
+      {{/if}}
+
+      {{#if (notEq @controller.view "sql")}}
+        <QueryResultsWrapper
+          @cachedAt={{@controller.cachedAt}}
+          @content={{@controller.results}}
+          @hideHeaderActions={{true}}
+          @onSetView={{@controller.setView}}
+          @query={{@controller.model}}
+          @results={{@controller.results}}
+          @showResults={{@controller.showResults}}
+          @view={{@controller.view}}
+        />
       {{/if}}
     </div>
   </template>

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
@@ -15,221 +15,211 @@ import ShareReport from "discourse/plugins/discourse-data-explorer/discourse/com
 
 export default <template>
   <div class="admin-detail">
-    {{#if @controller.disallow}}
-      <h1>{{i18n "explorer.admins_only"}}</h1>
-    {{else}}
-      <DPageSubheader @titleLabel={{i18n "explorer.queries"}}>
-        <:actions as |actions|>
-          <actions.Primary
-            @icon="plus"
-            @label="explorer.create"
-            @route="adminPlugins.show.explorer.new"
+    <DPageSubheader @titleLabel={{i18n "explorer.queries"}}>
+      <:actions as |actions|>
+        <actions.Primary
+          @icon="plus"
+          @label="explorer.create"
+          @route="adminPlugins.show.explorer.new"
+        />
+        <actions.Wrapped>
+          <DPickFilesButton
+            class="d-page-action-button btn-small"
+            @acceptedFormatsOverride={{@controller.acceptedImportFileTypes}}
+            @icon="upload"
+            @label="explorer.import.label"
+            @onFilesPicked={{@controller.import}}
+            @showButton="true"
           />
-          <actions.Wrapped>
-            <DPickFilesButton
-              class="d-page-action-button btn-small"
-              @acceptedFormatsOverride={{@controller.acceptedImportFileTypes}}
-              @icon="upload"
-              @label="explorer.import.label"
-              @onFilesPicked={{@controller.import}}
-              @showButton="true"
-            />
-          </actions.Wrapped>
-        </:actions>
-      </DPageSubheader>
+        </actions.Wrapped>
+      </:actions>
+    </DPageSubheader>
 
-      <DFilterControls
-        @array={{@controller.model.content}}
-        @inputPlaceholder={{i18n "explorer.search_placeholder"}}
-        @loading={{@controller.searchLoading}}
-        @noResultsMessage={{i18n "explorer.no_search_results"}}
-        @onResetFilters={{@controller.onResetFilters}}
-        @onTextFilterChange={{@controller.onTextFilterChange}}
-      >
-        <:aboveFilters>
-          {{#if @controller.othersDirty}}
-            <div class="warning">
-              {{dIcon "triangle-exclamation"}}
-              {{i18n "explorer.others_dirty"}}
-            </div>
-          {{/if}}
-        </:aboveFilters>
+    <DFilterControls
+      @array={{@controller.model.content}}
+      @inputPlaceholder={{i18n "explorer.search_placeholder"}}
+      @loading={{@controller.searchLoading}}
+      @noResultsMessage={{i18n "explorer.no_search_results"}}
+      @onResetFilters={{@controller.onResetFilters}}
+      @onTextFilterChange={{@controller.onTextFilterChange}}
+    >
+      <:aboveFilters>
+        {{#if @controller.othersDirty}}
+          <div class="warning">
+            {{dIcon "triangle-exclamation"}}
+            {{i18n "explorer.others_dirty"}}
+          </div>
+        {{/if}}
+      </:aboveFilters>
 
-        <:content as |filteredQueries|>
-          {{#if @controller.model.content.length}}
-            <DConditionalLoadingSpinner @condition={{@controller.loading}} />
+      <:content as |filteredQueries|>
+        {{#if @controller.model.content.length}}
+          <DConditionalLoadingSpinner @condition={{@controller.loading}} />
 
-            <DLoadMore @action={{@controller.loadMore}}>
-              <div class="container discourse-data-explorer-query-list">
-                <table class="d-table recent-queries">
-                  <thead class="d-table__header heading-container">
-                    <th class="col heading name">
-                      <div
-                        class="heading-toggle"
-                        role="button"
-                        {{on
-                          "click"
-                          (fn @controller.updateSortProperty "name")
-                        }}
-                      >
-                        <DTableHeaderToggle
-                          @asc={{not @controller.sortDescending}}
-                          @automatic="true"
-                          @field="name"
-                          @labelKey="explorer.query_name"
-                          @order={{@controller.order}}
-                        />
-                      </div>
-                    </th>
-                    <th class="col heading created-by">
-                      <div
-                        class="heading-toggle"
-                        role="button"
-                        {{on
-                          "click"
-                          (fn @controller.updateSortProperty "username")
-                        }}
-                      >
-                        <DTableHeaderToggle
-                          @asc={{not @controller.sortDescending}}
-                          @automatic="true"
-                          @field="username"
-                          @labelKey="explorer.query_user"
-                          @order={{@controller.order}}
-                        />
-                      </div>
-                    </th>
-                    <th class="col heading group-names">
-                      <div class="group-names-header">
-                        {{i18n "explorer.query_groups"}}
-                      </div>
-                    </th>
-                    <th class="col heading created-at">
-                      <div
-                        class="heading-toggle"
-                        role="button"
-                        {{on
-                          "click"
-                          (fn @controller.updateSortProperty "last_run_at")
-                        }}
-                      >
-                        <DTableHeaderToggle
-                          @asc={{not @controller.sortDescending}}
-                          @automatic="true"
-                          @field="last_run_at"
-                          @labelKey="explorer.query_time"
-                          @order={{@controller.order}}
-                        />
-                      </div>
-                    </th>
-                  </thead>
-                  <tbody>
-                    {{#each filteredQueries as |query|}}
-                      <tr class="d-table__row query-row">
-                        <td class="d-table__cell --overview">
-                          <LinkTo
-                            class="d-table__overview-link"
-                            @model={{query.id}}
-                            @route="adminPlugins.show.explorer.edit"
-                          >
-                            <div
-                              class="d-table__overview-name query-name"
-                            >{{query.name}}
-                              {{#if query.is_default}}
-                                <span class="query-badge">{{i18n
-                                    "explorer.default_query"
-                                  }}</span>
-                              {{/if}}
-                            </div>
-                            <div
-                              class="query-desc"
-                              title={{query.description}}
-                            >{{query.description}}</div>
-                          </LinkTo>
-                        </td>
-                        <td class="d-table__cell --detail query-created-by">
-                          <div class="d-table__mobile-label">
-                            {{i18n "explorer.query_user"}}
+          <DLoadMore @action={{@controller.loadMore}}>
+            <div class="container discourse-data-explorer-query-list">
+              <table class="d-table recent-queries">
+                <thead class="d-table__header heading-container">
+                  <th class="col heading name">
+                    <div
+                      class="heading-toggle"
+                      role="button"
+                      {{on "click" (fn @controller.updateSortProperty "name")}}
+                    >
+                      <DTableHeaderToggle
+                        @asc={{not @controller.sortDescending}}
+                        @automatic="true"
+                        @field="name"
+                        @labelKey="explorer.query_name"
+                        @order={{@controller.order}}
+                      />
+                    </div>
+                  </th>
+                  <th class="col heading created-by">
+                    <div
+                      class="heading-toggle"
+                      role="button"
+                      {{on
+                        "click"
+                        (fn @controller.updateSortProperty "username")
+                      }}
+                    >
+                      <DTableHeaderToggle
+                        @asc={{not @controller.sortDescending}}
+                        @automatic="true"
+                        @field="username"
+                        @labelKey="explorer.query_user"
+                        @order={{@controller.order}}
+                      />
+                    </div>
+                  </th>
+                  <th class="col heading group-names">
+                    <div class="group-names-header">
+                      {{i18n "explorer.query_groups"}}
+                    </div>
+                  </th>
+                  <th class="col heading created-at">
+                    <div
+                      class="heading-toggle"
+                      role="button"
+                      {{on
+                        "click"
+                        (fn @controller.updateSortProperty "last_run_at")
+                      }}
+                    >
+                      <DTableHeaderToggle
+                        @asc={{not @controller.sortDescending}}
+                        @automatic="true"
+                        @field="last_run_at"
+                        @labelKey="explorer.query_time"
+                        @order={{@controller.order}}
+                      />
+                    </div>
+                  </th>
+                </thead>
+                <tbody>
+                  {{#each filteredQueries as |query|}}
+                    <tr class="d-table__row query-row">
+                      <td class="d-table__cell --overview">
+                        <LinkTo
+                          class="d-table__overview-link"
+                          @model={{query.id}}
+                          @route="adminPlugins.show.explorer.edit"
+                        >
+                          <div
+                            class="d-table__overview-name query-name"
+                          >{{query.name}}
+                            {{#if query.is_default}}
+                              <span class="query-badge">{{i18n
+                                  "explorer.default_query"
+                                }}</span>
+                            {{/if}}
                           </div>
-                          {{#if query.username}}
-                            <div>
-                              <LinkTo
-                                @model={{query.username}}
-                                @route="user.summary"
-                              >
-                                {{query.username}}
-                              </LinkTo>
-                            </div>
-                          {{/if}}
-                        </td>
-                        <td class="d-table__cell --detail query-group-names">
-                          <div class="d-table__mobile-label">
-                            {{i18n "explorer.query_groups"}}
-                          </div>
-                          <div class="group-names">
-                            {{#each query.group_names as |group|}}
-                              <ShareReport @group={{group}} @query={{query}} />
-                            {{/each}}
-                            {{#unless query.group_names.length}}
-                              -
-                            {{/unless}}
-                          </div>
-                        </td>
-                        <td class="d-table__cell --detail query-created-at">
-                          <div class="d-table__mobile-label">
-                            {{i18n "explorer.query_time"}}
-                          </div>
-                          {{#if query.last_run_at}}
-                            <span>
-                              {{dAgeWithTooltip
-                                query.last_run_at
-                                format="medium"
-                              }}
-                            </span>
-                          {{else if query.created_at}}
-                            <span>
-                              {{dAgeWithTooltip
-                                query.created_at
-                                format="medium"
-                              }}
-                            </span>
-                          {{else}}
-                            -
-                          {{/if}}
-                        </td>
-                        <td class="d-table__cell-controls">
-                          <div class="d-table__cell-actions">
+                          <div
+                            class="query-desc"
+                            title={{query.description}}
+                          >{{query.description}}</div>
+                        </LinkTo>
+                      </td>
+                      <td class="d-table__cell --detail query-created-by">
+                        <div class="d-table__mobile-label">
+                          {{i18n "explorer.query_user"}}
+                        </div>
+                        {{#if query.username}}
+                          <div>
                             <LinkTo
-                              class="btn btn-text btn-default btn-small"
-                              @model={{query.id}}
-                              @route="adminPlugins.show.explorer.edit"
-                              {{on "click" @controller.scrollTop}}
+                              @model={{query.username}}
+                              @route="user.summary"
                             >
-                              {{i18n "edit"}}
+                              {{query.username}}
                             </LinkTo>
                           </div>
+                        {{/if}}
+                      </td>
+                      <td class="d-table__cell --detail query-group-names">
+                        <div class="d-table__mobile-label">
+                          {{i18n "explorer.query_groups"}}
+                        </div>
+                        <div class="group-names">
+                          {{#each query.group_names as |group|}}
+                            <ShareReport @group={{group}} @query={{query}} />
+                          {{/each}}
+                          {{#unless query.group_names.length}}
+                            -
+                          {{/unless}}
+                        </div>
+                      </td>
+                      <td class="d-table__cell --detail query-created-at">
+                        <div class="d-table__mobile-label">
+                          {{i18n "explorer.query_time"}}
+                        </div>
+                        {{#if query.last_run_at}}
+                          <span>
+                            {{dAgeWithTooltip
+                              query.last_run_at
+                              format="medium"
+                            }}
+                          </span>
+                        {{else if query.created_at}}
+                          <span>
+                            {{dAgeWithTooltip query.created_at format="medium"}}
+                          </span>
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                      <td class="d-table__cell-controls">
+                        <div class="d-table__cell-actions">
+                          <LinkTo
+                            class="btn btn-text btn-default btn-small"
+                            @model={{query.id}}
+                            @route="adminPlugins.show.explorer.edit"
+                            {{on "click" @controller.scrollTop}}
+                          >
+                            {{i18n "edit"}}
+                          </LinkTo>
+                        </div>
 
-                        </td>
-                      </tr>
-                    {{else}}
-                      <br />
-                      <em class="no-search-results">
-                        {{i18n "explorer.no_search_results"}}
-                      </em>
-                    {{/each}}
-                  </tbody>
-                </table>
-              </div>
-            </DLoadMore>
+                      </td>
+                    </tr>
+                  {{else}}
+                    <br />
+                    <em class="no-search-results">
+                      {{i18n "explorer.no_search_results"}}
+                    </em>
+                  {{/each}}
+                </tbody>
+              </table>
+            </div>
+          </DLoadMore>
 
-            <DConditionalLoadingSpinner
-              @condition={{@controller.model.loadingMore}}
-            />
+          <DConditionalLoadingSpinner
+            @condition={{@controller.model.loadingMore}}
+          />
 
-            <div class="explorer-pad-bottom"></div>
-          {{/if}}
-        </:content>
-      </DFilterControls>
-    {{/if}}
+          <div class="explorer-pad-bottom"></div>
+        {{/if}}
+      </:content>
+    </DFilterControls>
   </div>
 </template>

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer.js
@@ -1,3 +1,14 @@
-import Route from "@ember/routing/route";
+import { RouteException } from "discourse/controllers/exception";
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
-export default class extends Route {}
+export default class extends DiscourseRoute {
+  beforeModel() {
+    if (!this.currentUser?.admin) {
+      throw new RouteException({
+        status: 403,
+        desc: i18n("explorer.admins_only"),
+      });
+    }
+  }
+}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
@@ -15,11 +15,6 @@ export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
   };
 
   model(params, transition) {
-    if (!this.currentUser.admin) {
-      // display "Only available to admins" message
-      return { model: null, schema: null, disallow: true, groups: null };
-    }
-
     const groupPromise = ajax(
       "/admin/plugins/discourse-data-explorer/groups.json"
     );

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/index.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/index.js
@@ -16,11 +16,6 @@ export default class AdminPluginsExplorerIndex extends DiscourseRoute {
   }
 
   async model() {
-    if (!this.currentUser.admin) {
-      // display "Only available to admins" message
-      return { model: null, schema: null, disallow: true, groups: null };
-    }
-
     const [groups, model] = await Promise.all([
       ajax("/admin/plugins/discourse-data-explorer/groups.json"),
       this.store.findAll("query"),

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/run-query-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/run-query-test.js
@@ -14,6 +14,24 @@ import {
 } from "discourse/tests/helpers/ui-kit/pointer-gesture-helper";
 import { i18n } from "discourse-i18n";
 
+function stubPluginDetails(server, helper) {
+  server.get("/admin/plugins/discourse-data-explorer.json", () =>
+    helper.response({
+      id: "discourse-data-explorer",
+      name: "discourse-data-explorer",
+      enabled: true,
+      has_settings: true,
+      humanized_name: "Data Explorer",
+      is_discourse_owned: true,
+      admin_route: {
+        label: "explorer.title",
+        location: "discourse-data-explorer",
+        use_new_show_route: true,
+      },
+    })
+  );
+}
+
 acceptance("Run Query", function (needs) {
   needs.user();
   needs.settings({ data_explorer_enabled: true });
@@ -27,21 +45,7 @@ acceptance("Run Query", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/admin/plugins/discourse-data-explorer.json", () => {
-      return helper.response({
-        id: "discourse-data-explorer",
-        name: "discourse-data-explorer",
-        enabled: true,
-        has_settings: true,
-        humanized_name: "Data Explorer",
-        is_discourse_owned: true,
-        admin_route: {
-          label: "explorer.title",
-          location: "discourse-data-explorer",
-          use_new_show_route: true,
-        },
-      });
-    });
+    stubPluginDetails(server, helper);
 
     server.get("/admin/plugins/discourse-data-explorer/groups.json", () => {
       return helper.response([
@@ -582,5 +586,26 @@ acceptance("Run Query", function (needs) {
       heightWhenTornDown,
       "the detached panes keep the size they had when the separator went"
     );
+  });
+});
+
+acceptance("Run Query | non-admin", function (needs) {
+  needs.user({ admin: false });
+  needs.settings({ data_explorer_enabled: true });
+
+  needs.pretender((server, helper) => {
+    stubPluginDetails(server, helper);
+  });
+
+  test("shows the admins only error page", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/62");
+
+    assert.dom(".error-page .desc").hasText(i18n("explorer.admins_only"));
+  });
+
+  test("shows the admins only error page for a new query", async function (assert) {
+    await visit("/admin/plugins/discourse-data-explorer/queries/new");
+
+    assert.dom(".error-page .desc").hasText(i18n("explorer.admins_only"));
   });
 });


### PR DESCRIPTION
Stacked on #43475.

Previously, a non-admin opening a Data Explorer query page hit a route that returned a model with a `disallow` flag nothing set any more, so `setupController` dereferenced a missing query and the page rendered blank with a console error instead of an explanation.

This change throws a `RouteException` from the parent route, which renders the standard error page with the existing admins-only message, covers the new-query route that had no guard at all, and removes the unreachable template branches.