### PR TITLE
FIX: Track unread replies in channels with threading disabled

### DIFF
--- a/plugins/chat/app/queries/chat/channel_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/channel_unreads_query.rb
@@ -21,7 +21,7 @@ module Chat
     #   include_missing_memberships.
     def self.call(channel_ids:, user_id:, include_missing_memberships: false, include_read: true)
       # The CTE picks the candidate channel set up front and resolves the
-      # static per-channel filters (chatable_type, threading_enabled, muted,
+      # static per-channel filters (threading_enabled, muted, and
       # last_read_message_id) into columns. The three LATERAL aggregates then
       # run once per candidate, instead of three correlated subqueries each
       # joining tables that explode with the user's full membership lists.
@@ -36,7 +36,6 @@ module Chat
             memberships.chat_channel_id,
             memberships.last_read_message_id,
             memberships.muted,
-            chat_channels.chatable_type,
             chat_channels.threading_enabled
           FROM user_chat_channel_memberships AS memberships
           INNER JOIN chat_channels ON chat_channels.id = memberships.chat_channel_id
@@ -72,25 +71,24 @@ module Chat
                 AND cm.deleted_at IS NULL
             )
             +
-            -- (3) DM channel + threading disabled: thread replies the user is
-            -- a member of and hasn't read. Only fires for DM channels with
-            -- threading off (auto-enrolled DM threads).
+            -- (3) Thread replies that render inline in the channel stream,
+            -- meaning every reply in a non-forced thread while the channel has
+            -- threading disabled (see Chat::MessagesQuery). Such threads have
+            -- no pane of their own, so Chat::ThreadUnreadsQuery ignores them
+            -- and they are counted here instead, against the channel's own
+            -- read marker, for every member the stream shows them to.
             (
               SELECT COUNT(*)
-              FROM chat_messages cm
-              INNER JOIN chat_threads ct ON ct.id = cm.thread_id
-              INNER JOIN user_chat_thread_memberships uctm
-                      ON uctm.thread_id = cm.thread_id
-                     AND uctm.user_id = :user_id
-              WHERE lc.chatable_type = 'DirectMessage'
+              FROM chat_threads ct
+              INNER JOIN chat_messages cm
+                      ON cm.thread_id = ct.id
+                     AND cm.deleted_at IS NULL
+              WHERE ct.channel_id = lc.chat_channel_id
                 AND NOT lc.threading_enabled
-                AND cm.chat_channel_id = lc.chat_channel_id
-                AND cm.thread_id IS NOT NULL
+                AND NOT ct.force
                 AND cm.id != ct.original_message_id
                 AND cm.id > COALESCE(lc.last_read_message_id, 0)
-                AND cm.id > COALESCE(uctm.last_read_message_id, 0)
                 AND cm.user_id != :user_id
-                AND cm.deleted_at IS NULL
             ) AS cnt
         ) unread_calc ON true
         LEFT JOIN LATERAL (
@@ -105,8 +103,14 @@ module Chat
             AND NOT n.read
             AND (n.data::json->>'chat_channel_id')::bigint = lc.chat_channel_id
             AND (
-              ((cm.thread_id IS NULL OR cm.id = ct.original_message_id)
+              -- Mentions on a message in the channel stream, including replies
+              -- that render inline, are read via the channel's marker. Piece
+              -- (3) of unread_count above draws the same line.
+              ((cm.thread_id IS NULL
+                 OR cm.id = ct.original_message_id
+                 OR (NOT lc.threading_enabled AND NOT ct.force))
                 AND cm.id > COALESCE(lc.last_read_message_id, 0))
+              -- Mentions inside a thread pane are read via the thread's marker.
               OR (cm.thread_id IS NOT NULL
                 AND uctm.id IS NOT NULL
                 AND cm.id > COALESCE(uctm.last_read_message_id, 0))

--- a/plugins/chat/app/services/chat/update_user_channel_last_read.rb
+++ b/plugins/chat/app/services/chat/update_user_channel_last_read.rb
@@ -30,7 +30,6 @@ module Chat
     transaction do
       step :update_membership_state
       step :mark_associated_mentions_as_read
-      step :mark_dm_replies_as_read
     end
     step :publish_new_last_read_to_clients
 
@@ -66,24 +65,6 @@ module Chat
         channel_ids: [membership.chat_channel.id],
         message_id: message.id,
       )
-    end
-
-    def mark_dm_replies_as_read(channel:, guardian:, message:)
-      return unless channel.direct_message_channel? && !channel.threading_enabled
-
-      # For DM channels with threading disabled, mark thread memberships as read
-      # so reply messages don't leave uncleanable unread indicators
-      DB.exec(<<~SQL, user_id: guardian.user.id, channel_id: channel.id, message_id: message.id)
-        UPDATE user_chat_thread_memberships
-        SET last_read_message_id = chat_threads.last_message_id
-        FROM chat_threads
-        WHERE user_chat_thread_memberships.thread_id = chat_threads.id
-          AND user_chat_thread_memberships.user_id = :user_id
-          AND chat_threads.channel_id = :channel_id
-          AND chat_threads.last_message_id IS NOT NULL
-          AND chat_threads.last_message_id <= :message_id
-          AND (user_chat_thread_memberships.last_read_message_id IS NULL OR chat_threads.last_message_id > user_chat_thread_memberships.last_read_message_id)
-      SQL
     end
 
     def publish_new_last_read_to_clients(guardian:, channel:, message:)

--- a/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
@@ -22,6 +22,10 @@ describe Chat::ChannelUnreadsQuery do
     channel_1.add(current_user)
   end
 
+  def counts_for(user)
+    described_class.call(channel_ids: channel_ids, user_id: user.id).first
+  end
+
   context "with unread message" do
     before { Fabricate(:chat_message, chat_channel: channel_1) }
 
@@ -71,17 +75,34 @@ describe Chat::ChannelUnreadsQuery do
         )
       end
 
-      it "does not include other thread messages in the unread count" do
+      it "does include thread replies in the unread count, as they render inline" do
         Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
         Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
         expect(query.first).to eq(
           {
             mention_count: 0,
-            unread_count: 2,
+            unread_count: 4,
             watched_threads_unread_count: 0,
             channel_id: channel_1.id,
           },
         )
+      end
+
+      context "when threading is enabled" do
+        before { channel_1.update!(threading_enabled: true) }
+
+        it "does not include thread replies in the unread count" do
+          Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
+          Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
+          expect(query.first).to eq(
+            {
+              mention_count: 0,
+              unread_count: 2,
+              watched_threads_unread_count: 0,
+              channel_id: channel_1.id,
+            },
+          )
+        end
       end
     end
 
@@ -231,14 +252,54 @@ describe Chat::ChannelUnreadsQuery do
         create_mention(thread_message_1, channel_1)
         create_mention(thread_message_2, channel_1)
 
+        # Channel has threading disabled (default), so the thread replies render
+        # inline and count toward unread_count alongside the OM.
         expect(query.first).to eq(
           {
             mention_count: 2,
-            unread_count: 1,
+            unread_count: 3,
             watched_threads_unread_count: 0,
             channel_id: channel_1.id,
           },
         )
+      end
+    end
+
+    context "for unread mentions in a thread the user does not participate in" do
+      fab!(:thread_om) { Fabricate(:chat_message, chat_channel: channel_1) }
+      fab!(:thread) { Fabricate(:chat_thread, channel: channel_1, original_message: thread_om) }
+
+      it "counts a mention in a reply that renders inline" do
+        reply = Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
+        create_mention(reply, channel_1)
+
+        expect(thread.membership_for(current_user)).to be_nil
+        expect(query.first).to eq(
+          {
+            mention_count: 1,
+            unread_count: 2,
+            watched_threads_unread_count: 0,
+            channel_id: channel_1.id,
+          },
+        )
+      end
+
+      context "when threading is enabled" do
+        before { channel_1.update!(threading_enabled: true) }
+
+        it "does not count the mention at the channel level, as the reply lives in a thread" do
+          reply = Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
+          create_mention(reply, channel_1)
+
+          expect(query.first).to eq(
+            {
+              mention_count: 0,
+              unread_count: 1,
+              watched_threads_unread_count: 0,
+              channel_id: channel_1.id,
+            },
+          )
+        end
       end
     end
 
@@ -416,6 +477,112 @@ describe Chat::ChannelUnreadsQuery do
         watched_threads_unread_count: 0,
         channel_id: dm_channel.id,
       )
+    end
+
+    it "does not count SDK-forced thread replies at the channel level" do
+      first_message = Fabricate(:chat_message, chat_channel: dm_channel, user: other_user)
+      dm_channel.membership_for(current_user).mark_read!(first_message.id)
+
+      Chat::CreateMessage.call(
+        guardian: Guardian.new(other_user),
+        options: {
+          force_thread: true,
+        },
+        params: {
+          chat_channel_id: dm_channel.id,
+          message: "This is a forced thread reply",
+          in_reply_to_id: first_message.id,
+        },
+      )
+
+      expect(query.first).to eq(
+        mention_count: 0,
+        unread_count: 0,
+        watched_threads_unread_count: 0,
+        channel_id: dm_channel.id,
+      )
+    end
+  end
+
+  context "with category channel and reply messages (threading disabled)" do
+    fab!(:other_user, :user)
+    fab!(:bystander, :user)
+    fab!(:first_message) { Fabricate(:chat_message, chat_channel: channel_1, user: current_user) }
+
+    before do
+      channel_1.add(other_user)
+      channel_1.add(bystander)
+      [current_user, other_user, bystander].each do |user|
+        channel_1.membership_for(user).mark_read!(first_message.id)
+      end
+    end
+
+    def reply(user: other_user, force_thread: false)
+      Chat::CreateMessage.call(
+        guardian: Guardian.new(user),
+        options: {
+          force_thread: force_thread,
+        },
+        params: {
+          chat_channel_id: channel_1.id,
+          message: "This is a reply",
+          in_reply_to_id: first_message.id,
+        },
+      ).message_instance
+    end
+
+    it "counts replies to the user's message as unread" do
+      reply
+
+      expect(query.first).to eq(
+        mention_count: 0,
+        unread_count: 1,
+        watched_threads_unread_count: 0,
+        channel_id: channel_1.id,
+      )
+    end
+
+    it "counts the reply for channel members who are not in the thread" do
+      reply
+      expect(counts_for(bystander).unread_count).to eq(1)
+    end
+
+    it "does not count the sender's own reply as unread" do
+      reply(user: current_user)
+
+      expect(query.first).to eq(
+        mention_count: 0,
+        unread_count: 0,
+        watched_threads_unread_count: 0,
+        channel_id: channel_1.id,
+      )
+    end
+
+    it "does not count SDK-forced thread replies at the channel level" do
+      reply(force_thread: true)
+
+      expect(query.first).to eq(
+        mention_count: 0,
+        unread_count: 0,
+        watched_threads_unread_count: 0,
+        channel_id: channel_1.id,
+      )
+    end
+
+    it "stops counting the reply once the channel has been read" do
+      reply_message = reply
+
+      expect(query.first[:unread_count]).to eq(1)
+
+      Chat::UpdateUserChannelLastRead.call(
+        guardian: Guardian.new(current_user),
+        params: {
+          channel_id: channel_1.id,
+          message_id: reply_message.id,
+        },
+      )
+
+      expect(counts_for(current_user).unread_count).to eq(0)
     end
   end
 end

--- a/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
@@ -118,37 +118,6 @@ RSpec.describe Chat::UpdateUserChannelLastRead do
           result
           expect(membership.reload.last_viewed_at).not_to eq_time(old_last_viewed_at)
         end
-
-        context "with DM channel reply threads" do
-          fab!(:other_user, :user)
-          fab!(:dm_channel) do
-            Fabricate(:direct_message_channel, users: [current_user, other_user])
-          end
-          fab!(:first_message) do
-            Fabricate(:chat_message, chat_channel: dm_channel, user: other_user)
-          end
-
-          let(:params) { { channel_id: dm_channel.id, message_id: reply_message.id } }
-          let(:reply_message) do
-            Chat::CreateMessage.call(
-              guardian: Guardian.new(other_user),
-              params: {
-                chat_channel_id: dm_channel.id,
-                message: "This is a reply",
-                in_reply_to_id: first_message.id,
-              },
-            ).message_instance
-          end
-
-          it "marks DM reply thread memberships as read" do
-            thread = reply_message.thread
-            thread_membership = thread.membership_for(current_user)
-
-            expect { result }.to change { thread_membership.reload.last_read_message_id }.to(
-              reply_message.id,
-            )
-          end
-        end
       end
     end
   end

--- a/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
@@ -362,6 +362,47 @@ RSpec.describe "Message notifications - with sidebar" do
             expect(page).to have_css(".sidebar-row.channel-#{dm_channel.id} .urgent")
           end
         end
+
+        context "with category channel replies (threading disabled)" do
+          fab!(:channel) { Fabricate(:category_channel, threading_enabled: false) }
+          fab!(:first_message) do
+            Fabricate(:chat_message_with_service, chat_channel: channel, user: current_user)
+          end
+
+          before do
+            channel.add(current_user)
+            channel.add(other_user)
+            channel.membership_for(current_user).mark_read!(first_message.id)
+          end
+
+          def reply_to_first_message
+            Chat::CreateMessage.call(
+              guardian: other_user.guardian,
+              params: {
+                chat_channel_id: channel.id,
+                message: "This is a reply",
+                in_reply_to_id: first_message.id,
+              },
+            )
+          end
+
+          it "shows the unread indicator when someone replies to the user's message" do
+            visit("/")
+            expect(page).to have_no_css(".sidebar-row.channel-#{channel.id} .unread")
+
+            reply_to_first_message
+
+            expect(page).to have_css(".sidebar-row.channel-#{channel.id} .unread")
+          end
+
+          it "shows the unread indicator on a fresh page load after the reply" do
+            reply_to_first_message
+
+            visit("/")
+
+            expect(page).to have_css(".sidebar-row.channel-#{channel.id} .unread")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Replying to someone in a channel with threading disabled leaves no unread indicator, because the reply was tracked as a thread message while rendering in the channel stream. Essentially we have an expectation that the threading interface will handle this state, but don't have coverage when threading is disabled. 

This fix counts those replies against the channel's read marker, so both the unread dot and mentions inside the reply now show up when threading is disabled. 

Issue originally reported here: https://meta.discourse.org/t/chat-notifications-not-showing-for-replies-in-chat-channels/410620

To repro: 

1. Create channel with threading disabled
2. Post a message in that channel, then navigate away from the channel
3. Open an incognito window and log in as a different user
4. Join the channel and reply to that first message 
5. Switch to the original user, and note that you can see the unread dot in the sidebar
6. Refresh the page, you'll notice the unread dot in the sidebar goes away despite not having visited the channel 