### PR TITLE
FIX: Hide voice status in private rooms

### DIFF
--- a/plugins/voice/lib/voice/user_status_manager.rb
+++ b/plugins/voice/lib/voice/user_status_manager.rb
@@ -20,6 +20,7 @@ module Voice
     def self.set_voice_status(user, room)
       return unless SiteSetting.enable_user_status
       return unless SiteSetting.voice_auto_status_enabled
+      return clear_voice_status(user) if !room.public?
       return if user_has_non_voice_status?(user)
 
       set_status(user, status_description(room), EMOJI)
@@ -27,6 +28,7 @@ module Voice
 
     def self.set_afk_status(user, room)
       return unless SiteSetting.enable_user_status
+      return clear_voice_status(user) if !room.public?
       return unless voice_status_active?(user)
 
       set_status(user, status_description(room, afk: true), AFK_EMOJI)
@@ -77,15 +79,10 @@ module Voice
       status && !status.expired? && voice_emoji?(status.emoji)
     end
 
-    # Statuses are visible site-wide, so a non-public room's name must not
-    # appear in them — even room members get the generic description.
+    # Only public rooms publish a site-wide status.
     private_class_method def self.status_description(room, afk: false)
       prefix = afk ? "afk_" : ""
-      if room.public?
-        I18n.t("voice.user_status.#{prefix}in_room", room_name: room.name)
-      else
-        I18n.t("voice.user_status.#{prefix}in_private_room")
-      end
+      I18n.t("voice.user_status.#{prefix}in_room", room_name: room.name)
     end
 
     # Without an expiry to roll, an unchanged status needs no upsert — this

--- a/plugins/voice/spec/jobs/scheduled/publish_room_participants_spec.rb
+++ b/plugins/voice/spec/jobs/scheduled/publish_room_participants_spec.rb
@@ -104,6 +104,9 @@ RSpec.describe Jobs::PublishRoomParticipants do
   end
 
   describe "stale status sweep" do
+    # Only public rooms publish a status; a private room clears it instead.
+    fab!(:room) { Fabricate(:voice_room, public: true) }
+
     before do
       SiteSetting.enable_user_status = true
       SiteSetting.voice_auto_status_enabled = true
@@ -148,7 +151,7 @@ RSpec.describe Jobs::PublishRoomParticipants do
     end
 
     it "keeps a user's status while they are live in another active room" do
-      other_room = Fabricate(:voice_room)
+      other_room = Fabricate(:voice_room, public: true)
       Voice::ParticipantTracker.add(room.id, user1.id)
       Voice::UserStatusManager.set_voice_status(user1, other_room)
 

--- a/plugins/voice/spec/lib/voice/user_status_manager_spec.rb
+++ b/plugins/voice/spec/lib/voice/user_status_manager_spec.rb
@@ -31,12 +31,10 @@ RSpec.describe Voice::UserStatusManager do
       expect(messages).to be_empty
     end
 
-    it "does not leak the name of a private room" do
+    it "does not publish a status for a private room" do
       described_class.set_voice_status(user, private_room)
 
-      user.reload
-      expect(user.user_status.description).to eq("In a voice room")
-      expect(user.user_status.description).not_to include(private_room.name)
+      expect(user.reload.user_status).to be_nil
     end
 
     it "skips when user already has a non-Voice status" do
@@ -93,13 +91,11 @@ RSpec.describe Voice::UserStatusManager do
       expect(user.user_status.ends_at).to be_nil
     end
 
-    it "does not leak the name of a private room" do
+    it "does not publish an AFK status for a private room" do
       described_class.set_voice_status(user, private_room)
       described_class.set_afk_status(user, private_room)
 
-      user.reload
-      expect(user.user_status.description).to eq("AFK in a voice room")
-      expect(user.user_status.description).not_to include(private_room.name)
+      expect(user.reload.user_status).to be_nil
     end
 
     it "skips when the user has a non-Voice status" do
@@ -115,6 +111,45 @@ RSpec.describe Voice::UserStatusManager do
       described_class.set_afk_status(user, room)
 
       expect(user.user_status).to be_nil
+    end
+  end
+
+  %i[set_voice_status set_afk_status].each do |method|
+    describe ".#{method} in private rooms" do
+      it "clears an existing public-room status and releases ownership" do
+        described_class.set_voice_status(user, room)
+
+        described_class.public_send(method, user, private_room)
+
+        expect(user.reload.user_status).to be_nil
+        expect(Discourse.redis.smembers(described_class::OWNERS_KEY)).not_to include(user.id.to_s)
+      end
+
+      it "clears an existing AFK status" do
+        described_class.set_voice_status(user, room)
+        described_class.set_afk_status(user, room)
+
+        described_class.public_send(method, user, private_room)
+
+        expect(user.reload.user_status).to be_nil
+      end
+
+      it "clears a private-room status created before private statuses were disabled" do
+        user.set_status!("In a voice room", "studio_microphone")
+
+        described_class.public_send(method, user, private_room)
+
+        expect(user.reload.user_status).to be_nil
+      end
+
+      it "preserves a custom user status" do
+        user.set_status!("On vacation", "palm_tree")
+
+        described_class.public_send(method, user, private_room)
+
+        expect(user.reload.user_status.description).to eq("On vacation")
+        expect(user.user_status.emoji).to eq("palm_tree")
+      end
     end
   end
 


### PR DESCRIPTION
Do not publish site-wide voice or AFK statuses for private rooms. Clear existing voice statuses when entering a private room.

Add regression coverage for private-room statuses, public-to-private transitions, and preservation of unrelated custom statuses.