### PR TITLE
FEATURE: Add an "Unread first" chat channel list sort

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-list-sort-choice.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-list-sort-choice.gjs
@@ -25,6 +25,13 @@ export const SORT_OPTIONS = [
     descriptionKey: "chat.channel_list.sort.priority_description",
     labelKey: "chat.channel_list.sort.priority",
   },
+  {
+    value: CHAT_CHANNEL_LIST_SORTS.UNREAD_FIRST,
+    className: "chat-channel-list-sort-menu__unread-first --with-description",
+    dataOptionId: "unread_first",
+    descriptionKey: "chat.channel_list.sort.unread_first_description",
+    labelKey: "chat.channel_list.sort.unread_first",
+  },
 ];
 
 /**

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-constants.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-constants.js
@@ -37,6 +37,7 @@ export const CHAT_CHANNEL_LIST_SORTS = Object.freeze({
   ALPHABETICAL: "alphabetical",
   RECENT_ACTIVITY: "recent_activity",
   PRIORITY: "priority",
+  UNREAD_FIRST: "unread_first",
 });
 export const CHAT_CHANNEL_LIST_ACTIVE_DAYS = 30;
 export const CHAT_QUICK_REACTIONS_CUSTOM_DEFAULT = "heart|+1|smile";

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -567,6 +567,14 @@ export default class ChatChannelsManager extends Service {
       return this.#compareChannelsAlphabetically(channelA, channelB);
     }
 
+    if (sort === CHAT_CHANNEL_LIST_SORTS.UNREAD_FIRST) {
+      return (
+        this.#sidebarChannelUnreadTier(channelA) -
+          this.#sidebarChannelUnreadTier(channelB) ||
+        this.#compareChannelsAlphabetically(channelA, channelB)
+      );
+    }
+
     if (sort === CHAT_CHANNEL_LIST_SORTS.PRIORITY) {
       const priority =
         this.#sidebarChannelPriority(channelA) -
@@ -617,6 +625,17 @@ export default class ChatChannelsManager extends Service {
     }
 
     return this.#sidebarUnreadCount(channel) > 0 ? 1 : 2;
+  }
+
+  // Two tiers for the "unread first" sort: anything unread (including
+  // mentions and watched threads) comes before everything read. Muted
+  // channels count as read, matching the priority sort.
+  #sidebarChannelUnreadTier(channel) {
+    if (channel.currentUserMembership?.muted) {
+      return 1;
+    }
+
+    return this.#sidebarUnreadCount(channel) > 0 ? 0 : 1;
   }
 
   #sidebarUnreadCount(channel) {

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -665,6 +665,8 @@ en:
           recent_activity: "Recent activity"
           priority: "Priority"
           priority_description: "Mentions, then unreads, then recent activity"
+          unread_first: "Unread first"
+          unread_first_description: "Unread channels alphabetically, then the rest alphabetically"
         empty:
           filtered: "No channels match this filter."
           show_all: "Show all channels"

--- a/plugins/chat/lib/chat/user_option_extension.rb
+++ b/plugins/chat/lib/chat/user_option_extension.rb
@@ -84,7 +84,12 @@ module Chat
       end
 
       def base.chat_channel_list_sorts
-        @chat_channel_list_sorts ||= { alphabetical: 0, recent_activity: 1, priority: 2 }
+        @chat_channel_list_sorts ||= {
+          alphabetical: 0,
+          recent_activity: 1,
+          priority: 2,
+          unread_first: 3,
+        }
       end
 
       if !base.method_defined?(:chat_channel_list_sort_alphabetical?)

--- a/plugins/chat/spec/models/user_option_spec.rb
+++ b/plugins/chat/spec/models/user_option_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe UserOption do
       expect(user_option).not_to be_valid
       expect(user_option.errors[:chat_channel_list_sort]).to be_present
     end
+
+    it "accepts every sort the channel list offers" do
+      %w[alphabetical recent_activity priority unread_first].each do |sort|
+        user_option = described_class.new(chat_channel_list_sort: sort)
+        user_option.valid?
+        expect(user_option.errors[:chat_channel_list_sort]).to be_empty
+      end
+    end
   end
 
   describe "#chat_send_shortcut" do

--- a/plugins/chat/spec/system/sidebar_channel_list_options_spec.rb
+++ b/plugins/chat/spec/system/sidebar_channel_list_options_spec.rb
@@ -33,6 +33,36 @@ RSpec.describe "Chat sidebar channel list options" do
     sign_in(current_user)
   end
 
+  it "puts unread channels first, alphabetically, ahead of read channels" do
+    # Bravo is unread but older than Alpha's last message, so it separates
+    # "unread first" from "recent activity", which would place it last.
+    older_unread_channel = Fabricate(:category_channel, name: "Bravo channel")
+    older_unread_channel.add(current_user)
+    older_unread_message =
+      Fabricate(
+        :chat_message,
+        chat_channel: older_unread_channel,
+        user: message_author,
+        created_at: 3.days.ago,
+      )
+    older_unread_channel.update!(last_message: older_unread_message, messages_count: 1)
+
+    visit("/")
+
+    chat_sidebar.set_channel_sort("unread_first")
+
+    try_until_success(reason: "channel list re-sorts after the menu closes") do
+      expect(chat_sidebar.channel_names).to eq(["Bravo channel", "Zulu channel", "Alpha channel"])
+    end
+    try_until_success(reason: "channel sort preference saves asynchronously") do
+      expect(current_user.user_option.reload.chat_channel_list_sort).to eq("unread_first")
+    end
+
+    page.refresh
+
+    expect(chat_sidebar.channel_names).to eq(["Bravo channel", "Zulu channel", "Alpha channel"])
+  end
+
   it "sorts, filters, and persists the user's choices" do
     visit("/")
 

--- a/plugins/chat/test/javascripts/unit/services/chat-channels-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channels-manager-test.js
@@ -569,6 +569,45 @@ module("Unit | Service | chat-channels-manager", function (hooks) {
       );
     });
 
+    test("sorts unread channels alphabetically before read channels", function (assert) {
+      this.preferences.channelsSort = CHAT_CHANNEL_LIST_SORTS.UNREAD_FIRST;
+      this.buildChannel({ id: 1, slug: "alpha-read", createdAt: "2026-09-04" });
+      this.buildChannel({
+        id: 2,
+        slug: "zulu-unread",
+        createdAt: "2026-09-01",
+        unreadCount: 1,
+      });
+      this.buildChannel({
+        id: 3,
+        slug: "mike-mention",
+        createdAt: "2026-08-30",
+        mentionCount: 1,
+      });
+      this.buildChannel({ id: 4, slug: "bravo-read", createdAt: "2026-09-03" });
+      this.buildChannel({
+        id: 5,
+        slug: "charlie-muted",
+        createdAt: "2026-09-05",
+        unreadCount: 3,
+        muted: true,
+      });
+
+      assert.deepEqual(
+        this.subject.sidebarPublicMessageChannels.map(
+          (channel) => channel.slug
+        ),
+        [
+          "mike-mention",
+          "zulu-unread",
+          "alpha-read",
+          "bravo-read",
+          "charlie-muted",
+        ],
+        "unread channels come first, each tier alphabetical, muted counts as read"
+      );
+    });
+
     test("filters channels by recent activity", function (assert) {
       const clock = sinon.useFakeTimers(new Date("2026-09-03T12:00:00Z"));
 


### PR DESCRIPTION
The channel list can be sorted alphabetically, by recent activity, or by priority. Recent activity mixes read and unread channels by the age of their last message, so a channel you have already caught up on can sit above one with new messages, and priority reorders within its tiers by recency rather than by name.

This adds a fourth option, "Unread first": channels with unread messages sorted alphabetically, followed by read channels sorted alphabetically. Mentions and watched-thread unreads count as unread. Muted channels are treated as read, matching the priority sort. The option is saved per section (channels, starred, direct messages) like the existing sorts and applies to the sidebar, drawer, and mobile lists, which share one comparator.