### PR TITLE
FIX: Stop has_badge leaking between routes

### DIFF
--- a/frontend/discourse/app/controllers/badges/show.js
+++ b/frontend/discourse/app/controllers/badges/show.js
@@ -50,12 +50,19 @@ export default class ShowController extends Controller {
     return this.model?.grant_count - this.userBadgesGrantCount;
   }
 
-  @computed("model.allow_title", "model.has_badge", "model")
+  @computed("model.id", "userBadgesAll")
+  get currentUserHasBadge() {
+    return !!this.userBadgesAll?.some(
+      (userBadge) => userBadge.badge?.id === this.model?.id
+    );
+  }
+
+  @computed("model.allow_title", "currentUserHasBadge")
   get canSelectTitle() {
     return (
       this.siteSettings.enable_badges &&
       this.model?.allow_title &&
-      this.model?.has_badge
+      this.currentUserHasBadge
     );
   }
 

--- a/frontend/discourse/app/data/normalize.js
+++ b/frontend/discourse/app/data/normalize.js
@@ -10,8 +10,16 @@ import { TopicDetailsSchema } from "discourse/data/schemas/topic-details";
 import { UserBadgeSchema } from "discourse/data/schemas/user-badge";
 import { badgeGroupingDisplayName } from "discourse/models/badge-grouping";
 
-function badgeResource(raw, includedIds) {
+// `has_badge` is viewer-relative and the badge endpoints are the only ones
+// that compute it — they omit it instead of sending `false`, so `grantsKnown`
+// callers clear it. Everywhere else a badge is sideloaded by a payload that
+// knows nothing about the viewer's grants, and must leave the cache alone:
+// overwriting would flip the flag under whatever is on screen.
+function badgeResource(raw, includedIds, { grantsKnown = false } = {}) {
   const resource = resourceFrom("badge", BadgeSchema, raw);
+  if (grantsKnown) {
+    resource.attributes.has_badge = raw.has_badge ?? false;
+  }
   const relationships = {};
   maybeRelate(
     relationships,
@@ -89,11 +97,14 @@ export function normalizeBadgesPayload(payload) {
   collectBadgeMetaIncluded(payload, included);
   const includedIds = indexIncluded(included);
 
+  const opts = { grantsKnown: true };
   if (payload.badge) {
-    return { data: badgeResource(payload.badge, includedIds), included };
+    return { data: badgeResource(payload.badge, includedIds, opts), included };
   }
   return {
-    data: (payload.badges ?? []).map((raw) => badgeResource(raw, includedIds)),
+    data: (payload.badges ?? []).map((raw) =>
+      badgeResource(raw, includedIds, opts)
+    ),
     included,
   };
 }

--- a/frontend/discourse/app/data/normalize.js
+++ b/frontend/discourse/app/data/normalize.js
@@ -10,11 +10,6 @@ import { TopicDetailsSchema } from "discourse/data/schemas/topic-details";
 import { UserBadgeSchema } from "discourse/data/schemas/user-badge";
 import { badgeGroupingDisplayName } from "discourse/models/badge-grouping";
 
-// `has_badge` is viewer-relative and the badge endpoints are the only ones
-// that compute it — they omit it instead of sending `false`, so `grantsKnown`
-// callers clear it. Everywhere else a badge is sideloaded by a payload that
-// knows nothing about the viewer's grants, and must leave the cache alone:
-// overwriting would flip the flag under whatever is on screen.
 function badgeResource(raw, includedIds, { grantsKnown = false } = {}) {
   const resource = resourceFrom("badge", BadgeSchema, raw);
   if (grantsKnown) {

--- a/frontend/discourse/app/templates/badges/index.gjs
+++ b/frontend/discourse/app/templates/badges/index.gjs
@@ -27,6 +27,7 @@ export default <template>
               {{#each bg.badges as |b|}}
                 <DBadgeCard
                   @badge={{b}}
+                  @granted={{b.has_badge}}
                   @username={{@controller.currentUser.username}}
                 />
               {{/each}}

--- a/frontend/discourse/app/templates/badges/show.gjs
+++ b/frontend/discourse/app/templates/badges/show.gjs
@@ -28,6 +28,7 @@ export default <template>
       <DBadgeCard
         @badge={{@controller.model}}
         @count={{@controller.userBadgesGrantCount}}
+        @granted={{@controller.currentUserHasBadge}}
         @size="large"
       />
       <div

--- a/frontend/discourse/app/ui-kit/d-badge-card.gjs
+++ b/frontend/discourse/app/ui-kit/d-badge-card.gjs
@@ -53,7 +53,7 @@ export default class DBadgeCard extends Component {
       ids.push(`badge-granted-${badge.slug}`);
     }
 
-    if (badge.has_badge) {
+    if (this.args.granted) {
       ids.push(`badge-awarded-${badge.slug}`);
     }
 
@@ -112,7 +112,7 @@ export default class DBadgeCard extends Component {
         </div>
       </div>
 
-      {{#if @badge.has_badge}}
+      {{#if @granted}}
         <div
           aria-label={{i18n "notifications.titles.granted_badge"}}
           class="check-display status-checked"

--- a/frontend/discourse/tests/acceptance/badges-test.js
+++ b/frontend/discourse/tests/acceptance/badges-test.js
@@ -38,6 +38,17 @@ acceptance("Badges", function (needs) {
       "CustomBadge"
     );
   });
+
+  test("marks a badge the current user holds as granted", async function (assert) {
+    await visit("/badges/50/custombadge");
+
+    assert
+      .dom(".show-badge-details .check-display")
+      .exists("the badge is marked as granted");
+    assert
+      .dom(".badge-grant-info .btn-default")
+      .exists("the badge title can be selected");
+  });
 });
 
 acceptance("Badges - favorites", function (needs) {

--- a/frontend/discourse/tests/integration/ui-kit/d-badge-card-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-badge-card-test.gjs
@@ -1,0 +1,47 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DBadgeCard from "discourse/ui-kit/d-badge-card";
+
+module("Integration | ui-kit | DBadgeCard", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("granted", async function (assert) {
+    const badge = { slug: "custombadge" };
+
+    await render(
+      <template><DBadgeCard @badge={{badge}} @granted={{true}} /></template>
+    );
+
+    assert.dom(".check-display").exists();
+    assert
+      .dom(".badge-link")
+      .hasAttribute(
+        "aria-describedby",
+        "badge-summary-custombadge badge-awarded-custombadge"
+      );
+  });
+
+  test("not granted", async function (assert) {
+    const badge = { slug: "custombadge" };
+
+    await render(<template><DBadgeCard @badge={{badge}} /></template>);
+
+    assert.dom(".check-display").doesNotExist();
+    assert
+      .dom(".badge-link")
+      .hasAttribute("aria-describedby", "badge-summary-custombadge");
+  });
+
+  test("ignores has_badge on the badge itself", async function (assert) {
+    const badge = { slug: "custombadge", has_badge: true };
+
+    await render(<template><DBadgeCard @badge={{badge}} /></template>);
+
+    assert
+      .dom(".check-display")
+      .doesNotExist(
+        "the caller says who holds the badge, not the shared record"
+      );
+  });
+});

--- a/frontend/discourse/tests/unit/models/badge-test.js
+++ b/frontend/discourse/tests/unit/models/badge-test.js
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import Badge from "discourse/models/badge";
+import UserBadge from "discourse/models/user-badge";
 import pretender, {
   parsePostData,
   response,
@@ -47,6 +48,86 @@ module("Unit | Model | badge", function (hooks) {
     const badge = Badge.createFromJson(badgeJson);
 
     assert.false(Array.isArray(badge), "does not returns an array");
+  });
+
+  test("has_badge is kept when the payload provides it", function (assert) {
+    const badges = Badge.createFromJson({
+      badge_types: [{ id: 6, name: "Silver 1" }],
+      badges: [
+        {
+          id: 1127,
+          name: "Badge 1",
+          description: null,
+          badge_type_id: 6,
+          has_badge: true,
+        },
+        {
+          id: 1128,
+          name: "Badge 2",
+          description: null,
+          badge_type_id: 6,
+          has_badge: false,
+        },
+      ],
+    });
+
+    assert.true(badges[0].has_badge, "true is preserved");
+    assert.false(badges[1].has_badge, "false is preserved");
+  });
+
+  test("has_badge is cleared by a payload that omits it", function (assert) {
+    Badge.createFromJson({
+      badge_types: [{ id: 6, name: "Silver 1" }],
+      badges: [
+        {
+          id: 1126,
+          name: "Badge 1",
+          description: null,
+          badge_type_id: 6,
+          has_badge: true,
+        },
+      ],
+    });
+
+    const sideloaded = Badge.createFromJson({
+      badge_types: [{ id: 6, name: "Silver 1" }],
+      badges: [
+        { id: 1126, name: "Badge 1", description: null, badge_type_id: 6 },
+      ],
+    });
+
+    assert.false(
+      sideloaded[0].has_badge,
+      "a payload that cannot know about the viewer's grants clears the flag"
+    );
+  });
+
+  test("has_badge survives a badge sideloaded with user badges", function (assert) {
+    Badge.createFromJson({
+      badge_types: [{ id: 6, name: "Silver 1" }],
+      badges: [
+        {
+          id: 1129,
+          name: "Badge 1",
+          description: null,
+          badge_type_id: 6,
+          has_badge: true,
+        },
+      ],
+    });
+
+    const userBadges = UserBadge.createFromJson({
+      badge_types: [{ id: 6, name: "Silver 1" }],
+      badges: [
+        { id: 1129, name: "Badge 1", description: null, badge_type_id: 6 },
+      ],
+      user_badges: [{ id: 42, badge_id: 1129, granted_at: "2020-01-01" }],
+    });
+
+    assert.true(
+      userBadges[0].badge.has_badge,
+      "a payload that cannot know the viewer's grants leaves the flag alone"
+    );
   });
 
   test("updateFromJson", function (assert) {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/visual-bug-checkmarks-on-badges-appear-in-profiles-instead-of-the-badges-page/411831

If you visit `/my/badges`, and click through to the badge page (.e.g, `badges/130/licensed`), then return to your profile the badge state from the badge page leaks through... so you get a green checkmark icon that should never appear on your profile, as this is already a list of granted badges 

<img width="1111" height="261" alt="image" src="https://github.com/user-attachments/assets/720eed7e-89b3-4863-a65b-1aab773181d2" />

additionally `has_badge` is stored in shared cache, so when clicking the badge from your profile you can see the granted state flicker on before the transition completes 

the fix is to only let the badge index and global badge pages write to `has_badge`, and to have `DBadgeCard` get the badge explicitly from a `@granted` argument that isn't present on user profiles 