### PR TITLE
SECURITY: Require CAPTCHA for code-based account signup [backport 2026.8]

### DIFF
--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -22,6 +22,7 @@ import discourseDebounce from "discourse/lib/debounce";
 import escape from "discourse/lib/escape";
 import getURL from "discourse/lib/get-url";
 import discourseLater from "discourse/lib/later";
+import { applyBehaviorTransformer } from "discourse/lib/transformer";
 import UserFieldsValidationHelper from "discourse/lib/user-fields-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
@@ -274,10 +275,15 @@ export default class CodeLoginForm extends Component {
     }
 
     try {
-      const result = await ajax("/session/login-code/verify", {
-        type: "POST",
-        data,
-      });
+      const verify = () =>
+        ajax("/session/login-code/verify", {
+          type: "POST",
+          data,
+        });
+      const result =
+        this.isSignup && this.isCodeStep
+          ? await applyBehaviorTransformer("create-account", verify)
+          : await verify();
 
       if (
         (result?.user_fields_required || result?.name_required) &&
@@ -669,6 +675,13 @@ export default class CodeLoginForm extends Component {
               {{this.codeInstructions}}
             </p>
           {{/unless}}
+
+          {{#if this.isSignup}}
+            <PluginOutlet
+              @name="code-login-after-code"
+              @outletArgs={{lazyHash context=@context}}
+            />
+          {{/if}}
 
           {{#each this.otpGenerationArray as |generation|}}
             <DOtp

--- a/frontend/discourse/tests/integration/components/code-login-form-test.gjs
+++ b/frontend/discourse/tests/integration/components/code-login-form-test.gjs
@@ -1,6 +1,7 @@
 import { click, fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import CodeLoginForm from "discourse/components/code-login-form";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import formKit from "discourse/tests/helpers/form-kit-helper";
@@ -60,6 +61,41 @@ module("Integration | Component | CodeLoginForm", function (hooks) {
       .includesText("user@example.com");
     assert.dom(".d-otp-input").exists();
     assert.dom(".code-login-form__resend").exists();
+  });
+
+  test("runs create-account behavior transformers before verifying a signup code", async function (assert) {
+    stubCodeRequest();
+
+    let transformed = false;
+    let verificationRequests = 0;
+    withPluginApi((api) =>
+      api.registerBehaviorTransformer("create-account", async ({ next }) => {
+        transformed = true;
+        return next();
+      })
+    );
+    pretender.post("/session/login-code/verify", () => {
+      verificationRequests++;
+      return response({ error: i18n("email_login_code.invalid_code") });
+    });
+
+    await render(<template><CodeLoginForm @context="signup" /></template>);
+    await fillIn(
+      ".code-login-form__email-step .form-kit__control-input",
+      "user@example.com"
+    );
+    await formKit().submit();
+    await fillIn(".d-otp-input", "000000");
+
+    assert.true(
+      transformed,
+      "the signup verification passes through the transformer"
+    );
+    assert.strictEqual(
+      verificationRequests,
+      1,
+      "the transformer continues to code verification"
+    );
   });
 
   test("keeps a hidden email field for password managers after the email step", async function (assert) {

--- a/plugins/discourse-captcha/assets/javascripts/discourse/connectors/code-login-after-code/captcha-fields-connector.gjs
+++ b/plugins/discourse-captcha/assets/javascripts/discourse/connectors/code-login-after-code/captcha-fields-connector.gjs
@@ -1,0 +1,23 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import { eq } from "discourse/truth-helpers";
+import HCaptcha from "../../components/h-captcha";
+import ReCaptcha from "../../components/re-captcha";
+
+export default class CaptchaFieldsConnector extends Component {
+  @service siteSettings;
+
+  <template>
+    <div class="code-login-after-code-outlet captcha-fields-connector">
+      <div class="input-group">
+        {{#if (eq this.siteSettings.discourse_captcha_provider "hcaptcha")}}
+          <HCaptcha @siteKey={{this.siteSettings.hcaptcha_site_key}} />
+        {{else if
+          (eq this.siteSettings.discourse_captcha_provider "recaptcha")
+        }}
+          <ReCaptcha @siteKey={{this.siteSettings.recaptcha_site_key}} />
+        {{/if}}
+      </div>
+    </div>
+  </template>
+}

--- a/plugins/discourse-captcha/lib/discourse_captcha/captcha_verification.rb
+++ b/plugins/discourse-captcha/lib/discourse_captcha/captcha_verification.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module DiscourseCaptcha
+  module CaptchaVerification
+    private
+
+    def captcha_verification_error
+      return unless SiteSetting.discourse_captcha_enabled
+      return if SiteSetting.discourse_captcha_provider == CaptchaProvider::NONE
+
+      captcha_provider = captcha_provider_selector
+      return :captcha_not_configured if captcha_provider.nil?
+
+      captcha_token = captcha_provider.fetch_captcha_token(server_session)
+      return :captcha_verification_failed if captcha_token.blank?
+
+      validate_captcha_response(captcha_provider.send_captcha_verification(captcha_token))
+      nil
+    rescue StandardError => e
+      Rails.logger.warn("Captcha verification error: #{e.class} - #{e.message}")
+      :captcha_verification_failed
+    end
+
+    def captcha_provider_selector
+      case SiteSetting.discourse_captcha_provider
+      when CaptchaProvider::HCAPTCHA
+        if SiteSetting.hcaptcha_site_key.present? && SiteSetting.hcaptcha_secret_key.present?
+          DiscourseCaptcha::HcaptchaProvider.new
+        end
+      when CaptchaProvider::RECAPTCHA
+        if SiteSetting.recaptcha_site_key.present? && SiteSetting.recaptcha_secret_key.present?
+          DiscourseCaptcha::RecaptchaProvider.new
+        end
+      end
+    end
+
+    def validate_captcha_response(response)
+      raise Discourse::InvalidAccess if response.code.to_i >= 500
+
+      response_json = JSON.parse(response.body)
+      if response_json["success"].nil? || response_json["success"] == false
+        raise Discourse::InvalidAccess
+      end
+    end
+  end
+end

--- a/plugins/discourse-captcha/lib/discourse_captcha/create_users_controller_patch.rb
+++ b/plugins/discourse-captcha/lib/discourse_captcha/create_users_controller_patch.rb
@@ -6,46 +6,11 @@ module DiscourseCaptcha
     included { before_action :check_captcha, only: [:create] }
 
     def check_captcha
-      return unless SiteSetting.discourse_captcha_enabled
-      return if SiteSetting.discourse_captcha_provider == CaptchaProvider::NONE
+      return unless (error = captcha_verification_error)
 
-      captcha_provider = captcha_provider_selector
-      return fail_with("captcha_not_configured") if captcha_provider.nil?
-
-      captcha_token = captcha_provider.fetch_captcha_token(server_session)
-      raise Discourse::InvalidAccess.new if captcha_token.blank?
-
-      response = captcha_provider.send_captcha_verification(captcha_token)
-
-      validate_captcha_response(response)
-    rescue Discourse::InvalidAccess
-      fail_with("captcha_verification_failed")
-    rescue StandardError => e
-      Rails.logger.warn("Captcha verification error: #{e.class} - #{e.message}")
-      fail_with("captcha_verification_failed")
+      fail_with(error)
     end
 
-    private
-
-    def captcha_provider_selector
-      case SiteSetting.discourse_captcha_provider
-      when CaptchaProvider::HCAPTCHA
-        if SiteSetting.hcaptcha_site_key.present? && SiteSetting.hcaptcha_secret_key.present?
-          DiscourseCaptcha::HcaptchaProvider.new
-        end
-      when CaptchaProvider::RECAPTCHA
-        if SiteSetting.recaptcha_site_key.present? && SiteSetting.recaptcha_secret_key.present?
-          DiscourseCaptcha::RecaptchaProvider.new
-        end
-      end
-    end
-
-    def validate_captcha_response(response)
-      raise Discourse::InvalidAccess.new if response.code.to_i >= 500
-      response_json = JSON.parse(response.body)
-      if response_json["success"].nil? || response_json["success"] == false
-        raise Discourse::InvalidAccess.new
-      end
-    end
+    include CaptchaVerification
   end
 end

--- a/plugins/discourse-captcha/lib/discourse_captcha/session_controller_patch.rb
+++ b/plugins/discourse-captcha/lib/discourse_captcha/session_controller_patch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DiscourseCaptcha
+  module SessionControllerPatch
+    def process_verified_login_code(matched_user)
+      if matched_user.nil? && registration_via_login_code_open? && !signup_user_fields_missing? &&
+           !signup_full_name_missing? && (error = captcha_verification_error)
+        render json: { error: I18n.t(error) }
+        return
+      end
+
+      super
+    end
+
+    include CaptchaVerification
+  end
+end

--- a/plugins/discourse-captcha/plugin.rb
+++ b/plugins/discourse-captcha/plugin.rb
@@ -19,9 +19,13 @@ end
 
 require_relative "lib/discourse_captcha/engine"
 require_relative "lib/discourse_captcha/captcha_provider"
+require_relative "lib/discourse_captcha/captcha_verification"
+require_relative "lib/discourse_captcha/create_users_controller_patch"
+require_relative "lib/discourse_captcha/session_controller_patch"
 
 after_initialize do
   reloadable_patch { UsersController.include(DiscourseCaptcha::CreateUsersControllerPatch) }
+  reloadable_patch { SessionController.prepend(DiscourseCaptcha::SessionControllerPatch) }
 
   require_relative "app/services/problem_check/hcaptcha_configuration"
   require_relative "app/services/problem_check/recaptcha_configuration"

--- a/plugins/discourse-captcha/spec/requests/discourse_captcha/session_controller_spec.rb
+++ b/plugins/discourse-captcha/spec/requests/discourse_captcha/session_controller_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe SessionController do
+  describe "POST /session/login-code/verify" do
+    fab!(:existing_user, :user)
+
+    before do
+      SiteSetting.enable_local_logins_via_email = true
+      SiteSetting.enable_local_logins_via_code = true
+      SiteSetting.discourse_captcha_enabled = true
+      SiteSetting.discourse_captcha_provider = DiscourseCaptcha::CaptchaProvider::HCAPTCHA
+      SiteSetting.hcaptcha_site_key = "site-key"
+      SiteSetting.hcaptcha_secret_key = "secret-key"
+    end
+
+    it "does not create an account without completing CAPTCHA" do
+      email = "new.person@example.com"
+      code = EmailLoginCode.generate!(email:).code
+
+      expect { post "/session/login-code/verify.json", params: { email:, code: } }.not_to change(
+        User,
+        :count,
+      )
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["error"]).to eq(I18n.t("captcha_verification_failed"))
+      expect(session[:current_user_id]).to be_nil
+    end
+
+    it "creates an account after the CAPTCHA provider verifies the challenge" do
+      email = "new.person@example.com"
+      code = EmailLoginCode.generate!(email:).code
+      stub_request(:post, DiscourseCaptcha::HcaptchaProvider::CAPTCHA_VERIFICATION_URL).with(
+        body: {
+          secret: SiteSetting.hcaptcha_secret_key,
+          response: "captcha-token",
+        },
+      ).to_return(status: 200, body: '{"success":true}')
+
+      post "/captcha/hcaptcha/create.json", params: { token: "captcha-token" }
+
+      expect { post "/session/login-code/verify.json", params: { email:, code: } }.to change(
+        User,
+        :count,
+      ).by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["account_created"]).to eq(true)
+      expect(session[:current_user_id]).to eq(User.find_by_email(email).id)
+    end
+
+    it "logs in an existing account without CAPTCHA" do
+      code = EmailLoginCode.generate!(email: existing_user.email).code
+
+      post "/session/login-code/verify.json", params: { email: existing_user.email, code: }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.dig("user", "username")).to eq(existing_user.username)
+      expect(session[:current_user_id]).to eq(existing_user.id)
+    end
+
+    context "when signup requires user fields" do
+      fab!(:user_field, :user_field)
+
+      it "retains the CAPTCHA token until the required fields are submitted" do
+        email = "new.person@example.com"
+        code = EmailLoginCode.generate!(email:).code
+
+        expect { post "/session/login-code/verify.json", params: { email:, code: } }.not_to change(
+          User,
+          :count,
+        )
+        expect(response.parsed_body["user_fields_required"]).to eq(true)
+
+        stub_request(:post, DiscourseCaptcha::HcaptchaProvider::CAPTCHA_VERIFICATION_URL).to_return(
+          status: 200,
+          body: '{"success":true}',
+        )
+        post "/captcha/hcaptcha/create.json", params: { token: "captcha-token" }
+
+        expect {
+          post "/session/login-code/verify.json",
+               params: {
+                 email:,
+                 code:,
+                 user_fields: {
+                   user_field.id.to_s => "Developer",
+                 },
+               }
+        }.to change(User, :count).by(1)
+      end
+    end
+  end
+end

--- a/plugins/discourse-captcha/spec/system/signup_with_captcha_spec.rb
+++ b/plugins/discourse-captcha/spec/system/signup_with_captcha_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe "Signup with captcha" do
       expect(captcha).to have_no_recaptcha_container
     end
 
+    context "with code-based signup" do
+      before { SiteSetting.enable_local_logins_via_code = true }
+
+      it "displays the hCaptcha widget after requesting a signup code" do
+        signup_page.open
+        find(".code-login-form__email-step input[type='email']").fill_in(with: "test@example.com")
+        find(".code-login-form__continue").click
+
+        expect(captcha).to have_hcaptcha_container
+      end
+    end
+
     context "when site requires login" do
       before { SiteSetting.login_required = true }
 


### PR DESCRIPTION
Backport of #43421 to release/2026.8.

---

Previously, the CAPTCHA guard was attached only to `UsersController#create`, so a site with a configured provider still had one unprotected registration path: the email login-code flow created accounts without any verification.

This change moves the provider check into a shared `DiscourseCaptcha::CaptchaVerification` module and applies it to new-account creation in `process_verified_login_code`, so every anonymous signup path honours the configured anti-automation setting. Code login for existing accounts stays CAPTCHA-free.