### PR TITLE
DEV: Support email code flow during password resets

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -43,6 +43,10 @@ body.invite-page {
     flex-direction: column;
     width: 400px;
 
+    &__password {
+      width: 100%;
+    }
+
     .input {
       position: relative;
       margin-bottom: 1em;

--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -20,6 +20,7 @@ class Admin::EmailTemplatesController < Admin::AdminController
         invite_password_instructions
         new_version_mailer
         new_version_mailer_with_notes
+        password_reset_code_mailer
         system_messages.backup_failed
         system_messages.backup_succeeded
         system_messages.bulk_invite_failed

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -2,11 +2,18 @@
 
 class SessionController < ApplicationController
   before_action :check_local_login_allowed,
-                only: %i[create forgot_password passkey_challenge passkey_login]
+                only: %i[
+                  create
+                  forgot_password
+                  redeem_password_reset_code
+                  passkey_challenge
+                  passkey_login
+                ]
   before_action :ensure_login_code_allowed, only: %i[create_login_code verify_login_code]
   before_action :rate_limit_login, only: %i[create email_login]
   before_action :rate_limit_login_code_request, only: %i[create_login_code]
-  before_action :rate_limit_login_code_verify, only: %i[verify_login_code]
+  before_action :rate_limit_login_code_verify,
+                only: %i[verify_login_code redeem_password_reset_code]
   skip_before_action :redirect_to_login_if_required
   skip_before_action :redirect_to_profile_if_required
   skip_before_action :preload_json,
@@ -16,7 +23,11 @@ class SessionController < ApplicationController
   skip_before_action :check_xhr, only: %i[second_factor_auth_show]
 
   allow_in_readonly_mode :email_login
-  allow_in_staff_writes_only_mode :create, :forgot_password, :create_login_code, :verify_login_code
+  allow_in_staff_writes_only_mode :create,
+                                  :forgot_password,
+                                  :redeem_password_reset_code,
+                                  :create_login_code,
+                                  :verify_login_code
 
   ACTIVATE_USER_KEY = "activate_user"
   FORGOT_PASSWORD_EMAIL_LIMIT_PER_DAY = 6
@@ -710,13 +721,38 @@ class SessionController < ApplicationController
         5,
         1.hour,
       ).performed!
+      server_session.delete(:password_reset_code)
     end
 
     json = success_json
+    json[:email_code] = true if password_reset_via_code?(user)
     json[:user_found] = user.present? if !SiteSetting.hide_email_address_taken
     render json: json
   rescue RateLimiter::LimitExceeded
     render_json_error(I18n.t("rate_limiter.slow_down"))
+  end
+
+  def redeem_password_reset_code
+    expires_now
+    if !UpcomingChanges.enabled_for_user?(:enable_local_logins_via_code, current_user)
+      raise Discourse::NotFound
+    end
+
+    reset_code = server_session[:password_reset_code] || {}
+    User::CreatePasswordResetToken.call(
+      service_params.deep_merge(
+        login_code_id: reset_code[:login_code_id],
+        user_id: reset_code[:user_id],
+      ),
+    ) do
+      on_success do |email_token:|
+        server_session.delete(:password_reset_code)
+        render json:
+                 success_json.merge(redirect_url: path("/u/password-reset/#{email_token.token}"))
+      end
+      on_failed_policy(:can_write) { raise Discourse::ReadOnly }
+      on_failure { render json: invalid_login_code }
+    end
   end
 
   def current
@@ -1268,6 +1304,12 @@ class SessionController < ApplicationController
     allowed_domains.split("|").include?(hostname)
   end
 
+  def password_reset_via_code?(user)
+    # Another account's recipient needs a link they can open in their own session.
+    UpcomingChanges.enabled_for_user?(:enable_local_logins_via_code, current_user) &&
+      (!current_user || current_user == user)
+  end
+
   def enqueue_password_reset_for_user(user)
     RateLimiter.new(
       nil,
@@ -1275,6 +1317,18 @@ class SessionController < ApplicationController
       FORGOT_PASSWORD_EMAIL_LIMIT_PER_DAY,
       1.day,
     ).performed!
+
+    if password_reset_via_code?(user)
+      login_code = EmailLoginCode.generate!(email: user.email, purpose: :password_reset)
+      server_session[:password_reset_code] = { login_code_id: login_code.id, user_id: user.id }
+      Jobs.enqueue(
+        :send_email_login_code,
+        to_address: user.email,
+        code: login_code.code,
+        password_reset: true,
+      )
+      return
+    end
 
     email_token =
       user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:password_reset])

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1319,6 +1319,10 @@ class SessionController < ApplicationController
     ).performed!
 
     if password_reset_via_code?(user)
+      user
+        .email_tokens
+        .where(scope: [nil, EmailToken.scopes[:password_reset]])
+        .update_all(expired: true)
       login_code = EmailLoginCode.generate!(email: user.email, purpose: :password_reset)
       server_session[:password_reset_code] = { login_code_id: login_code.id, user_id: user.id }
       Jobs.enqueue(

--- a/app/jobs/regular/send_email_login_code.rb
+++ b/app/jobs/regular/send_email_login_code.rb
@@ -9,7 +9,12 @@ module Jobs
       raise Discourse::InvalidParameters.new(:code) if args[:code].blank?
       return if !UpcomingChanges.enabled?(:enable_local_logins_via_code)
 
-      message = EmailLoginCodeMailer.send_code(args[:to_address], args[:code])
+      message =
+        EmailLoginCodeMailer.send_code(
+          args[:to_address],
+          args[:code],
+          password_reset: args[:password_reset],
+        )
       Email::Sender.new(message, :email_login_code).send
     end
   end

--- a/app/mailers/email_login_code_mailer.rb
+++ b/app/mailers/email_login_code_mailer.rb
@@ -5,10 +5,10 @@ class EmailLoginCodeMailer < ActionMailer::Base
 
   layout "email_template"
 
-  def send_code(email, code)
+  def send_code(email, code, password_reset: false)
     build_email(
       email,
-      template: "email_login_code_mailer",
+      template: password_reset ? "password_reset_code_mailer" : "email_login_code_mailer",
       code: code,
       minutes: EmailLoginCode::VALID_FOR.in_minutes.to_i,
     )

--- a/app/models/email_login_code.rb
+++ b/app/models/email_login_code.rb
@@ -8,6 +8,8 @@ class EmailLoginCode < ActiveRecord::Base
   MAX_ATTEMPTS = 5
   VALID_FOR = 10.minutes
 
+  enum :purpose, { login: 0, password_reset: 1 }
+
   validates :email, :code_hash, presence: true
 
   scope :active,
@@ -19,15 +21,21 @@ class EmailLoginCode < ActiveRecord::Base
         end
   scope :for_email, ->(email) { where("lower(email) = ?", email.downcase) }
 
-  def self.generate!(email:)
+  def self.generate!(email:, purpose: :login)
     email = email.downcase
 
     code = SecureRandom.random_number(10**CODE_LENGTH).to_s.rjust(CODE_LENGTH, "0")
 
     record = nil
     transaction do
-      where("lower(email) = ?", email).delete_all
-      record = create!(email: email, code_hash: hash_code(code), expires_at: VALID_FOR.from_now)
+      for_email(email).where(purpose: purpose).delete_all
+      record =
+        create!(
+          email: email,
+          purpose: purpose,
+          code_hash: hash_code(code),
+          expires_at: VALID_FOR.from_now,
+        )
     end
 
     record.instance_variable_set(:@code, code)
@@ -90,6 +98,7 @@ end
 #  consumed_at :datetime
 #  email       :string           not null
 #  expires_at  :datetime         not null
+#  purpose     :integer          default("login"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/services/email_login_code/redeem.rb
+++ b/app/services/email_login_code/redeem.rb
@@ -48,7 +48,7 @@ class EmailLoginCode::Redeem
   private
 
   def fetch_login_code(params:)
-    EmailLoginCode.active.for_email(params.email).first
+    EmailLoginCode.login.active.for_email(params.email).first
   end
 
   def code_matches(login_code:, params:)

--- a/app/services/email_login_code/verify.rb
+++ b/app/services/email_login_code/verify.rb
@@ -23,7 +23,7 @@ class EmailLoginCode::Verify
   private
 
   def fetch_login_code(params:)
-    EmailLoginCode.active.for_email(params.email).first
+    EmailLoginCode.login.active.for_email(params.email).first
   end
 
   def code_matches(login_code:, params:)

--- a/app/services/invite/redeem_with_email_code.rb
+++ b/app/services/invite/redeem_with_email_code.rb
@@ -67,7 +67,7 @@ class Invite::RedeemWithEmailCode
   end
 
   def fetch_login_code(params:)
-    EmailLoginCode.active.for_email(params.email).first
+    EmailLoginCode.login.active.for_email(params.email).first
   end
 
   def code_matches(login_code:, params:)

--- a/app/services/user/create_password_reset_token.rb
+++ b/app/services/user/create_password_reset_token.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class User::CreatePasswordResetToken
+  include Service::Base
+
+  params do
+    attribute :code, :string
+
+    before_validation { self.code = code.to_s.strip }
+
+    validates :code, presence: true, format: { with: /\A\d{#{EmailLoginCode::CODE_LENGTH}}\z/o }
+  end
+
+  model :login_code
+  policy :code_matches
+  model :user
+  policy :can_write
+
+  transaction do
+    policy :consume_code
+    model :email_token, :create_email_token
+  end
+
+  private
+
+  def fetch_login_code(login_code_id:)
+    EmailLoginCode.password_reset.active.find_by(id: login_code_id)
+  end
+
+  def code_matches(login_code:, params:)
+    login_code.verify(params.code)
+  end
+
+  def fetch_user(user_id:, login_code:)
+    user = User.real.where(staged: false).find_by(id: user_id)
+    user if user&.email&.casecmp?(login_code.email)
+  end
+
+  def can_write(user:)
+    !Discourse.staff_writes_only_mode? || user.staff?
+  end
+
+  def consume_code(login_code:)
+    login_code.consume!
+  end
+
+  def create_email_token(user:)
+    user.email_tokens.create(email: user.email, scope: EmailToken.scopes[:password_reset])
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3096,6 +3096,7 @@ en:
         login: "Log In"
 
     forgot_password:
+      code_instructions: "If a matching account exists, we sent a verification code to its email address. Enter the code to reset your password."
       title: "Password Reset"
       action: "I forgot my password"
       invite: "Enter your username or email address, and we'll send you a password reset email."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3642,6 +3642,16 @@ en:
 
       This code expires in %{minutes} minutes. If you didn't request it, you can safely ignore this email.
 
+  password_reset_code_mailer:
+    title: "Password reset code"
+    subject_template: "%{code} is your password reset code"
+    text_body_template: |
+      Use this code to reset your password on %{site_name}:
+
+      ## %{code}
+
+      This code expires in %{minutes} minutes. If you didn't request it, you can safely ignore this email.
+
   invite_mailer:
     title: "Invite Mailer"
     subject_template: "%{inviter_name} invited you to '%{topic_title}' on %{site_domain_name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -603,6 +603,7 @@ Discourse::Application.routes.draw do
     post "session/email-login/:token" => "session#email_login"
     post "session/login-code" => "session#create_login_code"
     post "session/login-code/verify" => "session#verify_login_code"
+    post "session/password-reset-code/verify" => "session#redeem_password_reset_code"
     get "session/otp/:token" => "session#one_time_password", :constraints => { token: /[0-9a-f]+/ }
     post "session/otp/:token" => "session#one_time_password", :constraints => { token: /[0-9a-f]+/ }
     get "session/2fa" => "session#second_factor_auth_show"

--- a/db/migrate/20260909181443_add_purpose_to_email_login_codes.rb
+++ b/db/migrate/20260909181443_add_purpose_to_email_login_codes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddPurposeToEmailLoginCodes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :email_login_codes, :purpose, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5646,7 +5646,8 @@ CREATE TABLE public.email_login_codes (
     expires_at timestamp(6) without time zone NOT NULL,
     consumed_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    purpose integer DEFAULT 0 NOT NULL
 );
 
 
@@ -25068,6 +25069,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260909181443'),
 ('20260908160656'),
 ('20260908153158'),
 ('20260908112615'),

--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -23,6 +23,7 @@ import escape from "discourse/lib/escape";
 import getURL from "discourse/lib/get-url";
 import discourseLater from "discourse/lib/later";
 import { applyValueTransformer } from "discourse/lib/transformer";
+import DiscourseURL from "discourse/lib/url";
 import UserFieldsValidationHelper from "discourse/lib/user-fields-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
@@ -79,7 +80,14 @@ export default class CodeLoginForm extends Component {
   #cooldownTimer;
   #postSignupRedirectUrl;
   #usernameCheckSeq = 0;
-  @tracked _step = "email";
+  @tracked _step = this.args.initialStep ?? "email";
+
+  constructor() {
+    super(...arguments);
+    if (this.isCodeStep) {
+      this.startResendCooldown();
+    }
+  }
 
   willDestroy() {
     super.willDestroy(...arguments);
@@ -102,6 +110,10 @@ export default class CodeLoginForm extends Component {
 
   get isInvite() {
     return this.args.context === "invite";
+  }
+
+  get isPasswordReset() {
+    return this.args.context === "password-reset";
   }
 
   get isInviteEmailLocked() {
@@ -186,6 +198,10 @@ export default class CodeLoginForm extends Component {
   }
 
   get codeInstructions() {
+    if (this.isPasswordReset) {
+      return i18n("forgot_password.code_instructions");
+    }
+
     return trustHTML(
       i18n("code_login.code_instructions", { email: escape(this.email) })
     );
@@ -253,6 +269,7 @@ export default class CodeLoginForm extends Component {
     this.notice = null;
     this.otpGeneration++;
     this.step = "email";
+    this.args.onChangeEmail?.();
   }
 
   @action
@@ -291,7 +308,10 @@ export default class CodeLoginForm extends Component {
       data.second_factor_method = this.secondFactorMethod;
     }
 
-    if (this.isUserFieldsStep || this.#prefillUserFields()) {
+    if (
+      !this.isPasswordReset &&
+      (this.isUserFieldsStep || this.#prefillUserFields())
+    ) {
       data.user_fields = {};
       this.userFields.forEach((f) => (data.user_fields[f.field.id] = f.value));
       if (this.nameRequired) {
@@ -300,7 +320,10 @@ export default class CodeLoginForm extends Component {
     }
 
     try {
-      const result = await ajax("/session/login-code/verify", {
+      const endpoint = this.isPasswordReset
+        ? "/session/password-reset-code/verify"
+        : "/session/login-code/verify";
+      const result = await ajax(endpoint, {
         type: "POST",
         data,
       });
@@ -338,6 +361,11 @@ export default class CodeLoginForm extends Component {
           this.code = "";
           this.otpGeneration++;
         }
+        return;
+      }
+
+      if (this.isPasswordReset) {
+        DiscourseURL.redirectTo(result.redirect_url);
         return;
       }
 
@@ -590,6 +618,15 @@ export default class CodeLoginForm extends Component {
     this.notice = null;
 
     try {
+      if (this.isPasswordReset) {
+        await ajax("/session/forgot_password", {
+          type: "POST",
+          data: { login: this.email.trim() },
+        });
+        this.startResendCooldown();
+        return true;
+      }
+
       const honeypot = await ajax("/session/hp.json");
       const result = await ajax("/session/login-code", {
         type: "POST",

--- a/frontend/discourse/app/components/dialog-messages/confirm-session.gjs
+++ b/frontend/discourse/app/components/dialog-messages/confirm-session.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import ForgotPassword from "discourse/components/modal/forgot-password";
 import { ajax } from "discourse/lib/ajax";
 import { extractError, popupAjaxError } from "discourse/lib/ajax-error";
 import {
@@ -16,6 +17,7 @@ import { i18n } from "discourse-i18n";
 export default class ConfirmSession extends Component {
   @service dialog;
   @service currentUser;
+  @service modal;
   @service siteSettings;
 
   @tracked errorMessage;
@@ -94,6 +96,18 @@ export default class ConfirmSession extends Component {
   async sendPasswordResetEmail() {
     try {
       const result = await this.currentUser.changePassword();
+
+      if (result.email_code) {
+        this.dialog.cancel();
+        this.modal.show(ForgotPassword, {
+          model: {
+            codeSent: true,
+            emailOrUsername:
+              this.currentUser.email || this.currentUser.username,
+          },
+        });
+        return;
+      }
 
       if (result.success) {
         this.errorMessage = null;

--- a/frontend/discourse/app/components/modal/forgot-password.gjs
+++ b/frontend/discourse/app/components/modal/forgot-password.gjs
@@ -5,11 +5,13 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
+import CodeLoginForm from "discourse/components/code-login-form";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
 import cookie from "discourse/lib/cookie";
 import getURL from "discourse/lib/get-url";
 import { escapeExpression } from "discourse/lib/utilities";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
@@ -18,11 +20,12 @@ export default class ForgotPassword extends Component {
   @service siteSettings;
 
   @tracked
-  emailOrUsername = cookie("email") || this.args.model?.emailOrUsername || "";
+  emailOrUsername = this.args.model?.emailOrUsername ?? cookie("email") ?? "";
   @tracked disabled = false;
   @tracked helpSeen = false;
   @tracked offerHelp;
   @tracked flash;
+  @tracked codeSent = this.args.model?.codeSent ?? false;
 
   get submitDisabled() {
     if (this.disabled) {
@@ -32,6 +35,11 @@ export default class ForgotPassword extends Component {
     } else {
       return isEmpty(this.emailOrUsername.trim());
     }
+  }
+
+  @action
+  changeLogin() {
+    this.codeSent = false;
   }
 
   @action
@@ -59,6 +67,11 @@ export default class ForgotPassword extends Component {
         data: { login: this.emailOrUsername.trim() },
         type: "POST",
       });
+
+      if (data.email_code && data.user_found !== false) {
+        this.codeSent = true;
+        return;
+      }
 
       const emailOrUsername = escapeExpression(this.emailOrUsername);
 
@@ -101,7 +114,14 @@ export default class ForgotPassword extends Component {
       @title={{i18n "forgot_password.title"}}
     >
       <:body>
-        {{#if this.offerHelp}}
+        {{#if this.codeSent}}
+          <CodeLoginForm
+            @context="password-reset"
+            @initialEmail={{this.emailOrUsername}}
+            @initialStep="code"
+            @onChangeEmail={{this.changeLogin}}
+          />
+        {{else if this.offerHelp}}
           {{trustHTML this.offerHelp}}
         {{else if this.siteSettings.hide_email_address_taken}}
           <label for="username-or-email">
@@ -149,7 +169,7 @@ export default class ForgotPassword extends Component {
               @label="forgot_password.button_help"
             />
           {{/unless}}
-        {{else}}
+        {{else if (not this.codeSent)}}
           <DButton
             class="btn-primary forgot-password-reset"
             type="submit"

--- a/frontend/discourse/app/controllers/preferences/security.js
+++ b/frontend/discourse/app/controllers/preferences/security.js
@@ -3,6 +3,7 @@ import { action, computed } from "@ember/object";
 import { service } from "@ember/service";
 import ConfirmSession from "discourse/components/dialog-messages/confirm-session";
 import AuthTokenModal from "discourse/components/modal/auth-token";
+import ForgotPassword from "discourse/components/modal/forgot-password";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import CanCheckEmailsHelper from "discourse/lib/can-check-emails-helper";
@@ -131,8 +132,18 @@ export default class SecurityController extends Controller {
       this.set("passwordProgress", i18n("user.change_password.in_progress"));
       return this.model
         .changePassword()
-        .then(() => {
-          // password changed
+        .then((result) => {
+          if (result.email_code) {
+            this.set("passwordProgress", null);
+            this.modal.show(ForgotPassword, {
+              model: {
+                codeSent: true,
+                emailOrUsername: this.model.email || this.model.username,
+              },
+            });
+            return;
+          }
+
           this.setProperties({
             changePasswordProgress: false,
             passwordProgress: i18n("user.change_password.success"),

--- a/frontend/discourse/app/templates/password-reset.gjs
+++ b/frontend/discourse/app/templates/password-reset.gjs
@@ -91,6 +91,7 @@ export default <template>
             <DPasswordField
               autocomplete="new-password"
               autofocus="autofocus"
+              class="change-password-form__password"
               id="new-account-password"
               type={{if @controller.maskPassword "password" "text"}}
               @capsLockOn={{@controller.capsLockOn}}

--- a/frontend/discourse/tests/acceptance/forgot-password-test.js
+++ b/frontend/discourse/tests/acceptance/forgot-password-test.js
@@ -1,5 +1,8 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import sinon from "sinon";
+import DiscourseURL from "discourse/lib/url";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -113,3 +116,110 @@ acceptance(
     });
   }
 );
+
+acceptance("Forgot password - email codes", function (needs) {
+  needs.settings({ hide_email_address_taken: false });
+
+  needs.pretender((server, helper) => {
+    server.post("/session/forgot_password", () =>
+      helper.response({ success: "OK", email_code: true, user_found: true })
+    );
+    server.post("/session/password-reset-code/verify", () =>
+      helper.response({ error: i18n("email_login_code.invalid_code") })
+    );
+  });
+
+  test("verifies a reset code and lets the user change the account", async function (assert) {
+    await visit("/");
+    await click("header .login-button");
+    await click("#forgot-password-link");
+    await fillIn("#username-or-email", "someuser");
+    await click(".forgot-password-reset");
+
+    assert.dom(".d-otp-input").exists("the modal requests a verification code");
+    assert
+      .dom(".code-login-form__instructions")
+      .hasText(
+        i18n("forgot_password.code_instructions"),
+        "shows reset instructions"
+      );
+    assert
+      .dom(".forgot-password-reset")
+      .doesNotExist("hides the request button");
+
+    await fillIn(".d-otp-input", "000000");
+
+    assert
+      .dom(".code-login-form__error")
+      .hasText(
+        i18n("email_login_code.invalid_code"),
+        "shows the verification error"
+      );
+    assert.dom(".d-otp-input").hasValue("", "allows another attempt");
+
+    pretender.post("/session/forgot_password", (request) => {
+      assert.strictEqual(
+        new URLSearchParams(request.requestBody).get("login"),
+        "someuser",
+        "resends the reset code for the same account"
+      );
+      return response({ success: "OK", email_code: true, user_found: true });
+    });
+    await click(".code-login-form__resend");
+
+    assert
+      .dom(".code-login-form__notice")
+      .hasText(i18n("code_login.code_resent"), "confirms the code was resent");
+
+    await click(".code-login-form__change-email");
+
+    assert
+      .dom("#username-or-email")
+      .hasValue("someuser", "returns to account lookup");
+    assert.dom(".forgot-password-reset").exists("can request another code");
+  });
+
+  test("opens the password reset page after redeeming a code", async function (assert) {
+    const redirect = sinon.stub(DiscourseURL, "redirectTo");
+    pretender.post("/session/password-reset-code/verify", (request) => {
+      assert.strictEqual(
+        new URLSearchParams(request.requestBody).get("code"),
+        "123456",
+        "submits the entered code"
+      );
+      return response({
+        success: "OK",
+        redirect_url: "/u/password-reset/reset-token",
+      });
+    });
+
+    await visit("/");
+    await click("header .login-button");
+    await click("#forgot-password-link");
+    await fillIn("#username-or-email", "someuser");
+    await click(".forgot-password-reset");
+    await fillIn(".d-otp-input", "123456");
+
+    assert.true(
+      redirect.calledOnceWithExactly("/u/password-reset/reset-token"),
+      "loads the reset page returned by the server"
+    );
+  });
+
+  test("shows code entry when account existence is hidden", async function (assert) {
+    this.siteSettings.hide_email_address_taken = true;
+    pretender.post("/session/forgot_password", () =>
+      response({ success: "OK", email_code: true })
+    );
+
+    await visit("/");
+    await click("header .login-button");
+    await click("#forgot-password-link");
+    await fillIn("#username-or-email", "unknown@example.com");
+    await click(".forgot-password-reset");
+
+    assert
+      .dom(".d-otp-input")
+      .exists("shows code entry without disclosing account existence");
+  });
+});

--- a/frontend/discourse/tests/acceptance/user-preferences-security-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-security-test.js
@@ -1,5 +1,8 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import sinon from "sinon";
+import DiscourseURL from "discourse/lib/url";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import {
   acceptance,
   updateCurrentUser,
@@ -30,6 +33,60 @@ acceptance("User Preferences - Security", function (needs) {
     server.put("/u/eviltrout/remove-password", () => {
       return helper.response({ success: "Ok" });
     });
+  });
+
+  test("changes a password using an email code", async function (assert) {
+    const redirect = sinon.stub(DiscourseURL, "redirectTo");
+    pretender.post("/session/forgot_password.json", () =>
+      response({ success: "OK", email_code: true })
+    );
+    pretender.post("/session/password-reset-code/verify", () =>
+      response({ success: "OK", redirect_url: "/u/password-reset/reset-token" })
+    );
+
+    await visit("/u/eviltrout/preferences/security");
+    await click("#change-password-button");
+
+    assert
+      .dom(".forgot-password-modal .d-otp-input")
+      .exists("opens code entry");
+    assert
+      .dom("#username-or-email")
+      .doesNotExist("uses the code already requested");
+
+    await fillIn(".d-otp-input", "123456");
+
+    assert.true(
+      redirect.calledOnceWithExactly("/u/password-reset/reset-token"),
+      "loads the password reset page after verification"
+    );
+  });
+
+  test("opens code entry from the confirm-session dialog", async function (assert) {
+    this.siteSettings.enable_passkeys = true;
+    pretender.post("/session/forgot_password.json", () =>
+      response({ success: "OK", email_code: true })
+    );
+
+    await visit("/u/eviltrout/preferences/security");
+    await click(".pref-passkeys__add .btn");
+    await click(".dialog-body .confirm-session__reset-btn");
+
+    assert
+      .dom(".dialog-body .confirm-session")
+      .doesNotExist("dismisses the confirmation dialog");
+    assert
+      .dom(".forgot-password-modal .d-otp-input")
+      .exists("opens code entry for the requested reset");
+
+    await click(".code-login-form__change-email");
+
+    assert
+      .dom("#username-or-email")
+      .hasValue(
+        this.owner.lookup("service:current-user").email || "eviltrout",
+        "keeps the current account when returning to the request step"
+      );
   });
 
   test("recently connected devices", async function (assert) {

--- a/spec/jobs/regular/send_email_login_code_spec.rb
+++ b/spec/jobs/regular/send_email_login_code_spec.rb
@@ -33,4 +33,15 @@ RSpec.describe Jobs::SendEmailLoginCode do
     expect(email.subject).to include("123456")
     expect(email.body.to_s).to include("123456")
   end
+
+  it "sends the password reset template when requested" do
+    described_class.new.execute(to_address: "foo@example.com", code: "123456", password_reset: true)
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.to).to contain_exactly("foo@example.com")
+    expect(email.subject).to eq(
+      I18n.t("password_reset_code_mailer.subject_template", code: "123456"),
+    )
+    expect(email.body.to_s).to include("123456", "reset your password")
+  end
 end

--- a/spec/lib/read_only_mixin_spec.rb
+++ b/spec/lib/read_only_mixin_spec.rb
@@ -48,6 +48,8 @@ describe ReadOnlyMixin do
       [SessionController, :create],
       # Allows staff to reset their password (part 1/2)
       [SessionController, :forgot_password],
+      # Allows staff to redeem the verification code when resetting their password
+      [SessionController, :redeem_password_reset_code],
       # Allows staff to log in via an emailed one-time code (part 1/2)
       [SessionController, :create_login_code],
       # Allows staff to log in via an emailed one-time code (part 2/2)

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -288,11 +288,14 @@ RSpec.describe SvgSprite do
   end
 
   it "includes icons from plugin registry" do
+    original_icons = DiscoursePluginRegistry.svg_icons.dup
     DiscoursePluginRegistry.register_svg_icon "blender"
     DiscoursePluginRegistry.register_svg_icon "fab fa-bandcamp"
 
     expect(SvgSprite.all_icons).to include("blender")
     expect(SvgSprite.all_icons).to include("fab fa-bandcamp")
+  ensure
+    DiscoursePluginRegistry.svg_icons.replace(original_icons)
   end
 
   describe "icon sources registered by plugins" do

--- a/spec/models/email_login_code_spec.rb
+++ b/spec/models/email_login_code_spec.rb
@@ -25,6 +25,26 @@ RSpec.describe EmailLoginCode do
       expect(described_class.all).to contain_exactly(other_record, new_record)
     end
 
+    it "keeps login and password reset codes active for the same email" do
+      login_code = described_class.generate!(email: "foo@example.com")
+      reset_code = described_class.generate!(email: "FOO@example.com", purpose: :password_reset)
+
+      expect(described_class.active).to contain_exactly(login_code, reset_code)
+      expect(login_code).to be_login
+      expect(reset_code).to be_password_reset
+    end
+
+    it "only replaces codes for the requested purpose when resending" do
+      login_code = described_class.generate!(email: "foo@example.com")
+      described_class.generate!(email: "foo@example.com", purpose: :password_reset)
+
+      reset_code = described_class.generate!(email: "FOO@example.com", purpose: :password_reset)
+      expect(described_class.active).to contain_exactly(login_code, reset_code)
+
+      replacement_login_code = described_class.generate!(email: "FOO@example.com")
+      expect(described_class.active).to contain_exactly(replacement_login_code, reset_code)
+    end
+
     it "expires the code after 10 minutes" do
       freeze_time
 

--- a/spec/requests/admin/email_templates_controller_spec.rb
+++ b/spec/requests/admin/email_templates_controller_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Admin::EmailTemplatesController do
         expect(json["email_templates"]).to be_present
       end
 
+      it "includes the password reset code template" do
+        get "/admin/email/templates.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["email_templates"]).to include(
+          a_hash_including(
+            "id" => "password_reset_code_mailer",
+            "interpolation_keys" => %w[code minutes site_name],
+          ),
+        )
+      end
+
       it "returns overridden = true if subject or body has translation_overrides record" do
         put "/admin/email/templates/user_notifications.admin_login",
             params: {

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -3715,6 +3715,23 @@ RSpec.describe SessionController do
         end
       end
 
+      it "expires existing password reset and unscoped email tokens when sending a code" do
+        reset_token = Fabricate(:email_token, user: user, scope: EmailToken.scopes[:password_reset])
+        unscoped_token = Fabricate(:email_token, user: user)
+        login_token = Fabricate(:email_token, user: user, scope: EmailToken.scopes[:email_login])
+        other_user_token = Fabricate(:email_token, scope: EmailToken.scopes[:password_reset])
+        unscoped_token.update_column(:scope, nil)
+
+        post "/session/forgot_password.json", params: { login: user.email }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["email_code"]).to eq(true)
+        expect(reset_token.reload).to be_expired
+        expect(unscoped_token.reload).to be_expired
+        expect(login_token.reload).not_to be_expired
+        expect(other_user_token.reload).not_to be_expired
+      end
+
       it "sends a code when a logged-in user resets their own password" do
         sign_in(user)
 

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -3693,6 +3693,84 @@ RSpec.describe SessionController do
   end
 
   describe "#forgot_password" do
+    context "when email codes are enabled" do
+      before { SiteSetting.enable_local_logins_via_code = true }
+
+      it "sends a password reset code to the primary email for usernames and secondary emails" do
+        secondary_email = Fabricate(:secondary_email, user: user)
+
+        [user.username, secondary_email.email].each do |login|
+          expect_enqueued_with(
+            job: :send_email_login_code,
+            args: {
+              to_address: user.email,
+              password_reset: true,
+            },
+          ) { post "/session/forgot_password.json", params: { login: } }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body).to include("email_code" => true, "user_found" => true)
+          expect(EmailLoginCode.for_email(user.email).count).to eq(1)
+          expect(user.email_tokens.where(scope: EmailToken.scopes[:password_reset])).to be_empty
+        end
+      end
+
+      it "sends a code when a logged-in user resets their own password" do
+        sign_in(user)
+
+        expect_enqueued_with(
+          job: :send_email_login_code,
+          args: {
+            to_address: user.email,
+            password_reset: true,
+          },
+        ) { post "/session/forgot_password.json", params: { login: user.email } }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["email_code"]).to eq(true)
+      end
+
+      it "sends a link when staff reset another user's password" do
+        sign_in(admin)
+
+        expect_enqueued_with(
+          job: :critical_user_email,
+          args: {
+            type: "forgot_password",
+            user_id: user.id,
+          },
+        ) { post "/session/forgot_password.json", params: { login: user.email } }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).not_to have_key("email_code")
+        expect(EmailLoginCode.password_reset.for_email(user.email)).to be_empty
+      end
+
+      it "returns the same response for unknown emails when account existence is hidden" do
+        SiteSetting.hide_email_address_taken = true
+        post "/session/forgot_password.json", params: { login: user.email }
+        known_response = response.parsed_body
+
+        expect_not_enqueued_with(job: :send_email_login_code) do
+          post "/session/forgot_password.json", params: { login: "unknown@example.com" }
+        end
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq(known_response)
+        expect(response.parsed_body).to include("email_code" => true)
+        expect(response.parsed_body).not_to have_key("user_found")
+      end
+
+      it "preserves password reset request rate limits" do
+        RateLimiter.enable
+
+        3.times { post "/session/forgot_password.json", params: { login: user.email } }
+        post "/session/forgot_password.json", params: { login: user.email }
+
+        expect(response.status).to eq(422)
+      end
+    end
+
     context "when hide_email_address_taken is set" do
       before { SiteSetting.hide_email_address_taken = true }
 
@@ -3897,6 +3975,187 @@ RSpec.describe SessionController do
         expect(response.status).to eq(503)
         expect(Jobs::CriticalUserEmail.jobs.size).to eq(0)
       end
+    end
+  end
+
+  describe "#redeem_password_reset_code" do
+    before { SiteSetting.enable_local_logins_via_code = true }
+
+    def request_password_reset_code
+      post "/session/forgot_password.json", params: { login: user.email }
+      Jobs::SendEmailLoginCode.jobs.last["args"].first["code"]
+    end
+
+    it "exchanges the code for a reset page and changes the password there" do
+      code = request_password_reset_code
+
+      post "/session/password-reset-code/verify.json", params: { code: }
+
+      expect(response.status).to eq(200)
+      reset_url = response.parsed_body["redirect_url"]
+      expect(reset_url).to start_with("/u/password-reset/")
+      expect(user.user_auth_tokens).to be_empty
+
+      get reset_url
+      put reset_url, params: { password: "aNewSecurePassword123!" }
+
+      expect(response.status).to eq(200)
+      expect(user.reload.confirm_password?("aNewSecurePassword123!")).to eq(true)
+    end
+
+    it "keeps login and reset codes usable only for their own flow" do
+      SecureRandom
+        .stubs(:random_number)
+        .with(10**EmailLoginCode::CODE_LENGTH)
+        .returns(123_456, 654_321)
+      reset_code = request_password_reset_code
+      get "/session/hp.json"
+      honeypot = response.parsed_body
+      post "/session/login-code.json",
+           params: {
+             email: user.email,
+             password_confirmation: honeypot["value"],
+             challenge: honeypot["challenge"].reverse,
+           }
+      login_code = Jobs::SendEmailLoginCode.jobs.last["args"].first["code"]
+
+      post "/session/password-reset-code/verify.json", params: { code: login_code }
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+
+      post "/session/login-code/verify.json", params: { email: user.email, code: reset_code }
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+      expect(user.user_auth_tokens).to be_empty
+
+      post "/session/password-reset-code/verify.json", params: { code: reset_code }
+      expect(response.parsed_body["redirect_url"]).to start_with("/u/password-reset/")
+
+      post "/session/login-code/verify.json", params: { email: user.email, code: login_code }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.dig("user", "username")).to eq(user.username)
+      expect(user.user_auth_tokens.count).to eq(1)
+    end
+
+    it "requires the existing second factor before changing the password" do
+      second_factor = Fabricate(:user_second_factor_totp, user:)
+      code = request_password_reset_code
+      post "/session/password-reset-code/verify.json", params: { code: }
+      reset_url = response.parsed_body["redirect_url"]
+
+      get reset_url
+      put reset_url, params: { password: "aNewSecurePassword123!" }
+
+      expect(user.reload.confirm_password?("aNewSecurePassword123!")).to eq(false)
+      expect(user.user_auth_tokens).to be_empty
+
+      put reset_url,
+          params: {
+            password: "aNewSecurePassword123!",
+            second_factor_token: ROTP::TOTP.new(second_factor.data).now,
+            second_factor_method: UserSecondFactor.methods[:totp],
+          }
+
+      expect(response.status).to eq(200)
+      expect(user.reload.confirm_password?("aNewSecurePassword123!")).to eq(true)
+    end
+
+    it "rejects a code from another browser even when its identifiers are supplied" do
+      code = request_password_reset_code
+      login_code = EmailLoginCode.for_email(user.email).sole
+      reset!
+
+      expect do
+        post "/session/password-reset-code/verify.json",
+             params: {
+               code:,
+               login_code_id: login_code.id,
+               user_id: user.id,
+             }
+      end.not_to change(EmailToken, :count)
+
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+    end
+
+    it "invalidates the previous code when another is requested" do
+      SecureRandom
+        .stubs(:random_number)
+        .with(10**EmailLoginCode::CODE_LENGTH)
+        .returns(123_456, 654_321)
+      previous_code = request_password_reset_code
+      code = request_password_reset_code
+
+      post "/session/password-reset-code/verify.json", params: { code: previous_code }
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+
+      post "/session/password-reset-code/verify.json", params: { code: }
+      expect(response.parsed_body["redirect_url"]).to be_present
+    end
+
+    it "keeps the latest code usable when a resend is rate limited" do
+      RateLimiter.enable
+      request_password_reset_code
+      request_password_reset_code
+      code = request_password_reset_code
+
+      post "/session/forgot_password.json", params: { login: user.email }
+      expect(response.status).to eq(422)
+
+      post "/session/password-reset-code/verify.json", params: { code: }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["redirect_url"]).to be_present
+    end
+
+    it "allows the code to be redeemed only once" do
+      code = request_password_reset_code
+      post "/session/password-reset-code/verify.json", params: { code: }
+
+      expect do
+        post "/session/password-reset-code/verify.json", params: { code: }
+      end.not_to change(EmailToken, :count)
+
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+    end
+
+    it "clears an earlier reset request when the next account is unknown" do
+      code = request_password_reset_code
+      post "/session/forgot_password.json", params: { login: "unknown@example.com" }
+      post "/session/password-reset-code/verify.json", params: { code: }
+
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+      expect(user.email_tokens.where(scope: EmailToken.scopes[:password_reset])).to be_empty
+    end
+
+    it "returns 404 when email codes are disabled" do
+      SiteSetting.enable_local_logins_via_code = false
+      post "/session/password-reset-code/verify.json", params: { code: "123456" }
+
+      expect(response.status).to eq(404)
+    end
+
+    it "blocks verification when local logins are disabled" do
+      code = request_password_reset_code
+      SiteSetting.enable_local_logins = false
+      post "/session/password-reset-code/verify.json", params: { code: }
+
+      expect(response.status).to eq(403)
+      expect(user.email_tokens.where(scope: EmailToken.scopes[:password_reset])).to be_empty
+    end
+
+    it "blocks nonstaff when staff writes only mode is enabled after requesting a code" do
+      code = request_password_reset_code
+      Discourse.enable_readonly_mode(Discourse::STAFF_WRITES_ONLY_MODE_KEY)
+      post "/session/password-reset-code/verify.json", params: { code: }
+
+      expect(response.status).to eq(503)
+      expect(user.email_tokens.where(scope: EmailToken.scopes[:password_reset])).to be_empty
+    end
+
+    it "rate limits verification attempts" do
+      RateLimiter.enable
+
+      6.times { post "/session/password-reset-code/verify.json", params: { code: "123456" } }
+      post "/session/password-reset-code/verify.json", params: { code: "123456" }
+
+      expect(response.status).to eq(429)
     end
   end
 

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -3693,6 +3693,8 @@ RSpec.describe SessionController do
   end
 
   describe "#forgot_password" do
+    before { SiteSetting.enable_local_logins_via_code = false }
+
     context "when email codes are enabled" do
       before { SiteSetting.enable_local_logins_via_code = true }
 

--- a/spec/services/email_login_code/redeem_spec.rb
+++ b/spec/services/email_login_code/redeem_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe EmailLoginCode::Redeem do
       it { is_expected.to fail_to_find_a_model(:login_code) }
     end
 
+    context "when the code was issued for password reset" do
+      let(:login_code) { EmailLoginCode.generate!(email:, purpose: :password_reset) }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
     context "when the code is wrong" do
       let(:code) { login_code.code == "000000" ? "000001" : "000000" }
 
@@ -140,6 +146,8 @@ RSpec.describe EmailLoginCode::Redeem do
       end
 
       it "enqueues the welcome message" do
+        SiteSetting.send_welcome_message = true
+
         expect { result }.to change {
           Jobs::SendSystemMessage.jobs.count do |job|
             job["args"][0]["message_type"] == "welcome_user"

--- a/spec/services/email_login_code/verify_spec.rb
+++ b/spec/services/email_login_code/verify_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe EmailLoginCode::Verify do
       it { is_expected.to fail_to_find_a_model(:login_code) }
     end
 
+    context "when the code was issued for password reset" do
+      let(:login_code) { EmailLoginCode.generate!(email:, purpose: :password_reset) }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
     context "when the code is wrong" do
       let(:code) { login_code.code == "000000" ? "000001" : "000000" }
 

--- a/spec/services/invite/redeem_with_email_code_spec.rb
+++ b/spec/services/invite/redeem_with_email_code_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe Invite::RedeemWithEmailCode do
       it { is_expected.to fail_to_find_a_model(:login_code) }
     end
 
+    context "when the code was issued for password reset" do
+      let(:login_code) { EmailLoginCode.generate!(email:, purpose: :password_reset) }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
     context "when the code is wrong" do
       let(:code) { login_code.code == "000000" ? "000001" : "000000" }
 

--- a/spec/services/user/create_password_reset_token_spec.rb
+++ b/spec/services/user/create_password_reset_token_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe User::CreatePasswordResetToken do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:code) }
+    it { is_expected.to allow_values("123456", " 123456 ").for(:code) }
+    it { is_expected.not_to allow_values("12345", "1234567", "abcdef").for(:code) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:user)
+
+    let(:login_code) { EmailLoginCode.generate!(email: user.email, purpose: :password_reset) }
+    let(:code) { login_code.code }
+    let(:params) { { code: } }
+    let(:login_code_id) { login_code.id }
+    let(:user_id) { user.id }
+    let(:dependencies) { { login_code_id:, user_id: } }
+
+    context "when the contract is invalid" do
+      let(:code) { "invalid" }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "without a session code" do
+      let(:login_code_id) { nil }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
+    context "when the code was issued for login" do
+      let(:login_code) { EmailLoginCode.generate!(email: user.email) }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
+    context "when the code has expired" do
+      before { login_code.update!(expires_at: 1.second.ago) }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
+    context "when the code has been consumed" do
+      before { login_code.consume! }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
+    context "when the code has exhausted its attempts" do
+      before { login_code.update!(attempts: EmailLoginCode::MAX_ATTEMPTS) }
+
+      it { is_expected.to fail_to_find_a_model(:login_code) }
+    end
+
+    context "when the code is incorrect" do
+      let(:code) { (login_code.code.to_i + 1).modulo(1_000_000).to_s.rjust(6, "0") }
+
+      it "rejects the code and records the failed attempt" do
+        expect(result).to fail_a_policy(:code_matches)
+        expect(login_code.reload.attempts).to eq(1)
+        expect(user.email_tokens.where(scope: EmailToken.scopes[:password_reset])).to be_empty
+      end
+    end
+
+    context "without a session user" do
+      let(:user_id) { nil }
+
+      it { is_expected.to fail_to_find_a_model(:user) }
+    end
+
+    context "when the user email has changed" do
+      before do
+        login_code
+        user.update!(email: "changed@example.com")
+      end
+
+      it { is_expected.to fail_to_find_a_model(:user) }
+    end
+
+    context "when the user is staged" do
+      before { user.update!(staged: true) }
+
+      it { is_expected.to fail_to_find_a_model(:user) }
+    end
+
+    context "when staff writes only mode is enabled" do
+      before { Discourse.enable_readonly_mode(Discourse::STAFF_WRITES_ONLY_MODE_KEY) }
+
+      it { is_expected.to fail_a_policy(:can_write) }
+    end
+
+    context "when staff writes only mode is enabled for an admin" do
+      fab!(:user, :admin)
+
+      before { Discourse.enable_readonly_mode(Discourse::STAFF_WRITES_ONLY_MODE_KEY) }
+
+      it { is_expected.to run_successfully }
+    end
+
+    context "when the code matches" do
+      it "consumes the code and creates a password reset token without logging in" do
+        expect { result }.to change { user.email_tokens.count }.by(1)
+        expect(result).to run_successfully
+        expect(result.email_token).to have_attributes(
+          user_id: user.id,
+          email: user.email,
+          scope: EmailToken.scopes[:password_reset],
+        )
+        expect(login_code.reload.consumed_at).to be_present
+        expect(user.user_auth_tokens).to be_empty
+      end
+    end
+  end
+end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -14,6 +14,7 @@ shared_examples "login scenarios" do
   let(:user_menu) { PageObjects::Components::UserMenu.new }
 
   before do
+    SiteSetting.enable_local_logins_via_code = false
     SiteSetting.hide_email_address_taken = false
     Jobs.run_immediately!
   end
@@ -304,6 +305,8 @@ shared_examples "login scenarios" do
   end
 
   context "with two-factor authentication" do
+    let(:forgot_password_modal) { PageObjects::Modals::ForgotPassword.new }
+    let(:reset_password_page) { PageObjects::Pages::UserResetPassword.new }
     let!(:user_second_factor) { Fabricate(:user_second_factor_totp, user: user) }
     let!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup, user: user) }
 
@@ -384,6 +387,24 @@ shared_examples "login scenarios" do
       find(".email-login-form .btn-primary").click
 
       expect(page).to have_css(".header-dropdown-toggle.current-user")
+    end
+
+    it "can reset password with an email code and TOTP" do
+      SiteSetting.enable_local_logins_via_code = true
+
+      login_form.open.fill_username("john").forgot_password
+      forgot_password_modal.request_reset
+
+      wait_for(timeout: 5) { ActionMailer::Base.deliveries.count != 0 }
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to contain_exactly(user.email)
+      forgot_password_modal.submit_code(mail.subject[/(\d{6})/, 1])
+
+      expect(reset_password_page).to have_totp_description
+      reset_password_page.fill_in_totp(ROTP::TOTP.new(user_second_factor.data).now).submit_totp
+      reset_password_page.fill_in_new_password("newsuperpassword").submit_new_password
+
+      expect(reset_password_page).to have_logged_in_user
     end
 
     it "can reset password with TOTP" do

--- a/spec/system/page_objects/modals/forgot_password.rb
+++ b/spec/system/page_objects/modals/forgot_password.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class ForgotPassword < Base
+      MODAL_SELECTOR = ".forgot-password-modal"
+
+      def request_reset
+        find("#{full_modal_selector} .forgot-password-reset").click
+        self
+      end
+
+      def submit_code(code)
+        find("#{full_modal_selector} .d-otp-input").fill_in(with: code)
+        self
+      end
+    end
+  end
+end

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -22,6 +22,8 @@ describe "User preferences | Security" do
 
   shared_examples "security keys" do
     it "adds a 2FA security key and logs in with it" do
+      SiteSetting.enable_local_logins_via_code = false
+
       with_virtual_authenticator do
         confirm_session_modal =
           user_preferences_security_page


### PR DESCRIPTION
Previously, password resets required an email link even when enable_local_logins_via_code was enabled.

This change adds code verification to password reset flows while preserving two-factor checks, keeping reset codes separate from login codes, and retaining email links for staff-initiated resets of other accounts.

- Logged-in reset screens now support code entry.
- Staff resets for other users retain email links.
- Reset email template is available in admin.
- Reset codes no longer invalidate login/invite codes.