### PR TITLE
UX: make each assign tag a separate list item

### DIFF
--- a/frontend/discourse/app/lib/render-tags.js
+++ b/frontend/discourse/app/lib/render-tags.js
@@ -62,7 +62,9 @@ export default function (topic, params) {
   if (callbacks && topic) {
     callbacks.forEach((c) => {
       const html = c(topic, params);
-      if (html) {
+      if (Array.isArray(html)) {
+        callbackResults.push(...html.filter(Boolean));
+      } else if (html) {
         callbackResults.push(html);
       }
     });

--- a/frontend/discourse/tests/unit/lib/render-tags-test.js
+++ b/frontend/discourse/tests/unit/lib/render-tags-test.js
@@ -1,10 +1,15 @@
 import EmberObject from "@ember/object";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
-import renderTags from "discourse/lib/render-tags";
+import renderTags, {
+  addTagsHtmlCallback,
+  clearTagsHtmlCallbacks,
+} from "discourse/lib/render-tags";
 
 module("Unit | Utility | render-tags", function (hooks) {
   setupTest(hooks);
+
+  hooks.afterEach(() => clearTagsHtmlCallbacks());
 
   test("renderTags with tagClasses param", function (assert) {
     const topic = EmberObject.create({
@@ -37,5 +42,51 @@ module("Unit | Utility | render-tags", function (hooks) {
       dogTagLink.classList.contains("woof"),
       "adds the woof class to the dog tag"
     );
+  });
+
+  test("callback returning an array renders each item as its own li", function (assert) {
+    addTagsHtmlCallback(() => ["<a>one</a>", "<a>two</a>", "<a>three</a>"]);
+
+    const topic = EmberObject.create({
+      tags: [],
+      get(prop) {
+        return this[prop];
+      },
+    });
+
+    const result = renderTags(topic, {});
+    const div = document.createElement("div");
+    div.innerHTML = result;
+
+    const items = div.querySelectorAll(".discourse-tags > li");
+    assert.strictEqual(items.length, 3, "each array item gets its own li");
+    assert.strictEqual(items[0].querySelector("a").textContent, "one");
+    assert.strictEqual(items[1].querySelector("a").textContent, "two");
+    assert.strictEqual(items[2].querySelector("a").textContent, "three");
+    assert.dom(".discourse-tags__tag-separator", items[0]).exists();
+    assert.dom(".discourse-tags__tag-separator", items[1]).exists();
+    assert.dom(".discourse-tags__tag-separator", items[2]).doesNotExist();
+  });
+
+  test("callback returning an array alongside regular tags", function (assert) {
+    addTagsHtmlCallback(() => ["<a>one</a>", "<a>two</a>"]);
+
+    const topic = EmberObject.create({
+      tags: ["alpha", "beta"],
+      get(prop) {
+        return this[prop];
+      },
+    });
+
+    const result = renderTags(topic, {});
+    const div = document.createElement("div");
+    div.innerHTML = result;
+
+    const items = div.querySelectorAll(".discourse-tags > li");
+    assert.strictEqual(items.length, 4, "tags and array items each own li");
+    assert.dom('[data-tag-name="alpha"]', items[0]).exists();
+    assert.dom('[data-tag-name="beta"]', items[1]).exists();
+    assert.strictEqual(items[2].querySelector("a").textContent, "one");
+    assert.strictEqual(items[3].querySelector("a").textContent, "two");
   });
 });

--- a/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -4,7 +4,6 @@ import getURL from "discourse/lib/get-url";
 import { iconHTML } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { registerTopicFooterDropdown } from "discourse/lib/register-topic-footer-dropdown";
-import { applyValueTransformer } from "discourse/lib/transformer";
 import { escapeExpression } from "discourse/lib/utilities";
 import { renderAvatar } from "discourse/ui-kit/helpers/d-user-avatar";
 import { i18n } from "discourse-i18n";
@@ -415,27 +414,7 @@ function initialize(api) {
       )}">${escapeExpression(name)}</span></${tagName}>`;
     };
 
-    // is there's one assignment just return the tag
-    if (assignedTo.length === 1) {
-      return createTagHtml(assignedTo[0]);
-    }
-
-    // join multiple assignments with a separator
-    let result = "";
-    assignedTo.forEach((assignment, index) => {
-      result += createTagHtml(assignment);
-
-      // add separator if not the last tag
-      if (index < assignedTo.length - 1) {
-        const separator = applyValueTransformer("tag-separator", ",", {
-          topic,
-          index,
-        });
-        result += `<span class="discourse-tags__tag-separator">${separator}</span>`;
-      }
-    });
-
-    return result;
+    return assignedTo.map((assignment) => createTagHtml(assignment));
   });
 
   api.addModelSaveProperty("group", "assignable_level");

--- a/plugins/discourse-assign/test/javascripts/acceptance/assigned-topic-test.js
+++ b/plugins/discourse-assign/test/javascripts/acceptance/assigned-topic-test.js
@@ -126,6 +126,12 @@ acceptance("Assigned topic", function (needs) {
         "shows indirect assign notes"
       );
     assert
+      .dom(".discourse-tags > li:has(.assigned-to)")
+      .exists(
+        { count: 2 },
+        "user and group assignment each render in their own li"
+      );
+    assert
       .dom("#topic-footer-dropdown-reassign")
       .exists("shows reassign dropdown at the bottom of the topic");
   });


### PR DESCRIPTION
This renders each assign tag as a separate list item, rather than a list of links within a single list item, to more closely follow our standard tag pattern and to improve wrapping 


before, if one assign wraps they all do
<img width="440" alt="image" src="https://github.com/user-attachments/assets/e0b9adce-a7e8-4532-a6d0-7bc9d24dc5f8" />

after, each assign can wrap individually 
<img width="413"  alt="image" src="https://github.com/user-attachments/assets/7dbb8814-ae99-446d-89f5-d186ca09f9a8" />

