### PR TITLE
UX: use the discobot icon for user inbox "bot chat" tab

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-chats-tab.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-chats-tab.gjs
@@ -20,7 +20,7 @@ export default class AiBotChatsTab extends Component {
         @ariaCurrentContext="subNav"
         @route="discourse-ai-bot-conversations"
       >
-        {{dIcon "robot"}}
+        {{dIcon "discobot"}}
         <span>{{i18n "discourse_ai.bot_chats.tab_label"}}</span>
       </DNavigationItem>
     {{/if}}

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -504,3 +504,9 @@ body.has-ai-conversations-sidebar {
     display: block;
   }
 }
+
+.user-navigation .user-nav__messages-ai-bot-chats {
+  .d-icon.d-icon-discobot {
+    font-size: var(--font-0);
+  }
+}


### PR DESCRIPTION
This switches out the generic robot for discobot, to be more consistent with the sidebar and header icons 

before

<img width="216" height="107" alt="image" src="https://github.com/user-attachments/assets/e1444859-b072-4cd5-828e-cc6b98c24b3c" />


after

<img width="364" height="95" alt="image" src="https://github.com/user-attachments/assets/a916e1a8-fd38-4522-b614-6df6ba6d09bf" />