### PR TITLE
FIX: Do not overwrite permissions after editing

### DIFF
--- a/plugins/voice/app/services/voice/directory_broadcaster.rb
+++ b/plugins/voice/app/services/voice/directory_broadcaster.rb
@@ -33,7 +33,11 @@ module Voice
         Voice.room_index_channel,
         {
           type: action,
-          room: Voice::RoomSerializer.new(room, scope: Guardian.new(nil), root: false).as_json,
+          room:
+            Voice::RoomSerializer
+              .new(room, scope: Guardian.new(nil), root: false)
+              .as_json
+              .except(:can_manage, :can_invite, :membership),
         },
         **targets,
       )

--- a/plugins/voice/assets/javascripts/discourse/app/services/voice-rooms.js
+++ b/plugins/voice/assets/javascripts/discourse/app/services/voice-rooms.js
@@ -3,14 +3,16 @@ import Service, { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse/lib/decorators";
 
-// Directory broadcasts are serialized without a user, so fields the server
-// gates per user (chat availability, manager-only chat settings) are absent
-// from them. A broadcast replaces the whole room object; carry over what this
-// client already knows so a mid-call room update doesn't wipe its own state.
+// Shared directory broadcasts omit user-specific fields. Preserve them until
+// a response scoped to the current user supplies fresh values.
 const USER_GATED_ROOM_FIELDS = [
+  "can_manage",
+  "can_invite",
+  "membership",
   "chat_available",
   "chat_channel_id",
   "chat_idle_minutes",
+  "livekit_enabled",
 ];
 
 // Participant broadcasts arrive in arbitrary database order, so every list

--- a/plugins/voice/spec/services/voice/directory_broadcaster_spec.rb
+++ b/plugins/voice/spec/services/voice/directory_broadcaster_spec.rb
@@ -3,6 +3,19 @@
 RSpec.describe Voice::DirectoryBroadcaster do
   before { SiteSetting.voice_enabled = true }
 
+  it "omits user-specific permissions and membership from shared room updates" do
+    room = Fabricate(:voice_room, public: true)
+
+    messages =
+      MessageBus.track_publish(Voice.room_index_channel) do
+        described_class.broadcast(action: :updated, room: room)
+      end
+
+    payload = messages.first.data[:room]
+    expect(payload[:name]).to eq(room.name)
+    expect(payload.keys).not_to include(:can_manage, :can_invite, :membership)
+  end
+
   it "reaches anonymous subscribers through the anonymous_users pseudogroup when they are admitted" do
     SiteSetting.voice_allowed_groups =
       "#{Group::AUTO_GROUPS[:anonymous_users]}|#{Group::AUTO_GROUPS[:logged_in_users]}"

--- a/plugins/voice/test/javascripts/unit/services/voice-rooms-test.js
+++ b/plugins/voice/test/javascripts/unit/services/voice-rooms-test.js
@@ -4,6 +4,56 @@ import { module, test } from "qunit";
 module("Voice | Unit | Service | voice-rooms", function (hooks) {
   setupTest(hooks);
 
+  test("room edits preserve user-specific state across shared updates", function (assert) {
+    const service = this.owner.lookup("service:voice-rooms");
+    const membership = { id: 1, role_name: "moderator" };
+    service.upsertRoom({
+      id: 1,
+      slug: "watercooler",
+      name: "watercooler",
+      can_manage: true,
+      can_invite: true,
+      membership,
+      livekit_enabled: true,
+    });
+
+    service.handleDirectoryEvent({
+      type: "updated",
+      room: { id: 1, slug: "watercooler", name: "Watercooler" },
+    });
+
+    const room = service.roomById(1);
+    assert.strictEqual(room.name, "Watercooler", "the edited name is applied");
+    assert.true(room.can_manage, "the room can still be edited");
+    assert.true(room.can_invite, "invitation permissions are preserved");
+    assert.deepEqual(room.membership, membership, "membership is preserved");
+    assert.true(room.livekit_enabled, "manager-only settings are preserved");
+  });
+
+  test("user-scoped responses can revoke room permissions", function (assert) {
+    const service = this.owner.lookup("service:voice-rooms");
+    service.upsertRoom({
+      id: 1,
+      slug: "watercooler",
+      can_manage: true,
+      can_invite: true,
+      membership: { id: 1, role_name: "moderator" },
+    });
+
+    service.upsertRoom({
+      id: 1,
+      slug: "watercooler",
+      can_manage: false,
+      can_invite: false,
+      membership: null,
+    });
+
+    const room = service.roomById(1);
+    assert.false(room.can_manage, "management permissions can be revoked");
+    assert.false(room.can_invite, "invitation permissions can be revoked");
+    assert.strictEqual(room.membership, null, "membership can be removed");
+  });
+
   test("participant lists keep one canonical order across updates", function (assert) {
     const service = this.owner.lookup("service:voice-rooms");
 


### PR DESCRIPTION
Issue reported on meta:

> Small bug: when editing a room (ex: capitalizing the first letter of the room name), when I go back to edit it again, it doesn’t show any edit option until I refresh the whole page.

https://meta.discourse.org/t/voice-discord-style-voice-and-video-rooms-now-bundled-with-discourse/411337/44?u=pmusaraj