### PR TITLE
UX: Add btn-default class to 1 button

### DIFF
--- a/frontend/discourse/admin/components/modal/install-theme.gjs
+++ b/frontend/discourse/admin/components/modal/install-theme.gjs
@@ -433,7 +433,7 @@ export default class InstallThemeModal extends Component {
                   />
                 </div>
                 <DButton
-                  class="btn-small advanced-repo"
+                  class="btn-default btn-small advanced-repo"
                   @action={{this.toggleAdvanced}}
                   @label="admin.customize.theme.import_web_advanced"
                 />


### PR DESCRIPTION

|Before|After|
|---|---|
|<img width="792" height="328" alt="Screenshot 2026-09-09 234818" src="https://github.com/user-attachments/assets/4d3247e6-f1d3-4678-85a4-a845c4341755" />| <img width="790" height="326" alt="image" src="https://github.com/user-attachments/assets/046713ea-9093-4ae8-b8a9-b2baa7a6ebba" />|
