### PR TITLE
DEV: Bundle the guardian, glossary and URLs of a JSON:API request into a client

### DIFF
--- a/app/controllers/json_api_kit/base_controller/fetching.rb
+++ b/app/controllers/json_api_kit/base_controller/fetching.rb
@@ -8,31 +8,18 @@ module JsonApiKit
       ROOT = "/api"
 
       def index
-        render_document(
-          Document::Collection.for(
-            request.query_parameters,
-            resource:,
-            guardian:,
-            urls:,
-            glossary:,
-          ),
-        )
+        render_document(Document::Collection.for(request.query_parameters, resource:, client:))
       end
 
       def show
         render_document(
-          Document::Individual.for(
-            params[:id],
-            request.query_parameters,
-            resource:,
-            guardian:,
-            urls:,
-            glossary:,
-          ),
+          Document::Individual.for(params[:id], request.query_parameters, resource:, client:),
         )
       end
 
       private
+
+      def client = Client.new(guardian:, glossary:, urls:)
 
       def urls
         Urls.new(

--- a/lib/json_api_kit/client.rb
+++ b/lib/json_api_kit/client.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module JsonApiKit
+  Client = Data.define(:guardian, :glossary, :urls)
+end

--- a/lib/json_api_kit/document.rb
+++ b/lib/json_api_kit/document.rb
@@ -5,11 +5,16 @@ module JsonApiKit
     class << self
       private
 
-      def build(raw, resource:, urls:, glossary:)
-        parameters = Request::Parameters.new(raw.to_hash.deep_stringify_keys, glossary:, resource:)
-        contract = contract_class.for(parameters.to_h, resource:, glossary:)
+      def build(raw, resource:, client:)
+        parameters =
+          Request::Parameters.new(
+            raw.to_hash.deep_stringify_keys,
+            resource:,
+            glossary: client.glossary,
+          )
+        contract = contract_class.for(parameters.to_h, resource:, glossary: client.glossary)
         return Errors.new(*contract.refusals) if contract.invalid?
-        assemble(new(yield(contract.to_hash), urls:, glossary:, fieldsets: parameters.fieldsets))
+        assemble(new(yield(contract.to_hash), client:, fieldsets: parameters.fieldsets))
       rescue Error => error
         Errors.new(error)
       end
@@ -17,10 +22,11 @@ module JsonApiKit
       def assemble(document) = document.tap(&:to_h)
     end
 
-    def initialize(query, urls:, glossary:, fieldsets:)
+    delegate :urls, to: :client, private: true
+
+    def initialize(query, client:, fieldsets:)
       @query = query
-      @urls = urls
-      @glossary = glossary
+      @client = client
       @fieldsets = fieldsets
     end
 
@@ -30,14 +36,14 @@ module JsonApiKit
 
     private
 
-    attr_reader :query, :urls, :glossary, :fieldsets
+    attr_reader :query, :client, :fieldsets
 
     def contents = @contents ||= Contents.new(primary_records, query.included)
 
     def links = { self: { href: urls.current.to_s, type: Pagination::Profile::MEDIA_TYPE } }
 
     def included
-      contents.related.map { ResourceObject.new(it, urls:, glossary:, fieldsets:).to_h }
+      contents.related.map { ResourceObject.new(it, client:, fieldsets:).to_h }
     end
   end
 end

--- a/lib/json_api_kit/document/collection.rb
+++ b/lib/json_api_kit/document/collection.rb
@@ -6,8 +6,10 @@ module JsonApiKit
       class << self
         def contract_class = Request::Contract::Collection
 
-        def for(parameters, resource:, guardian:, urls:, glossary:, scoped_to: nil)
-          build(parameters, resource:, urls:, glossary:) { resource.all(it, guardian:, scoped_to:) }
+        def for(parameters, resource:, client:, scoped_to: nil)
+          build(parameters, resource:, client:) do
+            resource.all(it, guardian: client.guardian, scoped_to:)
+          end
         end
       end
 
@@ -17,7 +19,7 @@ module JsonApiKit
 
       def data
         contents.primary.map do
-          ResourceObject.new(it, urls:, glossary:, fieldsets:, meta: page_meta(it)).to_h
+          ResourceObject.new(it, client:, fieldsets:, meta: page_meta(it)).to_h
         end
       end
 

--- a/lib/json_api_kit/document/individual.rb
+++ b/lib/json_api_kit/document/individual.rb
@@ -6,8 +6,8 @@ module JsonApiKit
       class << self
         def contract_class = Request::Contract::Individual
 
-        def for(id, parameters, resource:, guardian:, urls:, glossary:)
-          build(parameters, resource:, urls:, glossary:) { resource.find(id, it, guardian:) }
+        def for(id, parameters, resource:, client:)
+          build(parameters, resource:, client:) { resource.find(id, it, guardian: client.guardian) }
         end
       end
 
@@ -15,7 +15,7 @@ module JsonApiKit
 
       def primary_records = [query.record]
 
-      def data = ResourceObject.new(contents.primary.sole, urls:, glossary:, fieldsets:).to_h
+      def data = ResourceObject.new(contents.primary.sole, client:, fieldsets:).to_h
     end
   end
 end

--- a/lib/json_api_kit/document/resource_object.rb
+++ b/lib/json_api_kit/document/resource_object.rb
@@ -4,11 +4,11 @@ module JsonApiKit
   class Document
     class ResourceObject
       delegate :type, :id, to: :record, private: true
+      delegate :glossary, :urls, to: :client, private: true
 
-      def initialize(record, urls:, glossary:, fieldsets:, meta: {})
+      def initialize(record, client:, fieldsets:, meta: {})
         @record = record
-        @urls = urls
-        @glossary = glossary
+        @client = client
         @fieldsets = fieldsets
         @meta = meta
       end
@@ -17,7 +17,7 @@ module JsonApiKit
 
       private
 
-      attr_reader :record, :urls, :glossary, :fieldsets, :meta
+      attr_reader :record, :client, :fieldsets, :meta
 
       def relationship(value) = Name::Relationship.new(value:, type:)
 

--- a/spec/integration/json_api_kit/documents_spec.rb
+++ b/spec/integration/json_api_kit/documents_spec.rb
@@ -164,9 +164,7 @@ RSpec.describe "a rendered document" do
   end
 
   describe "the status of a document" do
-    subject(:status) do
-      JsonApiKit::Document::Collection.for(params, resource:, guardian:, urls:, glossary:).status
-    end
+    subject(:status) { JsonApiKit::Document::Collection.for(params, resource:, client:).status }
 
     it "answers 200 for a rendered listing" do
       expect(status).to eq("200")
@@ -174,14 +172,7 @@ RSpec.describe "a rendered document" do
 
     context "when the document holds one record" do
       subject(:status) do
-        JsonApiKit::Document::Individual.for(
-          middle.id,
-          params,
-          resource:,
-          guardian:,
-          urls:,
-          glossary:,
-        ).status
+        JsonApiKit::Document::Individual.for(middle.id, params, resource:, client:).status
       end
 
       it "answers 200 for a rendered record" do
@@ -191,14 +182,7 @@ RSpec.describe "a rendered document" do
 
     context "when no record has that id" do
       subject(:status) do
-        JsonApiKit::Document::Individual.for(
-          -1,
-          params,
-          resource:,
-          guardian:,
-          urls:,
-          glossary:,
-        ).status
+        JsonApiKit::Document::Individual.for(-1, params, resource:, client:).status
       end
 
       it "answers 404 for a not found error" do

--- a/spec/integration/json_api_kit/errors_spec.rb
+++ b/spec/integration/json_api_kit/errors_spec.rb
@@ -56,15 +56,7 @@ RSpec.describe "a refused request" do
       end
 
       it "answers the status 400" do
-        expect(
-          JsonApiKit::Document::Collection.for(
-            params,
-            resource:,
-            guardian:,
-            urls:,
-            glossary:,
-          ).status,
-        ).to eq("400")
+        expect(JsonApiKit::Document::Collection.for(params, resource:, client:).status).to eq("400")
       end
     end
 

--- a/spec/integration/json_api_kit/support.rb
+++ b/spec/integration/json_api_kit/support.rb
@@ -100,37 +100,21 @@ RSpec.shared_context "with a listing of topics" do
   let(:scoped_to) { nil }
   let(:glossary) { JsonApiKit::Glossary.kit }
   let(:urls) { JsonApiKit::Urls.new(base:, current:, parameters: query) }
-
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:document) do
-    JsonApiKit::Document::Collection.for(
-      params,
-      resource:,
-      guardian:,
-      urls:,
-      glossary:,
-      scoped_to:,
-    ).to_h
+    JsonApiKit::Document::Collection.for(params, resource:, client:, scoped_to:).to_h
   end
 
   def one_document(id, **options)
-    JsonApiKit::Document::Individual.for(
-      id,
-      params,
-      resource:,
-      guardian:,
-      urls:,
-      glossary:,
-      **options,
-    ).to_h
+    JsonApiKit::Document::Individual.for(id, params, resource:, client:, **options).to_h
   end
 
   def listing_of(parameters)
     JsonApiKit::Document::Collection.for(
       parameters,
       resource:,
-      guardian:,
-      urls: JsonApiKit::Urls.new(base:, current:),
-      glossary:,
+      client:
+        JsonApiKit::Client.new(guardian:, glossary:, urls: JsonApiKit::Urls.new(base:, current:)),
       scoped_to:,
     ).to_h
   end

--- a/spec/lib/json_api_kit/document/collection_spec.rb
+++ b/spec/lib/json_api_kit/document/collection_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiKit::Document::Collection do
-  subject(:document) { described_class.new(listing, urls:, glossary:, fieldsets:) }
+  subject(:document) { described_class.new(listing, client:, fieldsets:) }
 
   fab!(:first_topic) do
     Fabricate(:topic, title: "Segments of a listing", created_at: Time.utc(2026, 8, 1))
@@ -10,6 +10,7 @@ RSpec.describe JsonApiKit::Document::Collection do
     Fabricate(:topic, title: "Cursors and their values", created_at: Time.utc(2026, 8, 2))
   end
   let(:glossary) { JsonApiKit::Glossary.kit }
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:fieldsets) { JsonApiKit::Request::Fieldsets.parse({}) }
   let(:resource) do
     Class.new(JsonApiKit::Resource) do
@@ -42,16 +43,14 @@ RSpec.describe JsonApiKit::Document::Collection do
 
       expect(JsonApiKit::Document::ResourceObject).to have_received(:new).with(
         first_record,
-        urls:,
-        glossary:,
+        client:,
         fieldsets:,
         meta: {
         },
       )
       expect(JsonApiKit::Document::ResourceObject).to have_received(:new).with(
         second_record,
-        urls:,
-        glossary:,
+        client:,
         fieldsets:,
         meta: {
         },
@@ -66,8 +65,7 @@ RSpec.describe JsonApiKit::Document::Collection do
 
         expect(JsonApiKit::Document::ResourceObject).to have_received(:new).with(
           first_record,
-          urls:,
-          glossary:,
+          client:,
           fieldsets:,
           meta: {
             page: {
@@ -77,8 +75,7 @@ RSpec.describe JsonApiKit::Document::Collection do
         )
         expect(JsonApiKit::Document::ResourceObject).to have_received(:new).with(
           second_record,
-          urls:,
-          glossary:,
+          client:,
           fieldsets:,
           meta: {
             page: {

--- a/spec/lib/json_api_kit/document/individual_spec.rb
+++ b/spec/lib/json_api_kit/document/individual_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiKit::Document::Individual do
-  subject(:document) { described_class.new(reading, urls:, glossary:, fieldsets:) }
+  subject(:document) { described_class.new(reading, client:, fieldsets:) }
 
   fab!(:topic) { Fabricate(:topic, title: "One record read on its own") }
   let(:glossary) { JsonApiKit::Glossary.kit }
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:fieldsets) { JsonApiKit::Request::Fieldsets.parse({}) }
   let(:resource) do
     Class.new(JsonApiKit::Resource) do

--- a/spec/lib/json_api_kit/document/resource_object_spec.rb
+++ b/spec/lib/json_api_kit/document/resource_object_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiKit::Document::ResourceObject do
-  subject(:resource_object) { described_class.new(record, urls:, glossary:, fieldsets:, meta:) }
+  subject(:resource_object) { described_class.new(record, client:, fieldsets:, meta:) }
 
   fab!(:topic) { Fabricate(:topic, title: "A row a document renders") }
   let(:glossary) { JsonApiKit::Glossary.kit }
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:fieldsets) { JsonApiKit::Request::Fieldsets.parse({}) }
   let(:guardian) { Guardian.new }
   let(:resource) do

--- a/spec/lib/json_api_kit/document_spec.rb
+++ b/spec/lib/json_api_kit/document_spec.rb
@@ -22,18 +22,12 @@ RSpec.describe JsonApiKit::Document do
   let(:urls) do
     JsonApiKit::Urls.new(base: "https://example.com/api", current: "https://example.com/api/topics")
   end
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:parameters) { {} }
 
   describe "Collection.for" do
     subject(:document) do
-      JsonApiKit::Document::Collection.for(
-        parameters,
-        resource:,
-        guardian:,
-        urls:,
-        glossary:,
-        scoped_to:,
-      )
+      JsonApiKit::Document::Collection.for(parameters, resource:, client:, scoped_to:)
     end
 
     let(:scoped_to) { nil }
@@ -67,9 +61,7 @@ RSpec.describe JsonApiKit::Document do
   end
 
   describe "Individual.for" do
-    subject(:document) do
-      JsonApiKit::Document::Individual.for(id, parameters, resource:, guardian:, urls:, glossary:)
-    end
+    subject(:document) { JsonApiKit::Document::Individual.for(id, parameters, resource:, client:) }
 
     let(:id) { topic.id }
 

--- a/spec/resources/group_resource_spec.rb
+++ b/spec/resources/group_resource_spec.rb
@@ -2,21 +2,14 @@
 
 RSpec.describe GroupResource do
   fab!(:group) { Fabricate(:group, name: "a_group") }
-
   let(:guardian) { Guardian.new }
   let(:glossary) { JsonApiKit::Glossary.kit }
   let(:urls) do
     JsonApiKit::Urls.new(base: "https://example.com/api", current: "https://example.com/api/groups")
   end
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:document) do
-    JsonApiKit::Document::Individual.for(
-      group.id,
-      {},
-      resource: described_class,
-      guardian:,
-      urls:,
-      glossary:,
-    )
+    JsonApiKit::Document::Individual.for(group.id, {}, resource: described_class, client:)
   end
 
   it "shows the name and nothing else" do

--- a/spec/resources/user_resource_spec.rb
+++ b/spec/resources/user_resource_spec.rb
@@ -2,21 +2,14 @@
 
 RSpec.describe UserResource do
   fab!(:user) { Fabricate(:user, username: "someone") }
-
   let(:guardian) { Guardian.new }
   let(:glossary) { JsonApiKit::Glossary.kit }
   let(:urls) do
     JsonApiKit::Urls.new(base: "https://example.com/api", current: "https://example.com/api/users")
   end
+  let(:client) { JsonApiKit::Client.new(guardian:, glossary:, urls:) }
   let(:document) do
-    JsonApiKit::Document::Individual.for(
-      user.id,
-      {},
-      resource: described_class,
-      guardian:,
-      urls:,
-      glossary:,
-    )
+    JsonApiKit::Document::Individual.for(user.id, {}, resource: described_class, client:)
   end
 
   it "shows the username and nothing else" do


### PR DESCRIPTION
They were passed together through six constructors. `Client` holds the three objects, and the documents take a client instead.