### PR TITLE
FEATURE: Improve filtered channel sections

### DIFF
--- a/frontend/discourse/app/components/sidebar/api-section.gjs
+++ b/frontend/discourse/app/components/sidebar/api-section.gjs
@@ -26,6 +26,7 @@ export default class SidebarApiSection extends Component {
         @expandWhenActive={{@expandWhenActive}}
         @headerActions={{@section.actions}}
         @headerActionsIcon={{@section.actionsIcon}}
+        @headerActionsInline={{@section.actionsInline}}
         @headerLinkText={{@section.text}}
         @headerLinkTitle={{@section.title}}
         @hideSectionHeader={{@section.hideSectionHeader}}

--- a/frontend/discourse/app/components/sidebar/section.gjs
+++ b/frontend/discourse/app/components/sidebar/section.gjs
@@ -20,6 +20,7 @@ import {
   WEB_LINK_KINDS,
   webLinkPayload,
 } from "discourse/lib/sidebar/link-drop";
+import { or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -116,12 +117,16 @@ export default class SidebarSection extends Component {
     return this.displaySectionContent ? "angle-down" : "angle-right";
   }
 
-  get isSingleHeaderAction() {
-    return this.args.headerActions?.length === 1;
+  get showInlineHeaderActions() {
+    return (
+      this.args.headerActionsInline || this.args.headerActions?.length === 1
+    );
   }
 
   get isMultipleHeaderActions() {
-    return this.args.headerActions?.length > 1;
+    return (
+      !this.args.headerActionsInline && this.args.headerActions?.length > 1
+    );
   }
 
   get displaySection() {
@@ -410,16 +415,18 @@ export default class SidebarSection extends Component {
               {{/if}}
             </SectionHeader>
 
-            {{#if this.isSingleHeaderAction}}
-              {{#each @headerActions as |headerAction|}}
+            {{#if this.showInlineHeaderActions}}
+              {{#each @headerActions key="@index" as |headerAction|}}
                 <button
                   aria-label={{headerAction.title}}
                   class="sidebar-section-header-button btn-icon btn-flat"
+                  data-sidebar-action-id={{headerAction.id}}
+                  disabled={{headerAction.disabled}}
                   title={{headerAction.title}}
                   type="button"
                   {{on "click" headerAction.action}}
                 >
-                  {{dIcon @headerActionsIcon}}
+                  {{dIcon (or headerAction.icon @headerActionsIcon)}}
                 </button>
               {{/each}}
             {{/if}}

--- a/frontend/discourse/app/lib/sidebar/base-custom-sidebar-section.js
+++ b/frontend/discourse/app/lib/sidebar/base-custom-sidebar-section.js
@@ -27,6 +27,15 @@ export default class BaseCustomSidebarSection {
   get actionsIcon() {}
 
   /**
+   * Render actions as separate buttons instead of a menu. Each action may
+   * specify an icon (falling back to actionsIcon), id, and disabled state.
+   * @returns {boolean}
+   */
+  get actionsInline() {
+    return false;
+  }
+
+  /**
    * @returns {BaseCustomSidebarSectionLink[]} Links for section
    */
   get links() {}

--- a/frontend/discourse/tests/integration/components/sidebar/section-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar/section-test.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import {
   click,
   find,
+  focus,
   render,
   settled,
   triggerEvent,
@@ -52,6 +53,84 @@ function belowAllLinks() {
 
 module("Integration | Component | Sidebar | Section", function (hooks) {
   setupRenderingTest(hooks);
+
+  test("inline header actions retain individual icons and callbacks", async function (assert) {
+    this.headerActions = [
+      {
+        id: "show",
+        icon: "eye",
+        title: "Show all",
+        action: () => assert.step("show"),
+      },
+      { id: "options", title: "Options", action: () => assert.step("options") },
+    ];
+    await render(
+      <template>
+        <Section
+          @headerActions={{this.headerActions}}
+          @headerActionsIcon="ellipsis-vertical"
+          @headerActionsInline={{true}}
+          @sectionName="test"
+        />
+      </template>
+    );
+    assert
+      .dom(".sidebar-section-header-button")
+      .exists({ count: 2 }, "both actions are separate buttons");
+    assert
+      .dom('[data-sidebar-action-id="show"] .d-icon-eye')
+      .exists("the action has its own icon");
+    assert
+      .dom('[data-sidebar-action-id="options"] .d-icon-ellipsis-vertical')
+      .exists("the shared icon remains a fallback");
+    await click('[data-sidebar-action-id="show"]');
+    await click('[data-sidebar-action-id="options"]');
+    assert.verifySteps(
+      ["show", "options"],
+      "each action runs its own callback"
+    );
+  });
+
+  test("inline actions retain focus when their state changes", async function (assert) {
+    this.headerActions = [
+      { id: "toggle", icon: "eye", title: "Show all", action() {} },
+    ];
+    await render(
+      <template>
+        <Section
+          @headerActions={{this.headerActions}}
+          @headerActionsInline={{true}}
+          @sectionName="test"
+        />
+      </template>
+    );
+    await focus('[data-sidebar-action-id="toggle"]');
+    this.set("headerActions", [
+      { id: "toggle", icon: "eye-slash", title: "Apply filters", action() {} },
+    ]);
+    await settled();
+    assert
+      .dom('[data-sidebar-action-id="toggle"]')
+      .isFocused("the updated action retains keyboard focus");
+    assert
+      .dom('[data-sidebar-action-id="toggle"] .d-icon-eye-slash')
+      .exists("the icon reflects the new state");
+  });
+
+  test("multiple header actions default to a dropdown", async function (assert) {
+    this.headerActions = [{ title: "First" }, { title: "Second" }];
+    await render(
+      <template>
+        <Section @headerActions={{this.headerActions}} @sectionName="test" />
+      </template>
+    );
+    assert
+      .dom(".sidebar-section-header-dropdown")
+      .exists("existing callers retain the dropdown");
+    assert
+      .dom(".sidebar-section-header-button")
+      .doesNotExist("inline buttons are opt-in");
+  });
 
   test("default displaySection value for section", async function (assert) {
     const template = <template>

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
@@ -11,6 +11,7 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ChatModalNewMessage from "discourse/plugins/chat/discourse/components/chat/modal/new-message";
+import ChatChannelListFilterToggle from "./chat-channel-list-filter-toggle";
 import ChatChannelListOptionsButton from "./chat-channel-list-options-button";
 import ChatChannelRow from "./chat-channel-row";
 import ChatSidebarChannelListFilterEmptyState from "./chat-sidebar-channel-list-filter-empty-state";
@@ -89,6 +90,7 @@ export default class ChannelsListDirect extends Component {
 
         {{#if this.site.desktopView}}
           <div class="chat-channel-divider__actions">
+            <ChatChannelListFilterToggle @section="dms" />
             <ChatChannelListOptionsButton @section="dms" />
           </div>
         {{/if}}
@@ -123,10 +125,7 @@ export default class ChannelsListDirect extends Component {
           />
         {{else}}
           {{#unless this.inSidebar}}
-            <ChatSidebarChannelListFilterEmptyState
-              @layout="empty-state"
-              @section="dms"
-            />
+            <ChatSidebarChannelListFilterEmptyState @section="dms" />
           {{/unless}}
         {{/each}}
       {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -11,6 +11,7 @@ import DEmptyState from "discourse/ui-kit/d-empty-state";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import ChatChannelListFilterToggle from "./chat-channel-list-filter-toggle";
 import ChatChannelListOptionsButton from "./chat-channel-list-options-button";
 import ChatChannelRow from "./chat-channel-row";
 import ChatSidebarChannelListFilterEmptyState from "./chat-sidebar-channel-list-filter-empty-state";
@@ -93,6 +94,7 @@ export default class ChannelsListPublic extends Component {
 
         {{#if this.canBrowseChannels}}
           <div class="chat-channel-divider__actions">
+            <ChatChannelListFilterToggle @section="channels" />
             <ChatChannelListOptionsButton @section="channels" />
           </div>
         {{/if}}
@@ -129,10 +131,7 @@ export default class ChannelsListPublic extends Component {
           />
         {{else}}
           {{#unless this.inSidebar}}
-            <ChatSidebarChannelListFilterEmptyState
-              @layout="empty-state"
-              @section="channels"
-            />
+            <ChatSidebarChannelListFilterEmptyState @section="channels" />
           {{/unless}}
         {{/each}}
       {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-starred.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-starred.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { or } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
+import ChatChannelListFilterToggle from "./chat-channel-list-filter-toggle";
 import ChatChannelListOptionsButton from "./chat-channel-list-options-button";
 import ChatChannelRow from "./chat-channel-row";
 import ChatSidebarChannelListFilterEmptyState from "./chat-sidebar-channel-list-filter-empty-state";
@@ -31,6 +32,7 @@ export default class ChannelsListStarred extends Component {
         <span class="channel-title">{{i18n "chat.starred_channels"}}</span>
 
         <div class="chat-channel-divider__actions">
+          <ChatChannelListFilterToggle @section="starred" />
           <ChatChannelListOptionsButton @section="starred" />
         </div>
       </div>
@@ -45,10 +47,7 @@ export default class ChannelsListStarred extends Component {
       {{else}}
         {{#if this.chatChannelsManager.starredChannels.length}}
           {{#unless this.inSidebar}}
-            <ChatSidebarChannelListFilterEmptyState
-              @layout="empty-state"
-              @section="starred"
-            />
+            <ChatSidebarChannelListFilterEmptyState @section="starred" />
           {{/unless}}
         {{else}}
           <div class="chat-channel-list__empty">

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-list-filter-toggle.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-list-filter-toggle.gjs
@@ -1,0 +1,46 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/ui-kit/d-button";
+
+export default class ChatChannelListFilterToggle extends Component {
+  @service chatChannelListPreferences;
+
+  get bypassed() {
+    return this.chatChannelListPreferences.isFilterBypassedFor(this.section);
+  }
+
+  get disabled() {
+    return this.chatChannelListPreferences.isSavingFilterFor(this.section);
+  }
+
+  get section() {
+    return this.args.section ?? "channels";
+  }
+
+  get visible() {
+    return !this.chatChannelListPreferences.isDefaultFilterFor(this.section);
+  }
+
+  @action
+  toggle() {
+    this.chatChannelListPreferences.toggleFilter(this.section);
+  }
+
+  <template>
+    {{#if this.visible}}
+      <DButton
+        class="btn-transparent chat-channel-list-filter-toggle title-action"
+        ...attributes
+        @action={{this.toggle}}
+        @disabled={{this.disabled}}
+        @icon={{if this.bypassed "eye-slash" "eye"}}
+        @title={{if
+          this.bypassed
+          "chat.channel_list.apply_filters"
+          "chat.channel_list.empty.show_all"
+        }}
+      />
+    {{/if}}
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-list-filter-toggle.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-list-filter-toggle.gjs
@@ -34,7 +34,7 @@ export default class ChatChannelListFilterToggle extends Component {
         ...attributes
         @action={{this.toggle}}
         @disabled={{this.disabled}}
-        @icon={{if this.bypassed "eye-slash" "eye"}}
+        @icon={{if this.bypassed "filter" "filter-circle-xmark"}}
         @title={{if
           this.bypassed
           "chat.channel_list.apply_filters"

--- a/plugins/chat/assets/javascripts/discourse/components/chat-sidebar-channel-list-filter-empty-state.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-sidebar-channel-list-filter-empty-state.gjs
@@ -1,67 +1,30 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import DButton from "discourse/ui-kit/d-button";
 import DEmptyState from "discourse/ui-kit/d-empty-state";
 import { i18n } from "discourse-i18n";
-import { CHAT_CHANNEL_LIST_FILTERS } from "discourse/plugins/chat/discourse/lib/chat-constants";
 import ChatZero from "./svg/chat-zero";
 
-/**
- * Shown when a chat channel list section is empty because its filter is
- * hiding every row. `@section` (`"channels"`, `"starred"`, or `"dms"`) picks
- * which section's filter the "show all" button resets. In the cover sidebar
- * the state is a slim section-list item; with `@layout="empty-state"` (used
- * by the drawer and mobile channel lists) it renders the same illustrated
- * empty state as the "no channels" DEmptyState so the two look alike.
- */
 export default class ChatSidebarChannelListFilterEmptyState extends Component {
   @service chatChannelListPreferences;
   @service sidebarState;
 
-  get section() {
-    return this.args.section ?? "channels";
-  }
-
-  get isSaving() {
-    return this.chatChannelListPreferences.isSavingFilterFor(this.section);
-  }
-
-  get isEmptyStateLayout() {
-    return this.args.layout === "empty-state";
-  }
-
   @action
   showAll() {
-    return this.chatChannelListPreferences.setFilter(
-      this.section,
-      CHAT_CHANNEL_LIST_FILTERS.ALL
+    this.chatChannelListPreferences.showAllChannels(
+      this.args.section ?? "channels"
     );
   }
 
   <template>
     {{#unless this.sidebarState.filter}}
-      {{#if this.isEmptyStateLayout}}
-        <DEmptyState
-          @ctaAction={{this.showAll}}
-          @ctaLabel={{i18n "chat.channel_list.empty.show_all"}}
-          @identifier="empty-channels-list"
-          @svgContent={{ChatZero}}
-          @title={{i18n "chat.channel_list.empty.filtered"}}
-        />
-      {{else}}
-        <li class="chat-sidebar-channels-filter-empty-state" ...attributes>
-          <span class="chat-sidebar-channels-filter-empty-state__text">
-            {{i18n "chat.channel_list.empty.filtered"}}
-          </span>
-          <DButton
-            class="btn-transparent chat-sidebar-channels-filter-empty-state__reset"
-            @action={{this.showAll}}
-            @disabled={{this.isSaving}}
-            @label="chat.channel_list.empty.show_all"
-          />
-        </li>
-      {{/if}}
+      <DEmptyState
+        @ctaAction={{this.showAll}}
+        @ctaLabel={{i18n "chat.channel_list.empty.show_all"}}
+        @identifier="empty-channels-list"
+        @svgContent={{ChatZero}}
+        @title={{i18n "chat.channel_list.empty.filtered"}}
+      />
     {{/unless}}
   </template>
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-sidebar-dms-filter-empty-state.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-sidebar-dms-filter-empty-state.gjs
@@ -1,5 +1,0 @@
-import ChatSidebarChannelListFilterEmptyState from "discourse/plugins/chat/discourse/components/chat-sidebar-channel-list-filter-empty-state";
-
-export default <template>
-  <ChatSidebarChannelListFilterEmptyState @section="dms" />
-</template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-sidebar-starred-filter-empty-state.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-sidebar-starred-filter-empty-state.gjs
@@ -1,5 +1,0 @@
-import ChatSidebarChannelListFilterEmptyState from "discourse/plugins/chat/discourse/components/chat-sidebar-channel-list-filter-empty-state";
-
-export default <template>
-  <ChatSidebarChannelListFilterEmptyState @section="starred" />
-</template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-list-options-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-list-options-button.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import ChatChannelListFilterToggle from "../../chat-channel-list-filter-toggle";
 import ChatChannelListOptionsButton from "../../chat-channel-list-options-button";
 
 /**
@@ -17,6 +18,7 @@ export default class ChatNavbarChannelListOptionsButton extends Component {
 
   <template>
     {{#if this.showButton}}
+      <ChatChannelListFilterToggle @section={{@section}} />
       <ChatChannelListOptionsButton @section={{@section}} />
     {{/if}}
   </template>

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -247,7 +247,7 @@ function channelListActions(section, menuService, preferences, links) {
   if (bypassed || (!preferences.isDefaultFilterFor(section) && !links.length)) {
     actions.push({
       id: "toggleChannelFilter",
-      icon: bypassed ? "eye-slash" : "eye",
+      icon: bypassed ? "filter" : "filter-circle-xmark",
       title: i18n(
         bypassed
           ? "chat.channel_list.apply_filters"

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -13,10 +13,7 @@ import { escapeExpression } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import ChatChannelListSidebarMenu from "discourse/plugins/chat/discourse/components/chat-channel-list-sidebar-menu";
 import ChatChannelSidebarContextMenu from "discourse/plugins/chat/discourse/components/chat-channel-sidebar-context-menu";
-import ChatSidebarChannelListFilterEmptyState from "discourse/plugins/chat/discourse/components/chat-sidebar-channel-list-filter-empty-state";
-import ChatSidebarDmsFilterEmptyState from "discourse/plugins/chat/discourse/components/chat-sidebar-dms-filter-empty-state";
 import ChatSidebarIndicators from "discourse/plugins/chat/discourse/components/chat-sidebar-indicators";
-import ChatSidebarStarredFilterEmptyState from "discourse/plugins/chat/discourse/components/chat-sidebar-starred-filter-empty-state";
 import { CHANNEL_LIST_SECTION_OPTIONS } from "discourse/plugins/chat/discourse/lib/chat-channel-list-options";
 import {
   CHAT_PANEL,
@@ -242,6 +239,26 @@ function createChannelLink(BaseCustomSidebarSectionLink, options = {}) {
       return showSuffix ? "" : "";
     }
   };
+}
+
+function channelListActions(section, menuService, preferences, links) {
+  const actions = [];
+  const bypassed = preferences.isFilterBypassedFor(section);
+  if (bypassed || (!preferences.isDefaultFilterFor(section) && !links.length)) {
+    actions.push({
+      id: "toggleChannelFilter",
+      icon: bypassed ? "eye-slash" : "eye",
+      title: i18n(
+        bypassed
+          ? "chat.channel_list.apply_filters"
+          : "chat.channel_list.empty.show_all"
+      ),
+      disabled: preferences.isSavingFilterFor(section),
+      action: () => preferences.toggleFilter(section),
+    });
+  }
+  actions.push(channelListOptionsAction(section, menuService));
+  return actions;
 }
 
 function channelListOptionsAction(section, menuService) {
@@ -497,14 +514,6 @@ export default {
               return this.sectionLinks;
             }
 
-            get emptyStateComponent() {
-              if (
-                !this.chatChannelListPreferences.isDefaultFilterFor("starred")
-              ) {
-                return ChatSidebarStarredFilterEmptyState;
-              }
-            }
-
             get displaySection() {
               return (
                 this.chatStateManager.hasPreloadedChannels &&
@@ -518,7 +527,20 @@ export default {
             }
 
             get actions() {
-              return [channelListOptionsAction("starred", this.menuService)];
+              return channelListActions(
+                "starred",
+                this.menuService,
+                this.chatChannelListPreferences,
+                this.sectionLinks
+              );
+            }
+
+            get actionsInline() {
+              return true;
+            }
+
+            get persistentActions() {
+              return this.actions.length > 1;
             }
 
             get actionsIcon() {
@@ -700,16 +722,6 @@ export default {
                 );
               }
 
-              get emptyStateComponent() {
-                if (
-                  !this.chatChannelListPreferences.isDefaultFilterFor(
-                    "channels"
-                  )
-                ) {
-                  return ChatSidebarChannelListFilterEmptyState;
-                }
-              }
-
               get name() {
                 return "chat-channels";
               }
@@ -727,7 +739,20 @@ export default {
                   return [];
                 }
 
-                return [channelListOptionsAction("channels", this.menuService)];
+                return channelListActions(
+                  "channels",
+                  this.menuService,
+                  this.chatChannelListPreferences,
+                  this.sectionLinks
+                );
+              }
+
+              get actionsInline() {
+                return true;
+              }
+
+              get persistentActions() {
+                return this.actions.length > 1;
               }
 
               get actionsIcon() {
@@ -1022,7 +1047,20 @@ export default {
               }
 
               get actions() {
-                return [channelListOptionsAction("dms", this.menuService)];
+                return channelListActions(
+                  "dms",
+                  this.menuService,
+                  this.chatChannelListPreferences,
+                  this.sectionLinks
+                );
+              }
+
+              get actionsInline() {
+                return true;
+              }
+
+              get persistentActions() {
+                return this.actions.length > 1;
               }
 
               get actionsIcon() {
@@ -1031,14 +1069,6 @@ export default {
 
               get links() {
                 return this.sectionLinks;
-              }
-
-              get emptyStateComponent() {
-                if (
-                  !this.chatChannelListPreferences.isDefaultFilterFor("dms")
-                ) {
-                  return ChatSidebarDmsFilterEmptyState;
-                }
               }
 
               get displaySection() {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-list-preferences.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-list-preferences.js
@@ -63,6 +63,7 @@ export default class ChatChannelListPreferences extends Service {
   @tracked isSavingChannelsSort = false;
   @tracked isSavingStarredSort = false;
   @tracked isSavingDmsSort = false;
+  @tracked _bypassedFilters = {};
 
   constructor() {
     super(...arguments);
@@ -89,6 +90,34 @@ export default class ChatChannelListPreferences extends Service {
     return (
       this[this.#section(section).filter.value] ?? CHAT_CHANNEL_LIST_FILTERS.ALL
     );
+  }
+
+  effectiveFilterFor(section) {
+    return this.isFilterBypassedFor(section)
+      ? CHAT_CHANNEL_LIST_FILTERS.ALL
+      : this.filterFor(section);
+  }
+
+  isFilterBypassedFor(section) {
+    return this._bypassedFilters[section] ?? false;
+  }
+
+  showAllChannels(section) {
+    if (SECTIONS[section] && !this.isSavingFilterFor(section)) {
+      this._bypassedFilters = { ...this._bypassedFilters, [section]: true };
+    }
+  }
+
+  applyFilter(section) {
+    this._bypassedFilters = { ...this._bypassedFilters, [section]: false };
+  }
+
+  toggleFilter(section) {
+    if (this.isFilterBypassedFor(section)) {
+      this.applyFilter(section);
+    } else {
+      this.showAllChannels(section);
+    }
   }
 
   isDefaultFilterFor(section) {
@@ -119,8 +148,18 @@ export default class ChatChannelListPreferences extends Service {
       return false;
     }
 
+    if (!this.currentUser || this.isSavingFilterFor(section)) {
+      return false;
+    }
+
+    const bypassed = this.isFilterBypassedFor(section);
+    this.applyFilter(section);
     const { field, value, saving } = SECTIONS[section].filter;
-    return await this.#save(field, value, saving, filter);
+    const saved = await this.#save(field, value, saving, filter);
+    if (!saved && bypassed) {
+      this.showAllChannels(section);
+    }
+    return saved;
   }
 
   async setSort(section, sort) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -522,7 +522,7 @@ export default class ChatChannelsManager extends Service {
   }
 
   #filterSidebarChannels(channels, section) {
-    const filter = this.chatChannelListPreferences.filterFor(section);
+    const filter = this.chatChannelListPreferences.effectiveFilterFor(section);
     const activeCutoff =
       filter === CHAT_CHANNEL_LIST_FILTERS.ACTIVE
         ? Date.now() - CHAT_CHANNEL_LIST_ACTIVE_DAYS * 24 * 60 * 60 * 1000

--- a/plugins/chat/assets/stylesheets/common/chat-channel-list-options.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-list-options.scss
@@ -57,22 +57,6 @@
   padding-inline-end: var(--space-2);
 }
 
-.chat-sidebar-channels-filter-empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-1);
-  padding: var(--space-1) 0 var(--space-1) var(--space-9);
-  color: var(--primary-medium);
-  font-size: var(--font-down-1-rem);
-  line-height: var(--line-height-medium);
-
-  &__reset {
-    padding: 0;
-    color: var(--tertiary);
-  }
-}
-
 .fk-d-menu-modal.chat-channel-list-options-menu-content {
   .dropdown-menu__subheader {
     padding-inline: var(--space-4);

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -644,6 +644,7 @@ en:
         cannot_create: "Sorry, you cannot send direct messages."
 
       channel_list:
+        apply_filters: "Apply filters to channels"
         title: "Channels"
         aria_label: "Switch to channels list"
         options:

--- a/plugins/chat/spec/system/list_channels/drawer_spec.rb
+++ b/plugins/chat/spec/system/list_channels/drawer_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "List channels | Drawer" do
 
         drawer_page.channels_index.show_all_channels
         expect(drawer_page).to have_channel(channel_1)
-        expect(drawer_page).to have_selector(".chat-channel-list-filter-toggle .d-icon-eye-slash")
+        expect(drawer_page).to have_selector(".chat-channel-list-filter-toggle .d-icon-filter")
 
         drawer_page.channels_index.toggle_channel_filter
         expect(drawer_page).to have_no_channel(channel_1)

--- a/plugins/chat/spec/system/list_channels/drawer_spec.rb
+++ b/plugins/chat/spec/system/list_channels/drawer_spec.rb
@@ -130,6 +130,32 @@ RSpec.describe "List channels | Drawer" do
         end
       end
 
+      it "temporarily shows all channels from the empty state and reapplies filters from the header" do
+        drawer_page.visit_index
+        drawer_page.channels_index.set_channel_filter("mentions")
+        expect(drawer_page).to have_no_channel(channel_1)
+        expect(drawer_page).to have_selector(
+          ".empty-state__title",
+          text: I18n.t("js.chat.channel_list.empty.filtered"),
+        )
+
+        drawer_page.channels_index.show_all_channels
+        expect(drawer_page).to have_channel(channel_1)
+        expect(drawer_page).to have_selector(".chat-channel-list-filter-toggle .d-icon-eye-slash")
+
+        drawer_page.channels_index.toggle_channel_filter
+        expect(drawer_page).to have_no_channel(channel_1)
+        expect(drawer_page).to have_selector(
+          ".empty-state__title",
+          text: I18n.t("js.chat.channel_list.empty.filtered"),
+        )
+
+        drawer_page.channels_index.toggle_channel_filter
+        expect(drawer_page).to have_channel(channel_1)
+        page.refresh
+        expect(drawer_page).to have_no_channel(channel_1)
+      end
+
       it "filters the channel list from the shared options menu" do
         unread_channel = Fabricate(:category_channel, name: "unread channel")
         unread_channel.add(current_user)

--- a/plugins/chat/spec/system/page_objects/chat/components/channels_index.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channels_index.rb
@@ -17,6 +17,14 @@ module PageObjects
           find(context).find(SELECTOR)
         end
 
+        def show_all_channels
+          component.find(".empty-state__cta .btn").click
+        end
+
+        def toggle_channel_filter
+          component.find(".chat-channel-list-filter-toggle").click
+        end
+
         def open_browse
           open_channel_list_options.option('[data-menu-option-id="browseChannels"]').click
         end

--- a/plugins/chat/spec/system/page_objects/sidebar/chat_sidebar.rb
+++ b/plugins/chat/spec/system/page_objects/sidebar/chat_sidebar.rb
@@ -44,7 +44,7 @@ module PageObjects
         find(selector).hover
         menu =
           PageObjects::Components::DMenu.new(
-            "#{selector} .sidebar-section-header-button",
+            "#{selector} [data-sidebar-action-id='channelListOptions']",
             "chat-channel-list-options-menu",
           )
         menu.expand
@@ -80,8 +80,8 @@ module PageObjects
         submenu.option(%([data-menu-option-id="#{sort}"])).click
       end
 
-      def show_all_channels
-        find(".chat-sidebar-channels-filter-empty-state__reset").click
+      def toggle_channel_filter
+        find("[data-sidebar-action-id='toggleChannelFilter']").click
       end
 
       def open_channel(channel)

--- a/plugins/chat/spec/system/sidebar_channel_list_options_spec.rb
+++ b/plugins/chat/spec/system/sidebar_channel_list_options_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe "Chat sidebar channel list options" do
     chat_sidebar.set_channel_filter("mentions")
 
     expect(page).to have_no_css(".chat-sidebar-channels-filter-empty-state")
-    expect(page).to have_css("[data-sidebar-action-id='toggleChannelFilter'] .d-icon-eye")
+    expect(page).to have_css(
+      "[data-sidebar-action-id='toggleChannelFilter'] .d-icon-filter-circle-xmark",
+    )
 
     chat_sidebar.toggle_channel_filter
 
@@ -76,7 +78,7 @@ RSpec.describe "Chat sidebar channel list options" do
     end
 
     expect(chat_sidebar.channel_names).to eq(["Zulu channel", "Alpha channel"])
-    expect(page).to have_css("[data-sidebar-action-id='toggleChannelFilter'] .d-icon-eye-slash")
+    expect(page).to have_css("[data-sidebar-action-id='toggleChannelFilter'] .d-icon-filter")
     chat_sidebar.toggle_channel_filter
     expect(chat_sidebar).to have_no_channel(read_channel)
     expect(chat_sidebar).to have_no_channel(unread_channel)

--- a/plugins/chat/spec/system/sidebar_channel_list_options_spec.rb
+++ b/plugins/chat/spec/system/sidebar_channel_list_options_spec.rb
@@ -60,21 +60,30 @@ RSpec.describe "Chat sidebar channel list options" do
     expect(chat_sidebar).to have_channel(unread_channel)
     expect(chat_sidebar).to have_no_channel(read_channel)
     expect(chat_sidebar.channel_names).to eq(["Zulu channel"])
+    expect(page).to have_no_css("[data-sidebar-action-id='toggleChannelFilter']")
 
     chat_sidebar.set_channel_filter("mentions")
 
-    expect(page).to have_css(
-      ".chat-sidebar-channels-filter-empty-state",
-      text: "No channels match this filter.",
-    )
+    expect(page).to have_no_css(".chat-sidebar-channels-filter-empty-state")
+    expect(page).to have_css("[data-sidebar-action-id='toggleChannelFilter'] .d-icon-eye")
 
-    chat_sidebar.show_all_channels
+    chat_sidebar.toggle_channel_filter
 
     expect(chat_sidebar).to have_channel(unread_channel)
     expect(chat_sidebar).to have_channel(read_channel)
-    try_until_success(reason: "reset channel filter preference saves asynchronously") do
-      expect(current_user.user_option.reload.chat_channel_list_filter).to eq("all")
+    try_until_success(reason: "temporary override retains the saved filter") do
+      expect(current_user.user_option.reload.chat_channel_list_filter).to eq("mentions")
     end
+
+    expect(chat_sidebar.channel_names).to eq(["Zulu channel", "Alpha channel"])
+    expect(page).to have_css("[data-sidebar-action-id='toggleChannelFilter'] .d-icon-eye-slash")
+    chat_sidebar.toggle_channel_filter
+    expect(chat_sidebar).to have_no_channel(read_channel)
+    expect(chat_sidebar).to have_no_channel(unread_channel)
+    chat_sidebar.toggle_channel_filter
+    page.refresh
+    expect(chat_sidebar).to have_no_channel(read_channel)
+    expect(chat_sidebar).to have_no_channel(unread_channel)
   end
 
   it "opens the new channel modal for staff from the channels options menu" do
@@ -99,19 +108,16 @@ RSpec.describe "Chat sidebar channel list options" do
     within(chat_sidebar.starred_section) do
       expect(page).to have_no_css(".channel-#{read_channel.id}")
     end
-    expect(page).to have_css(
-      ".sidebar-section[data-section-name='chat-starred-channels']",
-      text: "No channels match this filter.",
-    )
+    expect(page).to have_css(".sidebar-section[data-section-name='chat-starred-channels']")
     try_until_success(reason: "starred filter preference saves asynchronously") do
       expect(current_user.user_option.reload.chat_channel_list_filter_starred).to eq("unread")
     end
 
-    chat_sidebar.show_all_channels
+    chat_sidebar.toggle_channel_filter
 
     within(chat_sidebar.starred_section) { expect(page).to have_css(".channel-#{read_channel.id}") }
-    try_until_success(reason: "reset starred filter preference saves asynchronously") do
-      expect(current_user.user_option.reload.chat_channel_list_filter_starred).to eq("all")
+    try_until_success(reason: "temporary override retains the starred filter") do
+      expect(current_user.user_option.reload.chat_channel_list_filter_starred).to eq("unread")
     end
   end
 
@@ -133,19 +139,16 @@ RSpec.describe "Chat sidebar channel list options" do
     chat_sidebar.set_dm_filter("unread")
 
     within(chat_sidebar.dms_section) { expect(page).to have_no_css(".channel-#{dm_channel.id}") }
-    expect(page).to have_css(
-      ".sidebar-section[data-section-name='chat-dms']",
-      text: "No channels match this filter.",
-    )
+    expect(page).to have_css(".sidebar-section[data-section-name='chat-dms']")
     try_until_success(reason: "DM filter preference saves asynchronously") do
       expect(current_user.user_option.reload.chat_channel_list_filter_dms).to eq("unread")
     end
 
-    chat_sidebar.show_all_channels
+    chat_sidebar.toggle_channel_filter
 
     within(chat_sidebar.dms_section) { expect(page).to have_css(".channel-#{dm_channel.id}") }
-    try_until_success(reason: "reset DM filter preference saves asynchronously") do
-      expect(current_user.user_option.reload.chat_channel_list_filter_dms).to eq("all")
+    try_until_success(reason: "temporary override retains the DM filter") do
+      expect(current_user.user_option.reload.chat_channel_list_filter_dms).to eq("unread")
     end
   end
 end

--- a/plugins/chat/test/javascripts/components/channels-list-starred-test.gjs
+++ b/plugins/chat/test/javascripts/components/channels-list-starred-test.gjs
@@ -1,7 +1,6 @@
 import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import sinon from "sinon";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import ChannelsListStarred from "discourse/plugins/chat/discourse/components/channels-list-starred";
@@ -21,7 +20,6 @@ module("Integration | Component | ChannelsListStarred", function (hooks) {
   });
 
   test("shows the filtered empty state when the starred filter hides every channel", async function (assert) {
-    const setFilter = sinon.stub(this.preferences, "setFilter").resolves(true);
     this.preferences.starredFilter = CHAT_CHANNEL_LIST_FILTERS.UNREAD;
 
     const channel = this.fabricators.channel({
@@ -45,10 +43,32 @@ module("Integration | Component | ChannelsListStarred", function (hooks) {
 
     await click(".empty-state__cta .btn");
 
-    assert.true(
-      setFilter.calledWith("starred", "all"),
-      "the show all action resets the starred filter"
+    assert
+      .dom(".chat-channel-row")
+      .exists("the temporary override reveals the starred channel");
+    assert
+      .dom(".empty-state")
+      .doesNotExist("the filtered empty state is removed");
+    assert.strictEqual(
+      this.preferences.filterFor("starred"),
+      CHAT_CHANNEL_LIST_FILTERS.UNREAD,
+      "the preferred starred filter is retained"
     );
+    assert
+      .dom(".chat-channel-list-filter-toggle .d-icon-filter")
+      .exists("the header offers to reapply the filter");
+
+    await click(".chat-channel-list-filter-toggle");
+
+    assert
+      .dom(".chat-channel-row")
+      .doesNotExist("reapplying the filter hides the read starred channel");
+    assert
+      .dom(".empty-state .empty-state__title")
+      .hasText(
+        i18n("chat.channel_list.empty.filtered"),
+        "the filtered empty state returns"
+      );
   });
 
   test("keeps the plain empty message when there are no starred channels", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-channel-list-sidebar-menu-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-list-sidebar-menu-test.gjs
@@ -674,7 +674,7 @@ module(
             "the filter explanation is retained"
           );
         assert
-          .dom(".chat-channel-list-filter-toggle .d-icon-eye")
+          .dom(".chat-channel-list-filter-toggle .d-icon-filter-circle-xmark")
           .exists("the header offers to show all");
         await click(".empty-state__cta .btn");
         assert.strictEqual(
@@ -695,7 +695,7 @@ module(
             "the header offers to reapply filters"
           );
         assert
-          .dom(".chat-channel-list-filter-toggle .d-icon-eye-slash")
+          .dom(".chat-channel-list-filter-toggle .d-icon-filter")
           .exists("the icon changes");
         await click(".chat-channel-list-filter-toggle");
         assert.strictEqual(

--- a/plugins/chat/test/javascripts/components/chat-channel-list-sidebar-menu-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-list-sidebar-menu-test.gjs
@@ -16,6 +16,7 @@ import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import ChatChannelListFilterMenu from "discourse/plugins/chat/discourse/components/chat-channel-list-filter-menu";
+import ChatChannelListFilterToggle from "discourse/plugins/chat/discourse/components/chat-channel-list-filter-toggle";
 import ChatChannelListOptionsButton from "discourse/plugins/chat/discourse/components/chat-channel-list-options-button";
 import ChatChannelListSidebarMenu from "discourse/plugins/chat/discourse/components/chat-channel-list-sidebar-menu";
 import ChatChannelListSortMenu from "discourse/plugins/chat/discourse/components/chat-channel-list-sort-menu";
@@ -642,113 +643,74 @@ module(
       sidebarState.filter = "missing";
 
       await render(
-        <template>
-          <ul>
-            <ChatSidebarChannelListFilterEmptyState />
-          </ul>
-        </template>
+        <template><ChatSidebarChannelListFilterEmptyState /></template>
       );
 
       assert
-        .dom(".chat-sidebar-channels-filter-empty-state")
+        .dom(".empty-state")
         .doesNotExist("the channel-filter reset is hidden during text search");
     });
 
-    test("resets the channels filter by default", async function (assert) {
-      const preferences = getOwner(this).lookup(
-        "service:chat-channel-list-preferences"
-      );
-      const setFilter = sinon.stub(preferences, "setFilter").resolves(true);
-
-      await render(
-        <template>
-          <ul>
-            <ChatSidebarChannelListFilterEmptyState />
-          </ul>
-        </template>
-      );
-
-      assert
-        .dom(".chat-sidebar-channels-filter-empty-state")
-        .hasTagName("li", "the state is valid section-list content")
-        .includesText(
-          i18n("chat.channel_list.empty.filtered"),
-          "the empty state explains the filter"
+    for (const section of ["channels", "dms", "starred"]) {
+      test(`temporarily shows all ${section} and updates the header toggle`, async function (assert) {
+        const preferences = this.owner.lookup(
+          "service:chat-channel-list-preferences"
         );
-
-      await click(".chat-sidebar-channels-filter-empty-state__reset");
-
-      assert.true(
-        setFilter.calledWith("channels", "all"),
-        "the channels filter is reset"
-      );
-    });
-
-    test("resets the filter of the section it is rendered for", async function (assert) {
-      const preferences = getOwner(this).lookup(
-        "service:chat-channel-list-preferences"
-      );
-      const setFilter = sinon.stub(preferences, "setFilter").resolves(true);
-
-      await render(
-        <template>
-          <ul>
-            <ChatSidebarChannelListFilterEmptyState @section="starred" />
-            <ChatSidebarChannelListFilterEmptyState @section="dms" />
-          </ul>
-        </template>
-      );
-
-      await click(".chat-sidebar-channels-filter-empty-state__reset");
-
-      assert.true(
-        setFilter.calledWith("starred", "all"),
-        "the starred filter is reset"
-      );
-
-      const resets = document.querySelectorAll(
-        ".chat-sidebar-channels-filter-empty-state__reset"
-      );
-      await click(resets[1]);
-
-      assert.true(
-        setFilter.calledWith("dms", "all"),
-        "the dms filter is reset"
-      );
-    });
-
-    test("renders an illustrated state matching the no-channels layout", async function (assert) {
-      const preferences = getOwner(this).lookup(
-        "service:chat-channel-list-preferences"
-      );
-      const setFilter = sinon.stub(preferences, "setFilter").resolves(true);
-
-      await render(
-        <template>
-          <ChatSidebarChannelListFilterEmptyState
-            @layout="empty-state"
-            @section="dms"
-          />
-        </template>
-      );
-
-      assert
-        .dom(".empty-state__image")
-        .exists("the same illustration as the no-channels state is shown");
-      assert
-        .dom(".empty-state__title")
-        .hasText(
-          i18n("chat.channel_list.empty.filtered"),
-          "the title explains the filter"
+        preferences[`${section}Filter`] = "unread";
+        this.section = section;
+        await render(
+          <template>
+            <ChatChannelListFilterToggle @section={{this.section}} />
+            <ChatSidebarChannelListFilterEmptyState @section={{this.section}} />
+          </template>
         );
-
-      await click(".empty-state__cta .btn");
-
-      assert.true(
-        setFilter.calledWith("dms", "all"),
-        "the show all action resets the dms filter"
-      );
-    });
+        assert
+          .dom(".empty-state__image")
+          .exists("the illustrated state is retained");
+        assert
+          .dom(".empty-state__title")
+          .hasText(
+            i18n("chat.channel_list.empty.filtered"),
+            "the filter explanation is retained"
+          );
+        assert
+          .dom(".chat-channel-list-filter-toggle .d-icon-eye")
+          .exists("the header offers to show all");
+        await click(".empty-state__cta .btn");
+        assert.strictEqual(
+          preferences.filterFor(section),
+          "unread",
+          "the preference is retained"
+        );
+        assert.strictEqual(
+          preferences.effectiveFilterFor(section),
+          "all",
+          "the empty state bypasses the filter"
+        );
+        assert
+          .dom(".chat-channel-list-filter-toggle")
+          .hasAttribute(
+            "title",
+            i18n("chat.channel_list.apply_filters"),
+            "the header offers to reapply filters"
+          );
+        assert
+          .dom(".chat-channel-list-filter-toggle .d-icon-eye-slash")
+          .exists("the icon changes");
+        await click(".chat-channel-list-filter-toggle");
+        assert.strictEqual(
+          preferences.effectiveFilterFor(section),
+          "unread",
+          "the header reapplies the filter"
+        );
+        await click(".chat-channel-list-filter-toggle");
+        assert.strictEqual(
+          preferences.effectiveFilterFor(section),
+          "all",
+          "the header can also bypass the filter"
+        );
+      });
+    }
   }
 );
 

--- a/plugins/chat/test/javascripts/components/chat-navbar-channel-list-options-button-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-channel-list-options-button-test.gjs
@@ -44,11 +44,11 @@ module(
       );
 
       assert
-        .dom(".chat-channel-list-filter-toggle .d-icon-eye")
+        .dom(".chat-channel-list-filter-toggle .d-icon-filter-circle-xmark")
         .exists("mobile offers the temporary override");
       await click(".chat-channel-list-filter-toggle");
       assert
-        .dom(".chat-channel-list-filter-toggle .d-icon-eye-slash")
+        .dom(".chat-channel-list-filter-toggle .d-icon-filter")
         .exists("mobile can reapply filters");
       await click(".chat-channel-list-options-button");
 

--- a/plugins/chat/test/javascripts/components/chat-navbar-channel-list-options-button-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-navbar-channel-list-options-button-test.gjs
@@ -31,6 +31,9 @@ module(
 
     test("opens the section's shared options menu on mobile", async function (assert) {
       forceMobile();
+      this.owner.lookup(
+        "service:chat-channel-list-preferences"
+      ).channelsFilter = "unread";
 
       await render(
         <template>
@@ -40,6 +43,13 @@ module(
         </template>
       );
 
+      assert
+        .dom(".chat-channel-list-filter-toggle .d-icon-eye")
+        .exists("mobile offers the temporary override");
+      await click(".chat-channel-list-filter-toggle");
+      assert
+        .dom(".chat-channel-list-filter-toggle .d-icon-eye-slash")
+        .exists("mobile can reapply filters");
       await click(".chat-channel-list-options-button");
 
       assert

--- a/plugins/chat/test/javascripts/unit/services/chat-channel-list-preferences-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channel-list-preferences-test.js
@@ -11,6 +11,99 @@ import {
 module("Unit | Service | chat-channel-list-preferences", function (hooks) {
   setupTest(hooks);
 
+  test("temporarily bypasses each section without saving and reapplies the same preference", async function (assert) {
+    const user = logIn(this.owner);
+    user.set("user_option.chat_channel_list_filter", "unread");
+    user.set("user_option.chat_channel_list_filter_dms", "mentions");
+    user.set("user_option.chat_channel_list_filter_starred", "active");
+    const preferences = this.owner.lookup(
+      "service:chat-channel-list-preferences"
+    );
+    const requests = [];
+    pretender.put("/u/eviltrout.json", (request) => {
+      requests.push(request);
+      return response(200, { user: {} });
+    });
+
+    for (const section of ["channels", "dms", "starred"]) {
+      const preferred = preferences.filterFor(section);
+      preferences.showAllChannels(section);
+      assert.strictEqual(
+        preferences.effectiveFilterFor(section),
+        "all",
+        "the effective filter is bypassed"
+      );
+      assert.strictEqual(
+        preferences.filterFor(section),
+        preferred,
+        "the preferred filter is retained"
+      );
+      await preferences.setFilter(section, preferred);
+      assert.strictEqual(
+        preferences.effectiveFilterFor(section),
+        preferred,
+        "reselecting the preference reapplies it"
+      );
+    }
+    preferences.showAllChannels("channels");
+    assert.strictEqual(
+      preferences.effectiveFilterFor("dms"),
+      "mentions",
+      "DM filters are independent"
+    );
+    assert.strictEqual(
+      preferences.effectiveFilterFor("starred"),
+      "active",
+      "starred filters are independent"
+    );
+    preferences.toggleFilter("channels");
+    assert.strictEqual(
+      preferences.effectiveFilterFor("channels"),
+      "unread",
+      "the toggle restores the preference"
+    );
+    assert.strictEqual(
+      user.user_option.chat_channel_list_filter,
+      "unread",
+      "the user option is unchanged"
+    );
+    assert.strictEqual(
+      requests.length,
+      0,
+      "temporary changes and reselecting the preference make no requests"
+    );
+  });
+
+  test("changing sorting retains the override and choosing another filter clears it", async function (assert) {
+    const user = logIn(this.owner);
+    user.set("user_option.chat_channel_list_filter", "unread");
+    const preferences = this.owner.lookup(
+      "service:chat-channel-list-preferences"
+    );
+    pretender.put("/u/eviltrout.json", () => response(200, { user: {} }));
+    preferences.showAllChannels("channels");
+    await preferences.setSort("channels", "recent_activity");
+    assert.true(
+      preferences.isFilterBypassedFor("channels"),
+      "sorting retains the override"
+    );
+    await preferences.setFilter("channels", "invalid");
+    assert.true(
+      preferences.isFilterBypassedFor("channels"),
+      "invalid filter selections retain the override"
+    );
+    await preferences.setFilter("channels", "mentions");
+    assert.false(
+      preferences.isFilterBypassedFor("channels"),
+      "choosing a filter clears the override"
+    );
+    assert.strictEqual(
+      preferences.effectiveFilterFor("channels"),
+      "mentions",
+      "the newly selected filter takes effect"
+    );
+  });
+
   test("initializes from the current user", function (assert) {
     const currentUser = logIn(this.owner);
     currentUser.set("user_option.chat_channel_list_filter", "mentions");
@@ -340,7 +433,7 @@ module("Unit | Service | chat-channel-list-preferences", function (hooks) {
 
   test("rolls back a failed save", async function (assert) {
     const currentUser = logIn(this.owner);
-    currentUser.set("user_option.chat_channel_list_filter", "all");
+    currentUser.set("user_option.chat_channel_list_filter", "mentions");
     pretender.put("/u/eviltrout.json", () => {
       return response(422, { errors: ["Unable to save"] });
     });
@@ -349,18 +442,24 @@ module("Unit | Service | chat-channel-list-preferences", function (hooks) {
       "service:chat-channel-list-preferences"
     );
 
+    preferences.showAllChannels("channels");
+
     assert.false(
       await preferences.setFilter("channels", CHAT_CHANNEL_LIST_FILTERS.UNREAD),
       "the failed request is reported"
     );
+    assert.true(
+      preferences.isFilterBypassedFor("channels"),
+      "the temporary override is restored after failure"
+    );
     assert.strictEqual(
       preferences.filterFor("channels"),
-      "all",
+      "mentions",
       "the service value is restored"
     );
     assert.strictEqual(
       currentUser.user_option.chat_channel_list_filter,
-      "all",
+      "mentions",
       "the user option is restored"
     );
     assert.false(

--- a/plugins/chat/test/javascripts/unit/services/chat-channels-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channels-manager-test.js
@@ -511,6 +511,49 @@ module("Unit | Service | chat-channels-manager", function (hooks) {
       };
     });
 
+    test("temporarily bypasses filters in sidebar and drawer while retaining sorting", function (assert) {
+      this.preferences.channelsFilter = "unread";
+      this.preferences.channelsSort = "recent_activity";
+      const older = this.buildChannel({
+        id: 1,
+        slug: "alpha",
+        createdAt: "2026-09-01",
+        unreadCount: 1,
+      });
+      const newer = this.buildChannel({
+        id: 2,
+        slug: "zulu",
+        createdAt: "2026-09-03",
+      });
+      assert.deepEqual(
+        this.subject.sidebarPublicMessageChannels,
+        [older],
+        "the preferred filter applies"
+      );
+      this.preferences.showAllChannels("channels");
+      assert.deepEqual(
+        this.subject.sidebarPublicMessageChannels,
+        [newer, older],
+        "the sidebar retains recency sorting"
+      );
+      assert.deepEqual(
+        this.subject.publicMessageChannelsByPreference,
+        [newer, older],
+        "the drawer shares the override"
+      );
+      this.preferences.applyFilter("channels");
+      assert.deepEqual(
+        this.subject.sidebarPublicMessageChannels,
+        [older],
+        "the sidebar reapplies the filter"
+      );
+      assert.deepEqual(
+        this.subject.publicMessageChannelsByPreference,
+        [older],
+        "the drawer reapplies the filter"
+      );
+    });
+
     test("sorts channels alphabetically by default", function (assert) {
       this.buildChannel({ id: 1, slug: "zulu", createdAt: "2026-09-03" });
       this.buildChannel({ id: 2, slug: "alpha", createdAt: "2026-09-01" });


### PR DESCRIPTION
Followup https://github.com/discourse/discourse/commit/3dfc739016f9ee6523d91a5b6b28d0968ef028e6

When a channel section is empty because no channels match
the filter, we no longer show a bulky message + link for
the empty state.

Now, we show an eye icon in the header of the section, which
allows users to temporarily disable their filter and see all
channels in the section, still respecting their sort preferences.

This applies in the sidebar and in the channel list.

This commit also extends the sidebar section header to allow
for more than one action button.

**DM section, no channels**

<img width="257" height="45" alt="image" src="https://github.com/user-attachments/assets/64eef32e-86e3-4852-a0c7-480683c14981" />

**DM section, all channels temporarily shown**

<img width="273" height="120" alt="image" src="https://github.com/user-attachments/assets/0acbd1ab-a3fb-498f-ad4a-b6e175a45463" />


**DM in drawer and mobile, no channels matching filter**

<img width="553" height="670" alt="image" src="https://github.com/user-attachments/assets/604dc4be-9998-4b92-8175-8a16e9792c7e" />

**DM in drawer and mobile, all channels temporarily shown**

<img width="555" height="668" alt="image" src="https://github.com/user-attachments/assets/7be0588f-25be-458f-9b01-94a6f9ebf376" />


