### PR TITLE
FIX: Preserve external upload store checks

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -18,7 +18,8 @@ class UploadsController < ApplicationController
   before_action :is_asset_path,
                 :apply_cdn_headers,
                 only: %i[show show_short _show_secure_deprecated show_secure]
-  before_action :external_store_check, only: %i[_show_secure_deprecated show_secure]
+  # A symbol callback would overwrite the external upload actions' store check.
+  before_action(only: %i[_show_secure_deprecated show_secure]) { external_store_check }
 
   SECURE_REDIRECT_GRACE_SECONDS = 5
 

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -1139,6 +1139,20 @@ RSpec.describe UploadsController do
     context "when the store is not external" do
       before { sign_in(user) }
 
+      it "returns 404 even when direct S3 uploads are enabled" do
+        SiteSetting.enable_s3_uploads = false
+        SiteSetting.enable_direct_s3_uploads = true
+
+        post "/uploads/generate-presigned-put.json",
+             params: {
+               file_name: "test.png",
+               type: "card_background",
+               file_size: 1024,
+             }
+
+        expect(response.status).to eq(404)
+      end
+
       it "returns 404" do
         post "/uploads/generate-presigned-put.json",
              params: {


### PR DESCRIPTION
Prevent secure upload callbacks from replacing the store check for
external upload actions. Presigned upload requests must return 404
when S3 storage is disabled, even if direct S3 uploads are enabled.

Add regression coverage for this configuration.
