### PR TITLE
FIX: Clamp other traffic to zero in site traffic reports

### DIFF
--- a/app/models/concerns/reports/site_traffic.rb
+++ b/app/models/concerns/reports/site_traffic.rb
@@ -57,13 +57,16 @@ module Reports::SiteTraffic
               (COALESCE(MAX(lc.logged_in), 0) + COALESCE(MAX(lc.anonymous), 0)) AS page_view_likely_crawler,
               SUM(CASE WHEN ar.req_type = :page_view_crawler THEN ar.count ELSE 0 END) AS page_view_crawler,
               SUM(CASE WHEN ar.req_type = :page_view_embed THEN ar.count ELSE 0 END) AS page_view_embed,
-              SUM(
-                CASE WHEN ar.req_type = :page_view_anon THEN ar.count
-                    WHEN ar.req_type = :page_view_logged_in THEN ar.count
-                    WHEN ar.req_type = :page_view_anon_browser THEN -ar.count
-                    WHEN ar.req_type = :page_view_logged_in_browser THEN -ar.count
-                    ELSE 0
-                END
+              GREATEST(
+                0,
+                SUM(
+                  CASE WHEN ar.req_type = :page_view_anon THEN ar.count
+                      WHEN ar.req_type = :page_view_logged_in THEN ar.count
+                      WHEN ar.req_type = :page_view_anon_browser THEN -ar.count
+                      WHEN ar.req_type = :page_view_logged_in_browser THEN -ar.count
+                      ELSE 0
+                  END
+                )
               ) AS page_view_other
             FROM application_requests ar
             LEFT JOIN likely_crawlers lc ON lc.date = ar.date

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1810,6 +1810,32 @@ RSpec.describe Report do
         CachedCounting.disable
       end
 
+      it "clamps daily other traffic to zero while preserving browser counts" do
+        freeze_time Time.utc(2024, 1, 3)
+        dates = [2.days.ago.to_date, 1.day.ago.to_date, Time.zone.today]
+
+        dates
+          .zip([6, 4, 3])
+          .each do |date, logged_in_count|
+            ApplicationRequest.write_cache!(:page_view_anon, 2, date)
+            ApplicationRequest.write_cache!(:page_view_logged_in, logged_in_count, date)
+            ApplicationRequest.write_cache!(:page_view_anon_browser, 5, date)
+            ApplicationRequest.write_cache!(:page_view_logged_in_browser, 1, date)
+          end
+
+        series = reports.data.index_by { |report| report[:req] }
+
+        expect(series["page_view_other"][:data]).to eq(
+          dates.zip([2, 0, 0]).map { |date, count| { x: date, y: count } },
+        )
+        expect(series["page_view_anon_browser"][:data]).to eq(
+          dates.map { |date| { x: date, y: 5 } },
+        )
+        expect(series["page_view_logged_in_browser"][:data]).to eq(
+          dates.map { |date| { x: date, y: 1 } },
+        )
+      end
+
       it "exposes embedded pageviews as their own series without polluting other series" do
         Fabricate(:embeddable_host)
 


### PR DESCRIPTION
Browser pageview counters can exceed legacy pageview counters because deferred tracking does not require a matching legacy view. Subtracting these daily totals could produce negative other traffic and reduce the chart's tooltip total.

Clamp the daily remainder to zero after summing anonymous and logged-in traffic, preserving browser counts and positive remainders. Add regression coverage for positive, zero, and negative remainders.

Before:
<img width="1022" height="580" alt="Screenshot 2026-09-10 at 3 56 38 pm" src="https://github.com/user-attachments/assets/b697fabe-f074-474a-b522-63eead68ac28" />

After:
<img width="985" height="577" alt="Screenshot 2026-09-10 at 3 56 01 pm" src="https://github.com/user-attachments/assets/4bdbf4d7-5133-4d93-b722-a22d312f135c" />