### PR TITLE
FIX: Preserve topic scope in Ask AI header search

### DIFF
--- a/frontend/discourse/app/components/header.gjs
+++ b/frontend/discourse/app/components/header.gjs
@@ -175,7 +175,6 @@ export default class GlimmerHeader extends Component {
     this.search.visible = value ?? !this.search.visible;
     if (!this.search.visible) {
       this.search.highlightTerm = "";
-      this.search.inTopicContext = false;
       document.getElementById(SEARCH_BUTTON_ID)?.focus();
     }
   }

--- a/frontend/discourse/app/components/search-menu.gjs
+++ b/frontend/discourse/app/components/search-menu.gjs
@@ -371,17 +371,20 @@ export default class SearchMenu extends Component {
       this.loading = true;
       this.invalidTerm = false;
 
+      const searchContext = this.searchContext;
       this._activeSearch = searchForTerm(this.search.activeGlobalSearchTerm, {
         typeFilter: this.typeFilter,
         fullSearchUrl: this.fullSearchUrl,
-        searchContext: this.searchContext,
+        searchContext,
       });
 
       this._activeSearch
         .then((results) => {
-          // we ensure the current search term is the one used
-          // when starting the query
-          if (results) {
+          if (
+            results &&
+            searchContext?.type === this.searchContext?.type &&
+            searchContext?.id === this.searchContext?.id
+          ) {
             this.search.noResults = results.resultTypes.length === 0;
             this.search.results = results;
           }

--- a/frontend/discourse/app/components/search-menu/search-term.gjs
+++ b/frontend/discourse/app/components/search-menu/search-term.gjs
@@ -37,8 +37,6 @@ export default class SearchTerm extends Component {
       this.search.activeGlobalSearchTerm,
       input.target.value
     );
-
-    this.searchCleared = this.search.activeGlobalSearchTerm ? false : true;
   }
 
   @action
@@ -51,6 +49,10 @@ export default class SearchTerm extends Component {
 
   @action
   onKeydown(e) {
+    if (e.key === "Backspace") {
+      this.searchCleared = !e.target.value;
+    }
+
     if (e.key === "Escape") {
       this.args.closeSearchMenu();
       e.preventDefault();

--- a/frontend/discourse/app/services/search.js
+++ b/frontend/discourse/app/services/search.js
@@ -9,16 +9,34 @@ export default class Search extends Service {
   @service siteSettings;
 
   @tracked activeGlobalSearchTerm = "";
-  @tracked searchContext;
   @tracked highlightTerm;
   @tracked inTopicContext = false;
   @tracked visible = false;
   @tracked results = {};
   @tracked noResults = false;
   @tracked welcomeBannerSearchInViewport = false;
-
   // only relative for the widget search menu
   searchContextEnabled = false; // checkbox to scope search
+
+  @tracked _searchContext;
+
+  get searchContext() {
+    return this._searchContext;
+  }
+
+  set searchContext(context) {
+    if (
+      this.inTopicContext &&
+      (context?.type !== this._searchContext?.type ||
+        context?.id !== this._searchContext?.id)
+    ) {
+      this.inTopicContext = false;
+      this.results = {};
+      this.noResults = false;
+    }
+
+    this._searchContext = context;
+  }
 
   get currentSearchInputId() {
     if (this.welcomeBannerSearchInViewport) {

--- a/frontend/discourse/tests/unit/services/search-test.js
+++ b/frontend/discourse/tests/unit/services/search-test.js
@@ -1,0 +1,56 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Service | search", function (hooks) {
+  setupTest(hooks);
+
+  test("updating the same topic context preserves its search", function (assert) {
+    const search = this.owner.lookup("service:search");
+    const results = { posts: [{ id: 1 }] };
+    search.searchContext = { type: "topic", id: 280 };
+    search.inTopicContext = true;
+    search.results = results;
+
+    search.searchContext = { type: "topic", id: 280 };
+
+    assert.true(search.inTopicContext, "the same topic stays selected");
+    assert.strictEqual(search.results, results, "its results are preserved");
+  });
+
+  test("switching topics clears the previous topic's search results", function (assert) {
+    const search = this.owner.lookup("service:search");
+    search.searchContext = { type: "topic", id: 280 };
+    search.inTopicContext = true;
+    search.results = { posts: [{ id: 1 }] };
+    search.activeGlobalSearchTerm = "猫";
+
+    search.searchContext = { type: "topic", id: 281 };
+
+    assert.false(search.inTopicContext, "the previous topic scope is released");
+    assert.deepEqual(
+      search.results,
+      {},
+      "the previous topic's results are cleared"
+    );
+    assert.strictEqual(
+      search.activeGlobalSearchTerm,
+      "猫",
+      "the query remains available"
+    );
+  });
+
+  test("changing page context preserves a global search", function (assert) {
+    const search = this.owner.lookup("service:search");
+    const results = { topics: [{ id: 280 }] };
+    search.searchContext = { type: "topic", id: 280 };
+    search.results = results;
+
+    search.searchContext = null;
+
+    assert.strictEqual(
+      search.results,
+      results,
+      "global results remain available on other pages"
+    );
+  });
+});

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-discoveries-search-options.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-discoveries-search-options.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action, get } from "@ember/object";
 import { service } from "@ember/service";
@@ -33,9 +32,6 @@ export default class AiDiscoveriesSearchOptions extends Component {
   @service currentUser;
   @service discobotDiscoveries;
   @service search;
-
-  // even before the scope itself is released.
-  @tracked scopedTerm = null;
 
   get query() {
     return this.search.activeGlobalSearchTerm?.trim();
@@ -166,7 +162,7 @@ export default class AiDiscoveriesSearchOptions extends Component {
   }
 
   get scopedToTopic() {
-    return this.search.inTopicContext && this.scopedTerm === this.query;
+    return this.search.inTopicContext;
   }
 
   // A receipt rather than an armed mode: enter always runs the indexed search,
@@ -192,9 +188,6 @@ export default class AiDiscoveriesSearchOptions extends Component {
     return Boolean(this.args.searchTopics);
   }
 
-  // Only the options that have one: scope has never had a keybinding, so the
-  // three that map to enter, shift+enter and ctrl/cmd+enter say so and the rest
-  // stay quiet rather than inventing hints.
   // `get` rather than a native read: the option lives on a classic object, so
   // the row would not reorder or relabel when it changes.
   get asksByDefault() {
@@ -209,6 +202,7 @@ export default class AiDiscoveriesSearchOptions extends Component {
         kind: "topic",
         icon: "magnifying-glass",
         label: "discourse_ai.discobot_discoveries.search_this_topic",
+        title: this.scopedToTopic ? shortcutHint("enter") : undefined,
         active: this.scopedToTopic,
         action: this.searchThisTopic,
       });
@@ -263,13 +257,17 @@ export default class AiDiscoveriesSearchOptions extends Component {
   }
 
   get allTopicsTitle() {
+    if (this.scopedToTopic) {
+      return;
+    }
+
     return this.asksByDefault
       ? shortcutHint("shift", "enter")
       : shortcutHint("enter");
   }
 
   get askTitle() {
-    return this.asksByDefault
+    return this.asksByDefault && !this.scopedToTopic
       ? shortcutHint("enter")
       : shortcutHint("shift", "enter");
   }
@@ -284,8 +282,6 @@ export default class AiDiscoveriesSearchOptions extends Component {
   searchAllTopics() {
     // choosing the indexed results means the answer is no longer what was asked for
     this.discobotDiscoveries.dismissDiscovery();
-    // the input no longer carries a chip to step back out of a scope, so the
-    // wider reach has to release them
     this.args.clearTopicContext?.();
     this.args.clearPMInboxContext?.();
 
@@ -331,12 +327,12 @@ export default class AiDiscoveriesSearchOptions extends Component {
 
   @action
   searchThisTopic() {
-    this.scopedTerm = this.query;
     this.discobotDiscoveries.dismissDiscovery();
     this.args.searchTermChanged?.(this.query, {
       searchTopics: true,
       setTopicContext: true,
     });
+    this.search.focusSearchInput();
   }
 
   @action
@@ -356,32 +352,30 @@ export default class AiDiscoveriesSearchOptions extends Component {
   }
 
   <template>
-    {{#if this.query}}
-      {{! eslint-disable ember/template-no-invalid-interactive }}
-      <div
-        class="ai-discoveries-search-options"
-        {{on "keydown" this.search.handleArrowUpOrDown}}
-      >
-        {{#each this.options key="kind" as |option|}}
-          <DButton
-            class="btn-default btn-small ai-discoveries-search-options__option --{{option.kind}}
-              {{if option.active 'is-active'}}"
-            data-search-menu-navigation-item
-            @action={{option.action}}
-            @icon={{option.icon}}
-            @label={{option.label}}
-            @translatedLabel={{option.translatedLabel}}
-            @translatedTitle={{option.title}}
-          />
-        {{/each}}
+    {{! eslint-disable ember/template-no-invalid-interactive }}
+    <div
+      class="ai-discoveries-search-options"
+      {{on "keydown" this.search.handleArrowUpOrDown}}
+    >
+      {{#each this.options key="kind" as |option|}}
         <DButton
-          class="btn-default btn-small ai-discoveries-search-options__option --advanced"
-          @action={{@openAdvancedSearch}}
-          @ariaLabel="search.open_advanced"
-          @icon="sliders"
-          @translatedTitle={{this.advancedTitle}}
+          class="btn-default btn-small ai-discoveries-search-options__option --{{option.kind}}
+            {{if option.active 'is-active'}}"
+          data-search-menu-navigation-item
+          @action={{option.action}}
+          @icon={{option.icon}}
+          @label={{option.label}}
+          @translatedLabel={{option.translatedLabel}}
+          @translatedTitle={{option.title}}
         />
-      </div>
-    {{/if}}
+      {{/each}}
+      <DButton
+        class="btn-default btn-small ai-discoveries-search-options__option --advanced"
+        @action={{@openAdvancedSearch}}
+        @ariaLabel="search.open_advanced"
+        @icon="sliders"
+        @translatedTitle={{this.advancedTitle}}
+      />
+    </div>
   </template>
 }

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-search-discoveries.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-search-discoveries.js
@@ -216,9 +216,6 @@ export default apiInitializer((api) => {
     return false;
   });
 
-  // Enter always runs the indexed search, so nothing has to be remembered
-  // between submissions. Shift+Enter is the one that asks: Ctrl/Cmd+Enter is
-  // already advanced search, and a second Enter already means the same.
   api.addSearchMenuOnKeyDownCallback((searchTerm, event) => {
     if (!offersDiscoveries(searchTerm?.args?.location)) {
       return true;
@@ -227,9 +224,8 @@ export default apiInitializer((api) => {
     if (event.key === "Enter") {
       const query = search.activeGlobalSearchTerm?.trim();
 
-      // The preference decides which key asks; the other one does the opposite,
-      // so both remain reachable whichever way round it is.
-      if (event.shiftKey !== asksByDefault() && query) {
+      const enterAsks = !search.inTopicContext && asksByDefault();
+      if (event.shiftKey !== enterAsks && query) {
         // asking honours no scope, so picking it leaves any behind
         searchTerm.args.clearTopicContext();
         searchTerm.args.clearPMInboxContext();
@@ -239,13 +235,6 @@ export default apiInitializer((api) => {
 
       discobotDiscoveries.dismissDiscovery();
       return true;
-    }
-
-    // A different term has to be resubmitted anyway, so the option that answered
-    // the last one stops applying: the scope is released and the row goes back
-    // to offering all three.
-    if (search.inTopicContext) {
-      searchTerm.args.clearTopicContext();
     }
 
     // An answer belongs to the submission that asked for it, not to the text.
@@ -268,17 +257,9 @@ export default apiInitializer((api) => {
       offersDiscoveries(context?.location) ? [...value, "--with-ask-ai"] : value
   );
 
-  // scope is one of the options in the menu, and that row stays put while
-  // scoped, so the input never carries a chip for it
   // advanced search is offered in the options row instead
   api.registerValueTransformer(
     "search-menu-advanced-button-enabled",
-    ({ value, context }) =>
-      offersDiscoveries(context?.location) ? false : value
-  );
-
-  api.registerValueTransformer(
-    "search-menu-search-context-enabled",
     ({ value, context }) =>
       offersDiscoveries(context?.location) ? false : value
   );

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-search-discoveries-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-search-discoveries-test.js
@@ -461,7 +461,43 @@ acceptance("AI Discoveries - header search", function (needs) {
       .isFocused("the user's new focus is preserved");
   });
 
-  test("scoping to a topic leaves the input alone", async function (assert) {
+  test("the topic scope can be selected before typing", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+
+    assert.dom("#icon-search-input").hasValue("", "the query starts empty");
+    assert
+      .dom(".ai-discoveries-search-options__option.--ask")
+      .exists("AI is offered");
+    assert
+      .dom(".ai-discoveries-search-options__option.--search")
+      .exists("all topics is offered");
+    await click(".ai-discoveries-search-options__option.--topic");
+    assert
+      .dom(".search-context")
+      .exists("the topic chip appears before typing");
+    assert.dom("#icon-search-input").isFocused("the query is ready for typing");
+
+    await fillIn("#icon-search-input", "雰囲気");
+    await triggerKeyEvent("#icon-search-input", "keyup", "Enter");
+    assert.dom(".search-context").exists("typing preserves the selected topic");
+    assert
+      .dom(".search-result-post")
+      .exists("the query returns posts within the topic");
+    assert.strictEqual(
+      discoveryRequests,
+      0,
+      "opening the empty menu does not ask AI"
+    );
+  });
+
+  test("topic scope stays visible while editing the query", async function (assert) {
+    const searches = [];
+    pretender.get("/search/query", (request) => {
+      searches.push(request.queryParams);
+      return response(searchFixtures["search/query"]);
+    });
+
     await visit("/t/internationalization-localization/280");
     await click("#search-button");
     await fillIn("#icon-search-input", "dev");
@@ -474,21 +510,41 @@ acceptance("AI Discoveries - header search", function (needs) {
 
     assert
       .dom(".search-menu .search-context")
-      .doesNotExist("scoping does not put a chip in the input");
+      .exists("the input shows the removable topic scope");
     assert
       .dom(".ai-discoveries-search-options__option.--topic")
-      .hasClass("is-active", "the inline option carries the scope instead");
+      .hasClass("is-active", "the inline option also shows the selected scope");
     assert
       .dom(".ai-discoveries-search-options__option.--search")
       .exists("and the way back out stays offered");
 
-    await fillIn("#icon-search-input", "dev tooling");
+    await fillIn("#icon-search-input", "dev tooling 猫");
+    await triggerKeyEvent("#icon-search-input", "keyup", "ArrowLeft");
 
+    assert
+      .dom(".ai-discoveries-search-options__option.--topic")
+      .hasClass("is-active", "editing keeps the topic scope selected");
+    assert.dom(".search-menu .search-context").exists("the chip stays visible");
+
+    await triggerKeyEvent("#icon-search-input", "keyup", "Enter");
+    assert.strictEqual(
+      searches.at(-1)["search_context[id]"],
+      "280",
+      "the edited query still searches within the topic"
+    );
+
+    await click(".search-menu .search-context");
+    assert
+      .dom(".search-menu .search-context")
+      .doesNotExist("the chip removes the scope");
+    assert
+      .dom("#icon-search-input")
+      .hasValue("dev tooling 猫", "removing the scope keeps the query");
     assert
       .dom(".ai-discoveries-search-options__option.--topic")
       .doesNotHaveClass(
         "is-active",
-        "a changed term has to be resubmitted, so the scope stops applying"
+        "removing the chip deselects the topic option"
       );
 
     await click(".ai-discoveries-search-options__option.--topic");
@@ -498,6 +554,158 @@ acceptance("AI Discoveries - header search", function (needs) {
       .dom(".ai-discoveries-search-options__option.--topic")
       .doesNotHaveClass("is-active", "picking all topics releases the scope");
     assert.dom(".search-result-topic").exists("and searches beyond the topic");
+  });
+
+  test("a short topic search can be corrected with the keyboard when AI is the default", async function (assert) {
+    updateCurrentUser({ user_option: { ai_ask_ai_default: true } });
+    await visit("/t/internationalization-localization/280");
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+    await fillIn("#icon-search-input", "雰囲");
+    await triggerKeyEvent("#icon-search-input", "keyup", "ArrowDown");
+    await triggerKeyEvent(document.activeElement, "keydown", "ArrowDown");
+    await triggerKeyEvent(document.activeElement, "keydown", "Enter");
+    await triggerKeyEvent(document.activeElement, "keyup", "Enter");
+
+    assert
+      .dom(".search-menu .search-context")
+      .exists("the topic scope is selected");
+    assert
+      .dom("#icon-search-input")
+      .isFocused("the short query is ready to edit");
+    assert
+      .dom(".search-menu")
+      .includesText(
+        i18n("search.too_short"),
+        "the short query warning is shown"
+      );
+
+    await fillIn("#icon-search-input", "雰囲気");
+    await triggerKeyEvent("#icon-search-input", "keyup", "Enter");
+
+    assert.strictEqual(discoveryRequests, 0, "Enter does not switch to Ask AI");
+    assert
+      .dom(".search-menu .search-context")
+      .exists("the corrected search stays scoped");
+    assert.dom(".search-result-post").exists("matching posts are displayed");
+    assert.dom("#icon-search-input").isFocused("the query remains editable");
+  });
+
+  test("backspacing the query keeps the selected topic scope", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#search-button");
+    await fillIn("#icon-search-input", "雰囲");
+    await click(".ai-discoveries-search-options__option.--topic");
+
+    for (const term of ["雰", ""]) {
+      await triggerKeyEvent("#icon-search-input", "keydown", "Backspace");
+      await fillIn("#icon-search-input", term);
+      await triggerKeyEvent("#icon-search-input", "keyup", "Backspace");
+      assert
+        .dom(".search-context")
+        .exists("deleting query text keeps the topic chip");
+    }
+
+    await fillIn("#icon-search-input", "猫の雰囲気");
+    await triggerKeyEvent("#icon-search-input", "keyup", "Enter");
+    assert.dom(".search-context").exists("the replacement query stays scoped");
+    assert
+      .dom(".search-result-post")
+      .exists("the replacement query searches the topic");
+
+    await fillIn("#icon-search-input", "");
+    await triggerKeyEvent("#icon-search-input", "keydown", "Backspace");
+    await triggerKeyEvent("#icon-search-input", "keyup", "Backspace");
+    assert
+      .dom(".search-context")
+      .doesNotExist("Backspace in an already empty box removes the chip");
+  });
+
+  test("reopening search after selecting a post keeps the topic scope and results", async function (assert) {
+    pretender.get("/search/query", () => {
+      const payload = searchFixtures["search/query"];
+      return response({
+        ...payload,
+        posts: [{ ...payload.posts[0], topic_id: 280, post_number: 7 }],
+        topics: [
+          {
+            ...payload.topics[0],
+            id: 280,
+            slug: "internationalization-localization",
+          },
+        ],
+      });
+    });
+
+    await visit("/t/internationalization-localization/280");
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+    await fillIn("#icon-search-input", "dev");
+    await click(".ai-discoveries-search-options__option.--topic");
+    const results = findAll(".search-result-post .search-link").map(
+      (link) => link.href
+    );
+
+    await click(".search-result-post .search-link");
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+
+    assert.dom("#icon-search-input").hasValue("dev", "the query is restored");
+    assert.dom(".search-context").exists("the topic chip is restored");
+    assert
+      .dom(".ai-discoveries-search-options__option.--topic")
+      .hasClass("is-active", "the topic option still matches the results");
+    assert.deepEqual(
+      findAll(".search-result-post .search-link").map((link) => link.href),
+      results,
+      "the same matching posts are shown"
+    );
+
+    await triggerKeyEvent("#icon-search-input", "keydown", "Escape");
+    await visit("/latest");
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+    assert
+      .dom(".search-context")
+      .doesNotExist("leaving the topic clears its scope");
+    assert
+      .dom(".search-result-post")
+      .doesNotExist("the old topic's posts are no longer shown");
+  });
+
+  test("late topic results are discarded after navigating away", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+    await fillIn("#icon-search-input", "dev");
+
+    let pendingRequest;
+    pretender.get(
+      "/search/query",
+      (request) => {
+        pendingRequest = request;
+        return response(searchFixtures["search/query"]);
+      },
+      true
+    );
+
+    const selectTopic = click(".ai-discoveries-search-options__option.--topic");
+    await waitUntil(() => pendingRequest);
+    const closeSearch = triggerKeyEvent(
+      "#icon-search-input",
+      "keydown",
+      "Escape"
+    );
+    await waitFor("#icon-search-input", { count: 0 });
+    const navigateAway = click("#site-logo");
+    await waitUntil(() => currentURL() === "/");
+
+    pretender.resolve(pendingRequest);
+    await Promise.all([selectTopic, closeSearch, navigateAway]);
+    await triggerKeyEvent(document, "keypress", "/".charCodeAt(0));
+
+    assert.dom(".search-context").doesNotExist("the topic scope is cleared");
+    assert
+      .dom(".ai-discoveries-search-options__option.--search")
+      .exists("all topics remains available");
+    assert
+      .dom(".search-result-post")
+      .doesNotExist("the late response does not restore the old topic's posts");
   });
 
   test("topic scope can be selected with keyboard navigation", async function (assert) {
@@ -521,10 +729,9 @@ acceptance("AI Discoveries - header search", function (needs) {
 
     const results = findAll(".search-result-post .search-link");
     assert
-      .dom(".ai-discoveries-search-options__option.--topic")
-      .isFocused("results leave focus on the selected scope button");
+      .dom("#icon-search-input")
+      .isFocused("choosing the topic scope returns focus to the query");
 
-    await click("#icon-search-input");
     await triggerKeyEvent("#icon-search-input", "keyup", "ArrowDown");
     assert.dom(results[0]).isFocused("down enters the matching posts");
 

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-discoveries-search-options-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-discoveries-search-options-test.gjs
@@ -81,6 +81,31 @@ module(
       );
     });
 
+    test("topic scope remains selected when the query changes", async function (assert) {
+      const searchService = this.owner.lookup("service:search");
+      searchService.searchContext = { type: "topic", id: 280 };
+      searchService.inTopicContext = true;
+
+      await render(<template><AiDiscoveriesSearchOptions /></template>);
+
+      searchService.activeGlobalSearchTerm = "miyazaki 猫";
+      await settled();
+
+      assert
+        .dom(".ai-discoveries-search-options__option.--topic")
+        .hasClass("is-active", "the topic option stays selected after editing");
+
+      searchService.inTopicContext = false;
+      await settled();
+
+      assert
+        .dom(".ai-discoveries-search-options__option.--topic")
+        .doesNotHaveClass(
+          "is-active",
+          "clearing the scope deselects the option"
+        );
+    });
+
     test("the preferred option leads and owns Enter", async function (assert) {
       this.currentUser.user_option.ai_ask_ai_default = true;
 
@@ -863,14 +888,22 @@ module(
         );
     });
 
-    test("stays out of the menu with an empty box", async function (assert) {
-      this.owner.lookup("service:search").activeGlobalSearchTerm = "";
+    test("offers the search options before typing", async function (assert) {
+      const search = this.owner.lookup("service:search");
+      search.activeGlobalSearchTerm = "";
+      search.searchContext = { type: "topic", id: 280 };
 
       await render(<template><AiDiscoveriesSearchOptions /></template>);
 
       assert
-        .dom(".ai-discoveries-search-options")
-        .doesNotExist("there is no term to resolve");
+        .dom(".ai-discoveries-search-options__option.--ask")
+        .exists("AI is visible before typing");
+      assert
+        .dom(".ai-discoveries-search-options__option.--topic")
+        .exists("the current topic is offered before typing");
+      assert
+        .dom(".ai-discoveries-search-options__option.--search")
+        .exists("all topics is offered before typing");
     });
   }
 );


### PR DESCRIPTION
This PR will restore the 'in this topic' chip and keep its scope while editing the query or reopening search. And keep Enter searching within the selected topic, even when AI is the default.

Also show search options before typing (similar to when Ask is disabled), and clear topic results when navigating away, including responses that arrive after navigation.


https://github.com/user-attachments/assets/4ab193c0-7a59-46b5-85de-1d592a8d30c5

