### PR TITLE
FIX: Use same criteria for showing tag localizations and allow locale setting in /edit

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -238,6 +238,7 @@ class TagsController < ::ApplicationController
     updater_params =
       params.require(:tag_settings).permit(
         :name,
+        :locale,
         :slug,
         :description,
         removed_synonym_ids: [],

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,6 +18,7 @@ class Tag < ActiveRecord::Base
            if: Proc.new { |t| t.new_record? || t.will_save_change_to_target_tag_id? }
   validate :name_validator
   validates :description, length: { maximum: 1000 }
+  validates :locale, length: { maximum: 20 }
 
   before_validation :ensure_slug
 
@@ -185,7 +186,12 @@ class Tag < ActiveRecord::Base
       tag = tags_by_id[row.tag_id]
       next unless tag
 
-      name = tag.get_localization&.name || tag.name
+      name =
+        if ContentLocalization.show_translated_tag?(tag, guardian)
+          tag.get_localization&.name || tag.name
+        else
+          tag.name
+        end
       slug = row.tag_slug.presence || "#{row.tag_id}-tag"
       { id: tag.id, name:, slug: }
     end

--- a/app/serializers/tag_settings_serializer.rb
+++ b/app/serializers/tag_settings_serializer.rb
@@ -3,6 +3,7 @@
 class TagSettingsSerializer < ApplicationSerializer
   attributes :id,
              :name,
+             :locale,
              :slug,
              :description,
              :description_cooked,

--- a/app/services/tag_settings_updater.rb
+++ b/app/services/tag_settings_updater.rb
@@ -41,6 +41,7 @@ class TagSettingsUpdater
 
   def update_basic_attributes(params)
     @tag.name = DiscourseTagging.clean_tag(params[:name]) if params[:name].present?
+    @tag.locale = params[:locale].presence if params.key?(:locale)
     @tag.slug = params[:slug] if params.key?(:slug)
     @tag.description = params[:description] if params.key?(:description)
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6239,6 +6239,8 @@ en:
         synonyms_hint: "When the above tags are used, they will be replaced with %{baseTagName}."
         add_synonyms_confirm: "Any place that currently uses %{synonymNames} will be changed to use %{tagName} instead. Are you sure you want to make this change?"
       localization:
+        language: "Tag language"
+        language_description: "The primary language of this tag’s name and description."
         hint: "Add localizations to show different tag names for users in different languages."
         locale: "Locale"
         name: "Name"

--- a/frontend/discourse/admin/components/edit-category-localizations.gjs
+++ b/frontend/discourse/admin/components/edit-category-localizations.gjs
@@ -1,10 +1,12 @@
 import { fn, hash } from "@ember/helper";
 import { service } from "@ember/service";
+import { classNames } from "@ember-decorators/component";
 import { buildCategoryPanel } from "discourse/admin/components/edit-category-panel";
 import { uniqueItemsFromArray } from "discourse/lib/array-tools";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
+@classNames("form-kit__section")
 export default class EditCategoryLocalizations extends buildCategoryPanel(
   "localizations"
 ) {
@@ -29,11 +31,9 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
     <@form.Section>
       <@form.Field
         @description={{i18n "category.localization.language_description"}}
-        @format="full"
         @name="locale"
         @title={{i18n "category.localization.language"}}
         @type="select"
-        @validation="required"
         as |field|
       >
         <field.Control as |select|>

--- a/frontend/discourse/admin/controllers/edit-category/tabs.js
+++ b/frontend/discourse/admin/controllers/edit-category/tabs.js
@@ -195,10 +195,6 @@ export default class EditCategoryTabsController extends Controller {
   initFormData() {
     const data = getProperties(this.model, ...SIMPLIFIED_FIELD_LIST);
 
-    if (this.siteSettings.content_localization_enabled && !data.locale) {
-      data.locale = this.siteSettings.default_locale;
-    }
-
     if (!this.model.styleType) {
       data.style_type = "icon";
     }

--- a/frontend/discourse/app/components/tag-settings.gjs
+++ b/frontend/discourse/app/components/tag-settings.gjs
@@ -43,6 +43,7 @@ export default class TagSettings extends Component {
   get formData() {
     return {
       name: this.args.tag.name,
+      locale: this.args.tag.locale,
       slug: this.args.tag.slug,
       description: this.args.tag.description || "",
       synonyms: this.args.tag.synonyms || [],
@@ -386,6 +387,7 @@ export default class TagSettings extends Component {
         {{else if (eq @selectedTab "localizations")}}
           <TagSettingsLocalizations
             @form={{form}}
+            @locale={{transientData.locale}}
             @localizations={{transientData.localizations}}
             @tagId={{@tag.id}}
           />

--- a/frontend/discourse/app/components/tag-settings/localizations.gjs
+++ b/frontend/discourse/app/components/tag-settings/localizations.gjs
@@ -15,7 +15,9 @@ export default class TagSettingsLocalizations extends Component {
         (obj) => obj.value
       );
     const committed = (this.args.localizations || []).map((obj) => obj.locale);
-    const allLocales = uniqueItemsFromArray([...supported, ...committed]);
+    const allLocales = uniqueItemsFromArray(
+      [...supported, ...committed, this.args.locale].filter(Boolean)
+    );
 
     return allLocales.map((value) => ({
       name: this.languageNameLookup.getLanguageName(value),
@@ -24,91 +26,107 @@ export default class TagSettingsLocalizations extends Component {
   }
 
   <template>
-    {{#if (eq @localizations.length 0)}}
-      <@form.Alert @icon="circle-info">
-        {{i18n "tagging.localization.hint"}}
-      </@form.Alert>
-    {{/if}}
+    <@form.Field
+      @description={{i18n "tagging.localization.language_description"}}
+      @name="locale"
+      @title={{i18n "tagging.localization.language"}}
+      @type="select"
+      as |field|
+    >
+      <field.Control as |select|>
+        {{#each this.selectableLocales as |locale|}}
+          <select.Option @value={{locale.value}}>{{locale.name}}</select.Option>
+        {{/each}}
+      </field.Control>
+    </@form.Field>
 
-    {{#if @localizations.length}}
-      <@form.Collection @name="localizations" as |collection index|>
-        <collection.Field
-          @disabled={{true}}
-          @name="tag_id"
-          @showTitle={{false}}
-          @title="tag_id"
-          @type="input-hidden"
-          as |field|
-        >
-          <field.Control @value={{@tagId}} />
-        </collection.Field>
+    <@form.Section @title={{i18n "tagging.settings.localizations"}}>
+      {{#if (eq @localizations.length 0)}}
+        <@form.Alert @icon="circle-info">
+          {{i18n "tagging.localization.hint"}}
+        </@form.Alert>
+      {{/if}}
 
-        <@form.Row as |row|>
-          <row.Col @size={{2}}>
-            <collection.Field
-              @name="locale"
-              @title={{i18n "tagging.localization.locale"}}
-              @type="select"
-              @validation="required"
-              as |field|
-            >
-              <field.Control as |select|>
-                {{#each this.selectableLocales as |locale|}}
-                  <select.Option
-                    @value={{locale.value}}
-                  >{{locale.name}}</select.Option>
-                {{/each}}
-              </field.Control>
-            </collection.Field>
-          </row.Col>
+      {{#if @localizations.length}}
+        <@form.Collection @name="localizations" as |collection index|>
+          <collection.Field
+            @disabled={{true}}
+            @name="tag_id"
+            @showTitle={{false}}
+            @title="tag_id"
+            @type="input-hidden"
+            as |field|
+          >
+            <field.Control @value={{@tagId}} />
+          </collection.Field>
 
-          <row.Col @size={{3}}>
-            <collection.Field
-              @name="name"
-              @title={{i18n "tagging.localization.name"}}
-              @type="input"
-              @validation="required|length:1,50"
-              as |field|
-            >
-              <field.Control
-                placeholder={{i18n "tagging.settings.name_placeholder"}}
-                @maxlength="50"
+          <@form.Row as |row|>
+            <row.Col @size={{2}}>
+              <collection.Field
+                @name="locale"
+                @title={{i18n "tagging.localization.locale"}}
+                @type="select"
+                @validation="required"
+                as |field|
+              >
+                <field.Control as |select|>
+                  {{#each this.selectableLocales as |locale|}}
+                    <select.Option
+                      @value={{locale.value}}
+                    >{{locale.name}}</select.Option>
+                  {{/each}}
+                </field.Control>
+              </collection.Field>
+            </row.Col>
+
+            <row.Col @size={{3}}>
+              <collection.Field
+                @name="name"
+                @title={{i18n "tagging.localization.name"}}
+                @type="input"
+                @validation="required|length:1,50"
+                as |field|
+              >
+                <field.Control
+                  placeholder={{i18n "tagging.settings.name_placeholder"}}
+                  @maxlength="50"
+                />
+              </collection.Field>
+            </row.Col>
+
+            <row.Col @size={{6}}>
+              <collection.Field
+                @name="description"
+                @title={{i18n "tagging.localization.description"}}
+                @type="composer"
+                @validation="length:0,1000"
+                as |field|
+              >
+                <field.Control @height={{120}} />
+              </collection.Field>
+            </row.Col>
+
+            <row.Col @size={{1}}>
+              <@form.Button
+                class="btn-danger"
+                @action={{fn collection.remove index}}
+                @icon="trash-can"
+                @title="tagging.localization.remove"
               />
-            </collection.Field>
-          </row.Col>
-
-          <row.Col @size={{6}}>
-            <collection.Field
-              @name="description"
-              @title={{i18n "tagging.localization.description"}}
-              @type="composer"
-              @validation="length:0,1000"
-              as |field|
-            >
-              <field.Control @height={{120}} />
-            </collection.Field>
-          </row.Col>
-
-          <row.Col @size={{1}}>
-            <@form.Button
-              class="btn-danger"
-              @action={{fn collection.remove index}}
-              @icon="trash-can"
-              @title="tagging.localization.remove"
-            />
-          </row.Col>
-        </@form.Row>
-      </@form.Collection>
-    {{/if}}
-    <@form.Button
-      class="btn-default"
-      @action={{fn
-        @form.addItemToCollection
-        "localizations"
-        (hash tag_id=@tagId locale="" name="" description="")
-      }}
-      @icon="plus"
-      @label="tagging.localization.add"
-    />
+            </row.Col>
+          </@form.Row>
+        </@form.Collection>
+      {{/if}}
+      <@form.Button
+        class="btn-default"
+        @action={{fn
+          @form.addItemToCollection
+          "localizations"
+          (hash tag_id=@tagId locale="" name="" description="")
+        }}
+        @icon="plus"
+        @label="tagging.localization.add"
+      />
+    </@form.Section>
   </template>
 }

--- a/frontend/discourse/app/data/schemas/tag-settings.js
+++ b/frontend/discourse/app/data/schemas/tag-settings.js
@@ -6,6 +6,7 @@ export const TagSettingsSchema = withDefaults({
   fields: [
     ...attrs(
       "name",
+      "locale",
       "slug",
       "description",
       "synonyms",

--- a/frontend/discourse/tests/integration/components/edit-category-localizations-test.gjs
+++ b/frontend/discourse/tests/integration/components/edit-category-localizations-test.gjs
@@ -1,0 +1,40 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import EditCategoryLocalizations from "discourse/admin/components/edit-category-localizations";
+import Form from "discourse/components/form";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import formKit from "discourse/tests/helpers/form-kit-helper";
+import { NO_VALUE_OPTION } from "discourse/ui-kit/d-native-select";
+
+module("Integration | Component | EditCategoryLocalizations", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("source language can be cleared", async function (assert) {
+    this.siteSettings.available_content_localization_locales = [
+      { value: "en" },
+    ];
+    this.siteSettings.available_locales = [
+      { value: "en", name: "English" },
+      { value: "ja", name: "Japanese" },
+    ];
+    const data = { locale: "en", localizations: [] };
+
+    await render(
+      <template>
+        <Form @data={{data}} as |form|>
+          <EditCategoryLocalizations
+            @form={{form}}
+            @selectedTab="localizations"
+            @transientData={{data}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom(".edit-category-tab-localizations")
+      .hasClass("form-kit__section", "the panel uses FormKit section spacing");
+    await formKit().field("locale").select(NO_VALUE_OPTION);
+    assert.form().field("locale").hasValue(NO_VALUE_OPTION);
+  });
+});

--- a/frontend/discourse/tests/integration/components/tag-settings/localizations-test.gjs
+++ b/frontend/discourse/tests/integration/components/tag-settings/localizations-test.gjs
@@ -1,0 +1,47 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import Form from "discourse/components/form";
+import TagSettingsLocalizations from "discourse/components/tag-settings/localizations";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import formKit from "discourse/tests/helpers/form-kit-helper";
+import { NO_VALUE_OPTION } from "discourse/ui-kit/d-native-select";
+
+module(
+  "Integration | Component | TagSettings | Localizations",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("source language starts blank and can be selected and cleared", async function (assert) {
+      this.siteSettings.available_content_localization_locales = [
+        { value: "en" },
+        { value: "ja" },
+      ];
+      this.siteSettings.available_locales = [
+        { value: "en", name: "English" },
+        { value: "ja", name: "Japanese" },
+      ];
+      const data = { locale: null, localizations: [] };
+
+      await render(
+        <template>
+          <Form @data={{data}} as |form|>
+            <TagSettingsLocalizations
+              @form={{form}}
+              @locale={{data.locale}}
+              @localizations={{data.localizations}}
+            />
+          </Form>
+        </template>
+      );
+
+      assert
+        .dom(".form-kit__section-title")
+        .hasText("Localizations", "translations have a section heading");
+      assert.form().field("locale").hasValue(NO_VALUE_OPTION);
+      await formKit().field("locale").select("ja");
+      assert.form().field("locale").hasValue("ja");
+      await formKit().field("locale").select(NO_VALUE_OPTION);
+      assert.form().field("locale").hasValue(NO_VALUE_OPTION);
+    });
+  }
+);

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -264,9 +264,20 @@ RSpec.describe Tag do
       it "returns original name when tag is in user locale" do
         SiteSetting.content_localization_enabled = true
         I18n.locale = "en"
+        Fabricate(:tag_localization, tag: localized_tag, locale: "en", name: "felines")
 
         expect(Tag.top_tags).to include(
           { id: localized_tag.id, name: "cats", slug: localized_tag.slug },
+        )
+      end
+
+      it "returns original name when the tag source locale is missing" do
+        SiteSetting.content_localization_enabled = true
+        I18n.locale = "ja"
+        localized_tag.update!(locale: nil)
+
+        expect(Tag.top_tags).to contain_exactly(
+          { id: localized_tag.id, name: localized_tag.name, slug: localized_tag.slug },
         )
       end
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1162,6 +1162,24 @@ RSpec.describe TagsController do
     context "when signed in as admin" do
       before { sign_in(admin) }
 
+      it "rejects a source locale exceeding the maximum length" do
+        put "/tag/#{tag.id}/settings.json", params: { tag_settings: { locale: "a" * 21 } }
+
+        expect(response.status).to eq(422)
+        expect(tag.reload.locale).to be_nil
+      end
+
+      it "sets and clears the source locale" do
+        put "/tag/#{tag.id}/settings.json", params: { tag_settings: { locale: "ja" } }
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["tag_settings"]["locale"]).to eq("ja")
+        expect(tag.reload.locale).to eq("ja")
+
+        put "/tag/#{tag.id}/settings.json", params: { tag_settings: { locale: "" } }
+        expect(response.status).to eq(200)
+        expect(tag.reload.locale).to be_nil
+      end
+
       it "updates the tag name" do
         put "/tag/#{tag.id}/settings.json", params: { tag_settings: { name: "updated-name" } }
         expect(response.status).to eq(200)

--- a/spec/system/category_localizations_spec.rb
+++ b/spec/system/category_localizations_spec.rb
@@ -73,11 +73,13 @@ describe "Category Localizations" do
         expect(category_page).to have_setting_tab("localizations")
       end
 
-      it "defaults to site locale when category has no locale" do
+      it "shows no language when category has no locale" do
         category_without_locale = Fabricate(:category, locale: nil)
         category_page.visit_edit_localizations(category_without_locale)
 
-        expect(form.field("locale")).to have_value(SiteSetting.default_locale)
+        expect(form.field("locale")).to have_value(
+          PageObjects::Components::DNativeSelect::NO_VALUE_OPTION,
+        )
       end
 
       it "loads the saved locale correctly" do
@@ -93,7 +95,15 @@ describe "Category Localizations" do
         form.field("locale").select("ja")
         category_page.save_settings
 
-        expect(category_without_locale.reload.locale).to eq("ja")
+        page.refresh
+        expect(form.field("locale")).to have_value("ja")
+
+        form.field("locale").select_none
+        category_page.save_settings
+        page.refresh
+        expect(form.field("locale")).to have_value(
+          PageObjects::Components::DNativeSelect::NO_VALUE_OPTION,
+        )
       end
 
       describe "when editing a category with no category localizations" do

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -713,6 +713,19 @@ describe "Content Localization" do
         expect(page).to have_css(".title-wrapper .discourse-tag", text: "strategy")
       end
 
+      it "shows the original tag name consistently when its source language is missing" do
+        tag.update!(locale: nil)
+        sign_in(japanese_user)
+
+        visit("/")
+
+        expect(sidebar).to have_section_link(tag.name)
+        expect(topic_list).to have_topic_tag(topic, tag.name)
+
+        discovery.tag_drop.expand
+        expect(discovery.tag_drop).to have_option_name(tag.name)
+      end
+
       it "displays localized tag names in the composer tag chooser" do
         SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:everyone]
         SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:everyone]

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -23,6 +23,30 @@ describe "Tag Settings" do
   end
 
   context "when using the tag settings page" do
+    it "lets users set and clear the tag source language without assuming a default" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_supported_locales = "en|ja"
+      sign_in(admin)
+      tag_settings_page.visit_tab(tag_1, "localizations")
+
+      expect(form.field("locale")).to have_value(
+        PageObjects::Components::DNativeSelect::NO_VALUE_OPTION,
+      )
+      form.field("locale").select("ja")
+      tag_settings_page.click_save
+      expect(toasts).to have_success(I18n.t("js.tagging.settings.saved"))
+      page.refresh
+      expect(form.field("locale")).to have_value("ja")
+
+      form.field("locale").select_none
+      tag_settings_page.click_save
+      expect(toasts).to have_success(I18n.t("js.tagging.settings.saved"))
+      page.refresh
+      expect(form.field("locale")).to have_value(
+        PageObjects::Components::DNativeSelect::NO_VALUE_OPTION,
+      )
+    end
+
     it "loads the tag edit page for tags with empty slugs" do
       tag_1.update_column(:slug, "")
       sign_in(admin)


### PR DESCRIPTION
related: https://meta.discourse.org/t/tags-localization-issues/412057

The popular-tag dropdown used translations without checking the tag’s source language, while the sidebar, topic badges and selected filter required it to be set and different from the viewer’s language. This PR makes the dropdown use the same criteria as the rest.
  
Also standardize the /c/name/edit/localizations page and the /tag/slug/id/edit/localizations page
- new - add a source language selector for tags (category has it)
- fix - stopped blank category languages from defaulting to English
- ui fix - matched the localization headings, spacing and selector widths
- ux fix - switched category descriptions to the same composer as tags
- fix - redirected localization edit URLs to General when the feature is off

| cat | tag | 
|--|--|
| <img width="782" height="559" alt="Screenshot 2026-09-10 at 5 37 25 PM" src="https://github.com/user-attachments/assets/75522350-4c28-4bca-8e49-c6d03f1dbfeb" /> |  <img width="1069" height="584" alt="Screenshot 2026-09-10 at 5 37 18 PM" src="https://github.com/user-attachments/assets/1a50ce40-95ba-425f-a235-309abe420fc4" /> |