### PR TITLE
FIX: Support OAuth client authentication method choices

### DIFF
--- a/lib/discourse_mcp/oauth.rb
+++ b/lib/discourse_mcp/oauth.rb
@@ -160,14 +160,25 @@ module DiscourseMcp
           metadata["client_id"] == client_id && metadata["client_name"].is_a?(String) &&
             metadata["client_name"].bytesize <= 255 && redirect_uris.is_a?(Array) &&
             redirect_uris.present? && redirect_uris.length <= 20 &&
-            metadata.fetch("token_endpoint_auth_method", "none") == "none" &&
-            !metadata.key?("client_secret") && !metadata.key?("client_secret_expires_at") &&
+            supports_public_client_authentication?(metadata) && !metadata.key?("client_secret") &&
+            !metadata.key?("client_secret_expires_at") &&
             redirect_uris.all? do |value|
               value.is_a?(String) && McpOauthClient.valid_redirect_uri?(value)
             end
         raise Discourse::InvalidAccess if !valid
       end
       private_class_method :validate_metadata!
+
+      def self.supports_public_client_authentication?(metadata)
+        preferred_method = metadata.fetch("token_endpoint_auth_method", "none")
+        supported_methods = metadata["token_endpoint_auth_methods_supported"]
+        return preferred_method == "none" if supported_methods.nil?
+
+        supported_methods.is_a?(Array) &&
+          supported_methods.all? { |method| method.is_a?(String) } &&
+          supported_methods.include?(preferred_method) && supported_methods.include?("none")
+      end
+      private_class_method :supports_public_client_authentication?
 
       def self.canonicalize(value)
         case value

--- a/spec/lib/discourse_mcp/oauth_spec.rb
+++ b/spec/lib/discourse_mcp/oauth_spec.rb
@@ -88,6 +88,28 @@ describe DiscourseMcp::OAuth do
     expect(McpOauthClient.find_by(client_id:)).to eq(nil)
   end
 
+  it "accepts metadata when none is one of the supported client authentication methods" do
+    SiteSetting.mcp_oauth_client_id_metadata_policy = "any_domain"
+    client_id = "https://client.example.com/oauth/client.json"
+    allow(described_class::ClientResolver).to receive(:fetch_metadata).and_return(
+      {
+        "client_id" => client_id,
+        "client_name" => "Metadata client",
+        "redirect_uris" => ["https://client.example.com/callback"],
+        "token_endpoint_auth_method" => "private_key_jwt",
+        "token_endpoint_auth_methods_supported" => %w[none private_key_jwt],
+      },
+    )
+
+    resolved_client = described_class::ClientResolver.resolve!(client_id, user:)
+
+    expect(resolved_client).to have_attributes(
+      client_id: client_id,
+      registration_type: "cimd",
+      trust_state: "approved",
+    )
+  end
+
   it "rejects metadata that requires unsupported client authentication" do
     SiteSetting.mcp_oauth_client_id_metadata_policy = "any_domain"
     client_id = "https://client.example.com/oauth/client.json"
@@ -97,6 +119,25 @@ describe DiscourseMcp::OAuth do
         "client_name" => "Confidential metadata client",
         "redirect_uris" => ["https://client.example.com/callback"],
         "token_endpoint_auth_method" => "private_key_jwt",
+      },
+    )
+
+    expect { described_class::ClientResolver.resolve!(client_id, user:) }.to raise_error(
+      Discourse::InvalidAccess,
+    )
+    expect(McpOauthClient.find_by(client_id:)).to eq(nil)
+  end
+
+  it "rejects metadata when the preferred authentication method is not a supported choice" do
+    SiteSetting.mcp_oauth_client_id_metadata_policy = "any_domain"
+    client_id = "https://client.example.com/oauth/client.json"
+    allow(described_class::ClientResolver).to receive(:fetch_metadata).and_return(
+      {
+        "client_id" => client_id,
+        "client_name" => "Inconsistent metadata client",
+        "redirect_uris" => ["https://client.example.com/callback"],
+        "token_endpoint_auth_method" => "private_key_jwt",
+        "token_endpoint_auth_methods_supported" => ["none"],
       },
     )
 

--- a/spec/requests/mcp_oauth_authorizations_controller_spec.rb
+++ b/spec/requests/mcp_oauth_authorizations_controller_spec.rb
@@ -178,6 +178,34 @@ describe McpOauthAuthorizationsController do
     expect(response).to redirect_to(/\A#{Regexp.escape(redirect_uri)}\?code=/)
   end
 
+  it "shows consent when a metadata client supports public authentication as a choice" do
+    client_id = "https://client.example.com/oauth/client.json"
+    redirect_uri = "https://client.example.com/callback"
+    SiteSetting.mcp_oauth_client_id_metadata_policy = "any_domain"
+    allow(DiscourseMcp::OAuth::ClientResolver).to receive(:fetch_metadata).and_return(
+      {
+        "client_id" => client_id,
+        "client_name" => "Metadata client",
+        "redirect_uris" => [redirect_uri],
+        "token_endpoint_auth_method" => "private_key_jwt",
+        "token_endpoint_auth_methods_supported" => %w[none private_key_jwt],
+      },
+    )
+
+    get "/oauth2/mcp/authorize",
+        params: {
+          client_id:,
+          redirect_uri:,
+          response_type: "code",
+          code_challenge: "a" * 43,
+          code_challenge_method: "S256",
+          resource: DiscourseMcp.resource_url,
+          scope: "mcp:profile:read",
+        }
+
+    expect(response.status).to eq(200)
+  end
+
   it "rejects users without MCP access before registering a metadata client" do
     sign_in(user)
     client_id = "https://client.example.com/oauth/client.json"


### PR DESCRIPTION
ChatGPT's client metadata prefers `private_key_jwt` but also advertises `none` as a supported method. Discourse currently checks only the preferred value and rejects the client.

This PR uses the [RP Metadata Choices](https://openid.net/specs/openid-connect-rp-metadata-choices-1_0.html#section-4) list to select `none` when offered, while continuing to reject clients that require unsupported authentication.