### PR TITLE
FIX: Do not require ask ai agents to be 'enabled' since that's for AI bot

### DIFF
--- a/plugins/discourse-ai/app/jobs/regular/stream_discover_reply.rb
+++ b/plugins/discourse-ai/app/jobs/regular/stream_discover_reply.rb
@@ -362,7 +362,7 @@ module Jobs
       return fallback if DiscourseAi::Discoveries::Retrieval.explicit_filters?(query)
 
       agent = AiAgent.find_by_id_from_cache(SiteSetting.ai_ask_ai_query_rewriter_agent)
-      return fallback if agent.nil? || !agent.enabled?
+      return fallback if agent.nil?
       return fallback if !user.in_any_groups?(agent.allowed_group_ids.to_a)
 
       llm_model_id = agent.default_llm_id.presence || SiteSetting.ai_default_llm_model

--- a/plugins/discourse-ai/lib/discoveries.rb
+++ b/plugins/discourse-ai/lib/discoveries.rb
@@ -55,9 +55,7 @@ module DiscourseAi
         return false if Guardian.new(user).is_silenced?
 
         agent = discover_agent
-        if agent.nil? || !agent.enabled? || !user.in_any_groups?(agent.allowed_group_ids.to_a)
-          return false
-        end
+        return false if agent.nil? || !user.in_any_groups?(agent.allowed_group_ids.to_a)
 
         llm_model_id = agent.default_llm_id.presence || SiteSetting.ai_default_llm_model
         llm_model_id.present? && LlmModel.exists?(id: llm_model_id)

--- a/plugins/discourse-ai/spec/jobs/regular/stream_discover_reply_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/stream_discover_reply_spec.rb
@@ -213,6 +213,7 @@ describe Jobs::StreamDiscoverReply do
   end
 
   it "uses the configured rewrite agent's queries for retrieval" do
+    query_rewrite_agent.update!(enabled: false)
     allow(query_rewriter).to receive(:call).with(query).and_return(
       DiscourseAi::Discoveries::QueryRewriter::Result.new(
         keyword_query: "create plugin",

--- a/plugins/discourse-ai/spec/lib/discoveries_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discoveries_spec.rb
@@ -37,10 +37,10 @@ describe DiscourseAi::Discoveries do
       expect(described_class.enabled_for_user?(user)).to eq(true)
     end
 
-    it "requires the configured agent to be enabled" do
+    it "allows Ask AI when its agent is disabled for AI bot" do
       ai_agent.update!(enabled: false)
 
-      expect(described_class.enabled_for_user?(user)).to eq(false)
+      expect(described_class.enabled_for_user?(user)).to eq(true)
     end
 
     it "does not require the optional query rewrite agent" do


### PR DESCRIPTION
We don't want the Ask AI agents to appear in AI bot dropdown. 