### PR TITLE
DEV: Convert 5 components to glimmer

### DIFF
--- a/frontend/discourse/admin/components/admin-report-table-row.gjs
+++ b/frontend/discourse/admin/components/admin-report-table-row.gjs
@@ -1,24 +1,18 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import AdminReportTableCell from "discourse/admin/components/admin-report-table-cell";
 
-@tagName("")
-export default class AdminReportTableRow extends Component {
-  options = null;
+const AdminReportTableRow = <template>
+  <tr class="admin-report-table-row" ...attributes>
+    {{#each @labels as |label|}}
+      <AdminReportTableCell
+        @data={{@data}}
+        @hasRelatedItems={{@hasRelatedItems}}
+        @label={{label}}
+        @options={{@options}}
+        @reportFilters={{@reportFilters}}
+        @reportType={{@reportType}}
+      />
+    {{/each}}
+  </tr>
+</template>;
 
-  <template>
-    <tr class="admin-report-table-row" ...attributes>
-      {{#each this.labels as |label|}}
-        <AdminReportTableCell
-          @data={{this.data}}
-          @hasRelatedItems={{@hasRelatedItems}}
-          @label={{label}}
-          @options={{this.options}}
-          @reportFilters={{@reportFilters}}
-          @reportType={{@reportType}}
-        />
-      {{/each}}
-    </tr>
-  </template>
-}
+export default AdminReportTableRow;

--- a/frontend/discourse/app/components/categories-and-latest-topics.gjs
+++ b/frontend/discourse/app/components/categories-and-latest-topics.gjs
@@ -1,27 +1,23 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import CategoriesOnly from "discourse/components/categories-only";
 import CategoriesTopicList from "discourse/components/categories-topic-list";
 import PluginOutlet from "discourse/components/plugin-outlet";
 
-@tagName("")
-export default class CategoriesAndLatestTopics extends Component {
-  <template>
-    <div class="categories-and-latest" ...attributes>
-      <div class="column categories">
-        <CategoriesOnly @categories={{this.categories}} />
-      </div>
-
-      <div class="column">
-        <CategoriesTopicList
-          class="latest-topic-list"
-          @filter="latest"
-          @topics={{this.topics}}
-        />
-      </div>
-
-      <PluginOutlet @connectorTagName="div" @name="extra-categories-column" />
+const CategoriesAndLatestTopics = <template>
+  <div class="categories-and-latest" ...attributes>
+    <div class="column categories">
+      <CategoriesOnly @categories={{@categories}} />
     </div>
-  </template>
-}
+
+    <div class="column">
+      <CategoriesTopicList
+        class="latest-topic-list"
+        @filter="latest"
+        @topics={{@topics}}
+      />
+    </div>
+
+    <PluginOutlet @connectorTagName="div" @name="extra-categories-column" />
+  </div>
+</template>;
+
+export default CategoriesAndLatestTopics;

--- a/frontend/discourse/app/components/categories-and-top-topics.gjs
+++ b/frontend/discourse/app/components/categories-and-top-topics.gjs
@@ -1,27 +1,23 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import CategoriesOnly from "discourse/components/categories-only";
 import CategoriesTopicList from "discourse/components/categories-topic-list";
 import PluginOutlet from "discourse/components/plugin-outlet";
 
-@tagName("")
-export default class CategoriesAndTopTopics extends Component {
-  <template>
-    <div class="categories-and-top" ...attributes>
-      <div class="column categories">
-        <CategoriesOnly @categories={{this.categories}} />
-      </div>
-
-      <div class="column">
-        <CategoriesTopicList
-          class="top-topic-list"
-          @filter="top"
-          @topics={{this.topics}}
-        />
-      </div>
-
-      <PluginOutlet @connectorTagName="div" @name="extra-categories-column" />
+const CategoriesAndTopTopics = <template>
+  <div class="categories-and-top" ...attributes>
+    <div class="column categories">
+      <CategoriesOnly @categories={{@categories}} />
     </div>
-  </template>
-}
+
+    <div class="column">
+      <CategoriesTopicList
+        class="top-topic-list"
+        @filter="top"
+        @topics={{@topics}}
+      />
+    </div>
+
+    <PluginOutlet @connectorTagName="div" @name="extra-categories-column" />
+  </div>
+</template>;
+
+export default CategoriesAndTopTopics;

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/above-main-container/subscriptions-campaign.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/above-main-container/subscriptions-campaign.gjs
@@ -1,9 +1,6 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
 import CampaignBanner from "../../components/campaign-banner";
 
-@tagName("")
 export default class SubscriptionsCampaign extends Component {
   static shouldRender(args, context) {
     const { siteSettings } = context;

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/before-topic-list/subscriptions-campaign-sidebar.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/before-topic-list/subscriptions-campaign-sidebar.gjs
@@ -1,9 +1,6 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
 import CampaignBanner from "../../components/campaign-banner";
 
-@tagName("")
 export default class SubscriptionsCampaignSidebar extends Component {
   static shouldRender(args, context) {
     const { siteSettings } = context;


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* AdminReportTableRow, CategoriesAndLatestTopics, CategoriesAndTopTopics
* SubscriptionsCampaign, SubscriptionsCampaignSidebar (discourse-subscriptions)

`AdminReportTableRow` reads `options` directly from args instead of a class field.
