### PR TITLE
DEV: Convert 5 components to glimmer

### DIFF
--- a/frontend/discourse/admin/components/admin-report-inline-table.gjs
+++ b/frontend/discourse/admin/components/admin-report-inline-table.gjs
@@ -1,28 +1,24 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 
-@tagName("")
-export default class AdminReportInlineTable extends Component {
-  <template>
-    <div class="admin-report-inline-table" ...attributes>
-      <div class="table-container">
-        {{#each this.model.data as |data|}}
-          <a class="table-cell user-{{data.key}}" href={{data.url}}>
-            <span class="label">
-              {{#if data.icon}}
-                {{dIcon data.icon}}
-              {{/if}}
-              {{data.x}}
-            </span>
-            <span class="value">
-              {{dNumber data.y}}
-            </span>
-          </a>
-        {{/each}}
-      </div>
+const AdminReportInlineTable = <template>
+  <div class="admin-report-inline-table" ...attributes>
+    <div class="table-container">
+      {{#each @model.data as |data|}}
+        <a class="table-cell user-{{data.key}}" href={{data.url}}>
+          <span class="label">
+            {{#if data.icon}}
+              {{dIcon data.icon}}
+            {{/if}}
+            {{data.x}}
+          </span>
+          <span class="value">
+            {{dNumber data.y}}
+          </span>
+        </a>
+      {{/each}}
     </div>
-  </template>
-}
+  </div>
+</template>;
+
+export default AdminReportInlineTable;

--- a/frontend/discourse/admin/components/staff-actions.gjs
+++ b/frontend/discourse/admin/components/staff-actions.gjs
@@ -1,12 +1,12 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
+import { service } from "@ember/service";
 import DiscourseURL from "discourse/lib/url";
 
-@tagName("")
 export default class StaffActions extends Component {
+  @service store;
+
   @action
   openLinks(event) {
     const dataset = event.target.dataset;

--- a/frontend/discourse/app/components/ignored-user-list-item.gjs
+++ b/frontend/discourse/app/components/ignored-user-list-item.gjs
@@ -1,29 +1,17 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
 import { fn } from "@ember/helper";
-import { action } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
 import DButton from "discourse/ui-kit/d-button";
 
-@tagName("")
-export default class IgnoredUserListItem extends Component {
-  items = null;
-
-  @action
-  removeIgnoredUser(item) {
-    this.onRemoveIgnoredUser(item);
-  }
-
-  <template>
-    <div ...attributes>
-      <div class="ignored-user-list-item">
-        <span class="ignored-user-name">{{this.item}}</span>
-        <DButton
-          class="remove-ignored-user no-text btn-icon"
-          @action={{fn this.removeIgnoredUser this.item}}
-          @icon="xmark"
-        />
-      </div>
+const IgnoredUserListItem = <template>
+  <div ...attributes>
+    <div class="ignored-user-list-item">
+      <span class="ignored-user-name">{{@item}}</span>
+      <DButton
+        class="remove-ignored-user no-text btn-icon"
+        @action={{fn @onRemoveIgnoredUser @item}}
+        @icon="xmark"
+      />
     </div>
-  </template>
-}
+  </div>
+</template>;
+
+export default IgnoredUserListItem;

--- a/plugins/discourse-captcha/assets/javascripts/discourse/connectors/create-account-after-user-fields/captcha-fields-connector.gjs
+++ b/plugins/discourse-captcha/assets/javascripts/discourse/connectors/create-account-after-user-fields/captcha-fields-connector.gjs
@@ -1,12 +1,9 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 import { eq } from "discourse/truth-helpers";
 import HCaptcha from "../../components/h-captcha";
 import ReCaptcha from "../../components/re-captcha";
 
-@tagName("")
 export default class CaptchaFieldsConnector extends Component {
   @service siteSettings;
 

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/user-main-nav/billing.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/user-main-nav/billing.gjs
@@ -1,13 +1,10 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class Billing extends Component {
   @service currentUser;
 
@@ -15,7 +12,7 @@ export default class Billing extends Component {
     return (
       this.currentUser &&
       this.currentUser.username.toLowerCase() ===
-        this.model.username.toLowerCase()
+        this.args.model.username.toLowerCase()
     );
   }
 


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* AdminReportInlineTable, IgnoredUserListItem, StaffActions
* CaptchaFieldsConnector (discourse-captcha)
* Billing (discourse-subscriptions)

`StaffActions` gets an explicit `store` service injection, which it previously received implicitly.

`IgnoredUserListItem` drops a dead `items` field and an action that only forwarded to `@onRemoveIgnoredUser`.
