### PR TITLE
DEPS: Upgrade oauth2 to 2.x

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -73,6 +73,7 @@ reviewed:
     - net-smtp # Ruby (bundled gem)
     - nio4r # MIT + BSD
     - oauth # MIT
+    - oauth2 # MIT
     - oauth-tty # MIT
     - omniauth # MIT
     - pg # Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,12 +421,16 @@ GEM
       anonymous_loader (~> 0.1, >= 0.1.3)
       auth-sanitizer (~> 0.2, >= 0.2.3)
       version_gem (~> 1.1, >= 1.1.14)
-    oauth2 (1.4.11)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
+    oauth2 (2.0.25)
+      anonymous_loader (~> 0.1, >= 0.1.3)
+      auth-sanitizer (~> 0.2, >= 0.2.3)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.7)
+      version_gem (~> 1.1, >= 1.1.14)
     octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -440,21 +444,21 @@ GEM
     omniauth-facebook (10.0.0)
       bigdecimal
       omniauth-oauth2 (>= 1.2, < 3)
-    omniauth-github (2.0.0)
+    omniauth-github (2.0.1)
       omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.7.1)
-    omniauth-google-oauth2 (1.0.1)
-      jwt (>= 2.0)
-      oauth2 (~> 1.1)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-google-oauth2 (1.2.3)
+      jwt (>= 2.9.2, < 4)
+      oauth2 (~> 2.0)
       omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.7.1)
+      omniauth-oauth2 (~> 1.8)
     omniauth-oauth (1.2.1)
       oauth
       omniauth (>= 1.0, < 3)
       rack (>= 1.6.2, < 4)
-    omniauth-oauth2 (1.7.3)
-      oauth2 (>= 1.4, < 3)
-      omniauth (>= 1.9, < 3)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
     omniauth-twitter (1.5.0)
       cgi
       omniauth-oauth (~> 1.2)
@@ -1170,15 +1174,15 @@ CHECKSUMS
   nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   oauth (1.1.8) sha256=7bf0b774391af4f820a86ce2cc7fa38c3fad5121b5563592535cff4b2e16d50e
   oauth-tty (1.0.13) sha256=71ad5f93ceea6fd21fe9a731dc02a4b892c5de9d77e0b303e81bd73f9daeb4a3
-  oauth2 (1.4.11) sha256=6739fcc8872bc94f476b0cae3e8bd78a56d8364b1b79b0757794c25e152d5c10
+  oauth2 (2.0.25) sha256=2f736a2f93c2caa67c1b08dc3c9889bb907d62643f3183fefaa1723cba6a82ac
   octokit (10.0.0) sha256=82e99a539b7637b7e905e6d277bb0c1a4bed56735935cc33db6da7eae49a24e8
   oj (3.17.6) sha256=f511257e01a12030c3ceb8023cd2e96fca924ea9c741f57ea366816f1fd8e68c
   omniauth (2.1.2) sha256=def03277298b8f8a5d3ff16cdb2eb5edb9bffed60ee7dda24cc0c89b3ae6a0ce
   omniauth-facebook (10.0.0) sha256=dfdc6cbada5387572d554784861546cf6382f9fa16c4731cbe5813e570fcb9e1
-  omniauth-github (2.0.0) sha256=1ca26576125a97e27d3f8dc39cd98853d7382dd0fc04a40d3b9ec345ee378649
-  omniauth-google-oauth2 (1.0.1) sha256=2ed7a4ac8d98ab824c95e0d6760784abf1248262b3ba2ab56ec7ebd7074d12a6
+  omniauth-github (2.0.1) sha256=8ff8e70ac6d6db9d52485eef52cfa894938c941496e66b52b5e2773ade3ccad4
+  omniauth-google-oauth2 (1.2.3) sha256=bdbab67e64e50b7902eee2dcfc2225575cefba15ab89a3b6e92c8947987c1da9
   omniauth-oauth (1.2.1) sha256=25bf22c90234280fa825200490f03ff1ce7d76f1a4fbd6c882c6c5b169c58da8
-  omniauth-oauth2 (1.7.3) sha256=3f5a8f99fa72e0f91d2abd7475ceb972a4ae67ed59e049f314c0c1bad81f4745
+  omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
   omniauth-twitter (1.5.0) sha256=f7d488524113b2f654e1d7f722790dc03d92102cb7c947331ad2d68340a362e3
   openssl (3.3.2) sha256=7f4e01215dc9c4be1fca71d692406be3e6340b39c1f71a47fea9c497decd0f6c
   openssl-signature_algorithm (1.3.0) sha256=a3b40b5e8276162d4a6e50c7c97cdaf1446f9b2c3946a6fa2c14628e0c957e80

--- a/lib/auth/facebook_authenticator.rb
+++ b/lib/auth/facebook_authenticator.rb
@@ -27,6 +27,7 @@ class Auth::FacebookAuthenticator < Auth::ManagedAuthenticator
                           strategy = env["omniauth.strategy"]
                           strategy.options[:client_id] = SiteSetting.facebook_app_id
                           strategy.options[:client_secret] = SiteSetting.facebook_app_secret
+                          strategy.options[:client_options][:auth_scheme] = :request_body
                           strategy.options[:info_fields] = "name,first_name,last_name,email"
                           strategy.options[:image_size] = {
                             width: AVATAR_SIZE,

--- a/lib/auth/github_authenticator.rb
+++ b/lib/auth/github_authenticator.rb
@@ -63,6 +63,7 @@ class Auth::GithubAuthenticator < Auth::ManagedAuthenticator
                           strategy = env["omniauth.strategy"]
                           strategy.options[:client_id] = SiteSetting.github_client_id
                           strategy.options[:client_secret] = SiteSetting.github_client_secret
+                          strategy.options[:client_options][:auth_scheme] = :request_body
                         },
                       scope: "user:email"
   end

--- a/plugins/discourse-apple-auth/lib/omniauth_apple.rb
+++ b/plugins/discourse-apple-auth/lib/omniauth_apple.rb
@@ -20,7 +20,8 @@ module OmniAuth
       option :client_options,
              site: "https://appleid.apple.com",
              authorize_url: "/auth/authorize",
-             token_url: "/auth/token"
+             token_url: "/auth/token",
+             auth_scheme: :request_body
 
       option :authorize_params, response_mode: "form_post", scope: "email name"
 

--- a/plugins/discourse-microsoft-auth/spec/integration/microsoft_auth_spec.rb
+++ b/plugins/discourse-microsoft-auth/spec/integration/microsoft_auth_spec.rb
@@ -14,10 +14,11 @@ describe "Microsoft OAuth2" do
     SiteSetting.microsoft_auth_client_secret = client_secret
 
     stub_request(:post, "https://login.microsoftonline.com/common/oauth2/v2.0/token").with(
+      headers: {
+        "Authorization" => "Basic #{Base64.strict_encode64("#{client_id}:#{client_secret}")}",
+      },
       body:
         hash_including(
-          "client_id" => client_id,
-          "client_secret" => client_secret,
           "code" => temp_code,
           "grant_type" => "authorization_code",
           "redirect_uri" => "http://test.localhost/auth/microsoft_office365/callback",

--- a/plugins/discourse-oauth2-basic/lib/omniauth/strategies/oauth2_basic.rb
+++ b/plugins/discourse-oauth2-basic/lib/omniauth/strategies/oauth2_basic.rb
@@ -25,7 +25,9 @@ class OmniAuth::Strategies::Oauth2Basic < ::OmniAuth::Strategies::OAuth2
   end
 
   def callback_phase
-    super
+    response = super
+    raise env["omniauth.error"] if env["omniauth.error"].is_a?(Faraday::Error)
+    response
   rescue Faraday::Error => e
     detail =
       if e.is_a?(Faraday::TimeoutError)

--- a/plugins/discourse-oauth2-basic/spec/integration/token_request_failure_spec.rb
+++ b/plugins/discourse-oauth2-basic/spec/integration/token_request_failure_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe "OAuth2 Basic token request failures" do
+  before do
+    SiteSetting.oauth2_enabled = true
+    SiteSetting.oauth2_client_id = "client"
+    SiteSetting.oauth2_client_secret = "secret"
+    SiteSetting.oauth2_authorize_url = "https://id.example.com/authorize"
+    SiteSetting.oauth2_token_url = "https://id.example.com/token"
+    stub_request(:post, "https://id.example.com/token").to_timeout
+  end
+
+  it "reports the plugin's own failure when the token request times out" do
+    post "/auth/oauth2_basic"
+    expect(response.status).to eq(302)
+    expect(response.location).to start_with("https://id.example.com/authorize?")
+
+    post "/auth/oauth2_basic/callback", params: { state: session["omniauth.state"], code: "code" }
+    expect(response.status).to eq(302)
+    expect(response.location).to eq(
+      "/auth/failure?message=oauth2_basic_request_failed&strategy=oauth2_basic",
+    )
+  end
+end

--- a/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
+++ b/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
@@ -134,6 +134,7 @@ module OmniAuth
           discover! if options[:discovery]
 
           oauth2_callback_phase = super
+          raise env["omniauth.error"] if env["omniauth.error"].is_a?(Faraday::Error)
           return oauth2_callback_phase if env["omniauth.error"]
 
           oauth2_callback_phase

--- a/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
@@ -184,7 +184,7 @@ describe OmniAuth::Strategies::OpenIDConnect do
             body: hash_including("code" => "supersecretcode", "p" => "someallowedvalue"),
           ).to_return(
             status: 200,
-            body: { id_token: @token }.to_json,
+            body: { access_token: "AnAccessToken", id_token: @token }.to_json,
             headers: {
               "Content-Type" => "application/json",
             },

--- a/plugins/discourse-patreon/plugin.rb
+++ b/plugins/discourse-patreon/plugin.rb
@@ -113,7 +113,8 @@ class ::OmniAuth::Strategies::Patreon < ::OmniAuth::Strategies::OAuth2
   option :client_options,
          site: "https://www.patreon.com",
          authorize_url: "https://www.patreon.com/oauth2/authorize",
-         token_url: "https://api.patreon.com/oauth2/token"
+         token_url: "https://api.patreon.com/oauth2/token",
+         auth_scheme: :request_body
 
   option :authorize_params, response_type: "code"
 

--- a/spec/integration/discord_omniauth_spec.rb
+++ b/spec/integration/discord_omniauth_spec.rb
@@ -41,10 +41,11 @@ describe "Discord OAuth2" do
     SiteSetting.discord_secret = client_secret
 
     stub_request(:post, "https://discord.com/api/oauth2/token").with(
+      headers: {
+        "Authorization" => "Basic #{Base64.strict_encode64("#{client_id}:#{client_secret}")}",
+      },
       body:
         hash_including(
-          "client_id" => client_id,
-          "client_secret" => client_secret,
           "code" => temp_code,
           "grant_type" => "authorization_code",
           "redirect_uri" => "http://test.localhost/auth/discord/callback",


### PR DESCRIPTION
This moves `oauth2` from 1.4.11 to 2.0.25, with `omniauth-oauth2` 1.9.0, `omniauth-github` 2.0.1 and `omniauth-google-oauth2` 1.2.3, which are the versions that support it. It also unblocks the `jwt`, `web-push` and `openssl` bumps, which oauth2 1.4 was holding back.

The behaviour change in oauth2 2.x is that clients authenticate to the token endpoint with HTTP Basic auth by default, where 1.4 sent the client id and secret in the request body. Google, Microsoft, Discord and Amazon document both methods, so they take the new default. GitHub, Facebook, Patreon and Apple document only body credentials, and Apple's OpenID metadata lists `client_secret_post` alone, so those four strategies set `auth_scheme: :request_body` explicitly. This is erring on the side of caution - it may be possible to switch these to basic-auth in future.