### PR TITLE
FEATURE: support `-created-by` on the /filter route

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3299,6 +3299,7 @@ en:
       created_by: "Show topics created by a specific user or group"
       created_by_user: "Show topics created by username or group (without @)"
       created_by_multiple: "Show topics created by any of the specified users or groups (comma-separated)"
+      exclude_created_by: "Exclude topics created by a specific user or group"
       latest_post_before: "Show topics with last post before a date (YYYY-MM-DD or days ago)"
       latest_post_after: "Show topics with last post after a date (YYYY-MM-DD or days ago)"
       likes_min: "Show topics with at least this many likes"

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -69,7 +69,7 @@ class TopicsFilter
       when "created-before"
         filter_by_created(before: filter_values)
       when "created-by"
-        filter_created_by(names: filter_values.flat_map { |value| value.split(",") })
+        filter_created_by(values: key_prefixes.zip(filter_values))
       when "in"
         filter_in(values: filter_values)
       when "latest-post-after"
@@ -232,6 +232,7 @@ class TopicsFilter
         name: "created-by:",
         description: I18n.t("filter.description.created_by"),
         type: "username_group_list",
+        prefixes: [{ name: "-", description: I18n.t("filter.description.exclude_created_by") }],
         delimiters: [{ name: ",", description: I18n.t("filter.description.created_by_multiple") }],
       },
       {
@@ -446,8 +447,6 @@ class TopicsFilter
       value if value =~ /\A\d+\z/
     when "order"
       values.flat_map { |value| value.split(",") }
-    when "created-by"
-      values.flat_map { |value| value.split(",").map { |username| username.delete_prefix("@") } }
     else
       values
     end
@@ -759,35 +758,81 @@ class TopicsFilter
       SQL
   end
 
-  def filter_created_by(names:)
-    if names.include?("me") && @guardian.authenticated?
-      names = names.map { |n| n == "me" ? @guardian.user.username_lower : n }
+  # created-by:user,group => topics whose creator matches any of the given users/groups
+  # -created-by:user,group => topics whose creator matches none of them
+  def filter_created_by(values:)
+    include_names = []
+    exclude_names = []
+
+    values.each do |key_prefix, value|
+      names =
+        value
+          .split(",")
+          .map { |name| name.delete_prefix("@") }
+          .reject(&:blank?)
+          .map do |name|
+            name == "me" && @guardian.authenticated? ? @guardian.user.username_lower : name
+          end
+
+      if key_prefix == "-"
+        exclude_names.concat(names)
+      else
+        include_names.concat(names)
+      end
     end
 
-    if (user_ids = User.where("username_lower IN (?)", names.map(&:downcase)).pluck(:id)) &&
-         user_ids.any?
+    include_names.uniq!
+    exclude_names.uniq!
+
+    include_created_by(include_names) if include_names.present?
+    exclude_created_by(exclude_names) if exclude_names.present?
+
+    @scope
+  end
+
+  # Resolves names as usernames first -- mirrors the long-standing behaviour where a
+  # whole list is treated as usernames if any name matches one, otherwise as groups.
+  def include_created_by(names)
+    if (user_ids = created_by_user_ids(names)).present?
       @scope = @scope.joins(:user).where(user_id: user_ids)
-      return
-    end
-
-    if (
-         group_ids =
-           Group
-             .visible_groups(@guardian.user)
-             .members_visible_groups(@guardian.user)
-             .where("lower(name) IN (?)", names.map(&:downcase))
-             .pluck(:id)
-       ) && group_ids.any?
+    elsif (group_ids = created_by_group_ids(names)).present?
       @scope =
         @scope
           .joins(:user)
           .joins("INNER JOIN group_users ON group_users.user_id = users.id")
           .where("group_users.group_id IN (?)", group_ids)
           .distinct(:id)
-      return
+    else
+      @scope = @scope.none
+    end
+  end
+
+  # Users and groups are both resolved so a named group is never silently dropped, and
+  # unknown names exclude nothing. NULL user_ids (deleted creators) would fail NOT IN.
+  def exclude_created_by(names)
+    if (user_ids = created_by_user_ids(names)).present?
+      @scope = @scope.where("topics.user_id IS NULL OR topics.user_id NOT IN (?)", user_ids)
     end
 
-    @scope = @scope.none
+    if (group_ids = created_by_group_ids(names)).present?
+      @scope =
+        @scope.where(
+          "topics.user_id IS NULL OR topics.user_id NOT IN (?)",
+          GroupUser.where(group_id: group_ids).select(:user_id),
+        )
+    end
+  end
+
+  def created_by_user_ids(names)
+    User.where("username_lower IN (?)", names.map(&:downcase)).pluck(:id)
+  end
+
+  def created_by_group_ids(names)
+    Group
+      .visible_groups(@guardian.user)
+      .members_visible_groups(@guardian.user)
+      .where("lower(name) IN (?)", names.map(&:downcase))
+      .pluck(:id)
   end
 
   def apply_custom_filter!(scope:, filter_name:, values:)

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -2022,6 +2022,63 @@ RSpec.describe TopicsFilter do
           ).to eq([])
         end
       end
+
+      describe "when query string is `-created-by:@username`" do
+        it "excludes topics created by the named user" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:@#{user.username}")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user2.id)
+        end
+
+        it "keeps topics whose creator has been deleted" do
+          topic_by_deleted_user = Fabricate(:topic).tap { |t| t.update_columns(user_id: nil) }
+
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:@#{user.username}")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user2.id, topic_by_deleted_user.id)
+        end
+      end
+
+      describe "when query string is `-created-by:@username,@username2`" do
+        it "excludes topics created by any of the named users" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:@#{user.username},@#{user2.username}")
+              .pluck(:id),
+          ).to eq([])
+        end
+      end
+
+      describe "when query string is `created-by:@username -created-by:@username2`" do
+        it "includes topics by the first user and excludes topics by the second" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string(
+                "created-by:@#{user.username} -created-by:@#{user2.username}",
+              )
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user.id, topic2_by_user.id)
+        end
+      end
+
+      describe "when query string is `-created-by:@invalid`" do
+        it "excludes nothing when the user does not exist" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:@invalid")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user.id, topic2_by_user.id, topic_by_user2.id)
+        end
+      end
     end
 
     describe "when filtering by topic creator's group" do
@@ -2162,6 +2219,67 @@ RSpec.describe TopicsFilter do
           ).to contain_exactly(
             topic_by_super_private_group_owner.id,
             topic_by_super_private_group_user.id,
+          )
+        end
+      end
+
+      describe "when query string is `-created-by:group1`" do
+        it "excludes topics created by members of the specified group" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:group1")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_group2_user.id)
+        end
+
+        it "keeps topics whose creator has been deleted" do
+          topic_by_deleted_user = Fabricate(:topic).tap { |t| t.update_columns(user_id: nil) }
+
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:group1")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_group2_user.id, topic_by_deleted_user.id)
+        end
+      end
+
+      describe "when query string is `-created-by:group1,group2`" do
+        it "excludes topics created by members of any specified group" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:group1,group2")
+              .pluck(:id),
+          ).to eq([])
+        end
+      end
+
+      describe "when query string is `-created-by:@username,group1`" do
+        it "excludes topics created by the named user and by members of the group" do
+          other_topic = Fabricate(:topic)
+
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:@#{user_in_group2.username},group1")
+              .pluck(:id),
+          ).to contain_exactly(other_topic.id)
+        end
+      end
+
+      describe "when query string is `-created-by:invalid`" do
+        it "excludes nothing when the group does not exist" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-created-by:invalid")
+              .pluck(:id),
+          ).to contain_exactly(
+            topic_by_group1_user.id,
+            topic_by_group2_user.id,
+            topic_by_both_groups_user.id,
           )
         end
       end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1939,6 +1939,18 @@ RSpec.describe ListController do
           response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] },
         ).to contain_exactly(topic.id, topic2.id)
       end
+
+      it "returns only topics not created by the user when `q` query param is `-created-by:username`" do
+        sign_in(user)
+
+        get "/filter.json", params: { q: "-created-by:username" }
+
+        expect(response.status).to eq(200)
+
+        expect(
+          response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] },
+        ).to contain_exactly(topic2.id)
+      end
     end
 
     describe "when filtering with the `category:<category_slug>` filter" do


### PR DESCRIPTION
This allows users of the /filter route exclude topics created by specific users or groups. Currently we only have the include. 

Now we can do:
* `-created-by:staff` - excludes topics created by the staff group
* `-created-by:user1,user2` - excludes topics created by either user
* `-created-by:staff,user1` - excludes topics created by the staff group and user1 
* `created-by:staff -created-by:user1` - shows topics created by the staff group, except those created by user1