### PR TITLE
DEV: Stop dependabot proposing eslint, prettier and stylelint bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,6 +81,10 @@ updates:
     versioning-strategy: increase
     ignore:
       - dependency-name: "webpack" # Recent versions have bugs with `/static` loading. We're working to move away from webpack anyway.
+      # Pinned as exact peers by @discourse/lint-configs; bump them there, and the lint-configs update carries them here.
+      - dependency-name: "eslint"
+      - dependency-name: "prettier"
+      - dependency-name: "stylelint"
     groups:
       babel:
         patterns:
@@ -115,9 +119,3 @@ updates:
       fullcalendar:
         patterns:
           - "@fullcalendar/*"
-      lint:
-        patterns:
-          - "@discourse/lint-configs"
-          - "eslint"
-          - "prettier"
-          - "stylelint"


### PR DESCRIPTION
`@discourse/lint-configs` pins all three as exact peer dependencies, so a bump of any of them on its own can never install. The lint group existed to move them together with lint-configs, but dependabot still opened standalone bumps that only ever failed. Ignore the three and let the lint-configs update carry their versions.
