### PR TITLE
FIX: highlight the "All site settings" admin sidebar link

### DIFF
--- a/frontend/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/frontend/discourse/app/lib/sidebar/admin-nav-map.js
@@ -31,7 +31,8 @@ export const ADMIN_NAV_MAP = [
       {
         name: "admin_all_site_settings",
         route: "adminSiteSettingsCategory",
-        routeModels: ["all_settings"],
+        routeModels: ["all_results"],
+        currentWhen: "adminSiteSettingsCategory",
         label: "admin.config.site_settings.title",
         description: "admin.config.site_settings.header_description",
         icon: "gear",

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -146,6 +146,14 @@ describe "Admin | Sidebar Navigation" do
     )
   end
 
+  it "highlights the 'All site settings' link on the all settings page" do
+    visit("/admin/site_settings/category/all_results")
+
+    expect(page).to have_css(
+      '.sidebar-section-link-wrapper[data-list-item-name="admin_all_site_settings"] a.active',
+    )
+  end
+
   it "does not show the button to customize sidebar sections, that is only supported in the main panel" do
     visit("/")
     expect(sidebar).to have_add_section_button


### PR DESCRIPTION
Since #35263 this link has pointed at the `all_settings` category, which doesn't exist. The category route redirects unknown categories to `all_results`, so the link still went to the right place, but Ember never marked it active because the model didn't match the page.

Point it at `all_results` and give it a `currentWhen`, plus a system spec.