### PR TITLE
DEV: Convert 5 components to glimmer

### DIFF
--- a/frontend/discourse/app/components/topic-category.gjs
+++ b/frontend/discourse/app/components/topic-category.gjs
@@ -1,25 +1,24 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import dBoundCategoryLink from "discourse/ui-kit/helpers/d-bound-category-link";
 import dDiscourseTags from "discourse/ui-kit/helpers/d-discourse-tags";
 
-// Injections don't occur without a class
-@tagName("")
 export default class TopicCategory extends Component {
+  @service siteSettings;
+
   <template>
     <div ...attributes>
       <PluginOutlet
         @name="topic-category-link-wrapper"
-        @outletArgs={{lazyHash category=this.topic.category topic=this.topic}}
+        @outletArgs={{lazyHash category=@topic.category topic=@topic}}
       >
-        {{#unless this.topic.isPrivateMessage}}
+        {{#unless @topic.isPrivateMessage}}
           {{dBoundCategoryLink
-            this.topic.category
-            ancestors=this.topic.category.predecessors
+            @topic.category
+            ancestors=@topic.category.predecessors
             hideParent=true
           }}
         {{/unless}}
@@ -27,11 +26,11 @@ export default class TopicCategory extends Component {
       <div class="topic-header-extra">
         {{#if this.siteSettings.tagging_enabled}}
           <div class="list-tags">
-            {{dDiscourseTags this.topic mode="list" tags=this.topic.tags}}
+            {{dDiscourseTags @topic mode="list" tags=@topic.tags}}
           </div>
         {{/if}}
         {{#if this.siteSettings.topic_featured_link_enabled}}
-          {{topicFeaturedLink this.topic}}
+          {{topicFeaturedLink @topic}}
         {{/if}}
       </div>
 
@@ -39,7 +38,7 @@ export default class TopicCategory extends Component {
         <PluginOutlet
           @connectorTagName="div"
           @name="topic-category"
-          @outletArgs={{lazyHash topic=this.topic category=this.topic.category}}
+          @outletArgs={{lazyHash topic=@topic category=@topic.category}}
         />
       </span>
     </div>

--- a/frontend/discourse/app/ui-kit/d-tap-tile-grid.gjs
+++ b/frontend/discourse/app/ui-kit/d-tap-tile-grid.gjs
@@ -1,15 +1,9 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
 import { hash } from "@ember/helper";
-import { tagName } from "@ember-decorators/component";
 
-@tagName("")
-export default class DTapTileGrid extends Component {
-  activeTile = null;
+const DTapTileGrid = <template>
+  <div class="tap-tile-grid" ...attributes>
+    {{yield (hash activeTile=@activeTile)}}
+  </div>
+</template>;
 
-  <template>
-    <div class="tap-tile-grid" ...attributes>
-      {{yield (hash activeTile=this.activeTile)}}
-    </div>
-  </template>
-}
+export default DTapTileGrid;

--- a/plugins/discourse-gamification/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
+++ b/plugins/discourse-gamification/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
@@ -1,40 +1,39 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import { or } from "discourse/truth-helpers";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import fullnumber from "../helpers/fullnumber";
 
-@tagName("")
 export default class GamificationLeaderboardRow extends Component {
-  rank = null;
+  @service site;
+  @service siteSettings;
 
   <template>
     <div
-      class="user {{if this.rank.currentUser 'user-highlight'}}"
-      id="leaderboard-user-{{this.rank.id}}"
+      class="user {{if @rank.currentUser 'user-highlight'}}"
+      id="leaderboard-user-{{@rank.id}}"
     >
-      <div class="user__rank">{{this.rank.position}}</div>
+      <div class="user__rank">{{@rank.position}}</div>
       <div
         class="user__avatar clickable"
-        data-user-card={{this.rank.username}}
+        data-user-card={{@rank.username}}
         role="button"
       >
-        {{dAvatar this.rank imageSize="large"}}
+        {{dAvatar @rank imageSize="large"}}
         <span class="user__name">
           {{#if this.siteSettings.prioritize_username_in_ux}}
-            {{this.rank.username}}
+            {{@rank.username}}
           {{else}}
-            {{or this.rank.name this.rank.username}}
+            {{or @rank.name @rank.username}}
           {{/if}}
         </span>
       </div>
       <div class="user__score">
         {{#if this.site.mobileView}}
-          {{dNumber this.rank.total_score}}
+          {{dNumber @rank.total_score}}
         {{else}}
-          {{fullnumber this.rank.total_score}}
+          {{fullnumber @rank.total_score}}
         {{/if}}
       </div>
     </div>

--- a/plugins/discourse-gamification/assets/javascripts/discourse/connectors/user-card-metadata/gamification-score.gjs
+++ b/plugins/discourse-gamification/assets/javascripts/discourse/connectors/user-card-metadata/gamification-score.gjs
@@ -1,17 +1,13 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import { i18n } from "discourse-i18n";
 import GamificationScore from "../../components/gamification-score";
 
-@tagName("")
-export default class GamificationScoreConnector extends Component {
-  <template>
-    <div class="user-card-metadata-outlet gamification-score" ...attributes>
-      {{#if this.user.gamification_score}}
-        <span class="desc">{{i18n "gamification.score"}} </span>
-        <span><GamificationScore @model={{this.user}} /></span>
-      {{/if}}
-    </div>
-  </template>
-}
+const GamificationScoreConnector = <template>
+  <div class="user-card-metadata-outlet gamification-score" ...attributes>
+    {{#if @user.gamification_score}}
+      <span class="desc">{{i18n "gamification.score"}} </span>
+      <span><GamificationScore @model={{@user}} /></span>
+    {{/if}}
+  </div>
+</template>;
+
+export default GamificationScoreConnector;

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/components/product-list.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/components/product-list.gjs
@@ -1,16 +1,11 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { computed } from "@ember/object";
+import Component from "@glimmer/component";
 import { isEmpty } from "@ember/utils";
-import { tagName } from "@ember-decorators/component";
 import { i18n } from "discourse-i18n";
 import ProductItem from "./product-item";
 
-@tagName("")
 export default class ProductList extends Component {
-  @computed("products")
   get emptyProducts() {
-    return isEmpty(this.products);
+    return isEmpty(this.args.products);
   }
 
   <template>
@@ -18,8 +13,8 @@ export default class ProductList extends Component {
       {{#if this.emptyProducts}}
         <p>{{i18n "discourse_subscriptions.subscribe.no_products"}}</p>
       {{else}}
-        {{#each this.products as |product|}}
-          <ProductItem @isLoggedIn={{this.isLoggedIn}} @product={{product}} />
+        {{#each @products as |product|}}
+          <ProductItem @isLoggedIn={{@isLoggedIn}} @product={{product}} />
         {{/each}}
       {{/if}}
     </div>


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* DTapTileGrid, TopicCategory
* GamificationScoreConnector, GamificationLeaderboardRow (discourse-gamification)
* ProductList (discourse-subscriptions)

`TopicCategory` and `GamificationLeaderboardRow` get explicit `site`/`siteSettings` service injections, which they previously received implicitly.
