### PR TITLE
DEV: Convert 5 components to glimmer

### DIFF
--- a/frontend/discourse/admin/components/watched-word-uploader.gjs
+++ b/frontend/discourse/admin/components/watched-word-uploader.gjs
@@ -1,15 +1,11 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { computed, set } from "@ember/object";
+import Component from "@glimmer/component";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 import UppyUpload from "discourse/lib/uppy/uppy-upload";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class WatchedWordUploader extends Component {
   @service dialog;
 
@@ -21,12 +17,20 @@ export default class WatchedWordUploader extends Component {
     validateUploadedFilesOptions: {
       skipValidation: true,
     },
-    perFileData: () => ({ action_key: this.actionKey }),
+    perFileData: () => ({ action_key: this.args.actionKey }),
     uploadDone: () => {
       this.dialog.alert(i18n("admin.watched_words.form.upload_successful"));
-      this.done();
+      this.args.done();
     },
   });
+
+  get addDisabled() {
+    return this.uppyUpload?.uploading;
+  }
+
+  set addDisabled(value) {
+    this.uppyUpload.uploading = value;
+  }
 
   <template>
     <div class="watched-words-uploader" ...attributes>
@@ -42,13 +46,4 @@ export default class WatchedWordUploader extends Component {
       </label>
     </div>
   </template>
-
-  @computed("uppyUpload.uploading")
-  get addDisabled() {
-    return this.uppyUpload?.uploading;
-  }
-
-  set addDisabled(value) {
-    set(this, "uppyUpload.uploading", value);
-  }
 }

--- a/frontend/discourse/app/components/categories-boxes-with-topics.gjs
+++ b/frontend/discourse/app/components/categories-boxes-with-topics.gjs
@@ -1,8 +1,6 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
-import { tagName } from "@ember-decorators/component";
 import CategoriesBoxesTopic from "discourse/components/categories-boxes-topic";
 import CategoryLogo from "discourse/components/category-logo";
 import CategoryTitleBefore from "discourse/components/category-title-before";
@@ -12,10 +10,9 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import { categoryBadgeHTML } from "discourse/ui-kit/helpers/d-category-link";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
-@tagName("")
 export default class CategoriesBoxesWithTopics extends Component {
   get anyLogos() {
-    return this.categories.some((c) => {
+    return this.args.categories.some((c) => {
       return !isEmpty(c.get("uploaded_logo.url"));
     });
   }
@@ -37,7 +34,7 @@ export default class CategoriesBoxesWithTopics extends Component {
       }}
       ...attributes
     >
-      {{#each this.categories as |c|}}
+      {{#each @categories as |c|}}
         <div
           class="category category-box category-box-{{c.slug}}
             {{if c.isMuted 'muted'}}"

--- a/frontend/discourse/tests/integration/components/watched-word-uploader-test.gjs
+++ b/frontend/discourse/tests/integration/components/watched-word-uploader-test.gjs
@@ -11,10 +11,18 @@ import { i18n } from "discourse-i18n";
 module("Integration | Component | WatchedWordUploader", function (hooks) {
   setupRenderingTest(hooks);
 
+  let uploadedActionKey;
+
   hooks.beforeEach(function () {
-    pretender.post("/admin/customize/watched_words/upload.json", function () {
-      return response(200, {});
-    });
+    uploadedActionKey = undefined;
+
+    pretender.post(
+      "/admin/customize/watched_words/upload.json",
+      function (request) {
+        uploadedActionKey = request.requestBody.get("action_key");
+        return response(200, {});
+      }
+    );
   });
 
   test("sets the proper action key on uploads", async function (assert) {
@@ -23,12 +31,11 @@ module("Integration | Component | WatchedWordUploader", function (hooks) {
 
     const done = assert.async();
     this.set("actionNameKey", "flag");
-    this.set("doneUpload", function () {
+    this.set("doneUpload", () => {
       assert.strictEqual(
-        Object.entries(
-          this.uppyUpload.uppyWrapper.uppyInstance.getState().files
-        )[0][1].meta.action_key,
-        "flag"
+        uploadedActionKey,
+        "flag",
+        "sends the action key with the upload"
       );
       assert.true(
         dialog.alert.calledWith(

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/admin-report-emotion.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/admin-report-emotion.gjs
@@ -1,11 +1,8 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
 import getURL from "discourse/lib/get-url";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 
-@tagName("")
 export default class AdminReportEmotion extends Component {
   get todayLink() {
     let date = moment().format("YYYY-MM-DD");
@@ -32,7 +29,7 @@ export default class AdminReportEmotion extends Component {
   }
 
   _model() {
-    return "%20order%3A" + this.model.type;
+    return "%20order%3A" + this.args.model.type;
   }
 
   _filterURL(date) {
@@ -42,52 +39,52 @@ export default class AdminReportEmotion extends Component {
   <template>
     <div
       class="admin-report-counters"
-      title={{this.model.description}}
+      title={{@model.description}}
       ...attributes
     >
       <div class="cell title">
-        {{#if this.model.icon}}
-          {{dIcon this.model.icon}}
+        {{#if @model.icon}}
+          {{dIcon @model.icon}}
         {{/if}}
-        {{this.model.title}}
+        {{@model.title}}
       </div>
 
       <div class="cell value today-count">
         <a href={{this.todayLink}}>
-          {{dNumber this.model.todayCount}}
+          {{dNumber @model.todayCount}}
         </a>
       </div>
 
       <div
-        class="cell value yesterday-count {{this.model.yesterdayTrend}}"
-        title={{this.model.yesterdayCountTitle}}
+        class="cell value yesterday-count {{@model.yesterdayTrend}}"
+        title={{@model.yesterdayCountTitle}}
       >
         <a href={{this.yesterdayLink}}>
-          {{dNumber this.model.yesterdayCount}}
+          {{dNumber @model.yesterdayCount}}
         </a>
-        {{dIcon this.model.yesterdayTrendIcon}}
+        {{dIcon @model.yesterdayTrendIcon}}
       </div>
 
       <div
-        class="cell value sevendays-count {{this.model.sevenDaysTrend}}"
-        title={{this.model.sevenDaysCountTitle}}
+        class="cell value sevendays-count {{@model.sevenDaysTrend}}"
+        title={{@model.sevenDaysCountTitle}}
       >
         <a href={{this.lastSevenDaysLink}}>
-          {{dNumber this.model.lastSevenDaysCount}}
+          {{dNumber @model.lastSevenDaysCount}}
         </a>
-        {{dIcon this.model.sevenDaysTrendIcon}}
+        {{dIcon @model.sevenDaysTrendIcon}}
       </div>
 
       <div
-        class="cell value thirty-days-count {{this.model.thirtyDaysTrend}}"
-        title={{this.model.thirtyDaysCountTitle}}
+        class="cell value thirty-days-count {{@model.thirtyDaysTrend}}"
+        title={{@model.thirtyDaysCountTitle}}
       >
 
         <a href={{this.lastThirtyDaysLink}}>
-          {{dNumber this.model.lastThirtyDaysCount}}
+          {{dNumber @model.lastThirtyDaysCount}}
         </a>
-        {{#if this.model.canDisplayTrendIcon}}
-          {{dIcon this.model.thirtyDaysTrendIcon}}
+        {{#if @model.canDisplayTrendIcon}}
+          {{dIcon @model.thirtyDaysTrendIcon}}
         {{/if}}
       </div>
     </div>

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/components/product-item.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/components/product-item.gjs
@@ -1,32 +1,32 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
-import { tagName } from "@ember-decorators/component";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class ProductItem extends Component {
+  @service currentUser;
+
   <template>
     <div class="product" ...attributes>
-      <h2>{{this.product.name}}</h2>
+      <h2>{{@product.name}}</h2>
 
       <p class="product-description">
-        {{trustHTML this.product.description}}
+        {{trustHTML @product.description}}
       </p>
 
-      {{#if this.isLoggedIn}}
+      {{#if @isLoggedIn}}
         <div class="product-purchase">
-          {{#if this.product.repurchaseable}}
+          {{#if @product.repurchaseable}}
             <LinkTo
               class="btn btn-primary"
-              @model={{this.product.id}}
+              @model={{@product.id}}
               @route="subscribe.show"
             >
               {{i18n "discourse_subscriptions.subscribe.title"}}
             </LinkTo>
 
-            {{#if this.product.subscribed}}
+            {{#if @product.subscribed}}
               <LinkTo
                 class="billing-link"
                 @model={{this.currentUser.username}}
@@ -36,7 +36,7 @@ export default class ProductItem extends Component {
               </LinkTo>
             {{/if}}
           {{else}}
-            {{#if this.product.subscribed}}
+            {{#if @product.subscribed}}
               <span class="purchased">
                 &#x2713;
                 {{i18n "discourse_subscriptions.subscribe.purchased"}}
@@ -52,8 +52,8 @@ export default class ProductItem extends Component {
             {{else}}
               <LinkTo
                 class="btn btn-primary"
-                @disabled={{this.product.subscribed}}
-                @model={{this.product.id}}
+                @disabled={{@product.subscribed}}
+                @model={{@product.id}}
                 @route="subscribe.show"
               >
                 {{i18n "discourse_subscriptions.subscribe.title"}}

--- a/plugins/discourse-templates/assets/javascripts/discourse/connectors/editor-preview/d-templates.gjs
+++ b/plugins/discourse-templates/assets/javascripts/discourse/connectors/editor-preview/d-templates.gjs
@@ -1,15 +1,13 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 import DButton from "discourse/ui-kit/d-button";
 import FilterableList from "../../components/d-templates/filterable-list";
 
 const SELECTOR_EDITOR_PREVIEW =
   "#reply-control .d-editor-preview-wrapper > .d-editor-preview";
 
-@tagName("")
 export default class DTemplatesEditorPreview extends Component {
   static shouldRender(args, context) {
     return !context.site.mobileView;
@@ -17,8 +15,8 @@ export default class DTemplatesEditorPreview extends Component {
 
   @service appEvents;
 
-  templatesVisible = false;
-  onInsertTemplate;
+  @tracked templatesVisible = false;
+  @tracked onInsertTemplate;
 
   constructor() {
     super(...arguments);
@@ -41,8 +39,8 @@ export default class DTemplatesEditorPreview extends Component {
       elemEditorPreview.style.display = "none";
     }
 
-    this.set("onInsertTemplate", onInsertTemplate);
-    this.set("templatesVisible", true);
+    this.onInsertTemplate = onInsertTemplate;
+    this.templatesVisible = true;
   }
 
   @action
@@ -52,7 +50,7 @@ export default class DTemplatesEditorPreview extends Component {
       elemEditorPreview.style.display = "";
     }
 
-    this.set("templatesVisible", false);
+    this.templatesVisible = false;
   }
 
   <template>


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* CategoriesBoxesWithTopics, WatchedWordUploader
* AdminReportEmotion (discourse-ai)
* ProductItem (discourse-subscriptions)
* DTemplatesEditorPreview (discourse-templates)

`ProductItem` gets an explicit `currentUser` service injection, which it previously received implicitly.

`WatchedWordUploader`'s test reached the component through the `@done` callback's receiver, which a classic component set to itself and a glimmer component sets to `this.args`. It now asserts that the action key reaches the server, which is the contract it meant to check.
