### PR TITLE
UX: separate secondary reviewable actions that don't answer the question posed

### DIFF
--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -500,6 +500,14 @@
   }
 }
 
+.review-item__secondary-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--content-border-color);
+}
+
 .review-resources {
   &__list {
     @include unstyled-list;

--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -39,9 +39,10 @@ module ReviewableActionBuilder
     client_action: nil,
     confirm: false,
     require_reject_reason: false,
+    secondary: false,
     source: nil
   )
-    actions.add(id, bundle: bundle) do |action|
+    actions.add(id, bundle:, secondary:) do |action|
       source ||= type_source
       if source == "core"
         prefix = "reviewables.actions.#{id}"

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -168,7 +168,7 @@ class ReviewableFlaggedPost < Reviewable
     return if !author_silenced?
     return if !guardian.can_unsilence_user?(target_created_by)
 
-    build_action(actions, :unsilence_user, icon: "microphone-slash")
+    build_action(actions, :unsilence_user, icon: "microphone-slash", secondary: true)
   end
 
   def perform_ignore(performed_by, args)

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -49,7 +49,7 @@ class ReviewableUser < Reviewable
     end
 
     if status == "pending" && target&.uploaded_avatar_id.present?
-      build_action(actions, :remove_avatar, icon: "user-xmark")
+      build_action(actions, :remove_avatar, icon: "user-xmark", secondary: true)
     end
 
     if guardian.can_approve?(target)

--- a/app/serializers/reviewable_bundled_action_serializer.rb
+++ b/app/serializers/reviewable_bundled_action_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReviewableBundledActionSerializer < ApplicationSerializer
-  attributes :id, :icon, :label
+  attributes :id, :icon, :label, :secondary
   has_many :actions, serializer: ReviewableActionSerializer, root: "actions"
 
   def label
@@ -14,5 +14,9 @@ class ReviewableBundledActionSerializer < ApplicationSerializer
 
   def include_icon?
     icon.present?
+  end
+
+  def include_secondary?
+    object.secondary
   end
 end

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -39,7 +39,7 @@ import Composer from "discourse/models/composer";
 import { PENDING } from "discourse/models/reviewable";
 import { CLAIMED, UNCLAIMED } from "discourse/models/reviewable-history";
 import Topic from "discourse/models/topic";
-import { eq, not } from "discourse/truth-helpers";
+import { eq, not, or } from "discourse/truth-helpers";
 import DAsyncContent from "discourse/ui-kit/d-async-content";
 import DButton from "discourse/ui-kit/d-button";
 import DHorizontalOverflowNav from "discourse/ui-kit/d-horizontal-overflow-nav";
@@ -230,6 +230,18 @@ export default class ReviewableItem extends Component {
     }
 
     return this.siteSettings?.reviewable_claiming !== "required";
+  }
+
+  get primaryBundles() {
+    return (this.args.reviewable?.bundled_actions ?? []).filter(
+      (bundle) => !bundle.secondary
+    );
+  }
+
+  get secondaryBundles() {
+    return (this.args.reviewable?.bundled_actions ?? []).filter(
+      (bundle) => bundle.secondary
+    );
   }
 
   get tagCategoryId() {
@@ -865,7 +877,7 @@ export default class ReviewableItem extends Component {
                     @label="review.cancel"
                   />
                 {{else}}
-                  {{#each @reviewable.bundled_actions as |bundle|}}
+                  {{#each this.primaryBundles as |bundle|}}
                     <ReviewableBundledAction
                       @authorPenalties={{@reviewable.author_penalties}}
                       @bundle={{bundle}}
@@ -874,13 +886,26 @@ export default class ReviewableItem extends Component {
                     />
                   {{/each}}
 
-                  {{#if @reviewable.can_edit}}
-                    <DButton
-                      class="reviewable-action btn-default edit"
-                      @action={{this.edit}}
-                      @disabled={{this.disabled}}
-                      @label="review.edit"
-                    />
+                  {{#if (or this.secondaryBundles.length @reviewable.can_edit)}}
+                    <div class="review-item__secondary-actions">
+                      {{#each this.secondaryBundles as |bundle|}}
+                        <ReviewableBundledAction
+                          @authorPenalties={{@reviewable.author_penalties}}
+                          @bundle={{bundle}}
+                          @performAction={{this.perform}}
+                          @reviewableUpdating={{this.disabled}}
+                        />
+                      {{/each}}
+
+                      {{#if @reviewable.can_edit}}
+                        <DButton
+                          class="reviewable-action btn-default edit"
+                          @action={{this.edit}}
+                          @disabled={{this.disabled}}
+                          @label="review.edit"
+                        />
+                      {{/if}}
+                    </div>
                   {{/if}}
                 {{/if}}
               </div>

--- a/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
@@ -177,6 +177,31 @@ module("Integration | Component | Reviewable | Item", function (hooks) {
     assert.dom(".review-item__aside-title").hasText("Moderator actions");
   });
 
+  test("lists secondary actions below the answers to the context question", async function (assert) {
+    const pending = userReviewable(this, {
+      bundled_actions: [
+        actionBundle("approve_user", "Yes"),
+        { ...actionBundle("remove_avatar", "Remove avatar"), secondary: true },
+        actionBundle("delete_user", "No"),
+      ],
+    });
+
+    await render(
+      <template><ReviewableItem @reviewable={{pending}} /></template>
+    );
+
+    const answers = [
+      ...document.querySelectorAll(
+        ".review-item__moderator-actions > .reviewable-action"
+      ),
+    ].map((button) => button.textContent.trim());
+
+    assert.deepEqual(answers, ["Yes", "No"], "the answers stay together");
+    assert
+      .dom(".review-item__secondary-actions .reviewable-action")
+      .hasText("Remove avatar", "the secondary action is set apart");
+  });
+
   test("does not render help resources when not required", async function (assert) {
     await render(
       <template><ReviewableItem @reviewable={{reviewable}} /></template>

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -22,12 +22,15 @@ class Reviewable < ActiveRecord::Base
     end
 
     class Bundle < Item
-      attr_accessor :icon, :label, :actions
+      attr_accessor :icon, :label, :actions, :secondary
 
-      def initialize(id, icon: nil, label: nil)
+      # A secondary bundle holds actions that don't resolve the reviewable, so
+      # the client lists them apart from the answers to its context question.
+      def initialize(id, icon: nil, label: nil, secondary: false)
         super(id)
         @icon = icon
         @label = label
+        @secondary = secondary
         @actions = []
       end
 
@@ -71,8 +74,8 @@ class Reviewable < ActiveRecord::Base
       end
     end
 
-    def add_bundle(id, icon: nil, label: nil)
-      bundle = Bundle.new(id, icon: icon, label: label)
+    def add_bundle(id, icon: nil, label: nil, secondary: false)
+      bundle = Bundle.new(id, icon:, label:, secondary:)
       @bundles << bundle
       bundle
     end
@@ -81,14 +84,14 @@ class Reviewable < ActiveRecord::Base
     # id-keyed collection for the whole queue. Two reviewables offering the same
     # action would otherwise collapse into a single record, and every one of
     # them would render the last copy. Bundle ids are scoped by their callers.
-    def add(id, bundle: nil)
+    def add(id, bundle: nil, secondary: false)
       action_name = [reviewable.target_type&.underscore, id].compact_blank.join("-")
       scoped_id = [reviewable.id, action_name].compact_blank.join("-")
       action = Actions.common_actions[action_name] || Action.new(scoped_id)
       yield action if block_given?
       @content << action
 
-      bundle ||= add_bundle(scoped_id)
+      bundle ||= add_bundle(scoped_id, secondary:)
       bundle.actions << action
     end
   end

--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -109,7 +109,7 @@ module Chat
       return if !chat_message_creator&.silenced?
       return if !guardian.can_unsilence_user?(chat_message_creator)
 
-      build_action(actions, :unsilence_user, icon: "microphone-slash")
+      build_action(actions, :unsilence_user, icon: "microphone-slash", secondary: true)
     end
 
     def penalty_effect_for(action_id)

--- a/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
@@ -168,6 +168,12 @@ RSpec.describe Chat::ReviewableMessage, type: :model do
         expect(I18n.t(action.completed_message)).to eq("Author unsilenced.")
       end
 
+      it "is set apart from the actions that resolve the flag" do
+        secondary_bundles = reviewable.actions_for(moderator.guardian).bundles.select(&:secondary)
+
+        expect(secondary_bundles.flat_map(&:actions).map(&:server_action)).to eq(["unsilence_user"])
+      end
+
       it "is not offered to a user who cannot unsilence the author" do
         expect(unsilence_action(Fabricate(:user).guardian)).to eq(nil)
       end

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -560,6 +560,14 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(reviewable.reload.actions_for(guardian).has?(:unsilence_user)).to eq(true)
     end
 
+    it "is set apart from the actions that resolve the reviewable" do
+      UserSilencer.silence(author, moderator, post_id: flagged_post.id)
+
+      secondary_bundles = reviewable.reload.actions_for(guardian).bundles.select(&:secondary)
+
+      expect(secondary_bundles.flat_map(&:actions).map(&:server_action)).to eq(["unsilence_user"])
+    end
+
     it "is offered even when the silence is not linked to this post" do
       other_post = Fabricate(:post, user: author)
       UserSilencer.silence(author, moderator, post_id: other_post.id)

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -286,6 +286,12 @@ RSpec.describe ReviewableUser, type: :model do
 
         expect(reviewable.actions_for(Guardian.new(moderator)).has?(:remove_avatar)).to eq(false)
       end
+
+      it "is set apart from the approve and reject answers" do
+        secondary_bundles = reviewable.actions_for(moderator.guardian).bundles.select(&:secondary)
+
+        expect(secondary_bundles.flat_map(&:actions).map(&:server_action)).to eq(["remove_avatar"])
+      end
     end
 
     context "when approving" do

--- a/spec/serializers/reviewable_bundled_action_serializer_spec.rb
+++ b/spec/serializers/reviewable_bundled_action_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe ReviewableBundledActionSerializer do
+  fab!(:admin)
+  fab!(:reviewable, :reviewable_user)
+
+  it "includes the secondary flag only on secondary bundles" do
+    reviewable.target.update!(uploaded_avatar_id: Fabricate(:upload).id)
+
+    json =
+      reviewable
+        .actions_for(admin.guardian)
+        .bundles
+        .map { |bundle| described_class.new(bundle, root: false).as_json }
+
+    expect(json.select { |bundle| bundle.key?(:secondary) }).to contain_exactly(
+      include(id: "#{reviewable.id}-user-remove_avatar", secondary: true),
+    )
+  end
+end


### PR DESCRIPTION
We introduced some additional review queue actions that don't follow the pattern of:

> "is this content x?" 
> [yes] 
> [no] 

and the positioning can be a little odd: 

<img width="2176" height="518" alt="image" src="https://github.com/user-attachments/assets/39ff407d-8e5b-45ff-ac35-ae1d7aa29b8e" />


This PR introduces the concept of secondary actions, which create a group below the primary question-relative options.


<img width="1090" height="375" alt="image" src="https://github.com/user-attachments/assets/94f921ef-f186-40ef-af84-80783e35cdfd" />

