### PR TITLE
FIX: Update avatar when regenerating username

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -658,7 +658,16 @@ class UsersController < ApplicationController
       )
     end
 
-    render json: { username: }
+    # Keep a chosen avatar intact. Otherwise return the avatar derived from the
+    # suggestion so account-setup screens can update their preview immediately.
+    avatar_template =
+      if current_user&.uploaded_avatar_id
+        current_user.avatar_template
+      else
+        User.default_template(username)
+      end
+
+    render json: { username:, avatar_template: }
   end
 
   def check_email

--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -435,6 +435,7 @@ export default class CodeLoginForm extends Component {
       }
 
       this.username = result.username;
+      this.avatarTemplate = result.avatar_template;
       this.usernameError = null;
       this.usernameAvailable = false;
       await this.checkUsernameAvailability();

--- a/frontend/discourse/tests/integration/components/code-login-form-test.gjs
+++ b/frontend/discourse/tests/integration/components/code-login-form-test.gjs
@@ -372,17 +372,24 @@ module("Integration | Component | CodeLoginForm", function (hooks) {
       })
     );
     pretender.get("/u/random-username.json", () =>
-      response({ username: "QuietFalcon" })
+      response({
+        username: "QuietFalcon",
+        avatar_template: "/letter/q.png",
+      })
     );
 
     await goToCodeStep();
     await fillIn(".d-otp-input", "123456");
 
     assert.dom("#code-login-username").hasValue("jane");
+    assert.dom(".code-login-form__avatar img").hasAttribute("src", /letter\/j/);
 
     await click(".code-login-form__username-regen");
 
     assert.dom("#code-login-username").hasValue("QuietFalcon");
+    assert
+      .dom(".code-login-form__avatar img")
+      .hasAttribute("src", /letter\/q/, "the avatar follows the new username");
     assert.dom(".code-login-form__continue-to-site").isEnabled();
   });
 
@@ -399,7 +406,7 @@ module("Integration | Component | CodeLoginForm", function (hooks) {
     // The default pretender handler reports the username "taken" as
     // unavailable with the suggestion "nottaken".
     pretender.get("/u/random-username.json", () =>
-      response({ username: "taken" })
+      response({ username: "taken", avatar_template: "/letter/t.png" })
     );
 
     await goToCodeStep();

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2413,7 +2413,21 @@ RSpec.describe UsersController do
       get "/u/random-username.json"
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body["username"]).to match(/\A[A-Z][a-z]+[A-Z][a-z]+\d+\z/)
+      username = response.parsed_body["username"]
+      expect(username).to match(/\A[A-Z][a-z]+[A-Z][a-z]+\d+\z/)
+      expect(response.parsed_body["avatar_template"]).to eq(User.default_template(username))
+    end
+
+    it "keeps an uploaded avatar when generating a username" do
+      user = Fabricate(:user)
+      upload = Fabricate(:upload, user:)
+      user.update!(uploaded_avatar_id: upload.id)
+      sign_in(user)
+
+      get "/u/random-username.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["avatar_template"]).to eq(user.avatar_template)
     end
 
     it "rate limits requests per IP" do


### PR DESCRIPTION
**Previously**, rolling a new username on the account-ready screen left the avatar showing the original username's letter.

**In this update**, the random username response includes its matching avatar template and the account-ready screen applies both together while preserving uploaded avatars.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/3dd544b8-f4a2-4410-b4d7-76ce57242ff6) | ![after](https://github.com/user-attachments/assets/e8de391c-28ce-4e3e-9ea6-a19bb8b34e14) |