### PR TITLE
UX: Show the original Ask AI query in filtered results

### DIFF
--- a/app/assets/stylesheets/common/components/topic-query-filter.scss
+++ b/app/assets/stylesheets/common/components/topic-query-filter.scss
@@ -6,6 +6,46 @@
   width: 100%;
   gap: var(--space-2);
 
+  &__query {
+    @include form-item-sizing;
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    gap: var(--space-3);
+    padding-inline: 2.25em 0.75em;
+    color: var(--primary);
+    background: var(--d-input-bg-color);
+    border: var(--d-input-border);
+    border-color: var(--primary-low-mid);
+    border-radius: var(--d-input-border-radius);
+    transition:
+      border-color 0.15s,
+      box-shadow 0.15s;
+
+    &:hover {
+      color: var(--primary);
+    }
+
+    &:focus-visible {
+      border-color: var(--tertiary);
+      outline: 2px solid var(--tertiary);
+      outline-offset: 1px;
+      box-shadow: inset 0 0 0 1px var(--tertiary);
+    }
+  }
+
+  &__query-text {
+    overflow-wrap: anywhere;
+  }
+
+  &__reset {
+    margin-inline-start: auto;
+    flex-shrink: 0;
+    color: var(--primary-medium);
+  }
+
   &__label {
     background-color: var(--primary-low);
     display: flex;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5871,6 +5871,8 @@ en:
       with_category: "%{filter} %{category} topics"
       filter:
         title: "Filtered results for %{filter}"
+        results_for: "Results for: %{query}"
+        reset: "reset"
         button:
           label: "Filter"
       latest:

--- a/frontend/discourse/app/components/discovery/filter-navigation.gjs
+++ b/frontend/discourse/app/components/discovery/filter-navigation.gjs
@@ -1,4 +1,6 @@
 import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import BulkSelectToggle from "discourse/components/bulk-select-toggle";
 import FilterNavigationMenu from "discourse/components/discovery/filter-navigation-menu";
@@ -7,6 +9,8 @@ import bodyClass from "discourse/helpers/body-class";
 import { bind } from "discourse/lib/decorators";
 import { resettableTracked } from "discourse/lib/tracked-tools";
 import { applyValueTransformer } from "discourse/lib/transformer";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
 
 export default class DiscoveryFilterNavigation extends Component {
   @service site;
@@ -21,6 +25,10 @@ export default class DiscoveryFilterNavigation extends Component {
     );
 
     return this.args.canBulkSelect && (this.site.mobileView || enableOnDesktop);
+  }
+
+  get title() {
+    return this.args.title?.trim();
   }
 
   @bind
@@ -43,11 +51,27 @@ export default class DiscoveryFilterNavigation extends Component {
           </div>
         {{/if}}
 
-        <FilterNavigationMenu
-          @initialInputValue={{this.filterQueryString}}
-          @onChange={{this.updateQueryString}}
-          @tips={{@tips}}
-        />
+        {{#if this.title}}
+          <LinkTo
+            class="topic-query-filter__query"
+            @query={{hash q="" title=""}}
+            @route="discovery.filter"
+          >
+            {{dIcon "filter" class="topic-query-filter__icon"}}
+            <span class="topic-query-filter__query-text">
+              {{i18n "filters.filter.results_for" query=this.title}}
+            </span>
+            <span class="topic-query-filter__reset">
+              {{i18n "filters.filter.reset"}}
+            </span>
+          </LinkTo>
+        {{else}}
+          <FilterNavigationMenu
+            @initialInputValue={{this.filterQueryString}}
+            @onChange={{this.updateQueryString}}
+            @tips={{@tips}}
+          />
+        {{/if}}
 
         <PluginOutlet @name="after-filter-navigation-menu" />
       </div>

--- a/frontend/discourse/app/components/discovery/filter-navigation.gjs
+++ b/frontend/discourse/app/components/discovery/filter-navigation.gjs
@@ -27,8 +27,8 @@ export default class DiscoveryFilterNavigation extends Component {
     return this.args.canBulkSelect && (this.site.mobileView || enableOnDesktop);
   }
 
-  get title() {
-    return this.args.title?.trim();
+  get queryLabel() {
+    return this.args.queryLabel?.trim();
   }
 
   @bind
@@ -51,15 +51,15 @@ export default class DiscoveryFilterNavigation extends Component {
           </div>
         {{/if}}
 
-        {{#if this.title}}
+        {{#if this.queryLabel}}
           <LinkTo
             class="topic-query-filter__query"
-            @query={{hash q="" title=""}}
+            @query={{hash q="" query_label=""}}
             @route="discovery.filter"
           >
             {{dIcon "filter" class="topic-query-filter__icon"}}
             <span class="topic-query-filter__query-text">
-              {{i18n "filters.filter.results_for" query=this.title}}
+              {{i18n "filters.filter.results_for" query=this.queryLabel}}
             </span>
             <span class="topic-query-filter__reset">
               {{i18n "filters.filter.reset"}}

--- a/frontend/discourse/app/controllers/discovery/filter.js
+++ b/frontend/discourse/app/controllers/discovery/filter.js
@@ -5,8 +5,9 @@ import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 
 export default class extends Controller {
   @tracked q = "";
+  @tracked title = "";
 
-  queryParams = ["q"];
+  queryParams = ["q", "title"];
   bulkSelectHelper = new BulkSelectHelper(this);
 
   get canBulkSelect() {

--- a/frontend/discourse/app/controllers/discovery/filter.js
+++ b/frontend/discourse/app/controllers/discovery/filter.js
@@ -5,9 +5,9 @@ import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 
 export default class extends Controller {
   @tracked q = "";
-  @tracked title = "";
+  @tracked query_label = "";
 
-  queryParams = ["q", "title"];
+  queryParams = ["q", "query_label"];
   bulkSelectHelper = new BulkSelectHelper(this);
 
   get canBulkSelect() {

--- a/frontend/discourse/app/routes/discovery/filter.js
+++ b/frontend/discourse/app/routes/discovery/filter.js
@@ -20,7 +20,8 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
   }
 
   titleToken() {
-    const query = this.paramsFor(this.routeName).q;
+    const { q, title } = this.paramsFor(this.routeName);
+    const query = title?.trim() || q;
     return i18n("filters.filter.title", { filter: escapeExpression(query) });
   }
 }

--- a/frontend/discourse/app/routes/discovery/filter.js
+++ b/frontend/discourse/app/routes/discovery/filter.js
@@ -20,8 +20,8 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
   }
 
   titleToken() {
-    const { q, title } = this.paramsFor(this.routeName);
-    const query = title?.trim() || q;
+    const { q, query_label } = this.paramsFor(this.routeName);
+    const query = query_label?.trim() || q;
     return i18n("filters.filter.title", { filter: escapeExpression(query) });
   }
 }

--- a/frontend/discourse/app/templates/discovery/filter.gjs
+++ b/frontend/discourse/app/templates/discovery/filter.gjs
@@ -8,9 +8,9 @@ export default <template>
       <FilterNavigation
         @bulkSelectHelper={{@controller.bulkSelectHelper}}
         @canBulkSelect={{@controller.canBulkSelect}}
+        @queryLabel={{@controller.query_label}}
         @queryString={{@controller.q}}
         @tips={{@controller.model.topic_list.filter_option_info}}
-        @title={{@controller.title}}
         @updateTopicsListQueryParams={{@controller.updateTopicsListQueryParams}}
       />
     </:navigation>

--- a/frontend/discourse/app/templates/discovery/filter.gjs
+++ b/frontend/discourse/app/templates/discovery/filter.gjs
@@ -10,6 +10,7 @@ export default <template>
         @canBulkSelect={{@controller.canBulkSelect}}
         @queryString={{@controller.q}}
         @tips={{@controller.model.topic_list.filter_option_info}}
+        @title={{@controller.title}}
         @updateTopicsListQueryParams={{@controller.updateTopicsListQueryParams}}
       />
     </:navigation>

--- a/frontend/discourse/tests/acceptance/discovery-filter-test.js
+++ b/frontend/discourse/tests/acceptance/discovery-filter-test.js
@@ -17,14 +17,16 @@ acceptance("Discovery filter", function (needs) {
     });
   });
 
-  test("a titled filter can be reset to the normal filter view", async function (assert) {
-    const title = 'Questions about <plants> & "gardens"?';
-    await visit(`/filter?q=topic%3A11557&title=${encodeURIComponent(title)}`);
+  test("a labeled filter can be reset to the normal filter view", async function (assert) {
+    const queryLabel = 'Questions about <plants> & "gardens"?';
+    await visit(
+      `/filter?q=topic%3A11557&query_label=${encodeURIComponent(queryLabel)}`
+    );
 
     assert
       .dom(".topic-query-filter__query-text")
       .hasText(
-        `Results for: ${title}`,
+        `Results for: ${queryLabel}`,
         "the original query is displayed as text"
       );
     assert
@@ -63,7 +65,7 @@ acceptance("Discovery filter", function (needs) {
     );
   });
 
-  test("filters without a title keep the editable input", async function (assert) {
+  test("filters without a query label keep the editable input", async function (assert) {
     await visit("/filter?q=topic%3A11557");
 
     assert
@@ -74,8 +76,8 @@ acceptance("Discovery filter", function (needs) {
       .doesNotExist("ordinary filters have no query label");
   });
 
-  test("a blank title keeps the editable input", async function (assert) {
-    await visit("/filter?q=topic%3A11557&title=%20%20");
+  test("a blank query label keeps the editable input", async function (assert) {
+    await visit("/filter?q=topic%3A11557&query_label=%20%20");
 
     assert
       .dom(".topic-query-filter__filter-term")

--- a/frontend/discourse/tests/acceptance/discovery-filter-test.js
+++ b/frontend/discourse/tests/acceptance/discovery-filter-test.js
@@ -1,0 +1,87 @@
+import { click, currentURL, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Discovery filter", function (needs) {
+  let queries;
+
+  needs.hooks.beforeEach(() => {
+    queries = [];
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/filter.json", (request) => {
+      queries.push(request.queryParams.q);
+      return helper.response(discoveryFixtures["/latest.json"]);
+    });
+  });
+
+  test("a titled filter can be reset to the normal filter view", async function (assert) {
+    const title = 'Questions about <plants> & "gardens"?';
+    await visit(`/filter?q=topic%3A11557&title=${encodeURIComponent(title)}`);
+
+    assert
+      .dom(".topic-query-filter__query-text")
+      .hasText(
+        `Results for: ${title}`,
+        "the original query is displayed as text"
+      );
+    assert
+      .dom(".topic-query-filter__query-text plants")
+      .doesNotExist("the query label does not interpret markup");
+    assert
+      .dom(".topic-query-filter__filter-term")
+      .doesNotExist("the raw filter input is hidden");
+    assert.strictEqual(
+      queries.at(-1),
+      "topic:11557",
+      "the topic filter is sent to the server"
+    );
+
+    assert
+      .dom(".topic-query-filter__query .topic-query-filter__reset")
+      .hasText("reset", "the reset label is inside the clickable bar");
+
+    await click(".topic-query-filter__query-text");
+
+    assert.strictEqual(
+      currentURL(),
+      "/filter",
+      "reset clears both query parameters"
+    );
+    assert
+      .dom(".topic-query-filter__query")
+      .doesNotExist("reset removes the query label");
+    assert
+      .dom(".topic-query-filter__filter-term")
+      .hasValue("", "reset restores an empty filter input");
+    assert.strictEqual(
+      queries.at(-1),
+      "",
+      "reset reloads the unfiltered topics"
+    );
+  });
+
+  test("filters without a title keep the editable input", async function (assert) {
+    await visit("/filter?q=topic%3A11557");
+
+    assert
+      .dom(".topic-query-filter__filter-term")
+      .hasValue("topic:11557", "ordinary filters remain editable");
+    assert
+      .dom(".topic-query-filter__query")
+      .doesNotExist("ordinary filters have no query label");
+  });
+
+  test("a blank title keeps the editable input", async function (assert) {
+    await visit("/filter?q=topic%3A11557&title=%20%20");
+
+    assert
+      .dom(".topic-query-filter__filter-term")
+      .hasValue("topic:11557", "whitespace does not hide the filter");
+    assert
+      .dom(".topic-query-filter__reset")
+      .doesNotExist("there is no query label to reset");
+  });
+});

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-search-discoveries.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-search-discoveries.gjs
@@ -205,7 +205,7 @@ export default class AiSearchDiscoveries extends Component {
   get fullSearchUrl() {
     const topicFilter = `topic:${this.candidateTopicIds.join(",")}`;
     return getURL(
-      `/filter?q=${encodeURIComponent(topicFilter)}&title=${encodeURIComponent(this.query)}`
+      `/filter?q=${encodeURIComponent(topicFilter)}&query_label=${encodeURIComponent(this.query)}`
     );
   }
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-search-discoveries.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-search-discoveries.gjs
@@ -204,7 +204,9 @@ export default class AiSearchDiscoveries extends Component {
 
   get fullSearchUrl() {
     const topicFilter = `topic:${this.candidateTopicIds.join(",")}`;
-    return getURL(`/filter?q=${encodeURIComponent(topicFilter)}`);
+    return getURL(
+      `/filter?q=${encodeURIComponent(topicFilter)}&title=${encodeURIComponent(this.query)}`
+    );
   }
 
   get canContinueConversation() {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-search-discoveries-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-search-discoveries-test.gjs
@@ -497,7 +497,7 @@ module("Integration | Component | AiSearchDiscoveries", function (hooks) {
       .dom(".ai-discovery-sources__all-results")
       .hasAttribute(
         "href",
-        "/filter?q=topic%3A101%2C102%2C103%2C104",
+        "/filter?q=topic%3A101%2C102%2C103%2C104&title=miyazaki",
         "the full topic list contains every retrieval candidate"
       );
     assert.strictEqual(

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-search-discoveries-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-search-discoveries-test.gjs
@@ -497,7 +497,7 @@ module("Integration | Component | AiSearchDiscoveries", function (hooks) {
       .dom(".ai-discovery-sources__all-results")
       .hasAttribute(
         "href",
-        "/filter?q=topic%3A101%2C102%2C103%2C104&title=miyazaki",
+        "/filter?q=topic%3A101%2C102%2C103%2C104&query_label=miyazaki",
         "the full topic list contains every retrieval candidate"
       );
     assert.strictEqual(


### PR DESCRIPTION
Previously, Ask AI links exposed a long list of topic IDs in the filter input.

This change displays “Results for: QUERY” in a clickable bar that resets the filter.

<img width="1326" height="776" alt="image" src="https://github.com/user-attachments/assets/fc8c6514-a46a-480d-96ff-9081e7518846" />
