### PR TITLE
DEV: Convert 5 components to glimmer

### DIFF
--- a/frontend/discourse/app/components/group-manage-logs-filter.gjs
+++ b/frontend/discourse/app/components/group-manage-logs-filter.gjs
@@ -1,30 +1,24 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { concat, fn } from "@ember/helper";
-import { computed } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class GroupManageLogsFilter extends Component {
-  @computed("type")
   get label() {
-    return i18n(`groups.manage.logs.${this.type}`);
+    return i18n(`groups.manage.logs.${this.args.type}`);
   }
 
-  @computed("value", "type")
   get filterText() {
-    return this.type === "action"
-      ? i18n(`group_histories.actions.${this.value}`)
-      : this.value;
+    return this.args.type === "action"
+      ? i18n(`group_histories.actions.${this.args.value}`)
+      : this.args.value;
   }
 
   <template>
-    {{#if this.value}}
+    {{#if @value}}
       <DButton
         class="btn-default group-manage-logs-filter"
-        @action={{fn this.clearFilter this.type}}
+        @action={{fn @clearFilter @type}}
         @icon="circle-xmark"
         @translatedLabel={{concat this.label ": " this.filterText}}
       />

--- a/frontend/discourse/app/components/group-manage-logs-row.gjs
+++ b/frontend/discourse/app/components/group-manage-logs-row.gjs
@@ -1,25 +1,23 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
-import { action } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
+import { action, set } from "@ember/object";
 import DButton from "discourse/ui-kit/d-button";
 import dAgeWithTooltip from "discourse/ui-kit/helpers/d-age-with-tooltip";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class GroupManageLogsRow extends Component {
-  expandDetails = false;
+  @tracked expandDetails = false;
 
   @action
   toggleDetails() {
-    this.toggleProperty("expandDetails");
+    this.expandDetails = !this.expandDetails;
   }
 
   @action
   filter(params) {
-    this.set(`filters.${params.key}`, params.value);
+    set(this.args.filters, params.key, params.value);
   }
 
   <template>
@@ -27,54 +25,51 @@ export default class GroupManageLogsRow extends Component {
       <td>
         <DButton
           class="btn-default"
-          @action={{fn this.filter (hash value=this.log.action key="action")}}
-          @translatedLabel={{this.log.actionTitle}}
+          @action={{fn this.filter (hash value=@log.action key="action")}}
+          @translatedLabel={{@log.actionTitle}}
         />
       </td>
 
       <td>
-        <span>{{dAvatar this.log.acting_user imageSize="tiny"}}</span>
+        <span>{{dAvatar @log.acting_user imageSize="tiny"}}</span>
         <DButton
           class="btn-default"
           @action={{fn
             this.filter
-            (hash value=this.log.acting_user.username key="acting_user")
+            (hash value=@log.acting_user.username key="acting_user")
           }}
-          @translatedLabel={{this.log.acting_user.username}}
+          @translatedLabel={{@log.acting_user.username}}
         />
       </td>
 
       <td>
-        {{#if this.log.target_user}}
-          <span>{{dAvatar this.log.target_user imageSize="tiny"}}</span>
+        {{#if @log.target_user}}
+          <span>{{dAvatar @log.target_user imageSize="tiny"}}</span>
           <DButton
             class="btn-default"
             @action={{fn
               this.filter
-              (hash value=this.log.target_user.username key="target_user")
+              (hash value=@log.target_user.username key="target_user")
             }}
-            @translatedLabel={{this.log.target_user.username}}
+            @translatedLabel={{@log.target_user.username}}
           />
         {{/if}}
       </td>
 
       <td>
-        {{#if this.log.subject}}
+        {{#if @log.subject}}
           <DButton
             class="btn-default"
-            @action={{fn
-              this.filter
-              (hash value=this.log.subject key="subject")
-            }}
-            @translatedLabel={{this.log.subject}}
+            @action={{fn this.filter (hash value=@log.subject key="subject")}}
+            @translatedLabel={{@log.subject}}
           />
         {{/if}}
       </td>
 
-      <td>{{dAgeWithTooltip this.log.created_at format="medium"}}</td>
+      <td>{{dAgeWithTooltip @log.created_at format="medium"}}</td>
 
       <td class="group-manage-logs-expand-details">
-        {{#if this.log.prev_value}}
+        {{#if @log.prev_value}}
           <DButton
             class="btn-default"
             @action={{this.toggleDetails}}
@@ -89,12 +84,12 @@ export default class GroupManageLogsRow extends Component {
         <td colspan="6">
           <p>
             <strong>{{i18n "groups.manage.logs.from"}}</strong>:
-            <code>{{this.log.prev_value}}</code>
+            <code>{{@log.prev_value}}</code>
           </p>
 
           <p>
             <strong>{{i18n "groups.manage.logs.to"}}</strong>:
-            <code>{{this.log.new_value}}</code>
+            <code>{{@log.new_value}}</code>
           </p>
         </td>
       </tr>

--- a/frontend/discourse/app/components/selected-posts.gjs
+++ b/frontend/discourse/app/components/selected-posts.gjs
@@ -1,80 +1,76 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
 import { on } from "@ember/modifier";
-import { tagName } from "@ember-decorators/component";
 import routeAction from "discourse/helpers/route-action";
 import DButton from "discourse/ui-kit/d-button";
 import DCountI18n from "discourse/ui-kit/d-count-i18n";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
-export default class SelectedPosts extends Component {
-  <template>
-    <div ...attributes>
+const SelectedPosts = <template>
+  <div ...attributes>
+    <p>
+      <DCountI18n
+        @count={{@selectedPostsCount}}
+        @key="topic.multi_select.description"
+      />
+    </p>
+
+    {{#if @canSelectAll}}
       <p>
-        <DCountI18n
-          @count={{this.selectedPostsCount}}
-          @key="topic.multi_select.description"
-        />
-      </p>
-
-      {{#if this.canSelectAll}}
-        <p>
-          <a class="select-all" href {{on "click" this.selectAll}}>
-            {{i18n "topic.multi_select.select_all"}}
-          </a>
-        </p>
-      {{/if}}
-
-      {{#if this.canDeselectAll}}
-        <p>
-          <a href {{on "click" this.deselectAll}}>
-            {{i18n "topic.multi_select.deselect_all"}}
-          </a>
-        </p>
-      {{/if}}
-
-      {{#if this.canDeleteSelected}}
-        <DButton
-          class="btn-danger"
-          @action={{this.deleteSelected}}
-          @icon="trash-can"
-          @label="topic.multi_select.delete"
-        />
-      {{/if}}
-
-      {{#if this.canMergeTopic}}
-        <DButton
-          class="btn-primary move-to-topic"
-          @action={{routeAction "moveToTopic"}}
-          @icon="right-from-bracket"
-          @label="topic.move_to.action"
-        />
-      {{/if}}
-
-      {{#if this.canChangeOwner}}
-        <DButton
-          class="btn-primary"
-          @action={{routeAction "changeOwner"}}
-          @icon="user"
-          @label="topic.change_owner.action"
-        />
-      {{/if}}
-
-      {{#if this.canMergePosts}}
-        <DButton
-          class="btn-primary"
-          @action={{this.mergePosts}}
-          @icon="up-down"
-          @label="topic.merge_posts.action"
-        />
-      {{/if}}
-
-      <p class="cancel">
-        <a href {{on "click" this.toggleMultiSelect}}>
-          {{i18n "topic.multi_select.cancel"}}
+        <a class="select-all" href {{on "click" @selectAll}}>
+          {{i18n "topic.multi_select.select_all"}}
         </a>
       </p>
-    </div>
-  </template>
-}
+    {{/if}}
+
+    {{#if @canDeselectAll}}
+      <p>
+        <a href {{on "click" @deselectAll}}>
+          {{i18n "topic.multi_select.deselect_all"}}
+        </a>
+      </p>
+    {{/if}}
+
+    {{#if @canDeleteSelected}}
+      <DButton
+        class="btn-danger"
+        @action={{@deleteSelected}}
+        @icon="trash-can"
+        @label="topic.multi_select.delete"
+      />
+    {{/if}}
+
+    {{#if @canMergeTopic}}
+      <DButton
+        class="btn-primary move-to-topic"
+        @action={{routeAction "moveToTopic"}}
+        @icon="right-from-bracket"
+        @label="topic.move_to.action"
+      />
+    {{/if}}
+
+    {{#if @canChangeOwner}}
+      <DButton
+        class="btn-primary"
+        @action={{routeAction "changeOwner"}}
+        @icon="user"
+        @label="topic.change_owner.action"
+      />
+    {{/if}}
+
+    {{#if @canMergePosts}}
+      <DButton
+        class="btn-primary"
+        @action={{@mergePosts}}
+        @icon="up-down"
+        @label="topic.merge_posts.action"
+      />
+    {{/if}}
+
+    <p class="cancel">
+      <a href {{on "click" @toggleMultiSelect}}>
+        {{i18n "topic.multi_select.cancel"}}
+      </a>
+    </p>
+  </div>
+</template>;
+
+export default SelectedPosts;

--- a/frontend/discourse/app/components/subcategories-with-featured-topics.gjs
+++ b/frontend/discourse/app/components/subcategories-with-featured-topics.gjs
@@ -1,8 +1,6 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
-import { tagName } from "@ember-decorators/component";
 import CategoryTitleLink from "discourse/components/category-title-link";
 import ParentCategoryRow from "discourse/components/parent-category-row";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -10,13 +8,13 @@ import categoryListSubcategories from "discourse/helpers/category-list-subcatego
 import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class SubcategoriesWithFeaturedTopics extends Component {
   @service discovery;
+  @service site;
 
   <template>
     <div ...attributes>
-      {{#each this.categories as |category|}}
+      {{#each @categories as |category|}}
         {{#if this.site.mobileView}}
           <PluginOutlet
             @name="mobile-subcategories-with-featured-topics-list"

--- a/plugins/discourse-gamification/assets/javascripts/discourse/components/gamification-score.gjs
+++ b/plugins/discourse-gamification/assets/javascripts/discourse/components/gamification-score.gjs
@@ -1,11 +1,11 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
-import { tagName } from "@ember-decorators/component";
+import { service } from "@ember/service";
 import fullnumber from "../helpers/fullnumber";
 
-@tagName("")
 export default class GamificationScore extends Component {
+  @service site;
+
   <template>
     <span class="gamification-score" ...attributes>
       {{#if this.site.default_gamification_leaderboard_id}}
@@ -14,10 +14,10 @@ export default class GamificationScore extends Component {
           @model={{this.site.default_gamification_leaderboard_id}}
           @route="gamificationLeaderboard.byName"
         >
-          {{fullnumber this.model.gamification_score}}
+          {{fullnumber @model.gamification_score}}
         </LinkTo>
       {{else}}
-        {{fullnumber this.model.gamification_score}}
+        {{fullnumber @model.gamification_score}}
       {{/if}}
     </span>
   </template>


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* GroupManageLogsFilter, GroupManageLogsRow, SelectedPosts, SubcategoriesWithFeaturedTopics
* GamificationScore (discourse-gamification)

`SubcategoriesWithFeaturedTopics` and `GamificationScore` get explicit `site` service injections, which they previously received implicitly.

`GroupManageLogsRow` writes into the `@filters` object with a dynamic key, so it keeps using `set` rather than plain assignment.
