### PR TITLE
UX: keep unresolved review queue items in queue after taking action

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -433,18 +433,19 @@ class Reviewable < ActiveRecord::Base
       result.affected_reviewable_ids |= resolved_reviewable_ids(affected_candidate_ids)
     end
 
-    unless status == :pending
-      if update_count || result.remove_reviewable_ids.present?
-        Jobs.enqueue(
-          :notify_reviewable,
-          reviewable_id: id,
-          performing_username: performed_by.username,
-          updated_reviewable_ids: result.remove_reviewable_ids,
-        )
-      end
+    # An action that leaves the reviewable pending didn't resolve it, so it stays in the queue.
+    result.remove_reviewable_ids -= [id] if pending?
 
-      notify_users(result, guardian)
+    if update_count || result.remove_reviewable_ids.present?
+      Jobs.enqueue(
+        :notify_reviewable,
+        reviewable_id: id,
+        performing_username: performed_by.username,
+        updated_reviewable_ids: result.remove_reviewable_ids,
+      )
     end
+
+    notify_users(result, guardian)
 
     result
   end

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -178,7 +178,7 @@ class ReviewableFlaggedPost < Reviewable
   def perform_unsilence_user(performed_by, _args)
     UserSilencer.unsilence(target_user, performed_by, reviewable_id: id)
 
-    create_result(:success) { |result| result.remove_reviewable_ids = [] }
+    create_result(:success)
   end
 
   def perform_unsilence_user_and_ignore(performed_by, args)

--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -155,7 +155,7 @@ module Chat
     def perform_unsilence_user(performed_by, _args)
       UserSilencer.unsilence(chat_message_creator, performed_by, reviewable_id: id)
 
-      create_result(:success) { |result| result.remove_reviewable_ids = [] }
+      create_result(:success)
     end
 
     def perform_delete_and_ignore(performed_by, args)

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -620,6 +620,20 @@ RSpec.describe Reviewable, type: :model do
       )
     end
 
+    it "keeps the reviewable in the queue when the action leaves it pending" do
+      reviewable =
+        PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post).reviewable
+      UserSilencer.silence(post.user, moderator, post_id: post.id)
+
+      perform_result = nil
+      expect { perform_result = reviewable.perform(moderator, :unsilence_user) }.not_to change {
+        Jobs::NotifyReviewable.jobs.size
+      }
+
+      expect(reviewable.reload).to be_pending
+      expect(perform_result.remove_reviewable_ids).to be_empty
+    end
+
     it "triggers a notification on approve -> reject to update status" do
       reviewable = Fabricate(:reviewable_queued_post, status: Reviewable.statuses[:approved])
 


### PR DESCRIPTION
We've got some secondary actions like "remove avatar" and "unsilence user" in the review queue now, but the interaction is a little odd because "remove avatar" doesn't resolve the flag, but the actions will be hidden until refresh. 

This PR adjusts these so the secondary actions don't hide the primary actions, so the flag can still be resolved without a refresh. 

Before

https://github.com/user-attachments/assets/38e5ecab-ff1d-4200-b5f5-9ef11475f3fa




After 


https://github.com/user-attachments/assets/8f830358-7064-4090-b12b-f58d6a61cbc3

