### PR TITLE
DEV: Convert 5 components to glimmer

### DIFF
--- a/frontend/discourse/app/components/modal/history/revisions.gjs
+++ b/frontend/discourse/app/components/modal/history/revisions.gjs
@@ -1,11 +1,9 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import EmberObject from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
-import { tagName } from "@ember-decorators/component";
 import LinksRedirect from "discourse/components/links-redirect";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -24,39 +22,38 @@ function tagClasses(tagChanges, state, className) {
   }, {});
 }
 
-@tagName("")
 export default class Revisions extends Component {
   @service languageNameLookup;
 
   get fakePreviousTagsTopic() {
     // discourseTags expects a topic structure
     return EmberObject.create({
-      tags: (this.get("previousTagChanges") || []).map((tag) => tag.name),
+      tags: (this.args.previousTagChanges || []).map((tag) => tag.name),
     });
   }
 
   get previousTagClassesMap() {
-    return tagClasses(this.get("previousTagChanges"), "deleted", "diff-del");
+    return tagClasses(this.args.previousTagChanges, "deleted", "diff-del");
   }
 
   get fakeCurrentTagsTopic() {
     return EmberObject.create({
-      tags: (this.get("currentTagChanges") || []).map((tag) => tag.name),
+      tags: (this.args.currentTagChanges || []).map((tag) => tag.name),
     });
   }
 
   get currentTagClassesMap() {
-    return tagClasses(this.get("currentTagChanges"), "inserted", "diff-ins");
+    return tagClasses(this.args.currentTagChanges, "inserted", "diff-ins");
   }
 
   get previousLocale() {
-    const locale = this.get("model.locale_changes.previous");
+    const locale = this.args.model?.locale_changes?.previous;
     const language = this.languageNameLookup.getLanguageName(locale);
     return language || i18n("post.revisions.locale.no_locale_set");
   }
 
   get currentLocale() {
-    const locale = this.get("model.locale_changes.current");
+    const locale = this.args.model?.locale_changes?.current;
     const language = this.languageNameLookup.getLanguageName(locale);
     return language || i18n("post.revisions.locale.locale_removed");
   }

--- a/frontend/discourse/app/components/shared-draft-controls.gjs
+++ b/frontend/discourse/app/components/shared-draft-controls.gjs
@@ -1,30 +1,38 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { action, computed } from "@ember/object";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action, get } from "@ember/object";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 import CategoryChooser from "discourse/select-kit/components/category-chooser";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class SharedDraftControls extends Component {
   @service dialog;
+  @service site;
 
-  publishing = false;
+  @tracked publishing = false;
 
-  @computed("topic.destination_category_id")
+  // `destination_category_id` is a plain field on the topic model, so it is only tracked
+  // when read through `get`.
   get validCategory() {
+    if (!this.args.topic) {
+      return false;
+    }
+
+    const destinationCategoryId = get(
+      this.args.topic,
+      "destination_category_id"
+    );
+
     return (
-      this.topic?.destination_category_id &&
-      this.topic?.destination_category_id !==
-        this.site.shared_drafts_category_id
+      destinationCategoryId &&
+      destinationCategoryId !== this.site.shared_drafts_category_id
     );
   }
 
   @action
   updateDestinationCategory(categoryId) {
-    return this.topic.updateDestinationCategory(categoryId);
+    return this.args.topic.updateDestinationCategory(categoryId);
   }
 
   @action
@@ -32,19 +40,19 @@ export default class SharedDraftControls extends Component {
     this.dialog.yesNoConfirm({
       message: i18n("shared_drafts.confirm_publish"),
       didConfirm: () => {
-        this.set("publishing", true);
-        const destinationCategoryId = this.topic.destination_category_id;
-        return this.topic
+        this.publishing = true;
+        const destinationCategoryId = this.args.topic.destination_category_id;
+        return this.args.topic
           .publish()
           .then(() => {
-            this.topic.setProperties({
+            this.args.topic.setProperties({
               category_id: destinationCategoryId,
               destination_category_id: undefined,
               is_shared_draft: false,
             });
           })
           .finally(() => {
-            this.set("publishing", false);
+            this.publishing = false;
           });
       },
     });
@@ -61,7 +69,7 @@ export default class SharedDraftControls extends Component {
           <label>{{i18n "shared_drafts.destination_category"}}</label>
           <CategoryChooser
             @onChange={{this.updateDestinationCategory}}
-            @value={{this.topic.destination_category_id}}
+            @value={{@topic.destination_category_id}}
           />
         </div>
 

--- a/frontend/discourse/app/components/slow-mode-info.gjs
+++ b/frontend/discourse/app/components/slow-mode-info.gjs
@@ -1,7 +1,5 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { action, computed } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { action, get, set } from "@ember/object";
 import { durationTextFromSeconds } from "discourse/helpers/slow-mode";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Topic from "discourse/models/topic";
@@ -9,23 +7,31 @@ import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class SlowModeInfo extends Component {
-  @computed("topic.slow_mode_seconds")
+  // `slow_mode_seconds` and `closed` are plain fields on the topic model, so they are
+  // only tracked when read through `get`.
   get durationText() {
-    return durationTextFromSeconds(this.topic?.slow_mode_seconds);
+    return durationTextFromSeconds(
+      this.args.topic && get(this.args.topic, "slow_mode_seconds")
+    );
   }
 
-  @computed("topic.slow_mode_seconds", "topic.closed")
   get showSlowModeNotice() {
-    return this.topic?.slow_mode_seconds > 0 && !this.topic?.closed;
+    if (!this.args.topic) {
+      return false;
+    }
+
+    return (
+      get(this.args.topic, "slow_mode_seconds") > 0 &&
+      !get(this.args.topic, "closed")
+    );
   }
 
   @action
   disableSlowMode() {
-    Topic.setSlowMode(this.topic.id, 0)
+    Topic.setSlowMode(this.args.topic.id, 0)
       .catch(popupAjaxError)
-      .then(() => this.set("topic.slow_mode_seconds", 0));
+      .then(() => set(this.args.topic, "slow_mode_seconds", 0));
   }
 
   <template>
@@ -40,7 +46,7 @@ export default class SlowModeInfo extends Component {
             }}
           </span>
 
-          {{#if this.user.canManageTopic}}
+          {{#if @user.canManageTopic}}
             <DButton
               class="slow-mode-remove"
               @action={{this.disableSlowMode}}

--- a/frontend/discourse/tests/integration/components/slow-mode-info-test.gjs
+++ b/frontend/discourse/tests/integration/components/slow-mode-info-test.gjs
@@ -1,4 +1,5 @@
-import { render } from "@ember/test-helpers";
+import { set } from "@ember/object";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import SlowModeInfo from "discourse/components/slow-mode-info";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -28,6 +29,22 @@ module("Integration | Component | SlowModeInfo", function (hooks) {
     await render(<template><SlowModeInfo @topic={{this.topic}} /></template>);
 
     assert.dom(".slow-mode-heading").exists();
+  });
+
+  test("hides the notice once slow mode is turned off", async function (assert) {
+    const topic = { slow_mode_seconds: 3600, closed: false };
+    this.set("topic", topic);
+
+    await render(<template><SlowModeInfo @topic={{this.topic}} /></template>);
+
+    assert.dom(".slow-mode-heading").exists("renders the notice");
+
+    set(topic, "slow_mode_seconds", 0);
+    await settled();
+
+    assert
+      .dom(".slow-mode-heading")
+      .doesNotExist("drops the notice when the topic is updated");
   });
 
   test("staff and TL4 users can disable slow mode", async function (assert) {

--- a/plugins/discourse-cakeday/assets/javascripts/discourse/components/emoji-images.gjs
+++ b/plugins/discourse-cakeday/assets/javascripts/discourse/components/emoji-images.gjs
@@ -1,24 +1,21 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { computed } from "@ember/object";
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
-import { tagName } from "@ember-decorators/component";
 import { emojiUnescape } from "discourse/lib/text";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class EmojiImages extends Component {
-  @computed("list")
+  @service siteSettings;
+
   get emojiHTML() {
-    return this.list
+    return this.args.list
       .split("|")
       .map((et) => emojiUnescape(`:${et}:`, { skipTitle: true }));
   }
 
-  @computed("title")
   get titleText() {
-    return i18n(this.title);
+    return i18n(this.args.title);
   }
 
   <template>

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/components/payment-plan.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/components/payment-plan.gjs
@@ -1,8 +1,6 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
-import { action, computed } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
+import { action } from "@ember/object";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
@@ -10,21 +8,18 @@ import formatCurrency from "../helpers/format-currency";
 
 const RECURRING = "recurring";
 
-@tagName("")
 export default class PaymentPlan extends Component {
-  @computed("selectedPlan")
   get selectedClass() {
-    return this.selectedPlan === this.plan.id ? "btn-primary" : "";
+    return this.args.selectedPlan === this.args.plan.id ? "btn-primary" : "";
   }
 
-  @computed("plan.type")
   get recurringPlan() {
-    return this.plan?.type === RECURRING;
+    return this.args.plan?.type === RECURRING;
   }
 
   @action
   planClick() {
-    this.clickPlan(this.plan);
+    this.args.clickPlan(this.args.plan);
     return false;
   }
 
@@ -34,14 +29,14 @@ export default class PaymentPlan extends Component {
         "btn-discourse-subscriptions-subscribe"
         this.selectedClass
       }}
-      @action={{this.planClick}}
+      @action={{@planClick}}
     >
       <span class="interval">
         {{#if this.recurringPlan}}
           {{i18n
             (concat
               "discourse_subscriptions.plans.interval.adverb."
-              this.plan.recurring.interval
+              @plan.recurring.interval
             )
           }}
         {{else}}
@@ -50,7 +45,7 @@ export default class PaymentPlan extends Component {
       </span>
 
       <span class="amount">
-        {{formatCurrency this.plan.currency this.plan.amountDollars}}
+        {{formatCurrency @plan.currency @plan.amountDollars}}
       </span>
     </DButton>
   </template>


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* Revisions, SharedDraftControls, SlowModeInfo
* EmojiImages (discourse-cakeday)
* PaymentPlan (discourse-subscriptions)

`SharedDraftControls` gets an explicit `site` service injection and `EmojiImages` a `siteSettings` one, which they previously received implicitly.

`SlowModeInfo` and `SharedDraftControls` read `slow_mode_seconds`, `closed` and `destination_category_id`, which are plain fields on the topic model rather than tracked ones, so their getters read them through `get`. A new test covers the notice disappearing when slow mode is turned off, which nothing exercised before.
