### PR TITLE
DEV: Convert 10 components to glimmer

### DIFF
--- a/frontend/discourse/admin/components/email-styles-editor.gjs
+++ b/frontend/discourse/admin/components/email-styles-editor.gjs
@@ -1,66 +1,43 @@
-/* eslint-disable ember/no-classic-components */
-import { tracked } from "@glimmer/tracking";
-import Component from "@ember/component";
-import { fn } from "@ember/helper";
-import { action, computed } from "@ember/object";
+import Component from "@glimmer/component";
+import { action, get } from "@ember/object";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 import AceEditor from "discourse/components/ace-editor";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class EmailStylesEditor extends Component {
   @service dialog;
 
-  @tracked _editorIdOverride;
-
-  @computed("fieldName")
-  get editorId() {
-    if (this._editorIdOverride !== undefined) {
-      return this._editorIdOverride;
-    }
-    return this.fieldName;
-  }
-
-  set editorId(value) {
-    this._editorIdOverride = value;
-  }
-
-  @computed("styles", "fieldName")
   get editorContents() {
-    return this.styles[this.fieldName];
+    return get(this.args.styles, this.args.fieldName);
   }
 
-  set editorContents(value) {
-    this.styles.setField(this.fieldName, value);
-  }
-
-  @computed("fieldName")
   get currentEditorMode() {
-    return this.fieldName === "css" ? "scss" : this.fieldName;
+    return this.args.fieldName === "css" ? "scss" : this.args.fieldName;
   }
 
-  @computed("fieldName", "styles.html", "styles.css")
   get resetDisabled() {
     return (
-      this.get(`styles.${this.fieldName}`) ===
-      this.get(`styles.default_${this.fieldName}`)
+      get(this.args.styles, this.args.fieldName) ===
+      get(this.args.styles, `default_${this.args.fieldName}`)
     );
+  }
+
+  @action
+  updateEditorContents(value) {
+    this.args.styles.setField(this.args.fieldName, value);
   }
 
   @action
   reset() {
     this.dialog.yesNoConfirm({
       message: i18n("admin.customize.email_style.reset_confirm", {
-        fieldName: i18n(`admin.customize.email_style.${this.fieldName}`),
+        fieldName: i18n(`admin.customize.email_style.${this.args.fieldName}`),
       }),
       didConfirm: () => {
-        this.styles.setField(
-          this.fieldName,
-          this.styles.get(`default_${this.fieldName}`)
+        this.updateEditorContents(
+          get(this.args.styles, `default_${this.args.fieldName}`)
         );
-        this.notifyPropertyChange("editorContents");
       },
     });
   }
@@ -69,9 +46,9 @@ export default class EmailStylesEditor extends Component {
     <div ...attributes>
       <AceEditor
         @content={{this.editorContents}}
-        @editorId={{this.editorId}}
+        @editorId={{@fieldName}}
         @mode={{this.currentEditorMode}}
-        @onChange={{fn (mut this.editorContents)}}
+        @onChange={{this.updateEditorContents}}
         @save={{@save}}
       />
 

--- a/frontend/discourse/app/components/categories-topic-list.gjs
+++ b/frontend/discourse/app/components/categories-topic-list.gjs
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
-import { tagName } from "@ember-decorators/component";
+import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import LatestTopicListItem from "discourse/components/topic-list/latest-topic-list-item";
 import getUrl from "discourse/lib/get-url";
@@ -9,20 +8,21 @@ import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 // Exists so plugins can use it
-@tagName("")
 export default class CategoriesTopicList extends Component {
+  @service siteSettings;
+
   <template>
     <div ...attributes>
       <div aria-level="2" class="table-heading" role="heading">
-        {{i18n (concat "filters." this.filter ".title")}}
+        {{i18n (concat "filters." @filter ".title")}}
         <PluginOutlet
           @connectorTagName="div"
           @name="categories-topics-table-heading"
         />
       </div>
 
-      {{#if this.topics}}
-        {{#each this.topics as |t|}}
+      {{#if @topics}}
+        {{#each @topics as |t|}}
           <LatestTopicListItem @topic={{t}} />
         {{/each}}
 
@@ -35,18 +35,18 @@ export default class CategoriesTopicList extends Component {
           }}
             <a
               class="btn btn-default pull-right"
-              href={{getUrl (concat "/" this.filter "?order=created")}}
+              href={{getUrl (concat "/" @filter "?order=created")}}
             >{{i18n "more"}}</a>
           {{else}}
             <a
               class="btn btn-default pull-right"
-              href={{getUrl (concat "/" this.filter)}}
+              href={{getUrl (concat "/" @filter)}}
             >{{i18n "more"}}</a>
           {{/if}}
         </div>
       {{else}}
         <div class="no-topics">
-          <h3>{{i18n (concat "topics.none." this.filter)}}</h3>
+          <h3>{{i18n (concat "topics.none." @filter)}}</h3>
         </div>
       {{/if}}
     </div>

--- a/frontend/discourse/app/components/category-unread.gjs
+++ b/frontend/discourse/app/components/category-unread.gjs
@@ -1,36 +1,29 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
 import { or } from "discourse/truth-helpers";
 import dElement from "discourse/ui-kit/helpers/d-element";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
-export default class CategoryUnread extends Component {
-  <template>
-    {{#let (dElement (or @tagName "span")) as |TagName|}}
-      <TagName class="category__badges" ...attributes>
-        {{#if this.unreadTopicsCount}}
-          <a
-            class="badge new-posts badge-notification"
-            href={{this.category.unreadUrl}}
-            title={{i18n "topic.unread_topics" count=this.unreadTopicsCount}}
-          >{{i18n
-              "filters.unread.lower_title_with_count"
-              count=this.unreadTopicsCount
-            }}</a>
-        {{/if}}
-        {{#if this.newTopicsCount}}
-          <a
-            class="badge new-posts badge-notification"
-            href={{this.category.newUrl}}
-            title={{i18n "topic.new_topics" count=this.newTopicsCount}}
-          >{{i18n
-              "filters.new.lower_title_with_count"
-              count=this.newTopicsCount
-            }}</a>
-        {{/if}}
-      </TagName>
-    {{/let}}
-  </template>
-}
+const CategoryUnread = <template>
+  {{#let (dElement (or @tagName "span")) as |TagName|}}
+    <TagName class="category__badges" ...attributes>
+      {{#if @unreadTopicsCount}}
+        <a
+          class="badge new-posts badge-notification"
+          href={{@category.unreadUrl}}
+          title={{i18n "topic.unread_topics" count=@unreadTopicsCount}}
+        >{{i18n
+            "filters.unread.lower_title_with_count"
+            count=@unreadTopicsCount
+          }}</a>
+      {{/if}}
+      {{#if @newTopicsCount}}
+        <a
+          class="badge new-posts badge-notification"
+          href={{@category.newUrl}}
+          title={{i18n "topic.new_topics" count=@newTopicsCount}}
+        >{{i18n "filters.new.lower_title_with_count" count=@newTopicsCount}}</a>
+      {{/if}}
+    </TagName>
+  {{/let}}
+</template>;
+
+export default CategoryUnread;

--- a/frontend/discourse/app/components/directory-item.gjs
+++ b/frontend/discourse/app/components/directory-item.gjs
@@ -1,7 +1,5 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { computed } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import DirectoryItemUserFieldValue from "discourse/components/directory-item-user-field-value";
 import directoryColumnIsUserField from "discourse/helpers/directory-column-is-user-field";
 import directoryItemLabel from "discourse/helpers/directory-item-label";
@@ -13,9 +11,12 @@ import dFormatDuration from "discourse/ui-kit/helpers/d-format-duration";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class DirectoryItem extends Component {
-  columns = null;
+  @service currentUser;
+
+  get me() {
+    return deepEqual(this.args.item?.user?.id, this.currentUser?.id);
+  }
 
   <template>
     <div
@@ -24,19 +25,16 @@ export default class DirectoryItem extends Component {
       ...attributes
     >
       <div class="directory-table__cell" role="rowheader">
-        <DUserInfo @headingLevel={{3}} @user={{this.item.user}} />
+        <DUserInfo @headingLevel={{3}} @user={{@item.user}} />
       </div>
 
-      {{#each this.columns as |column|}}
+      {{#each @columns as |column|}}
         {{#if (directoryColumnIsUserField column=column)}}
           <div class="directory-table__cell--user-field" role="cell">
             <span class="directory-table__label">
               <span>{{column.name}}</span>
             </span>
-            <DirectoryItemUserFieldValue
-              @column={{column}}
-              @item={{this.item}}
-            />
+            <DirectoryItemUserFieldValue @column={{column}} @item={{@item}} />
           </div>
         {{else}}
           <div class="directory-table__cell" role="cell">
@@ -45,30 +43,25 @@ export default class DirectoryItem extends Component {
                 {{#if column.icon}}
                   {{dIcon column.icon}}
                 {{/if}}
-                {{directoryItemLabel item=this.item column=column}}
+                {{directoryItemLabel item=@item column=column}}
               </span>
             </span>
-            {{directoryItemValue item=this.item column=column}}
+            {{directoryItemValue item=@item column=column}}
           </div>
         {{/if}}
 
       {{/each}}
 
-      {{#if this.showTimeRead}}
+      {{#if @showTimeRead}}
         <div class="directory-table__cell time-read" role="cell">
           <span class="directory-table__label">
             <span>{{i18n "directory.time_read"}}</span>
           </span>
           <span class="directory-table__value">
-            {{dFormatDuration this.item.time_read}}
+            {{dFormatDuration @item.time_read}}
           </span>
         </div>
       {{/if}}
     </div>
   </template>
-
-  @computed("item.user.id", "currentUser.id")
-  get me() {
-    return deepEqual(this.item?.user?.id, this.currentUser?.id);
-  }
 }

--- a/frontend/discourse/app/components/discourse-linked-text.gjs
+++ b/frontend/discourse/app/components/discourse-linked-text.gjs
@@ -1,26 +1,30 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
-import Component from "@ember/component";
-import { computed } from "@ember/object";
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { trustHTML } from "@ember/template";
-import { tagName } from "@ember-decorators/component";
 import { i18n } from "discourse-i18n";
 
-@tagName("span")
 export default class DiscourseLinkedText extends Component {
-  @computed("text", "textParams")
   get translatedText() {
-    if (this.text) {
-      return i18n(this.text);
+    if (this.args.text) {
+      return i18n(this.args.text, this.args.textParams);
     }
   }
 
+  @action
   click(event) {
     if (event.target.tagName.toUpperCase() === "A") {
-      this.action(this.actionParam);
+      this.args.action(this.args.actionParam);
     }
 
-    return false;
+    event.preventDefault();
+    event.stopPropagation();
   }
 
-  <template>{{trustHTML this.translatedText}}</template>
+  <template>
+    {{! eslint-disable ember/template-no-invalid-interactive }}
+    <span ...attributes {{on "click" this.click}}>{{trustHTML
+        this.translatedText
+      }}</span>
+  </template>
 }

--- a/frontend/discourse/app/components/google-search.gjs
+++ b/frontend/discourse/app/components/google-search.gjs
@@ -1,25 +1,18 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { computed, set } from "@ember/object";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import getURL from "discourse/lib/get-url";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class GoogleSearch extends Component {
-  @computed("siteSettings.login_required")
+  @service siteSettings;
+
   get hidden() {
-    return this.siteSettings?.login_required;
+    return this.siteSettings.login_required;
   }
 
-  set hidden(value) {
-    set(this, "siteSettings.login_required", value);
-  }
-
-  @computed
   get siteUrl() {
     return `${location.protocol}//${location.host}${getURL("/")}`;
   }
@@ -32,7 +25,7 @@ export default class GoogleSearch extends Component {
       <PluginOutlet
         @defaultGlimmer={{true}}
         @name="google-search"
-        @outletArgs={{lazyHash searchTerm=this.searchTerm siteUrl=this.siteUrl}}
+        @outletArgs={{lazyHash searchTerm=@searchTerm siteUrl=this.siteUrl}}
       >
         <form
           action="//google.com/search"
@@ -45,7 +38,7 @@ export default class GoogleSearch extends Component {
             type="text"
             value={{@searchTerm}}
           />
-          <input name="as_sitesearch" type="hidden" value={{@siteUrl}} />
+          <input name="as_sitesearch" type="hidden" value={{this.siteUrl}} />
           <button class="btn btn-primary" type="submit">{{i18n
               "search.search_google_button"
             }}</button>

--- a/frontend/discourse/app/components/mobile-category-topic.gjs
+++ b/frontend/discourse/app/components/mobile-category-topic.gjs
@@ -1,30 +1,35 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
-import Component from "@ember/component";
-import { classNameBindings, tagName } from "@ember-decorators/component";
 import PostCountOrBadges from "discourse/components/topic-list/post-count-or-badges";
 import TopicStatus from "discourse/components/topic-status";
 import coldAgeClass from "discourse/helpers/cold-age-class";
 import dAgeWithTooltip from "discourse/ui-kit/helpers/d-age-with-tooltip";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dTopicLink from "discourse/ui-kit/helpers/d-topic-link";
 
-@tagName("tr")
-@classNameBindings(":category-topic-link", "topic.archived", "topic.visited")
-export default class MobileCategoryTopic extends Component {
-  <template>
+const MobileCategoryTopic = <template>
+  <tr
+    class={{dConcatClass
+      "category-topic-link"
+      (if @topic.archived "archived")
+      (if @topic.visited "visited")
+    }}
+    ...attributes
+  >
     <td class="main-link">
       <div class="topic-inset">
-        <TopicStatus @disableActions={{true}} @topic={{this.topic}} />
-        {{dTopicLink this.topic}}
-        {{#if this.topic.unseen}}
+        <TopicStatus @disableActions={{true}} @topic={{@topic}} />
+        {{dTopicLink @topic}}
+        {{#if @topic.unseen}}
           <span class="badge-notification new-topic"></span>
         {{/if}}
-        <span class={{coldAgeClass this.topic.last_posted_at}}>{{dAgeWithTooltip
-            this.topic.last_posted_at
+        <span class={{coldAgeClass @topic.last_posted_at}}>{{dAgeWithTooltip
+            @topic.last_posted_at
           }}</span>
       </div>
     </td>
     <td class="num posts">
-      <PostCountOrBadges @postBadgesEnabled={{true}} @topic={{this.topic}} />
+      <PostCountOrBadges @postBadgesEnabled={{true}} @topic={{@topic}} />
     </td>
-  </template>
-}
+  </tr>
+</template>;
+
+export default MobileCategoryTopic;

--- a/frontend/discourse/app/components/reviewable-field.gjs
+++ b/frontend/discourse/app/components/reviewable-field.gjs
@@ -1,13 +1,12 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
-import Component from "@ember/component";
-
-export default class ReviewableField extends Component {
-  <template>
-    {{#if this.value}}
-      <div class={{this.classes}}>
-        <div class="name">{{this.name}}</div>
-        <div class="value">{{this.value}}</div>
+const ReviewableField = <template>
+  <div ...attributes>
+    {{#if @value}}
+      <div class={{@classes}}>
+        <div class="name">{{@name}}</div>
+        <div class="value">{{@value}}</div>
       </div>
     {{/if}}
-  </template>
-}
+  </div>
+</template>;
+
+export default ReviewableField;

--- a/frontend/discourse/app/components/user-summary-category-search.gjs
+++ b/frontend/discourse/app/components/user-summary-category-search.gjs
@@ -1,19 +1,14 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
-import { computed } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
-import { tagName } from "@ember-decorators/component";
 
-@tagName("")
 export default class UserSummaryCategorySearch extends Component {
   @service site;
 
-  @computed("user", "category")
   get searchParams() {
-    let query = `@${this.get("user.username")} #${this.get("category.slug")}`;
-    if (this.searchOnlyFirstPosts) {
+    let query = `@${this.args.user?.username} #${this.args.category?.slug}`;
+    if (this.args.searchOnlyFirstPosts) {
       query += " in:first";
     }
     return query;

--- a/frontend/discourse/app/components/user-summary-topics-list.gjs
+++ b/frontend/discourse/app/components/user-summary-topics-list.gjs
@@ -1,19 +1,14 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
-import { computed } from "@ember/object";
 import { LinkTo } from "@ember/routing";
-import { tagName } from "@ember-decorators/component";
 import { i18n } from "discourse-i18n";
 
 // should be kept in sync with 'UserSummary::MAX_SUMMARY_RESULTS'
 const MAX_SUMMARY_RESULTS = 6;
 
-@tagName("")
 export default class UserSummaryTopicsList extends Component {
-  @computed("items.length")
   get hasMore() {
-    return this.items?.length >= MAX_SUMMARY_RESULTS;
+    return this.args.items?.length >= MAX_SUMMARY_RESULTS;
   }
 
   <template>

--- a/frontend/discourse/tests/integration/components/discourse-linked-text-test.gjs
+++ b/frontend/discourse/tests/integration/components/discourse-linked-text-test.gjs
@@ -1,0 +1,49 @@
+import { hash } from "@ember/helper";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DiscourseLinkedText from "discourse/components/discourse-linked-text";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | DiscourseLinkedText", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("interpolates the text params into the translation", async function (assert) {
+    await render(
+      <template>
+        <DiscourseLinkedText
+          @text="pwa.install_banner"
+          @textParams={{hash title="Discourse"}}
+        />
+      </template>
+    );
+
+    assert
+      .dom("span")
+      .hasText(
+        "Do you want to install Discourse on this device?",
+        "renders the translation with its params applied"
+      );
+  });
+
+  test("calls the action when the link is clicked", async function (assert) {
+    let received = "not called";
+    const linkClicked = (param) => (received = param);
+
+    await render(
+      <template>
+        <DiscourseLinkedText
+          @action={{linkClicked}}
+          @actionParam="param"
+          @text="pwa.install_banner"
+          @textParams={{hash title="Discourse"}}
+        />
+      </template>
+    );
+
+    await click("span");
+    assert.strictEqual(received, "not called", "ignores clicks off the link");
+
+    await click("a");
+    assert.strictEqual(received, "param", "passes the action param through");
+  });
+});

--- a/frontend/discourse/tests/integration/components/email-styles-editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/email-styles-editor-test.gjs
@@ -1,0 +1,64 @@
+import Service from "@ember/service";
+import { click, render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import EmailStylesEditor from "discourse/admin/components/email-styles-editor";
+import EmailStyle from "discourse/admin/models/email-style";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+class DialogStub extends Service {
+  yesNoConfirm(options) {
+    options.didConfirm();
+  }
+}
+
+module("Integration | Component | EmailStylesEditor", function (hooks) {
+  setupRenderingTest(hooks);
+
+  let aceSizing;
+
+  hooks.beforeEach(function () {
+    this.owner.register("service:dialog", DialogStub);
+
+    // ace only finishes its first render inside a sized element
+    aceSizing = document.createElement("style");
+    aceSizing.textContent = ".ace_editor { width: 300px; height: 200px; }";
+    document.head.append(aceSizing);
+  });
+
+  hooks.afterEach(function () {
+    aceSizing.remove();
+  });
+
+  test("resetting follows the edited field", async function (assert) {
+    const styles = EmailStyle.create({
+      css: "body { color: red; }",
+      default_css: "body { color: red; }",
+    });
+
+    await render(
+      <template>
+        <EmailStylesEditor @fieldName="css" @styles={{styles}} />
+      </template>
+    );
+
+    assert
+      .dom(".btn-default")
+      .isDisabled("there is nothing to reset while css matches its default");
+
+    styles.setField("css", "body { color: blue; }");
+    await settled();
+
+    assert.dom(".btn-default").isEnabled("an edited field can be reset");
+
+    await click(".btn-default");
+
+    assert.strictEqual(
+      styles.css,
+      "body { color: red; }",
+      "resetting restores the default"
+    );
+    assert
+      .dom(".btn-default")
+      .isDisabled("the reset field matches its default again");
+  });
+});

--- a/frontend/discourse/tests/integration/components/google-search-test.gjs
+++ b/frontend/discourse/tests/integration/components/google-search-test.gjs
@@ -1,0 +1,29 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import GoogleSearch from "discourse/components/google-search";
+import getURL from "discourse/lib/get-url";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | GoogleSearch", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("scopes the search to this site", async function (assert) {
+    await render(<template><GoogleSearch @searchTerm="cats" /></template>);
+
+    assert.dom("input[name='q']").hasValue("cats", "carries the search term");
+    assert
+      .dom("input[name='as_sitesearch']")
+      .hasValue(
+        `${location.protocol}//${location.host}${getURL("/")}`,
+        "restricts the search to this site's url"
+      );
+  });
+
+  test("hides itself when login is required", async function (assert) {
+    this.siteSettings.login_required = true;
+
+    await render(<template><GoogleSearch @searchTerm="cats" /></template>);
+
+    assert.dom(".google-search-form").hasClass("hidden");
+  });
+});

--- a/frontend/discourse/tests/integration/components/mobile-category-topic-test.gjs
+++ b/frontend/discourse/tests/integration/components/mobile-category-topic-test.gjs
@@ -1,0 +1,33 @@
+import { render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import MobileCategoryTopic from "discourse/components/mobile-category-topic";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | MobileCategoryTopic", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("marks the row as archived and visited", async function (assert) {
+    const topic = this.owner.lookup("service:store").createRecord("topic", {
+      id: 1,
+      title: "A topic",
+      highest_post_number: 1,
+    });
+
+    await render(
+      <template>
+        <table><tbody><MobileCategoryTopic @topic={{topic}} /></tbody></table>
+      </template>
+    );
+
+    assert.dom("tr").hasClass("category-topic-link", "renders a table row");
+    assert.dom("tr").doesNotHaveClass("archived");
+    assert.dom("tr").doesNotHaveClass("visited");
+
+    topic.set("archived", true);
+    topic.set("last_read_post_number", 1);
+    await settled();
+
+    assert.dom("tr").hasClass("archived", "follows the topic's archived state");
+    assert.dom("tr").hasClass("visited", "follows the topic's visited state");
+  });
+});


### PR DESCRIPTION
Done with the help of our glimmer conversion skill.

* CategoriesTopicList, CategoryUnread, DirectoryItem, DiscourseLinkedText, EmailStylesEditor, GoogleSearch, MobileCategoryTopic, ReviewableField, UserSummaryCategorySearch, UserSummaryTopicsList

`DiscourseLinkedText` interpolates `textParams` into the translation again; the argument was dropped when `@discourseComputed` became `@computed`, which left `pwa.install_banner`'s `%{title}` unresolved.

`GoogleSearch` fills the hidden `as_sitesearch` input from its own `siteUrl` getter rather than a `@siteUrl` argument nothing passes.

`EmailStylesEditor` reads the edited field with `get`, so the editor and the reset button follow the model without a manual `notifyPropertyChange`, and it drops an `editorId` override nothing set.

`ReviewableField` keeps its wrapper element: `.reviewable-user-details:not(:last-child)` only draws a border on the fields their parent inlines, and removing the wrapper would change that.
