### PR TITLE
FIX: Prevent real names leaking into username-only quotes

### DIFF
--- a/app/jobs/regular/change_display_name.rb
+++ b/app/jobs/regular/change_display_name.rb
@@ -51,8 +51,9 @@ module Jobs
     end
 
     def update_post(post)
-      post.raw = update_raw(post.raw)
-      post.cooked = update_cooked(post.cooked)
+      rewritten = update_content(post.raw, post.cooked)
+      post.raw = rewritten[:raw]
+      post.cooked = rewritten[:cooked]
 
       post.update_columns(raw: post.raw, cooked: post.cooked)
       post.sync_first_post_caches
@@ -63,28 +64,29 @@ module Jobs
     end
 
     def update_revision(revision)
-      if revision.modifications["raw"] || revision.modifications["cooked"]
-        revision.modifications["raw"]&.map! { |raw| update_raw(raw) }
-        revision.modifications["cooked"]&.map! { |cooked| update_cooked(cooked) }
-        revision.save!
+      raw_versions = revision.modifications["raw"]
+      cooked_versions = revision.modifications["cooked"]
+      return if raw_versions.blank?
+
+      raw_versions.each_index do |index|
+        rewritten = update_content(raw_versions[index], cooked_versions&.at(index))
+        raw_versions[index] = rewritten[:raw]
+        cooked_versions[index] = rewritten[:cooked] if cooked_versions
       end
+
+      revision.save!
     rescue => e
       Discourse.warn_exception(e, message: "Failed to update post revision with id #{revision.id}")
     end
 
-    def update_raw(raw)
-      @quote_rewriter.rewrite_raw_display_name(raw, old_display_name, new_display_name)
-    end
-
-    # Uses Nokogiri instead of rebake, because it works for posts and revisions
-    # and there is no reason to invalidate oneboxes, run the post analyzer etc.
-    # when only the display name changes.
-    def update_cooked(cooked)
-      doc = Nokogiri::HTML5.fragment(cooked)
-
-      @quote_rewriter.rewrite_cooked_display_name(doc, old_display_name, new_display_name)
-
-      doc.to_html
+    def update_content(raw, cooked)
+      @quote_rewriter.rewrite_display_name(
+        raw: raw,
+        cooked: cooked,
+        old_display_name: old_display_name,
+        new_display_name: new_display_name,
+        username: user.username,
+      )
     end
   end
 end

--- a/lib/quote_rewriter.rb
+++ b/lib/quote_rewriter.rb
@@ -44,15 +44,60 @@ class QuoteRewriter
       end
   end
 
-  def rewrite_raw_display_name(raw, old_display_name, new_display_name)
+  def rewrite_display_name(raw:, cooked:, old_display_name:, new_display_name:, username:)
+    hide_display_name = !SiteSetting.enable_names?
+    display_name = hide_display_name ? username : new_display_name
+    username_to_remove = username if hide_display_name
+    rewritten_raw =
+      rewrite_raw_display_name(
+        raw,
+        old_display_name,
+        display_name,
+        username_to_remove: username_to_remove,
+      )
+
+    return { raw: raw, cooked: cooked } if rewritten_raw == raw
+    return { raw: rewritten_raw, cooked: cooked } if cooked.nil?
+
+    doc = Nokogiri::HTML5.fragment(cooked)
+    rewrite_cooked_display_name(
+      doc,
+      old_display_name,
+      display_name,
+      hide_display_name: hide_display_name,
+    )
+
+    { raw: rewritten_raw, cooked: doc.to_html }
+  end
+
+  def rewrite_raw_display_name(raw, old_display_name, new_display_name, username_to_remove: nil)
     escaped_old_display_name = Regexp.escape(old_display_name)
     pattern =
       /(?<pre>\[quote\s*=\s*["'']?)#{escaped_old_display_name}(?<post>\,[^\]]*username[^\]]*\])/i
 
-    raw.gsub(pattern, "\\k<pre>#{new_display_name}\\k<post>")
+    raw.gsub(pattern) do |quote|
+      match = pattern.match(quote)
+      pre = match[:pre]
+      post = match[:post]
+
+      if username_to_remove
+        username_attribute = /,\s*username:\s*#{Regexp.escape(username_to_remove)}(?=\s*[,"'\]])/i
+        rewritten_post = post.sub(username_attribute, "")
+        next quote if rewritten_post == post
+
+        post = rewritten_post
+      end
+
+      "#{pre}#{new_display_name}#{post}"
+    end
   end
 
-  def rewrite_cooked_display_name(cooked, old_display_name, new_display_name)
+  def rewrite_cooked_display_name(
+    cooked,
+    old_display_name,
+    new_display_name,
+    hide_display_name: false
+  )
     formatted_old_display_name = PrettyText::Helpers.format_username(old_display_name)
     escaped_old_display_name = Regexp.escape(formatted_old_display_name)
     pattern = /(?<=\s)#{escaped_old_display_name}(?=:)/i
@@ -62,7 +107,9 @@ class QuoteRewriter
       .each do |aside|
         next unless div = aside.at_css("div.title")
 
-        if aside["data-display-name"] == old_display_name
+        if hide_display_name && aside["data-display-name"] == old_display_name
+          aside.remove_attribute("data-display-name")
+        elsif aside["data-display-name"] == old_display_name
           aside["data-display-name"] = new_display_name
         end
 

--- a/spec/jobs/change_display_name_spec.rb
+++ b/spec/jobs/change_display_name_spec.rb
@@ -68,5 +68,28 @@ RSpec.describe Jobs::ChangeDisplayName do
           RAW
       end
     end
+
+    context "when names are disabled and a user changes their name from their username to a real name" do
+      let(:old_display_name) { username }
+      let(:new_display_name) { "Jeff Atwood" }
+
+      let(:post_attributes) { { raw: <<~RAW } }
+        [quote="#{username}, post:1, topic:#{quoted_post.topic.id}"]
+        quoted post
+        [/quote]
+      RAW
+
+      before do
+        SiteSetting.enable_names = false
+        with_search_indexer_enabled { SearchIndexer.index(post, force: true) }
+        user.update!(name: new_display_name)
+      end
+
+      it "does not add the new real name to the post search index" do
+        with_search_indexer_enabled { described_class.new.execute(args) }
+
+        expect(post.reload.post_search_data.raw_data).not_to include(new_display_name)
+      end
+    end
   end
 end

--- a/spec/lib/quote_rewriter_spec.rb
+++ b/spec/lib/quote_rewriter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe QuoteRewriter do
-  subject(:quote_rewriter) { described_class.new(post.id) }
+  subject(:quote_rewriter) { described_class.new(user.id) }
 
   before { stub_image_size }
 
@@ -13,6 +13,8 @@ RSpec.describe QuoteRewriter do
   let(:avatar_url) { user.avatar_template_url.gsub("{size}", "48") }
 
   describe "#rewrite_raw_username" do
+    before { SiteSetting.enable_names = false }
+
     context "when using the old quote format" do
       let(:post_attributes) { { raw: <<~RAW } }
             [quote="codinghorror, post:1, topic:#{quoted_post.topic.id}"]
@@ -46,6 +48,81 @@ RSpec.describe QuoteRewriter do
           [/quote]
         RAW
         )
+      end
+    end
+  end
+
+  describe "#rewrite_cooked_username" do
+    before { SiteSetting.enable_names = false }
+
+    let(:post_attributes) { { raw: <<~RAW } }
+          [quote="codinghorror, post:1, topic:#{quoted_post.topic.id}"]
+          quoted post
+          [/quote]
+        RAW
+
+    it "rewrites the username when names are disabled" do
+      doc = Nokogiri::HTML5.fragment(post.cooked)
+      avatar_img = PrettyText.avatar_img(user.avatar_template, "tiny")
+
+      quote_rewriter.rewrite_cooked_username(doc, "codinghorror", "codingterror", avatar_img)
+
+      quote = doc.at_css("aside.quote")
+
+      expect(quote["data-username"]).to eq("codingterror")
+      expect(quote.at_css(".title").text.squish).to eq("codingterror:")
+    end
+  end
+
+  describe "#rewrite_display_name" do
+    before { SiteSetting.enable_names = false }
+
+    context "when the raw quote uses a username attribution" do
+      let(:post_attributes) { { raw: <<~RAW } }
+            [quote="codinghorror, post:1, topic:#{quoted_post.topic.id}"]
+            quoted post
+            [/quote]
+          RAW
+
+      it "does not add the new display name to raw or cooked" do
+        rewritten =
+          quote_rewriter.rewrite_display_name(
+            raw: post.raw,
+            cooked: post.cooked,
+            old_display_name: "codinghorror",
+            new_display_name: "Jeff Atwood",
+            username: "codinghorror",
+          )
+
+        expect(rewritten[:raw]).to eq(post.raw)
+        expect(rewritten[:cooked]).to eq(post.cooked)
+      end
+    end
+
+    context "when the raw quote uses a display name attribution" do
+      let(:post_attributes) { { raw: <<~RAW } }
+            [quote="Jeff, post:1, topic:#{quoted_post.topic.id}, username:codinghorror"]
+            quoted post
+            [/quote]
+          RAW
+
+      it "replaces the existing display name with the username in raw and cooked" do
+        rewritten =
+          quote_rewriter.rewrite_display_name(
+            raw: post.raw,
+            cooked: post.cooked,
+            old_display_name: "Jeff",
+            new_display_name: "Mr. Atwood",
+            username: "codinghorror",
+          )
+
+        expect(rewritten[:raw]).to include(
+          %([quote="codinghorror, post:1, topic:#{quoted_post.topic.id}"]),
+        )
+        quote = Nokogiri::HTML5.fragment(rewritten[:cooked]).at_css("aside.quote")
+
+        expect(quote["data-display-name"]).to be_nil
+        expect(quote.at_css(".title").text.squish).to eq("codinghorror:")
       end
     end
   end


### PR DESCRIPTION
follow-up to a183f14d0936bd272bcc67d381ffad2b1c8d6bac

Respect `enable_names` when updating quote attributions, keeping username-only quotes unchanged and replacing existing display names with usernames when names are disabled.