### PR TITLE
FIX: Chat thread list incorrectly sorts non-participated threads above read threads

### DIFF
--- a/plugins/chat/app/services/chat/action/fetch_threads.rb
+++ b/plugins/chat/app/services/chat/action/fetch_threads.rb
@@ -49,7 +49,7 @@ module Chat
           .where("last_message.deleted_at IS NULL")
           .where("chat_threads.replies_count > 0")
           .order(
-            "CASE WHEN user_chat_thread_memberships.last_read_message_id IS NULL OR user_chat_thread_memberships.last_read_message_id < chat_threads.last_message_id THEN true ELSE false END DESC, last_message.created_at DESC",
+            "CASE WHEN user_chat_thread_memberships.id IS NOT NULL AND (user_chat_thread_memberships.last_read_message_id IS NULL OR user_chat_thread_memberships.last_read_message_id < chat_threads.last_message_id) THEN true ELSE false END DESC, last_message.created_at DESC",
           )
           .limit(limit)
           .offset(offset)

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -212,8 +212,10 @@ RSpec.describe Chat::Api::ChannelThreadsController do
     it "returns the threads of the channel" do
       get "/chat/api/channels/#{public_channel.id}/threads"
       expect(response.status).to eq(200)
+      # thread_1 and thread_3 have memberships with last_read IS NULL → unread (sort first)
+      # thread_2 has no membership → sorts by date after unread threads
       expect(response.parsed_body["threads"].map { |thread| thread["id"] }).to eq(
-        [thread_3.id, thread_2.id, thread_1.id],
+        [thread_3.id, thread_1.id, thread_2.id],
       )
     end
 

--- a/plugins/chat/spec/services/actions/fetch_threads_spec.rb
+++ b/plugins/chat/spec/services/actions/fetch_threads_spec.rb
@@ -127,6 +127,42 @@ RSpec.describe Chat::Action::FetchThreads do
     end
   end
 
+  context "when no-membership threads are mixed with fully-read participated threads" do
+    fab!(:thread_4) { Fabricate(:chat_thread, channel:) }
+
+    before do
+      thread_4.update!(replies_count: 2)
+      # thread_4 has no membership and an older last message than thread_1/2/3
+      thread_4.original_message.update!(created_at: 4.weeks.ago)
+      # mark all participated threads as fully read so none are unread
+      [thread_1, thread_2, thread_3].each { |t| t.membership_for(current_user).mark_read! }
+    end
+
+    it "sorts by date rather than treating no-membership as unread" do
+      expect(threads.map(&:id)).to eq([thread_1.id, thread_2.id, thread_3.id, thread_4.id])
+    end
+  end
+
+  context "when unread participated threads are mixed with no-membership threads" do
+    fab!(:thread_4) { Fabricate(:chat_thread, channel:) }
+
+    before do
+      thread_4.update!(replies_count: 2)
+      # thread_4 has no membership but the newest last message
+      thread_4.original_message.update!(created_at: 1.second.ago)
+      # thread_1 retains its unread membership (last_read IS NULL); threads 2 and 3 are read
+      [thread_2, thread_3].each { |t| t.membership_for(current_user).mark_read! }
+    end
+
+    it "sorts unread member threads first, then remaining threads by date" do
+      # thread_1: member + unread → first (unread priority)
+      # thread_4: no membership, newest → second (by date)
+      # thread_2: member, read, 2 weeks old → third (by date)
+      # thread_3: member, read, 3 weeks old → fourth (by date)
+      expect(threads.map(&:id)).to eq([thread_1.id, thread_4.id, thread_2.id, thread_3.id])
+    end
+  end
+
   context "when there are muted threads" do
     let(:thread) { Fabricate(:chat_thread, channel:) }
 


### PR DESCRIPTION
Previously, the `FetchThreads` `ORDER BY` treated threads with no membership row (a `LEFT JOIN` null) identically to threads with unread messages, causing un-participated threads to sort above threads the user had actively read.

This change gates the unread sort condition on `user_chat_thread_memberships.id IS NOT NULL`, so only threads where the user has an actual membership can trigger unread priority.