### PR TITLE
FIX: Show descriptions and bot members for automatic groups created by plugins

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -344,7 +344,7 @@ class GroupsController < ApplicationController
         "(SELECT value FROM user_custom_fields ucf WHERE ucf.user_id = users.id AND ucf.name = #{ActiveRecord::Base.connection.quote(params[:order_field])}) #{dir} NULLS LAST"
     end
 
-    users = group.users.human_users
+    users = group.listed_users
     total = users.count
 
     if (filter = params[:filter]).present?

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -654,21 +654,20 @@ class Group < ActiveRecord::Base
   end
 
   def self.reset_groups_user_count!(only_group_ids: [])
-    where_sql =
-      if only_group_ids.present?
-        "WHERE group_id IN (#{only_group_ids.map(&:to_i).join(",")}) AND user_id > 0"
-      else
-        "WHERE user_id > 0"
-      end
+    params = { auto_group_ids: AUTO_GROUP_IDS.keys }
+    params[:only_group_ids] = only_group_ids.map(&:to_i) if only_group_ids.present?
 
-    DB.exec <<-SQL
+    DB.exec(<<~SQL, params)
       WITH tally AS (
         SELECT
-          group_id,
-          COUNT(user_id) users
-        FROM group_users
-        #{where_sql}
-        GROUP BY group_id
+          g.id AS group_id,
+          COUNT(gu.user_id) AS users
+        FROM groups g
+        LEFT JOIN group_users gu
+          ON gu.group_id = g.id
+         AND (gu.user_id > 0 OR (g.automatic AND g.id NOT IN (:auto_group_ids)))
+        #{"WHERE g.id IN (:only_group_ids)" if params[:only_group_ids]}
+        GROUP BY g.id
       )
       UPDATE groups
          SET user_count = tally.users
@@ -951,16 +950,18 @@ class Group < ActiveRecord::Base
     GroupManager.new(self).remove(user_ids)
   end
 
+  # Bots in built-in and hand-managed groups are incidental (e.g. the system user
+  # as owner), but automatic groups maintained elsewhere may exist to hold bots.
+  def hides_bot_members?
+    !automatic || AUTO_GROUP_IDS.key?(id)
+  end
+
+  def listed_users
+    hides_bot_members? ? human_users : users
+  end
+
   def recalculate_user_count
-    DB.exec <<~SQL
-      UPDATE groups g
-      SET user_count =
-        (SELECT COUNT(gu.user_id)
-         FROM group_users gu
-         WHERE gu.group_id = g.id
-         AND gu.user_id > 0)
-      WHERE g.id = #{id};
-    SQL
+    Group.reset_user_count(self)
   end
 
   def add_automatically(user, subject: nil)

--- a/app/serializers/basic_group_serializer.rb
+++ b/app/serializers/basic_group_serializer.rb
@@ -45,8 +45,8 @@ class BasicGroupSerializer < ApplicationSerializer
   end
 
   def bio_cooked
-    if object.automatic
-      return I18n.t("groups.default_descriptions.#{Group::AUTO_GROUP_IDS[object.id]}")
+    if auto_group_name = Group::AUTO_GROUP_IDS[object.id]
+      return I18n.t("groups.default_descriptions.#{auto_group_name}")
     end
 
     object.bio_cooked

--- a/app/serializers/found_group_serializer.rb
+++ b/app/serializers/found_group_serializer.rb
@@ -4,8 +4,7 @@ class FoundGroupSerializer < ApplicationSerializer
   attributes :id, :automatic, :name, :full_name, :display_name
 
   def display_name
-    if object.automatic
-      auto_group_name = Group::AUTO_GROUP_IDS[object.id]
+    if auto_group_name = Group::AUTO_GROUP_IDS[object.id]
       I18n.t("groups.default_full_names.#{auto_group_name}")
     else
       object.full_name || object.name

--- a/lib/group_manager.rb
+++ b/lib/group_manager.rb
@@ -62,7 +62,7 @@ class GroupManager
   end
 
   def decrease_group_user_count(removed_user_ids)
-    Group.update_counters(@group.id, user_count: -removed_user_ids.size)
+    Group.update_counters(@group.id, user_count: -counted_user_ids(removed_user_ids).size)
   end
 
   private
@@ -238,7 +238,11 @@ class GroupManager
   end
 
   def increase_group_user_count(added_user_ids)
-    Group.update_counters(@group.id, user_count: added_user_ids.size)
+    Group.update_counters(@group.id, user_count: counted_user_ids(added_user_ids).size)
+  end
+
+  def counted_user_ids(user_ids)
+    @group.hides_bot_members? ? user_ids.select(&:positive?) : user_ids
   end
 
   def grant_other_available_title(removed_user_ids)

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -449,6 +449,7 @@ en:
 
     ai_bot:
       ai_users: "AI users"
+      ai_users_bio: "Automatic group of bot accounts that post as AI agents and LLMs"
       errors:
         invalid_agent_id: "The specified AI agent does not exist or you do not have access to it"
         cannot_send_pm_to_agent: "You cannot send personal messages to this AI agent"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -449,7 +449,7 @@ en:
 
     ai_bot:
       ai_users: "AI users"
-      ai_users_bio: "Automatic group of bot accounts that post as AI agents and LLMs"
+      ai_users_bio: "Automatic group of AI bot accounts"
       errors:
         invalid_agent_id: "The specified AI agent does not exist or you do not have access to it"
         cannot_send_pm_to_agent: "You cannot send personal messages to this AI agent"

--- a/plugins/discourse-ai/lib/ai_bot/user_flair.rb
+++ b/plugins/discourse-ai/lib/ai_bot/user_flair.rb
@@ -61,7 +61,7 @@ module DiscourseAi::AiBot::UserFlair
 
   def self.ensure_group!
     group = Group.find_or_initialize_by(name: GROUP_NAME)
-    group.bio_raw = I18n.t("discourse_ai.ai_bot.ai_users_bio") if group.new_record?
+    group.bio_raw = I18n.t("discourse_ai.ai_bot.ai_users_bio") if group.bio_raw.blank?
     group.assign_attributes(
       automatic: true,
       flair_icon: FLAIR_ICON,

--- a/plugins/discourse-ai/lib/ai_bot/user_flair.rb
+++ b/plugins/discourse-ai/lib/ai_bot/user_flair.rb
@@ -61,6 +61,7 @@ module DiscourseAi::AiBot::UserFlair
 
   def self.ensure_group!
     group = Group.find_or_initialize_by(name: GROUP_NAME)
+    group.bio_raw = I18n.t("discourse_ai.ai_bot.ai_users_bio") if group.new_record?
     group.assign_attributes(
       automatic: true,
       flair_icon: FLAIR_ICON,

--- a/plugins/discourse-ai/spec/lib/ai_bot/user_flair_spec.rb
+++ b/plugins/discourse-ai/spec/lib/ai_bot/user_flair_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe DiscourseAi::AiBot::UserFlair do
     expect(group.bio_cooked).to be_present
   end
 
+  it "gives an existing AI users group without a bio the default bio" do
+    Fabricate(:ai_agent, user: bot_user)
+    group = Group.find_by(name: described_class::GROUP_NAME)
+    group.update_columns(bio_raw: nil, bio_cooked: nil)
+
+    described_class.sync_all!
+
+    expect(group.reload.bio_raw).to eq(I18n.t("discourse_ai.ai_bot.ai_users_bio"))
+    expect(group.bio_cooked).to be_present
+  end
+
   it "keeps an edited bio on an existing AI users group" do
     Fabricate(:ai_agent, user: bot_user)
     group = Group.find_by(name: described_class::GROUP_NAME)

--- a/plugins/discourse-ai/spec/lib/ai_bot/user_flair_spec.rb
+++ b/plugins/discourse-ai/spec/lib/ai_bot/user_flair_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe DiscourseAi::AiBot::UserFlair do
     expect(group.users).to contain_exactly(bot_user)
   end
 
+  it "gives a new AI users group a default bio" do
+    Fabricate(:ai_agent, user: bot_user)
+
+    group = Group.find_by(name: described_class::GROUP_NAME)
+    expect(group.bio_raw).to eq(I18n.t("discourse_ai.ai_bot.ai_users_bio"))
+    expect(group.bio_cooked).to be_present
+  end
+
+  it "keeps an edited bio on an existing AI users group" do
+    Fabricate(:ai_agent, user: bot_user)
+    group = Group.find_by(name: described_class::GROUP_NAME)
+    group.update!(bio_raw: "Our helpful bots")
+
+    described_class.sync_all!
+
+    expect(group.reload.bio_raw).to eq("Our helpful bots")
+  end
+
   it "updates the flair icon on an existing AI users group" do
     agent = Fabricate(:ai_agent, user: bot_user)
     group = Group.find_by(name: described_class::GROUP_NAME)

--- a/spec/lib/group_manager_spec.rb
+++ b/spec/lib/group_manager_spec.rb
@@ -21,6 +21,34 @@ RSpec.describe GroupManager do
     end
   end
 
+  describe "user_count" do
+    fab!(:bot)
+
+    it "counts bots in automatic groups not created by core" do
+      automatic_group = Fabricate(:group, automatic: true)
+      automatic_manager = GroupManager.new(automatic_group)
+
+      expect { automatic_manager.add([user.id, bot.id]) }.to change {
+        automatic_group.reload.user_count
+      }.by(2)
+      expect { automatic_manager.remove([bot.id]) }.to change {
+        automatic_group.reload.user_count
+      }.by(-1)
+    end
+
+    it "does not count bots in hand-managed groups" do
+      expect { manager.add([user.id, bot.id]) }.to change { group.reload.user_count }.by(1)
+      expect { manager.remove([bot.id]) }.not_to change { group.reload.user_count }
+    end
+
+    it "does not count bots in core automatic groups" do
+      staff_manager = GroupManager.new(Group[:staff])
+
+      expect { staff_manager.add([user.id, bot.id]) }.to change { Group[:staff].user_count }.by(1)
+      expect { staff_manager.remove([bot.id]) }.not_to change { Group[:staff].user_count }
+    end
+  end
+
   describe "#remove" do
     before { manager.add([user.id, user2.id]) }
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -692,6 +692,39 @@ RSpec.describe Group do
     expect(g.human_users).to contain_exactly(admin, other_admin, other_user)
   end
 
+  describe ".reset_user_count" do
+    fab!(:bot)
+    fab!(:group)
+
+    it "counts bots in automatic groups not created by core" do
+      group.update_columns(automatic: true)
+      group.add(bot)
+      group.update_columns(user_count: 0)
+
+      Group.reset_user_count(group)
+
+      expect(group.reload.user_count).to eq(1)
+    end
+
+    it "does not count bots in hand-managed groups" do
+      group.add(bot)
+      group.add(Fabricate(:user))
+      group.update_columns(user_count: 0)
+
+      Group.reset_user_count(group)
+
+      expect(group.reload.user_count).to eq(1)
+    end
+
+    it "resets groups without any counted members to zero" do
+      group.update_columns(user_count: 4)
+
+      Group.ensure_consistency!
+
+      expect(group.reload.user_count).to eq(0)
+    end
+  end
+
   it "can set members via usernames helper" do
     g = Fabricate(:group)
     u1 = Fabricate(:user)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1834,7 +1834,50 @@ RSpec.describe GroupsController do
     fab!(:user3) { Fabricate(:user, last_seen_at: nil, last_posted_at: nil, email: "c@test.org") }
 
     fab!(:bot)
-    let(:group) { Fabricate(:group, users: [user1, user2, user3, bot]) }
+    let(:group) { Fabricate(:group, users: [user1, user2, user3]) }
+
+    it "lists bot members of automatic groups not created by core" do
+      group.update_columns(automatic: true)
+      group.add(bot)
+
+      get "/groups/#{group.name}/members.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["members"].map { |m| m["id"] }).to contain_exactly(
+        user1.id,
+        user2.id,
+        user3.id,
+        bot.id,
+      )
+      expect(response.parsed_body["meta"]["total"]).to eq(4)
+    end
+
+    it "does not list bot members of hand-managed groups" do
+      group.add(bot)
+
+      get "/groups/#{group.name}/members.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["members"].map { |m| m["id"] }).to contain_exactly(
+        user1.id,
+        user2.id,
+        user3.id,
+      )
+      expect(response.parsed_body["meta"]["total"]).to eq(3)
+    end
+
+    it "does not list bot members of core automatic groups" do
+      sign_in(admin)
+      Group[:admins].add(bot)
+
+      get "/groups/admins/members.json"
+
+      expect(response.status).to eq(200)
+      member_ids = response.parsed_body["members"].map { |m| m["id"] }
+      expect(member_ids).to include(admin.id)
+      expect(member_ids).not_to include(bot.id)
+      expect(response.parsed_body["meta"]["total"]).to eq(Group[:admins].human_users.count)
+    end
 
     it "allows members to be sorted by supported columns" do
       get "/groups/#{group.name}/members.json", params: { order: "last_seen_at" }

--- a/spec/serializers/basic_group_serializer_spec.rb
+++ b/spec/serializers/basic_group_serializer_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe BasicGroupSerializer do
     end
   end
 
+  describe "#bio_cooked" do
+    describe "core automatic group" do
+      let(:group) { Group.find(Group::AUTO_GROUPS[:admins]) }
+
+      it "uses the default description" do
+        expect(serializer.as_json[:bio_cooked]).to eq(I18n.t("groups.default_descriptions.admins"))
+      end
+    end
+
+    describe "automatic group not created by core" do
+      fab!(:group) { Fabricate(:group, automatic: true, bio_raw: "Bot accounts") }
+
+      it "uses the group's own bio" do
+        expect(serializer.as_json[:bio_cooked]).to eq(group.bio_cooked)
+        expect(serializer.as_json[:bio_excerpt]).to eq("Bot accounts")
+      end
+    end
+  end
+
   describe "#bio_raw" do
     subject(:serializer) do
       described_class.new(group, scope: guardian, root: false, owner_group_ids: [group.id])


### PR DESCRIPTION
Currently we have a broken description for the AI Users group and it shows a user count without listing any users. 

<img width="346" height="282" alt="image" src="https://github.com/user-attachments/assets/3270f915-3676-47bb-9644-d570dc2a848f" />

This was because core assumes automatic groups aren't added by plugins, and adding one from the AI plugin included core's whole description hash as its description. Negative ID users (bots) are also removed from user groups, so we need to allow them here. 

This change only uses core's default group names and descriptions for core's own groups, so plugin-added automatic groups show their own bio and name. Built-in and manual groups still hide bot users. 

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/186d80cb-032f-4a6d-91ef-24a724115306" />

Reported here: https://meta.discourse.org/t/description-of-the-ai-users-group/412047
