### PR TITLE
FIX: Allow MCP clients to discover all supported scopes

### DIFF
--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -58,10 +58,7 @@ class McpController < ApplicationController
   rescue DiscourseMcp::AuthenticationError => error
     response.set_header(
       "WWW-Authenticate",
-      DiscourseMcp::Authenticator.challenge(
-        scope: DiscourseMcp::INITIAL_SCOPE,
-        error: error.oauth_error,
-      ),
+      DiscourseMcp::Authenticator.challenge(error: error.oauth_error),
     )
     render json: jsonrpc_error(nil, -32_001, "Authorization required"), status: :unauthorized
   end

--- a/app/controllers/mcp_oauth_metadata_controller.rb
+++ b/app/controllers/mcp_oauth_metadata_controller.rb
@@ -8,7 +8,7 @@ class McpOauthMetadataController < ApplicationController
     render json: {
              resource: DiscourseMcp.resource_url,
              authorization_servers: [DiscourseMcp.issuer],
-             scopes_supported: [DiscourseMcp::INITIAL_SCOPE],
+             scopes_supported: DiscourseMcp.registry.scopes,
              bearer_methods_supported: ["header"],
            }
   end

--- a/spec/requests/mcp_controller_spec.rb
+++ b/spec/requests/mcp_controller_spec.rb
@@ -78,12 +78,12 @@ describe "MCP transport" do
     McpPrimitive.create!(kind: "tool", identifier: "discourse_current_user_get", enabled: true)
   end
 
-  it "challenges requests without bearer credentials" do
+  it "directs unauthenticated clients to resource metadata for scope selection" do
     post "/mcp", params: payload.to_json, headers: headers.except("HTTP_AUTHORIZATION")
 
     expect(response.status).to eq(401)
     expect(response.headers["WWW-Authenticate"]).to eq(
-      %(Bearer resource_metadata="#{DiscourseMcp.protected_resource_metadata_url}", scope="mcp:profile:read"),
+      %(Bearer resource_metadata="#{DiscourseMcp.protected_resource_metadata_url}"),
     )
     expect(response.parsed_body.dig("error", "code")).to eq(-32_001)
   end

--- a/spec/requests/mcp_oauth_metadata_controller_spec.rb
+++ b/spec/requests/mcp_oauth_metadata_controller_spec.rb
@@ -3,11 +3,11 @@
 describe McpOauthMetadataController do
   before { SiteSetting.mcp_server_enabled = true }
 
-  it "advertises the initial scope in protected resource metadata" do
+  it "advertises every registered scope in protected resource metadata" do
     get "/.well-known/oauth-protected-resource/mcp"
 
     expect(response.status).to eq(200)
-    expect(response.parsed_body["scopes_supported"]).to eq(["mcp:profile:read"])
+    expect(response.parsed_body["scopes_supported"]).to eq(DiscourseMcp.registry.scopes)
   end
 
   it "advertises every registered scope in authorization server metadata" do


### PR DESCRIPTION
Bug: MCP clients (like ChatGPT web) following the initial authentication challenge request only `mcp:profile:read`. The protected resource metadata also lists only that scope, so these clients cannot discover the other tools after connecting.

- `/.well-known/oauth-authorization-server` lists all scopes. Codex’s discovery code reads this.
- `/.well-known/oauth-protected-resource/mcp` lists only `mcp:profile:read`. Web appears to use this or the initial authentication challenge, which also specifies profile-only.

The PR updates `/.well-known/oauth-protected-resource/mcp` to advertise the full list and removes the profile-only scope from the initial challenge.