### PR TITLE
FIX: Avoid serialized HTML length for content splitter offsets

### DIFF
--- a/plugins/discourse-ai/lib/translation/content_splitter.rb
+++ b/plugins/discourse-ai/lib/translation/content_splitter.rb
@@ -64,13 +64,16 @@ module DiscourseAi
 
         begin
           doc = Nokogiri::HTML5.fragment(text)
-          max_length_within_target = 0
 
-          doc.children.each do |node|
-            html = node.to_html
-            end_pos = max_length_within_target + html.length
-            return max_length_within_target if max_length_within_target > 0 && end_pos > target_pos
-            max_length_within_target = end_pos
+          line_offsets = [0]
+          text.each_line { |line| line_offsets << line_offsets.last + line.length }
+
+          node_starts = doc.children.map do |node|
+            line_offsets[node.line - 1]
+          end.uniq
+
+          node_starts.each_cons(2) do |current_start, next_start|
+            return current_start if current_start > 0 && next_start > target_pos
           end
           nil
         rescue Nokogiri::SyntaxError


### PR DESCRIPTION
Fixes incorrect chunk boundaries in `ContentSplitter` for Discourse AI translation when the content contains HTML.

The HTML splitting logic used the length of Nokogiri's serialized HTML (`node.to_html.length`) to determine positions in the original input. The serialized representation does not necessarily have the same length as the original source, which can cause the calculated split position to drift.

As a result, content could be split in the middle of words or Markdown syntax.

## Why does this happen?

The splitter was mixing offsets from two different representations:

* the split position is an offset in the original input string;
* the HTML node length was calculated from Nokogiri's serialized output.

Using the original source positions keeps the calculated offsets aligned with the string that is actually being split.

## Testing

Here's the standalone variant of content splitter along with the text where the bug appeared [discourse-ai-translation-content-splitter-test.zip](https://github.com/user-attachments/files/32094104/discourse-ai-translation-content-splitter-test.zip)

Tested the splitter with:

* the original problematic content;
* multiple HTML elements;
* HTML elements around Markdown headings and links;
* nested HTML;
* HTML entities;
* void/self-closing elements;
* HTML attributes containing special characters;
* large HTML blocks;
* content without HTML.

Verified that chunks stay within the configured chunk size and that concatenating the resulting chunks reproduces the original input.

## LLM used

I don't know Ruby and couldn't find the source of the bug without LLM, so most of the work to find, write tests for that and patch of the bug was done with LLM. But I could verify that this patch fixes content splitter and it works with my text.