### PR TITLE
UX: Show workflow data table row counts at a glance

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/data-table/manager.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/data-table/manager.gjs
@@ -114,6 +114,9 @@ export default class DataTablesManager extends PaginatedListManager {
             "discourse_workflows.data_tables.columns"
           }}</th>
         <th class="d-table__header-cell">{{i18n
+            "discourse_workflows.data_tables.rows"
+          }}</th>
+        <th class="d-table__header-cell">{{i18n
             "discourse_workflows.data_tables.size"
           }}</th>
         <th class="d-table__header-cell"></th>
@@ -132,7 +135,13 @@ export default class DataTablesManager extends PaginatedListManager {
           <div class="d-table__mobile-label">
             {{i18n "discourse_workflows.data_tables.columns"}}
           </div>
-          {{dataTable.columns.length}}
+          {{dataTable.column_count}}
+        </td>
+        <td class="d-table__cell --detail">
+          <div class="d-table__mobile-label">
+            {{i18n "discourse_workflows.data_tables.rows"}}
+          </div>
+          {{dataTable.row_count}}
         </td>
         <td class="d-table__cell --detail">
           <div class="d-table__mobile-label">

--- a/plugins/discourse-workflows/app/controllers/discourse_workflows/data_tables_controller.rb
+++ b/plugins/discourse-workflows/app/controllers/discourse_workflows/data_tables_controller.rb
@@ -6,15 +6,15 @@ module DiscourseWorkflows
 
     def index
       DiscourseWorkflows::DataTable::List.call(service_params) do |result|
-        on_success do |data_tables:, total_rows:, table_sizes:, load_more_url:|
+        on_success do |data_tables:, total_rows:, table_stats:, load_more_url:|
           render json: {
                    data_tables:
                      serialize_data(
                        data_tables,
                        DiscourseWorkflows::DataTableSerializer,
-                       table_sizes: table_sizes,
+                       table_stats:,
                      ),
-                   meta: { total_rows: total_rows, load_more_url: load_more_url }.compact,
+                   meta: { total_rows:, load_more_url: }.compact,
                  }
         end
         on_failure { render(json: failed_json, status: :unprocessable_entity) }

--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/data_table_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/data_table_serializer.rb
@@ -2,18 +2,28 @@
 
 module DiscourseWorkflows
   class DataTableSerializer < ApplicationSerializer
-    attributes :id, :name, :size, :columns, :created_at, :updated_at
+    attributes :id, :name, :size, :columns, :column_count, :row_count, :created_at, :updated_at
+
+    def column_count
+      columns.size
+    end
+
+    def row_count
+      @options[:table_stats].fetch(object.id).fetch(:row_count)
+    end
+
+    def include_row_count?
+      @options.key?(:table_stats)
+    end
 
     def columns
-      object.columns.map { |c| { name: c["name"], type: c["type"] } }
+      @columns ||= object.columns
     end
 
     def size
-      if @options[:table_sizes]
-        @options[:table_sizes].fetch(object.id, 0)
-      else
-        DiscourseWorkflows::DataTables::Facade.size_bytes(object.id)
-      end
+      return @options[:table_stats].fetch(object.id).fetch(:size) if @options[:table_stats]
+
+      DiscourseWorkflows::DataTables::Facade.size_bytes(object.id)
     end
   end
 end

--- a/plugins/discourse-workflows/app/services/discourse_workflows/data_table/list.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/data_table/list.rb
@@ -14,7 +14,7 @@ module DiscourseWorkflows
     end
 
     model :data_tables, optional: true
-    model :table_sizes, :compute_table_sizes, optional: true
+    model :table_stats, :compute_table_stats, optional: true
     model :total_rows, :compute_total_rows
     model :load_more_url, :compute_load_more_url, optional: true
 
@@ -31,8 +31,8 @@ module DiscourseWorkflows
       context[:page].records
     end
 
-    def compute_table_sizes(data_tables:)
-      DiscourseWorkflows::DataTables::Facade.batch_size_bytes(data_tables.map(&:id))
+    def compute_table_stats(data_tables:)
+      DiscourseWorkflows::DataTables::Facade.batch_stats(data_tables.map(&:id))
     end
 
     def compute_total_rows

--- a/plugins/discourse-workflows/lib/discourse_workflows/data_tables/facade.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/data_tables/facade.rb
@@ -87,8 +87,10 @@ module DiscourseWorkflows
           Storage.total_size_bytes
         end
 
-        def batch_size_bytes(data_table_ids)
-          Storage.batch_size_bytes(data_table_ids)
+        def batch_stats(data_table_ids)
+          return {} if data_table_ids.empty?
+
+          with_statement_timeout { Storage.batch_stats(data_table_ids) }
         end
 
         def size_bytes(data_table_id)
@@ -102,12 +104,36 @@ module DiscourseWorkflows
         def drop_table!(data_table_id)
           Storage.drop_table!(data_table_id)
         end
+
+        def with_statement_timeout
+          connection = ActiveRecord::Base.connection
+          previous_timeout =
+            connection.select_value("SHOW statement_timeout") if connection.transaction_open?
+
+          connection.transaction(requires_new: true) do
+            connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT_MS}ms'")
+
+            result = yield
+
+            if previous_timeout
+              connection.execute(
+                "SET LOCAL statement_timeout = #{connection.quote(previous_timeout)}",
+              )
+            end
+
+            result
+          end
+        rescue ActiveRecord::QueryCanceled, PG::QueryCanceled
+          raise StatementTimeout, "Data table query exceeded the maximum allowed execution time"
+        end
       end
 
       SORT_DIRECTIONS = { "asc" => "ASC", "desc" => "DESC" }.freeze
       MAX_LIMIT = 100
 
       attr_reader :data_table
+
+      delegate :with_statement_timeout, to: :class, private: true
 
       def initialize(data_table)
         @data_table = data_table
@@ -352,15 +378,6 @@ module DiscourseWorkflows
         end
       rescue PG::LockNotAvailable
         raise
-      end
-
-      def with_statement_timeout
-        connection.transaction do
-          connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT_MS}ms'")
-          yield
-        end
-      rescue ActiveRecord::QueryCanceled
-        raise StatementTimeout, "Data table query exceeded the maximum allowed execution time"
       end
     end
   end

--- a/plugins/discourse-workflows/lib/discourse_workflows/data_tables/storage.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/data_tables/storage.rb
@@ -90,31 +90,28 @@ module DiscourseWorkflows
         end
 
         def size_bytes(data_table_id)
-          batch_size_bytes([data_table_id]).fetch(data_table_id, 0)
+          DB
+            .query_single(
+              "SELECT pg_total_relation_size(to_regclass(:table_name))",
+              table_name: quoted_table(data_table_id),
+            )
+            .first
+            .to_i
         end
 
-        def batch_size_bytes(data_table_ids)
+        def batch_stats(data_table_ids)
           return {} if data_table_ids.empty?
 
-          names = data_table_ids.map { |id| table_name(id) }
-          DB
-            .query(<<~SQL, names: names)
-            SELECT c.relname, pg_total_relation_size(c.oid) AS size_bytes
-            FROM pg_class c
-            JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE n.nspname = current_schema()
-              AND c.relname = ANY(ARRAY[:names])
-              AND c.relkind = 'r'
+          queries = data_table_ids.map { |id| <<~SQL }
+            SELECT #{Integer(id)} AS data_table_id,
+                   COUNT(*) AS row_count,
+                   pg_total_relation_size(#{connection.quote(quoted_table(id))}::regclass) AS size
+            FROM #{quoted_table(id)}
           SQL
-            .to_h do |row|
-              id =
-                row
-                  .relname
-                  .delete_prefix("discourse_workflows_data_table_")
-                  .delete_suffix("_rows")
-                  .to_i
-              [id, row.size_bytes.to_i]
-            end
+
+          DB
+            .query(queries.join(" UNION ALL "))
+            .to_h { |row| [row.data_table_id, { size: row.size, row_count: row.row_count }] }
         end
 
         def quoted_table(data_table_id)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/data_tables/facade_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/data_tables/facade_spec.rb
@@ -618,13 +618,24 @@ RSpec.describe DiscourseWorkflows::DataTables::Facade do
   end
 
   describe "statement timeout" do
-    it "raises StatementTimeout when a query exceeds the limit" do
-      stub_const(DiscourseWorkflows::DataTables::Facade, :STATEMENT_TIMEOUT_MS, 100) do
-        expect {
-          facade.send(:with_statement_timeout) do
-            ActiveRecord::Base.connection.execute("SELECT pg_sleep(1)")
-          end
-        }.to raise_error(described_class::StatementTimeout)
+    it "preserves the connection timeout after successful batch statistics" do
+      DB.exec("SET LOCAL statement_timeout = '2s'")
+
+      described_class.batch_stats([data_table.id])
+
+      expect(DB.query_single("SHOW statement_timeout").first).to eq("2s")
+    end
+
+    it "cancels slow counts and restores the connection timeout" do
+      table_name = DiscourseWorkflows::DataTables::Storage.quoted_table(data_table.id)
+      DB.exec("CREATE TEMP VIEW #{table_name} AS SELECT 1 AS id FROM pg_sleep(1)")
+      original_timeout = DB.query_single("SHOW statement_timeout").first
+
+      stub_const(described_class, :STATEMENT_TIMEOUT_MS, 50) do
+        [-> { described_class.batch_stats([data_table.id]) }, -> { facade.count }].each do |query|
+          expect { query.call }.to raise_error(described_class::StatementTimeout)
+          expect(DB.query_single("SHOW statement_timeout").first).to eq(original_timeout)
+        end
       end
     end
   end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/data_tables/storage_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/data_tables/storage_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe DiscourseWorkflows::DataTables::Storage do
     )
   end
 
+  describe ".size_bytes" do
+    it "returns the table size or zero for a missing table" do
+      expect(described_class.size_bytes(data_table.id)).to be > 0
+      expect(described_class.size_bytes(-1)).to eq(0)
+    end
+  end
+
   describe ".columns" do
     it "returns all columns with mapped types ordered by attnum" do
       columns = described_class.columns(data_table.id)

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/data_tables_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/data_tables_controller_spec.rb
@@ -35,12 +35,23 @@ RSpec.describe DiscourseWorkflows::DataTablesController do
                      :get,
                      -> { "/admin/plugins/discourse-workflows/data-tables.json" }
 
-    it "lists data tables" do
+    it "lists data tables with their row counts" do
+      empty_data_table = Fabricate(:discourse_workflows_data_table)
+      2.times { insert_data_table_row(data_table) }
+
       get "/admin/plugins/discourse-workflows/data-tables.json"
+
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
-      expect(json["data_tables"].length).to eq(1)
-      expect(json["data_tables"][0]["name"]).to eq(data_table.name)
+      expect(json["data_tables"]).to contain_exactly(
+        include(
+          "id" => data_table.id,
+          "name" => data_table.name,
+          "column_count" => 4,
+          "row_count" => 2,
+        ),
+        include("id" => empty_data_table.id, "column_count" => 4, "row_count" => 0),
+      )
       expect(json["data_tables"][0]["size"]).to be > 0
     end
 

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/data_table/list_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/data_table/list_spec.rb
@@ -18,22 +18,12 @@ RSpec.describe DiscourseWorkflows::DataTable::List do
     end
 
     context "when there are no data tables" do
-      it { is_expected.to run_successfully }
-
-      it "returns an empty collection" do
+      it "returns an empty page" do
+        expect(result).to run_successfully
         expect(result[:data_tables]).to be_empty
-      end
-
-      it "returns zero total rows" do
         expect(result[:total_rows]).to eq(0)
-      end
-
-      it "does not return a load more url" do
         expect(result[:load_more_url]).to be_nil
-      end
-
-      it "returns empty table sizes" do
-        expect(result[:table_sizes]).to eq({})
+        expect(result[:table_stats]).to eq({})
       end
     end
 
@@ -41,59 +31,40 @@ RSpec.describe DiscourseWorkflows::DataTable::List do
       fab!(:data_table_a) { Fabricate(:discourse_workflows_data_table, name: "Alpha") }
       fab!(:data_table_b) { Fabricate(:discourse_workflows_data_table, name: "Bravo") }
 
-      it { is_expected.to run_successfully }
-
-      it "returns data tables ordered by id descending" do
+      it "returns all data tables ordered by id descending" do
+        expect(result).to run_successfully
         expect(result[:data_tables].map(&:id)).to eq([data_table_b.id, data_table_a.id])
-      end
-
-      it "returns the total count" do
         expect(result[:total_rows]).to eq(2)
-      end
-
-      it "does not return a load more url when all results fit" do
         expect(result[:load_more_url]).to be_nil
-      end
-
-      it "returns table sizes keyed by data table id" do
-        expect(result[:table_sizes].keys).to contain_exactly(data_table_a.id, data_table_b.id)
+        expect(result[:table_stats].keys).to contain_exactly(data_table_a.id, data_table_b.id)
       end
     end
 
     context "with pagination" do
-      let(:params) { { limit: 2 } }
-
       fab!(:data_table_1) { Fabricate(:discourse_workflows_data_table, name: "First") }
       fab!(:data_table_2) { Fabricate(:discourse_workflows_data_table, name: "Second") }
       fab!(:data_table_3) { Fabricate(:discourse_workflows_data_table, name: "Third") }
 
-      it "returns only the requested number of data tables" do
-        expect(result[:data_tables].size).to eq(2)
-      end
+      let(:params) { { limit: 2 } }
 
-      it "returns a load more url with cursor" do
-        last_id = result[:data_tables].last.id
+      it "returns the first page with statistics and a next-page cursor" do
+        expect(result).to run_successfully
+        expect(result[:data_tables].map(&:id)).to eq([data_table_3.id, data_table_2.id])
+        expect(result[:total_rows]).to eq(3)
+        expect(result[:table_stats].keys).to contain_exactly(data_table_3.id, data_table_2.id)
         expect(result[:load_more_url]).to eq(
-          "/admin/plugins/discourse-workflows/data-tables.json?cursor=#{last_id}&limit=2",
+          "/admin/plugins/discourse-workflows/data-tables.json?cursor=#{data_table_2.id}&limit=2",
         )
       end
 
-      it "returns the total count of all data tables" do
-        expect(result[:total_rows]).to eq(3)
-      end
-
-      it "returns table sizes only for returned data tables" do
-        expect(result[:table_sizes].keys.size).to eq(2)
-      end
-
       context "when using a cursor" do
-        let(:params) { { limit: 2, cursor: data_table_3.id } }
+        let(:params) { { limit: 2, cursor: data_table_2.id } }
 
-        it "returns data tables after the cursor" do
-          expect(result[:data_tables].map(&:id)).to eq([data_table_2.id, data_table_1.id])
-        end
-
-        it "does not return a load more url when no more results" do
+        it "returns the final page after the cursor" do
+          expect(result).to run_successfully
+          expect(result[:data_tables].map(&:id)).to eq([data_table_1.id])
+          expect(result[:total_rows]).to eq(3)
+          expect(result[:table_stats].keys).to eq([data_table_1.id])
           expect(result[:load_more_url]).to be_nil
         end
       end

--- a/plugins/discourse-workflows/spec/system/data_tables_spec.rb
+++ b/plugins/discourse-workflows/spec/system/data_tables_spec.rb
@@ -7,12 +7,15 @@ RSpec.describe "Discourse Workflows - Data Tables" do
 
   before { sign_in(admin) }
 
-  it "shows existing data tables" do
+  it "shows existing data tables with their row counts" do
     data_table = Fabricate(:discourse_workflows_data_table, name: "users_cache")
+    2.times { insert_data_table_row(data_table) }
 
     data_tables_page.visit_index
 
     expect(data_tables_page).to have_data_table("users_cache")
+    expect(data_tables_page).to have_row_count_column
+    expect(data_tables_page).to have_data_table_row_count(data_table, 2)
   end
 
   it "creates a new data table and navigates to its viewer" do

--- a/plugins/discourse-workflows/spec/system/page_objects/pages/data_tables.rb
+++ b/plugins/discourse-workflows/spec/system/page_objects/pages/data_tables.rb
@@ -22,6 +22,28 @@ module PageObjects
           page.has_no_css?(".d-table__overview-name", text: name)
         end
 
+        def has_row_count_column?
+          headers =
+            %w[name columns rows size].map do |column|
+              I18n.t("js.discourse_workflows.data_tables.#{column}")
+            end
+
+          page.has_css?(
+            ".d-table__header",
+            text: headers.join(" "),
+            exact_text: true,
+            normalize_ws: true,
+          )
+        end
+
+        def has_data_table_row_count?(data_table, count)
+          page.has_css?(
+            ".d-table__row[data-item-id='#{data_table.id}'] .d-table__cell:nth-child(3)",
+            text: count.to_s,
+            exact_text: true,
+          )
+        end
+
         def click_add_data_table
           if page.has_css?(".workflows-empty-state", wait: 5)
             find(".workflows-empty-state .btn-primary").click


### PR DESCRIPTION
Previously, the workflow data table list showed column counts and storage sizes but omitted row counts, making table volumes difficult to compare.

This change adds exact row counts between Columns and Size, fetching counts and sizes together under a 500 ms timeout and restoring the previous timeout afterward.

<img width="1505" height="1041" alt="2026-09-11 @ 09 50 46" src="https://github.com/user-attachments/assets/1c1f2a3d-78ac-41c6-97e8-32d8e2e013df" />
