### PR TITLE
UX: stack the sentiment analysis report into cards on mobile

### DIFF
--- a/plugins/discourse-ai/assets/stylesheets/modules/sentiment/common/dashboard.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/sentiment/common/dashboard.scss
@@ -196,6 +196,36 @@
 .sentiment-analysis-table {
   font-weight: bold;
   font-size: var(--font-up-1);
+
+  @include viewport.until(sm) {
+    thead {
+      display: none;
+    }
+
+    &__row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      column-gap: var(--space-2);
+      row-gap: var(--space-2);
+      padding: var(--space-3);
+      margin-bottom: var(--space-2);
+      border: 1px solid var(--primary-low);
+      border-radius: var(--d-border-radius);
+    }
+
+    &__title {
+      flex: 1 1 auto;
+    }
+
+    &__total-score {
+      flex: 0 0 auto;
+    }
+
+    .sentiment-horizontal-bar {
+      flex: 1 1 100%;
+    }
+  }
 }
 
 .sentiment-horizontal-bar {


### PR DESCRIPTION
On small screens, each category's positive/neutral/negative bar was squeezed into a cramped table row. Rows now stack into full-width cards with the bar spanning the whole width, with no change on desktop.

Before:

<img width=300 src="https://github.com/user-attachments/assets/81a3d0c6-bc66-485b-a119-0fe301d30e4d" />

After:

<img width=300 src="https://github.com/user-attachments/assets/d89a79fe-b381-4ab7-8b92-3e5711492cd7" />