### PR TITLE
DEV: Upgrade to Rack 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,9 @@ gem "highline", require: false
 
 gem "rack"
 
+# `prometheus_exporter`, pulled in by discourse-prometheus, lists it as a runtime dependency.
+gem "webrick", require: false
+
 gem "rack-protection" # security
 gem "cbor", require: false
 gem "cose", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -109,8 +109,7 @@ gem "mini_racer"
 
 gem "highline", require: false
 
-# TODO: upgrade to Rack 3 now that Unicorn has been removed
-gem "rack", "< 3"
+gem "rack"
 
 gem "rack-protection" # security
 gem "cbor", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -796,6 +796,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.2)
     wisper (2.0.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -989,6 +990,7 @@ DEPENDENCIES
   unf
   web-push
   webmock
+  webrick
   yaml-lint
   yard
   zendesk_api
@@ -1338,6 +1340,7 @@ CHECKSUMS
   version_gem (1.1.15) sha256=a73241587b29252e3567e0c818ded80730eb754d43b508f6ce4db22ca9ba27d0
   web-push (3.1.0) sha256=501ab00340c58fb70dabda59f28a86b3cccb0930c6f1f30721b2a5b24de7187d
   webmock (3.26.4) sha256=8d8da206d217ebe6968cfb09c77f4533c23074e1432bad865f3994eacbaad50d
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   wisper (2.0.1) sha256=ce17bc5c3a166f241a2e6613848b025c8146fce2defba505920c1d1f3f88fae6
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   yaml-lint (0.1.2) sha256=e3960b171766ae187338a169815e99fe10fcb0d9c22b1c539e8d57e114324c8a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,19 +515,20 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.24)
+    rack (3.2.7)
     rack-mini-profiler (5.0.0)
       rack (>= 1.2.0)
-    rack-protection (3.2.0)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
-    rack-session (1.0.2)
-      rack (< 3)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -795,7 +796,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
     wisper (2.0.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -933,7 +933,7 @@ DEPENDENCIES
   propshaft
   pry-rails
   puma
-  rack (< 3)
+  rack
   rack-mini-profiler
   rack-protection
   rails-dom-testing
@@ -1213,12 +1213,12 @@ CHECKSUMS
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (2.2.24) sha256=ef16526a0d871c43753452338c754040a664c8b41bf0dd7450b85f7772adca5f
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rack-mini-profiler (5.0.0) sha256=99c5ba087fa91c8d9ba80a43f6b2213f1ebead6e863d49286170129d391302e1
-  rack-protection (3.2.0) sha256=3c74ba7fc59066453d61af9bcba5b6fe7a9b3dab6f445418d3b391d5ea8efbff
-  rack-session (1.0.2) sha256=a02115e5420b4de036839b9811e3f7967d73446a554b42aa45106af335851d76
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
-  rackup (1.0.1) sha256=ba86604a28989fe1043bff20d819b360944ca08156406812dca6742b24b3c249
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   rails_failover (2.3.0) sha256=eed6ea0674fd6f9f6b070ad297ad2ead121ecf9202920f6068b6a4f29d9491c9
@@ -1338,7 +1338,6 @@ CHECKSUMS
   version_gem (1.1.15) sha256=a73241587b29252e3567e0c818ded80730eb754d43b508f6ce4db22ca9ba27d0
   web-push (3.1.0) sha256=501ab00340c58fb70dabda59f28a86b3cccb0930c6f1f30721b2a5b24de7187d
   webmock (3.26.4) sha256=8d8da206d217ebe6968cfb09c77f4533c23074e1432bad865f3994eacbaad50d
-  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   wisper (2.0.1) sha256=ce17bc5c3a166f241a2e6613848b025c8146fce2defba505920c1d1f3f88fae6
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   yaml-lint (0.1.2) sha256=e3960b171766ae187338a169815e99fe10fcb0d9c22b1c539e8d57e114324c8a

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -158,7 +158,7 @@ class PostsController < ApplicationController
     # Stuff the user in the request object, because that's what IncomingLink wants
     if params[:user_id]
       user = User.find_by(id: params[:user_id].to_i)
-      request["u"] = user.username_lower if user
+      request.params["u"] = user.username_lower if user
     end
 
     guardian.ensure_can_see!(post)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1498,7 +1498,7 @@ class TopicsController < ApplicationController
         current_user: current_user,
         topic_id: @topic_view.topic.id,
         post_number: @topic_view.current_post_number,
-        username: request["u"],
+        username: request.params["u"],
         ip_address: request.remote_ip,
       }
       # defer this way so we do not capture the whole controller

--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -225,7 +225,7 @@ class UserAvatarsController < ApplicationController
 
   # this protects us from a DoS
   def render_blank
-    path = Rails.root + "public/images/avatar.png"
+    path = Rails.root.join("public/images/avatar.png").to_s
     expires_in 10.minutes, public: true
     response.headers["Last-Modified"] = Time.new(1990, 01, 01).httpdate
     response.headers["Content-Length"] = File.size(path).to_s

--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -225,7 +225,7 @@ class UserAvatarsController < ApplicationController
 
   # this protects us from a DoS
   def render_blank
-    path = Rails.root.join("public/images/avatar.png").to_s
+    path = Rails.public_path.join("images/avatar.png").to_s
     expires_in 10.minutes, public: true
     response.headers["Last-Modified"] = Time.new(1990, 01, 01).httpdate
     response.headers["Content-Length"] = File.size(path).to_s

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -34,11 +34,11 @@ def setup_message_bus_env(env)
     end
 
     extra_headers = {
-      "Access-Control-Allow-Origin" => cors_origin,
-      "Access-Control-Allow-Methods" => "GET, POST",
-      "Access-Control-Allow-Headers" =>
+      "access-control-allow-origin" => cors_origin,
+      "access-control-allow-methods" => "GET, POST",
+      "access-control-allow-headers" =>
         "X-SILENCE-LOGGER, X-Shared-Session-Key, Dont-Chunk, Discourse-Present, Discourse-Deferred-Track-View",
-      "Access-Control-Max-Age" => "7200",
+      "access-control-max-age" => "7200",
     }
 
     user = nil
@@ -47,7 +47,7 @@ def setup_message_bus_env(env)
     rescue Discourse::InvalidAccess => e
       # this is bad we need to remove the cookie
       if e.opts[:delete_cookie].present?
-        extra_headers["Set-Cookie"] = "_t=del; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+        extra_headers["set-cookie"] = "_t=del; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
       end
     rescue => e
       Discourse.warn_exception(e, message: "Unexpected error in Message Bus", env: env)
@@ -76,11 +76,11 @@ def setup_message_bus_env(env)
         [Group::AUTO_GROUPS[:anonymous_users]]
       end
 
-    extra_headers["Discourse-Logged-Out"] = "1" if env[Auth::DefaultCurrentUserProvider::BAD_TOKEN]
+    extra_headers["discourse-logged-out"] = "1" if env[Auth::DefaultCurrentUserProvider::BAD_TOKEN]
 
     if Rails.env.development?
       # Adding no-transform prevents the expressjs ember-cli proxy buffering/compressing the response
-      extra_headers["Cache-Control"] = "no-transform, must-revalidate, private, max-age=0"
+      extra_headers["cache-control"] = "no-transform, must-revalidate, private, max-age=0"
     end
 
     hash = {
@@ -100,8 +100,8 @@ MessageBus.extra_response_headers_lookup do |env|
   setup_message_bus_env(env)
   headers = env["__mb"][:extra_headers]
   if view_tracking_data = env["discourse.view_tracking_data"]
-    headers["X-Discourse-TrackView"] = "1" if view_tracking_data[:track_view]
-    headers["X-Discourse-BrowserPageView"] = "1" if view_tracking_data[:browser_page_view]
+    headers["x-discourse-trackview"] = "1" if view_tracking_data[:track_view]
+    headers["x-discourse-browserpageview"] = "1" if view_tracking_data[:browser_page_view]
   end
   headers
 end
@@ -125,7 +125,7 @@ MessageBus.on_middleware_error do |env, e|
   if Discourse::InvalidAccess === e
     [403, {}, ["Invalid Access"]]
   elsif RateLimiter::LimitExceeded === e
-    [429, { "Retry-After" => e.available_in.to_s }, [e.description]]
+    [429, { "retry-after" => e.available_in.to_s }, [e.description]]
   end
 end
 

--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -91,7 +91,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
 
   Rack::MiniProfiler.config.content_security_policy_nonce =
     Proc.new do |env, headers|
-      if csp = headers["Content-Security-Policy"] || headers["Content-Security-Policy-Report-Only"]
+      if csp = headers["content-security-policy"] || headers["content-security-policy-report-only"]
         csp[/script-src[^;]+'nonce-([^']+)'/, 1]
       end
     end

--- a/config/initializers/008-rack-cors.rb
+++ b/config/initializers/008-rack-cors.rb
@@ -32,19 +32,19 @@ class Discourse::Cors
   end
 
   def self.apply_headers(cors_origins, env, headers)
-    if headers["Access-Control-Allow-Origin"]
+    if headers["access-control-allow-origin"]
       # Already configured. Probably by ApplicationController#apply_cdn_headers
     elsif cors_origins
       origin = env["HTTP_ORIGIN"]
       origin = nil if origin && cors_origins.exclude?(origin)
 
-      headers["Access-Control-Allow-Origin"] = origin || cors_origins[0]
+      headers["access-control-allow-origin"] = origin || cors_origins[0]
       headers[
-        "Access-Control-Allow-Headers"
+        "access-control-allow-headers"
       ] = "Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Present, User-Api-Key, User-Api-Client-Id, Authorization"
-      headers["Access-Control-Allow-Credentials"] = "true"
-      headers["Access-Control-Allow-Methods"] = "POST, PUT, GET, OPTIONS, DELETE"
-      headers["Access-Control-Max-Age"] = "7200"
+      headers["access-control-allow-credentials"] = "true"
+      headers["access-control-allow-methods"] = "POST, PUT, GET, OPTIONS, DELETE"
+      headers["access-control-max-age"] = "7200"
     end
 
     headers

--- a/config/initializers/200-first_middlewares.rb
+++ b/config/initializers/200-first_middlewares.rb
@@ -79,9 +79,9 @@ if Rails.env.test?
       status, headers, body = @app.call(env)
       if headers["Content-Type"]&.match?(/html/) && BlockRequestsMiddleware.current_example_location
         headers["Set-Cookie"] = [
-          headers["Set-Cookie"],
+          *headers["Set-Cookie"],
           "#{RSPEC_CURRENT_EXAMPLE_COOKIE_STRING}=#{BlockRequestsMiddleware.current_example_location}; path=/;",
-        ].compact.join("\n")
+        ]
       end
       [status, headers, body]
     end

--- a/config/initializers/200-first_middlewares.rb
+++ b/config/initializers/200-first_middlewares.rb
@@ -69,7 +69,7 @@ if Rails.env.test?
            )
         return [
           503,
-          { "Content-Type" => "text/plain" },
+          { "content-type" => "text/plain" },
           [
             "Blocked by BlockRequestsMiddleware for requests initiated by #{request.cookies[RSPEC_CURRENT_EXAMPLE_COOKIE_STRING]} when running #{self.class.current_example_location}",
           ]
@@ -77,9 +77,9 @@ if Rails.env.test?
       end
 
       status, headers, body = @app.call(env)
-      if headers["Content-Type"]&.match?(/html/) && BlockRequestsMiddleware.current_example_location
-        headers["Set-Cookie"] = [
-          *headers["Set-Cookie"],
+      if headers["content-type"]&.match?(/html/) && BlockRequestsMiddleware.current_example_location
+        headers["set-cookie"] = [
+          *headers["set-cookie"],
           "#{RSPEC_CURRENT_EXAMPLE_COOKIE_STRING}=#{BlockRequestsMiddleware.current_example_location}; path=/;",
         ]
       end

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -125,11 +125,11 @@ class Auth::DefaultCurrentUserProvider
     user_api_key = @env[USER_API_KEY]
     api_key = @env[HEADER_API_KEY]
 
-    if @env.present? && request.params[PARAMETER_USER_API_KEY] && api_parameter_allowed?
+    if @env.present? && api_parameter_allowed? && request.params[PARAMETER_USER_API_KEY]
       user_api_key ||= request.params[PARAMETER_USER_API_KEY]
     end
 
-    if @env.present? && request.params[API_KEY] && api_parameter_allowed?
+    if @env.present? && api_parameter_allowed? && request.params[API_KEY]
       api_key ||= request.params[API_KEY]
     end
 

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -125,11 +125,13 @@ class Auth::DefaultCurrentUserProvider
     user_api_key = @env[USER_API_KEY]
     api_key = @env[HEADER_API_KEY]
 
-    if @env.present? && request[PARAMETER_USER_API_KEY] && api_parameter_allowed?
-      user_api_key ||= request[PARAMETER_USER_API_KEY]
+    if @env.present? && request.params[PARAMETER_USER_API_KEY] && api_parameter_allowed?
+      user_api_key ||= request.params[PARAMETER_USER_API_KEY]
     end
 
-    api_key ||= request[API_KEY] if @env.present? && request[API_KEY] && api_parameter_allowed?
+    if @env.present? && request.params[API_KEY] && api_parameter_allowed?
+      api_key ||= request.params[API_KEY]
+    end
 
     auth_token = find_auth_token
     current_user = nil
@@ -409,7 +411,7 @@ class Auth::DefaultCurrentUserProvider
 
   def lookup_api_user(api_key_value, request)
     if api_key = ApiKey.active.with_key(api_key_value).includes(:user).first
-      api_username = header_api_key? ? @env[HEADER_API_USERNAME] : request[API_USERNAME]
+      api_username = header_api_key? ? @env[HEADER_API_USERNAME] : request.params[API_USERNAME]
 
       return nil if !api_key.request_allowed?(@env)
 
@@ -418,10 +420,16 @@ class Auth::DefaultCurrentUserProvider
           api_key.user if !api_username || (api_key.user.username_lower == api_username.downcase)
         elsif api_username
           User.find_by(username_lower: api_username.downcase)
-        elsif user_id = header_api_key? ? @env[HEADER_API_USER_ID] : request["api_user_id"]
+        elsif user_id = header_api_key? ? @env[HEADER_API_USER_ID] : request.params["api_user_id"]
           User.find_by(id: user_id.to_i)
         elsif external_id =
-              header_api_key? ? @env[HEADER_API_USER_EXTERNAL_ID] : request["api_user_external_id"]
+              (
+                if header_api_key?
+                  @env[HEADER_API_USER_EXTERNAL_ID]
+                else
+                  request.params["api_user_external_id"]
+                end
+              )
           SingleSignOnRecord.find_by(external_id: external_id.to_s).try(:user)
         end
 

--- a/lib/content_security_policy/middleware.rb
+++ b/lib/content_security_policy/middleware.rb
@@ -11,10 +11,10 @@ class ContentSecurityPolicy
       request = Rack::Request.new(env)
       _, headers, _ = response = @app.call(env)
 
-      return response if headers["Content-Security-Policy"].present?
+      return response if headers["content-security-policy"].present?
       return response unless html_response?(headers)
 
-      prevent_framing = headers["X-Frame-Options"] == "DENY"
+      prevent_framing = headers["x-frame-options"] == "DENY"
 
       # The EnforceHostname middleware ensures request.host_with_port can be trusted
       protocol = (SiteSetting.force_https || request.ssl?) ? "https://" : "http://"
@@ -24,7 +24,7 @@ class ContentSecurityPolicy
 
       if SiteSetting.content_security_policy || prevent_framing
         enforced_policy = policy(theme_id, base_url: base_url, path_info: env["PATH_INFO"])
-        headers["Content-Security-Policy"] = (
+        headers["content-security-policy"] = (
           if prevent_framing
             policy_preventing_framing(enforced_policy)
           else
@@ -32,7 +32,7 @@ class ContentSecurityPolicy
           end
         )
       end
-      headers["Content-Security-Policy-Report-Only"] = policy(
+      headers["content-security-policy-report-only"] = policy(
         theme_id,
         base_url: base_url,
         path_info: env["PATH_INFO"],
@@ -54,7 +54,7 @@ class ContentSecurityPolicy
     end
 
     def html_response?(headers)
-      headers["Content-Type"] && headers["Content-Type"] =~ /html/
+      headers["content-type"] && headers["content-type"] =~ /html/
     end
   end
 end

--- a/lib/demon/rails_autospec.rb
+++ b/lib/demon/rails_autospec.rb
@@ -14,9 +14,13 @@ class Demon::RailsAutospec < Demon::Base
   private
 
   def after_fork
-    require "rack"
+    require "rackup"
     ENV["RAILS_ENV"] = "test"
-    Rack::Server.start(config: "config.ru", AccessLog: [], Port: ENV["TEST_SERVER_PORT"] || 60_099)
+    Rackup::Server.start(
+      config: "config.ru",
+      AccessLog: [],
+      Port: ENV["TEST_SERVER_PORT"] || 60_099,
+    )
   rescue => e
     STDERR.puts e.message
     STDERR.puts e.backtrace.join("\n")

--- a/lib/hijack.rb
+++ b/lib/hijack.rb
@@ -102,7 +102,7 @@ module Hijack
             headers["X-Runtime"] = "#{"%0.6f" % duration}"
           end
 
-          headers.each { |name, val| io.write "#{name}: #{val}\r\n" }
+          headers.each { |name, val| Array(val).each { |v| io.write "#{name}: #{v}\r\n" } }
 
           io.write "\r\n"
           io.write body

--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -94,7 +94,7 @@ module Middleware
         return false if @request.path.ends_with?("robots.txt")
         return false if @request.path.ends_with?("llms.txt")
         return false if @request.path.ends_with?("srv/status")
-        return false if @request.params[Auth::DefaultCurrentUserProvider::API_KEY]
+        return false if @request.GET[Auth::DefaultCurrentUserProvider::API_KEY]
         return false if @env[Auth::DefaultCurrentUserProvider::USER_API_KEY]
         return false if @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY]
 
@@ -237,7 +237,7 @@ module Middleware
       def no_cache_bypass
         request = Rack::Request.new(@env)
         request.cookies["_bypass_cache"].nil? && (request.path != "/srv/status") &&
-          request.params[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
+          request.GET[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::USER_API_KEY].nil?
       end

--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -341,14 +341,14 @@ module Middleware
             # technically lua will cast for us, but might as well be
             # prudent here, hence the to_i
             if count.to_i < GlobalSetting.anon_cache_store_threshold
-              headers["X-Discourse-Cached"] = "skip"
+              headers["x-discourse-cached"] = "skip"
               return status, headers, response
             end
           end
 
           headers_stripped =
             Rack::Headers[headers].delete_if { |k, _| %w[set-cookie x-miniprofiler-ids].include? k }
-          headers_stripped["X-Discourse-Cached"] = "true"
+          headers_stripped["x-discourse-cached"] = "true"
           parts = []
           response.each { |part| parts << part }
 
@@ -362,7 +362,7 @@ module Middleware
           Discourse.redis.setex(cache_key_body, cache_duration, compress(parts.join))
           Discourse.redis.setex(cache_key_other, cache_duration, [status, headers_stripped].to_json)
 
-          headers["X-Discourse-Cached"] = "store"
+          headers["x-discourse-cached"] = "store"
         else
           parts = response
         end
@@ -431,7 +431,7 @@ module Middleware
           @app.call(env)
         end
 
-      result[1]["Set-Cookie"] = "dosp=1; Path=/" if force_anon
+      result[1]["set-cookie"] = "dosp=1; Path=/" if force_anon
 
       result
     end

--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -94,7 +94,7 @@ module Middleware
         return false if @request.path.ends_with?("robots.txt")
         return false if @request.path.ends_with?("llms.txt")
         return false if @request.path.ends_with?("srv/status")
-        return false if @request[Auth::DefaultCurrentUserProvider::API_KEY]
+        return false if @request.params[Auth::DefaultCurrentUserProvider::API_KEY]
         return false if @env[Auth::DefaultCurrentUserProvider::USER_API_KEY]
         return false if @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY]
 
@@ -237,7 +237,7 @@ module Middleware
       def no_cache_bypass
         request = Rack::Request.new(@env)
         request.cookies["_bypass_cache"].nil? && (request.path != "/srv/status") &&
-          request[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
+          request.params[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::USER_API_KEY].nil?
       end
@@ -316,7 +316,7 @@ module Middleware
             if req_params = other[1].delete(ADP)
               env[ADP] = req_params
             end
-            [other[0], other[1], [body]]
+            [other[0], Rack::Headers[other[1]], [body]]
           end
         end
       end
@@ -347,7 +347,7 @@ module Middleware
           end
 
           headers_stripped =
-            headers.dup.delete_if { |k, _| %w[Set-Cookie X-MiniProfiler-Ids].include? k }
+            Rack::Headers[headers].delete_if { |k, _| %w[set-cookie x-miniprofiler-ids].include? k }
           headers_stripped["X-Discourse-Cached"] = "true"
           parts = []
           response.each { |part| parts << part }
@@ -387,8 +387,8 @@ module Middleware
       return @app.call(env) if defined?(@@disabled) && @@disabled
 
       if PAYLOAD_INVALID_REQUEST_METHODS.include?(env[Rack::REQUEST_METHOD]) &&
-           env[Rack::RACK_INPUT].read(1).present?
-        return 413, { "Cache-Control" => "private, max-age=0, must-revalidate" }, []
+           env[Rack::RACK_INPUT]&.read(1).present?
+        return 413, { "cache-control" => "private, max-age=0, must-revalidate" }, []
       end
 
       helper = Helper.new(env)

--- a/lib/middleware/crawler_hooks.rb
+++ b/lib/middleware/crawler_hooks.rb
@@ -12,8 +12,8 @@ module Middleware
       request = Rack::Request.new(env)
       status, headers, response = @app.call(env)
 
-      if status == 200 && headers["X-Discourse-Crawler-View"] &&
-           headers["Content-Type"]&.include?("text/html") &&
+      if status == 200 && headers["x-discourse-crawler-view"] &&
+           headers["content-type"]&.include?("text/html") &&
            !non_localizable_path?(request_path_without_base_path(request)) &&
            ContentLocalization.crawler_locale_param_enabled?
         response = transform_response(request:, response:)

--- a/lib/middleware/default_headers.rb
+++ b/lib/middleware/default_headers.rb
@@ -25,7 +25,7 @@ module Middleware
       headers[
         "Cross-Origin-Opener-Policy"
       ] = SiteSetting.cross_origin_opener_policy_header if is_html_response &&
-        headers["Cross-Origin-Opener-Policy"].nil?
+        headers["cross-origin-opener-policy"].nil?
 
       [status, headers, body]
     end
@@ -33,7 +33,7 @@ module Middleware
     private
 
     def html_response?(headers)
-      headers["Content-Type"] && headers["Content-Type"] =~ /html/
+      headers["content-type"] && headers["content-type"] =~ /html/
     end
   end
 end

--- a/lib/middleware/default_headers.rb
+++ b/lib/middleware/default_headers.rb
@@ -19,11 +19,11 @@ module Middleware
       default_headers.each do |header_name, value|
         next if !is_html_response && HTML_ONLY_HEADERS.include?(header_name)
 
-        headers[header_name] ||= value
+        headers[header_name.downcase] ||= value
       end
 
       headers[
-        "Cross-Origin-Opener-Policy"
+        "cross-origin-opener-policy"
       ] = SiteSetting.cross_origin_opener_policy_header if is_html_response &&
         headers["cross-origin-opener-policy"].nil?
 

--- a/lib/middleware/discourse_public_exceptions.rb
+++ b/lib/middleware/discourse_public_exceptions.rb
@@ -44,7 +44,7 @@ module Middleware
           rescue Mime::Type::InvalidMimeType
             return [
               400,
-              { "Cache-Control" => "private, max-age=0, must-revalidate" },
+              { "cache-control" => "private, max-age=0, must-revalidate" },
               ["Invalid MIME type"]
             ]
           end
@@ -56,7 +56,7 @@ module Middleware
             if error.cause.is_a?(EOFError)
               return [
                 400,
-                { "Cache-Control" => "private, max-age=0, must-revalidate" },
+                { "cache-control" => "private, max-age=0, must-revalidate" },
                 ["Invalid request"]
               ]
             else

--- a/lib/middleware/missing_avatars.rb
+++ b/lib/middleware/missing_avatars.rb
@@ -15,7 +15,7 @@ module Middleware
         path = "#{Rails.root.join("public#{env["REQUEST_PATH"]}")}"
         unless File.exist?(path)
           default_image = "#{Rails.public_path.join("images/d-logo-sketch-small.png")}"
-          return 200, { "Content-Type" => "image/png" }, [File.read(default_image)]
+          return 200, { "content-type" => "image/png" }, [File.read(default_image)]
         end
       end
 

--- a/lib/middleware/overload_protections.rb
+++ b/lib/middleware/overload_protections.rb
@@ -10,7 +10,7 @@ module Middleware
       if overloaded?(env) && !authenticated_request?(env)
         return [
           503,
-          { "Content-Type" => "text/plain" },
+          { "content-type" => "text/plain" },
           ["Server is currently experiencing high load. Please try again later."]
         ]
       end

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -260,7 +260,7 @@ class Middleware::RequestTracker
       request_data[:user_agent] = user_agent
     end
 
-    if cache = headers["X-Discourse-Cached"]
+    if cache = headers["x-discourse-cached"]
       request_data[:cache] = cache
     end
 
@@ -283,8 +283,8 @@ class Middleware::RequestTracker
 
     if data
       if result && (headers = result[1])
-        headers["X-Discourse-TrackView"] = "1" if data[:track_view]
-        headers["X-Discourse-BrowserPageView"] = "1" if data[:browser_page_view]
+        headers["x-discourse-trackview"] = "1" if data[:track_view]
+        headers["x-discourse-browserpageview"] = "1" if data[:browser_page_view]
       end
 
       if @@detailed_request_loggers
@@ -319,13 +319,13 @@ class Middleware::RequestTracker
       TEXT
 
       headers = {
-        "Content-Type" => "text/plain",
-        "Retry-After" => available_in.to_s,
-        "Discourse-Rate-Limit-Error-Code" => error_code,
+        "content-type" => "text/plain",
+        "retry-after" => available_in.to_s,
+        "discourse-rate-limit-error-code" => error_code,
       }
 
       if username = cookie&.[](:username)
-        headers["X-Discourse-Username"] = username
+        headers["x-discourse-username"] = username
       end
 
       return 429, headers, [message]
@@ -337,9 +337,9 @@ class Middleware::RequestTracker
         message = "Too many crawling requests. Error code: #{error_code}."
 
         headers = {
-          "Content-Type" => "text/plain",
-          "Retry-After" => available_in.to_s,
-          "Discourse-Rate-Limit-Error-Code" => error_code,
+          "content-type" => "text/plain",
+          "retry-after" => available_in.to_s,
+          "discourse-rate-limit-error-code" => error_code,
         }
 
         return 429, headers, [message]
@@ -385,27 +385,27 @@ class Middleware::RequestTracker
 
     # possibly transferred?
     if info && (headers = result[1])
-      headers["X-Runtime"] = "%0.6f" % info[:total_duration]
+      headers["x-runtime"] = "%0.6f" % info[:total_duration]
 
       if GlobalSetting.enable_performance_http_headers
         if redis = info[:redis]
-          headers["X-Redis-Calls"] = redis[:calls].to_s
-          headers["X-Redis-Time"] = "%0.6f" % redis[:duration]
+          headers["x-redis-calls"] = redis[:calls].to_s
+          headers["x-redis-time"] = "%0.6f" % redis[:duration]
         end
 
         if sql = info[:sql]
-          headers["X-Sql-Calls"] = sql[:calls].to_s
-          headers["X-Sql-Time"] = "%0.6f" % sql[:duration]
+          headers["x-sql-calls"] = sql[:calls].to_s
+          headers["x-sql-time"] = "%0.6f" % sql[:duration]
         end
 
         if queue = env[Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY]
-          headers["X-Queue-Time"] = "%0.6f" % queue
+          headers["x-queue-time"] = "%0.6f" % queue
         end
       end
     end
 
     if env[Auth::DefaultCurrentUserProvider::BAD_TOKEN] && (headers = result[1])
-      headers["Discourse-Logged-Out"] = "1"
+      headers["discourse-logged-out"] = "1"
     end
 
     result
@@ -582,7 +582,7 @@ class Middleware::RequestTracker
 
     return extract_beacon_view_tracking_data(env) if is_beacon_tracking_request?(request)
 
-    is_html_request = headers["Content-Type"]&.include?("text/html")
+    is_html_request = headers["content-type"]&.include?("text/html")
     is_ajax_request = request.xhr?
 
     # This Discourse-Track-View request header is set in `lib/ajax.js`,

--- a/lib/theme_resolver.rb
+++ b/lib/theme_resolver.rb
@@ -6,7 +6,7 @@ module ThemeResolver
 
     theme_id = nil
 
-    if (preview_theme_id = request[:preview_theme_id]&.to_i) &&
+    if (preview_theme_id = request.params["preview_theme_id"]&.to_i) &&
          guardian.allow_themes?([preview_theme_id], include_preview: true)
       theme_id = preview_theme_id
     end

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -15,7 +15,7 @@ module DiscourseSubscriptions
 
     def create
       begin
-        payload = request.body.read
+        payload = request.raw_post
         sig_header = request.env["HTTP_STRIPE_SIGNATURE"]
         webhook_secret = SiteSetting.discourse_subscriptions_webhook_secret
 

--- a/plugins/discourse-workflows/app/controllers/discourse_workflows/webhooks_controller.rb
+++ b/plugins/discourse-workflows/app/controllers/discourse_workflows/webhooks_controller.rb
@@ -101,7 +101,7 @@ module DiscourseWorkflows
         path_params: {
         },
         query_params: is_resume ? query.except("signature") : query,
-        raw_body: request.raw_post,
+        raw_body: request.raw_post.to_s,
         remote_ip: request.remote_ip,
         ips: request.respond_to?(:ips) ? request.ips : [],
         raw_authorization: request.headers["Authorization"],

--- a/plugins/discourse-workflows/lib/discourse_workflows/webhook_request_parser.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/webhook_request_parser.rb
@@ -23,7 +23,7 @@ module DiscourseWorkflows
       if @request.content_type&.include?("application/json")
         parse_json_body
       else
-        if @request.raw_post.bytesize > MAX_BODY_SIZE
+        if @request.raw_post.to_s.bytesize > MAX_BODY_SIZE
           raise Discourse::InvalidParameters, BODY_TOO_LARGE_ERROR
         end
         @params.except(:path, :listener_id, :controller, :action, :format).to_unsafe_h

--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "rate limiter integration" do
          }
 
     expect(response.status).to eq(429)
-    expect(response.headers["Retry-After"].to_i).to be > 29
+    expect(response.headers["retry-after"].to_i).to be > 29
   end
 
   it "does not rate-limit valid requests" do
@@ -69,7 +69,7 @@ RSpec.describe "rate limiter integration" do
 
     data = response.parsed_body
 
-    expect(response.headers["Retry-After"]).to eq("60")
+    expect(response.headers["retry-after"]).to eq("60")
     expect(data["extras"]["wait_seconds"]).to eq(60)
   end
 end

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -643,7 +643,7 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
     @provider.log_on_user(user, {}, @provider.cookie_jar)
 
     cookie_info = get_cookie_info(@provider.cookie_jar, "_t")
-    expect(cookie_info[:samesite]).to eq("Lax")
+    expect(cookie_info[:samesite]).to eq("lax")
     expect(cookie_info[:httponly]).to eq(true)
     expect(cookie_info.key?(:secure)).to eq(false)
 

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1939,7 +1939,7 @@ RSpec.describe CookedPostProcessor do
     let(:post) { Fabricate(:post, user: user_with_auto_groups, raw: <<~RAW) }
         link to a topic: #{topic.url}?u=foo
 
-        a tricky link to a topic: #{topic.url}?bob=bob;u=sam&jane=jane
+        a tricky link to a topic: #{topic.url}?bob=bob&u=sam&jane=jane
 
         link to an external topic: https://google.com/?u=bar
 

--- a/spec/lib/hijack_spec.rb
+++ b/spec/lib/hijack_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Hijack do
         tester = Hijack::Tester.new(env)
         tester.hijack_test { render body: "hello", status: :created }
 
-        expect(tester.io.string).to include("Access-Control-Allow-Origin: www.rainbows.com")
+        expect(tester.io.string).to include("access-control-allow-origin: www.rainbows.com")
       end
 
     env = {}
@@ -94,12 +94,12 @@ RSpec.describe Hijack do
     expect(status).to eq(200)
 
     expected = {
-      "Access-Control-Allow-Origin" => "www.rainbows.com",
-      "Access-Control-Allow-Headers" =>
+      "access-control-allow-origin" => "www.rainbows.com",
+      "access-control-allow-headers" =>
         "Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Present, User-Api-Key, User-Api-Client-Id, Authorization",
-      "Access-Control-Allow-Credentials" => "true",
-      "Access-Control-Allow-Methods" => "POST, PUT, GET, OPTIONS, DELETE",
-      "Access-Control-Max-Age" => "7200",
+      "access-control-allow-credentials" => "true",
+      "access-control-allow-methods" => "POST, PUT, GET, OPTIONS, DELETE",
+      "access-control-max-age" => "7200",
     }
 
     expect(headers).to eq(expected)
@@ -114,7 +114,7 @@ RSpec.describe Hijack do
         tester = Hijack::Tester.new(env)
         tester.hijack_test { render body: "hello", status: :created }
 
-        expect(tester.io.string).to include("Access-Control-Allow-Origin: https://www.rainbows.com")
+        expect(tester.io.string).to include("access-control-allow-origin: https://www.rainbows.com")
       end
 
     env = {}
@@ -129,12 +129,12 @@ RSpec.describe Hijack do
     expect(status).to eq(200)
 
     expected = {
-      "Access-Control-Allow-Origin" => "https://www.rainbows.com",
-      "Access-Control-Allow-Headers" =>
+      "access-control-allow-origin" => "https://www.rainbows.com",
+      "access-control-allow-headers" =>
         "Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Present, User-Api-Key, User-Api-Client-Id, Authorization",
-      "Access-Control-Allow-Credentials" => "true",
-      "Access-Control-Allow-Methods" => "POST, PUT, GET, OPTIONS, DELETE",
-      "Access-Control-Max-Age" => "7200",
+      "access-control-allow-credentials" => "true",
+      "access-control-allow-methods" => "POST, PUT, GET, OPTIONS, DELETE",
+      "access-control-max-age" => "7200",
     }
 
     expect(headers).to eq(expected)
@@ -147,7 +147,7 @@ RSpec.describe Hijack do
       render body: "hello world", status: :payment_required
     end
 
-    expect(tester.io.string).to include("Hello-World: sam")
+    expect(tester.io.string).to include("hello-world: sam")
   end
 
   it "handles expires_in" do
@@ -180,7 +180,7 @@ RSpec.describe Hijack do
     end
 
     result =
-      "HTTP/1.1 302 Found\r\nLocation: http://awesome.com\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: 0\r\nConnection: close\r\nX-Runtime: 1.000000\r\n\r\n"
+      "HTTP/1.1 302 Found\r\nlocation: http://awesome.com\r\ncontent-type: text/html; charset=utf-8\r\ncontent-length: 0\r\nconnection: close\r\nx-runtime: 1.000000\r\n\r\n"
     expect(tester.io.string).to eq(result)
   end
 
@@ -192,7 +192,7 @@ RSpec.describe Hijack do
     end
 
     result =
-      "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 0\r\nConnection: close\r\nX-Runtime: 1.000000\r\n\r\n"
+      "HTTP/1.1 200 OK\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 0\r\nconnection: close\r\nx-runtime: 1.000000\r\n\r\n"
     expect(tester.io.string).to eq(result)
   end
 
@@ -204,7 +204,7 @@ RSpec.describe Hijack do
     end
 
     result =
-      "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 11\r\nConnection: close\r\nX-Runtime: 1.000000\r\n\r\nhello world"
+      "HTTP/1.1 200 OK\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-length: 11\r\nconnection: close\r\nx-runtime: 1.000000\r\n\r\nhello world"
     expect(tester.io.string).to eq(result)
   end
 
@@ -213,7 +213,7 @@ RSpec.describe Hijack do
     tester.hijack_test
 
     expected =
-      "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: 0\r\nConnection: close\r\nX-Runtime: 0.000000\r\n\r\n"
+      "HTTP/1.1 500 Internal Server Error\r\ncontent-type: text/html; charset=utf-8\r\ncontent-length: 0\r\nconnection: close\r\nx-runtime: 0.000000\r\n\r\n"
     expect(tester.io.string).to eq(expected)
   end
 

--- a/spec/lib/json_api_kit/document/collection_spec.rb
+++ b/spec/lib/json_api_kit/document/collection_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe JsonApiKit::Document::Collection do
       it "renders a link to the page at each end" do
         expect(document.to_h[:links]).to eq(
           self: self_link,
-          prev: "https://example.com/api/topics?page[before]=#{page_cursor}",
-          next: "https://example.com/api/topics?page[after]=#{page_cursor}",
+          prev: "https://example.com/api/topics?page%5Bbefore%5D=#{page_cursor}",
+          next: "https://example.com/api/topics?page%5Bafter%5D=#{page_cursor}",
         )
       end
     end

--- a/spec/lib/json_api_kit/document/page_links_spec.rb
+++ b/spec/lib/json_api_kit/document/page_links_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe JsonApiKit::Document::PageLinks do
 
     it "returns a link to the page at each end" do
       expect(links).to eq(
-        prev: "https://example.com/api/topics?page[before]=read-back-here",
-        next: "https://example.com/api/topics?page[after]=read-on-here",
+        prev: "https://example.com/api/topics?page%5Bbefore%5D=read-back-here",
+        next: "https://example.com/api/topics?page%5Bafter%5D=read-on-here",
       )
     end
 
@@ -30,7 +30,7 @@ RSpec.describe JsonApiKit::Document::PageLinks do
       it "returns a next link only" do
         expect(links).to eq(
           prev: nil,
-          next: "https://example.com/api/topics?page[after]=read-on-here",
+          next: "https://example.com/api/topics?page%5Bafter%5D=read-on-here",
         )
       end
     end

--- a/spec/lib/json_api_kit/document/relationship_object_spec.rb
+++ b/spec/lib/json_api_kit/document/relationship_object_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe JsonApiKit::Document::RelationshipObject do
         expect(relationship_object.to_h[:links]).to eq(
           self: relationship_url,
           related: related_url,
-          prev: "#{relationship_url}?page[before]=read-back-here",
-          next: "#{relationship_url}?page[after]=read-on-here",
+          prev: "#{relationship_url}?page%5Bbefore%5D=read-back-here",
+          next: "#{relationship_url}?page%5Bafter%5D=read-on-here",
         )
       end
     end

--- a/spec/lib/json_api_kit/url_spec.rb
+++ b/spec/lib/json_api_kit/url_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe JsonApiKit::Url do
 
   describe "#to_s" do
     it "returns the address with the parameters it carries" do
-      expect(url.to_s).to eq("https://example.com/api/topics?page[size]=2&sort=createdAt")
+      expect(url.to_s).to eq("https://example.com/api/topics?page%5Bsize%5D=2&sort=createdAt")
     end
 
     context "when it carries no parameter" do
@@ -26,14 +26,14 @@ RSpec.describe JsonApiKit::Url do
 
       it "writes it in camel case" do
         expect(url.at(before_size: 2).to_s).to eq(
-          "https://example.com/api/topics?page[beforeSize]=2",
+          "https://example.com/api/topics?page%5BbeforeSize%5D=2",
         )
       end
     end
 
     it "adds the cursor to the parameters it carries" do
       expect(url.at(after: "a-cursor").to_s).to eq(
-        "https://example.com/api/topics?page[size]=2&page[after]=a-cursor&sort=createdAt",
+        "https://example.com/api/topics?page%5Bsize%5D=2&page%5Bafter%5D=a-cursor&sort=createdAt",
       )
     end
 
@@ -46,7 +46,7 @@ RSpec.describe JsonApiKit::Url do
 
       it "drops the other end" do
         expect(url.at(before: "a-cursor").to_s).to eq(
-          "https://example.com/api/topics?page[size]=2&page[before]=a-cursor",
+          "https://example.com/api/topics?page%5Bsize%5D=2&page%5Bbefore%5D=a-cursor",
         )
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe JsonApiKit::Url do
 
       it "drops the anchor and the window, and keeps the page size" do
         expect(url.at(after: "a-cursor").to_s).to eq(
-          "https://example.com/api/topics?page[size]=2&page[after]=a-cursor",
+          "https://example.com/api/topics?page%5Bsize%5D=2&page%5Bafter%5D=a-cursor",
         )
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe JsonApiKit::Url do
 
       it "carries only that cursor" do
         expect(url.at(after: "a-cursor").to_s).to eq(
-          "https://example.com/api/topics?page[after]=a-cursor",
+          "https://example.com/api/topics?page%5Bafter%5D=a-cursor",
         )
       end
     end

--- a/spec/lib/json_api_kit/urls_spec.rb
+++ b/spec/lib/json_api_kit/urls_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe JsonApiKit::Urls do
 
   describe "#current" do
     it "returns the URL a caller read with the parameters they sent" do
-      expect(urls.current.to_s).to eq("https://example.com/api/topics?page[size]=2&sort=createdAt")
+      expect(urls.current.to_s).to eq(
+        "https://example.com/api/topics?page%5Bsize%5D=2&sort=createdAt",
+      )
     end
   end
 

--- a/spec/lib/middleware/anonymous_cache_spec.rb
+++ b/spec/lib/middleware/anonymous_cache_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe Middleware::AnonymousCache do
       is_anon = false
       _status, headers, _body = app.call(env.dup)
       expect(is_anon).to eq(true)
-      expect(headers["Set-Cookie"]).to eq("dosp=1; Path=/")
+      expect(headers["set-cookie"]).to eq("dosp=1; Path=/")
 
       # tricky change, a 50ms delay still will trigger protection
       # once it is tripped

--- a/spec/lib/middleware/anonymous_cache_spec.rb
+++ b/spec/lib/middleware/anonymous_cache_spec.rb
@@ -208,11 +208,11 @@ RSpec.describe Middleware::AnonymousCache do
         global_setting :compress_anon_cache, true
 
         payload = "x" * 1000
-        helper.cache([200, { "HELLO" => "WORLD" }, [payload]])
+        helper.cache([200, { "hello" => "WORLD" }, [payload]])
 
         helper = new_helper("ANON_CACHE_DURATION" => 10)
         expect(helper.cached).to eq(
-          [200, { "X-Discourse-Cached" => "true", "HELLO" => "WORLD" }, [payload]],
+          [200, { "x-discourse-cached" => "true", "hello" => "WORLD" }, [payload]],
         )
 
         # depends on i7z implementation, but lets assume it is stable unless we discover
@@ -221,11 +221,11 @@ RSpec.describe Middleware::AnonymousCache do
       end
 
       it "handles brotli switching" do
-        helper.cache([200, { "HELLO" => "WORLD" }, ["hello ", "my world"]])
+        helper.cache([200, { "hello" => "WORLD" }, ["hello ", "my world"]])
 
         helper = new_helper("ANON_CACHE_DURATION" => 10)
         expect(helper.cached).to eq(
-          [200, { "X-Discourse-Cached" => "true", "HELLO" => "WORLD" }, ["hello my world"]],
+          [200, { "x-discourse-cached" => "true", "hello" => "WORLD" }, ["hello my world"]],
         )
 
         helper = new_helper("ANON_CACHE_DURATION" => 10, "HTTP_ACCEPT_ENCODING" => "gz, br")
@@ -235,23 +235,23 @@ RSpec.describe Middleware::AnonymousCache do
       it "includes the forced color mode in the cache key" do
         dark_helper =
           new_helper("ANON_CACHE_DURATION" => 10, "HTTP_COOKIE" => "forced_color_mode=dark")
-        dark_helper.cache([200, { "HELLO" => "WORLD" }, ["dark mode"]])
+        dark_helper.cache([200, { "hello" => "WORLD" }, ["dark mode"]])
 
         light_helper =
           new_helper("ANON_CACHE_DURATION" => 10, "HTTP_COOKIE" => "forced_color_mode=light")
         expect(light_helper.cached).to eq(nil)
 
-        light_helper.cache([200, { "HELLO" => "WORLD" }, ["light mode"]])
+        light_helper.cache([200, { "hello" => "WORLD" }, ["light mode"]])
 
         auto_helper = new_helper("ANON_CACHE_DURATION" => 10)
         expect(auto_helper.cached).to eq(nil)
 
-        auto_helper.cache([200, { "HELLO" => "WORLD" }, ["auto color mode"]])
+        auto_helper.cache([200, { "hello" => "WORLD" }, ["auto color mode"]])
 
         unknown_helper =
           new_helper("ANON_CACHE_DURATION" => 10, "HTTP_COOKIE" => "forced_color_mode=blada")
         expect(unknown_helper.cached).to eq(
-          [200, { "HELLO" => "WORLD", "X-Discourse-Cached" => "true" }, ["auto color mode"]],
+          [200, { "hello" => "WORLD", "x-discourse-cached" => "true" }, ["auto color mode"]],
         )
 
         dark_helper =
@@ -261,31 +261,31 @@ RSpec.describe Middleware::AnonymousCache do
         auto_helper = new_helper("ANON_CACHE_DURATION" => 10)
 
         expect(dark_helper.cached).to eq(
-          [200, { "HELLO" => "WORLD", "X-Discourse-Cached" => "true" }, ["dark mode"]],
+          [200, { "hello" => "WORLD", "x-discourse-cached" => "true" }, ["dark mode"]],
         )
         expect(light_helper.cached).to eq(
-          [200, { "HELLO" => "WORLD", "X-Discourse-Cached" => "true" }, ["light mode"]],
+          [200, { "hello" => "WORLD", "x-discourse-cached" => "true" }, ["light mode"]],
         )
         expect(auto_helper.cached).to eq(
-          [200, { "HELLO" => "WORLD", "X-Discourse-Cached" => "true" }, ["auto color mode"]],
+          [200, { "hello" => "WORLD", "x-discourse-cached" => "true" }, ["auto color mode"]],
         )
       end
 
       it "returns cached data for cached requests" do
         helper.is_mobile = true
         expect(helper.cached).to eq(nil)
-        helper.cache([200, { "HELLO" => "WORLD" }, ["hello ", "my world"]])
+        helper.cache([200, { "hello" => "WORLD" }, ["hello ", "my world"]])
 
         helper = new_helper("ANON_CACHE_DURATION" => 10)
         helper.is_mobile = true
         expect(helper.cached).to eq(
-          [200, { "X-Discourse-Cached" => "true", "HELLO" => "WORLD" }, ["hello my world"]],
+          [200, { "x-discourse-cached" => "true", "hello" => "WORLD" }, ["hello my world"]],
         )
 
         expect(crawler.cached).to eq(nil)
-        crawler.cache([200, { "HELLO" => "WORLD" }, ["hello ", "world"]])
+        crawler.cache([200, { "hello" => "WORLD" }, ["hello ", "world"]])
         expect(crawler.cached).to eq(
-          [200, { "X-Discourse-Cached" => "true", "HELLO" => "WORLD" }, ["hello world"]],
+          [200, { "x-discourse-cached" => "true", "hello" => "WORLD" }, ["hello world"]],
         )
       end
     end
@@ -394,16 +394,10 @@ RSpec.describe Middleware::AnonymousCache do
 
   describe "invalid request payload" do
     it "returns 413 for GET request with payload" do
-      status, headers, _ =
-        middleware.call(
-          env.tap do |environment|
-            environment[Rack::RACK_INPUT].write("test")
-            environment[Rack::RACK_INPUT].rewind
-          end,
-        )
+      status, headers, _ = middleware.call(env(Rack::RACK_INPUT => StringIO.new("test")))
 
       expect(status).to eq(413)
-      expect(headers["Cache-Control"]).to eq("private, max-age=0, must-revalidate")
+      expect(headers["cache-control"]).to eq("private, max-age=0, must-revalidate")
     end
   end
 

--- a/spec/lib/middleware/crawler_hooks_spec.rb
+++ b/spec/lib/middleware/crawler_hooks_spec.rb
@@ -16,8 +16,8 @@ describe Middleware::CrawlerHooks do
   let(:middleware) { Middleware::CrawlerHooks.new(app) }
   let(:app) do
     lambda do |env|
-      headers = { "Content-Type" => "text/html; charset=utf-8" }
-      headers["X-Discourse-Crawler-View"] = "true" if env["X-Discourse-Crawler-View"]
+      headers = { "content-type" => "text/html; charset=utf-8" }
+      headers["x-discourse-crawler-view"] = "true" if env["X-Discourse-Crawler-View"]
       [200, headers, html_response]
     end
   end
@@ -27,8 +27,8 @@ describe Middleware::CrawlerHooks do
         [
           200,
           {
-            "Content-Type" => "application/json; charset=utf-8",
-            "X-Discourse-Crawler-View" => "true",
+            "content-type" => "application/json; charset=utf-8",
+            "x-discourse-crawler-view" => "true",
           },
           ['{ "key": "value" }'],
         ]
@@ -41,9 +41,9 @@ describe Middleware::CrawlerHooks do
         [
           200,
           {
-            "Content-Type" => "application/zip",
-            "Content-Disposition" => "attachment; filename=\"file.zip\"",
-            "X-Discourse-Crawler-View" => "true",
+            "content-type" => "application/zip",
+            "content-disposition" => "attachment; filename=\"file.zip\"",
+            "x-discourse-crawler-view" => "true",
           },
           ["PK\x03\x04binarydata".b],
         ]
@@ -55,7 +55,7 @@ describe Middleware::CrawlerHooks do
       lambda do |_|
         [
           404,
-          { "Content-Type" => "text/html; charset=utf-8" },
+          { "content-type" => "text/html; charset=utf-8" },
           ["<html><body>Not found</body></html>"],
         ]
       end,
@@ -80,7 +80,7 @@ describe Middleware::CrawlerHooks do
       status, headers, response = middleware.call(env("HTTP_USER_AGENT" => regular_user_agent))
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(html_response)
     end
   end
@@ -90,7 +90,7 @@ describe Middleware::CrawlerHooks do
       status, headers, response = middleware.call(env("HTTP_USER_AGENT" => crawler_user_agent))
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(html_response)
     end
 
@@ -110,7 +110,7 @@ describe Middleware::CrawlerHooks do
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("application/json")
+      expect(headers["content-type"]).to include("application/json")
       expect(response).to eq(['{ "key": "value" }'])
     end
 
@@ -130,7 +130,7 @@ describe Middleware::CrawlerHooks do
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to eq("application/zip")
+      expect(headers["content-type"]).to eq("application/zip")
       expect(response).to eq(["PK\x03\x04binarydata".b])
     end
 
@@ -149,8 +149,8 @@ describe Middleware::CrawlerHooks do
             [
               200,
               {
-                "Content-Type" => "text/html; charset=utf-8",
-                "X-Discourse-Crawler-View" => "true",
+                "content-type" => "text/html; charset=utf-8",
+                "x-discourse-crawler-view" => "true",
               },
               response_body,
             ]
@@ -169,7 +169,7 @@ describe Middleware::CrawlerHooks do
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(response_body)
     end
 
@@ -189,8 +189,8 @@ describe Middleware::CrawlerHooks do
             [
               200,
               {
-                "Content-Type" => "text/html; charset=utf-8",
-                "X-Discourse-Crawler-View" => "true",
+                "content-type" => "text/html; charset=utf-8",
+                "x-discourse-crawler-view" => "true",
               },
               response_body,
             ]
@@ -209,7 +209,7 @@ describe Middleware::CrawlerHooks do
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(response_body)
     end
 
@@ -233,12 +233,12 @@ describe Middleware::CrawlerHooks do
               "locale" => "fr",
             },
             "HTTP_USER_AGENT" => crawler_user_agent,
-            "X-Discourse-Crawler-View" => true,
+            "x-discourse-crawler-view" => true,
           ),
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(html_response)
     end
 
@@ -254,12 +254,12 @@ describe Middleware::CrawlerHooks do
               "locale" => "fr",
             },
             "HTTP_USER_AGENT" => crawler_user_agent,
-            "X-Discourse-Crawler-View" => true,
+            "x-discourse-crawler-view" => true,
           ),
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(html_response)
     end
 
@@ -276,12 +276,12 @@ describe Middleware::CrawlerHooks do
               Discourse::LOCALE_PARAM => "fr",
             },
             "HTTP_USER_AGENT" => crawler_user_agent,
-            "X-Discourse-Crawler-View" => true,
+            "x-discourse-crawler-view" => true,
           ),
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(html_response)
     end
 
@@ -302,7 +302,7 @@ describe Middleware::CrawlerHooks do
       # Create our middleware and test response transformation
       middleware_instance =
         Middleware::CrawlerHooks.new(
-          lambda { |_| [200, { "X-Discourse-Crawler-View" => "true" }, []] },
+          lambda { |_| [200, { "x-discourse-crawler-view" => "true" }, []] },
         )
       response = html_response
 
@@ -324,12 +324,12 @@ describe Middleware::CrawlerHooks do
           env(
             :path => "https://discourse.site",
             "HTTP_USER_AGENT" => crawler_user_agent,
-            "X-Discourse-Crawler-View" => true,
+            "x-discourse-crawler-view" => true,
           ),
         )
 
       expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
+      expect(headers["content-type"]).to include("text/html")
       expect(response).to eq(html_response)
     end
 
@@ -362,7 +362,7 @@ describe Middleware::CrawlerHooks do
 
       middleware_instance =
         Middleware::CrawlerHooks.new(
-          lambda { |_| [200, { "X-Discourse-Crawler-View" => "true" }, []] },
+          lambda { |_| [200, { "x-discourse-crawler-view" => "true" }, []] },
         )
 
       transformed_response =
@@ -397,7 +397,7 @@ describe Middleware::CrawlerHooks do
 
       middleware_instance =
         Middleware::CrawlerHooks.new(
-          lambda { |_| [200, { "X-Discourse-Crawler-View" => "true" }, []] },
+          lambda { |_| [200, { "x-discourse-crawler-view" => "true" }, []] },
         )
 
       transformed_response =

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Middleware::RequestTracker do
       agent = (+"Evil Googlebot String \xc3\x28").force_encoding("Windows-1252")
 
       middleware =
-        Middleware::RequestTracker.new(->(env) { ["200", { "Content-Type" => "text/html" }, [""]] })
+        Middleware::RequestTracker.new(->(env) { ["200", { "content-type" => "text/html" }, [""]] })
       middleware.call(env("HTTP_USER_AGENT" => agent))
 
       CachedCounting.flush
@@ -46,7 +46,7 @@ RSpec.describe Middleware::RequestTracker do
       expect {
         middleware =
           Middleware::RequestTracker.new(
-            ->(env) { ["200", { "Content-Type" => "text/html" }, [""]] },
+            ->(env) { ["200", { "content-type" => "text/html" }, [""]] },
           )
         middleware.call(env("HTTP_USER_AGENT" => agent))
 
@@ -66,7 +66,7 @@ RSpec.describe Middleware::RequestTracker do
       expect {
         middleware =
           Middleware::RequestTracker.new(
-            ->(env) { ["200", { "Content-Type" => "text/html" }, [""]] },
+            ->(env) { ["200", { "content-type" => "text/html" }, [""]] },
           )
         middleware.call(env("HTTP_USER_AGENT" => agent))
 
@@ -91,7 +91,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env("HTTP_DISCOURSE_TRACK_VIEW" => val),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.2,
         )
 
@@ -115,20 +115,20 @@ RSpec.describe Middleware::RequestTracker do
       status, headers = middleware.call(env("HTTP_DISCOURSE_TRACK_VIEW" => "1"))
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-TrackView"]).to eq("1")
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
+      expect(headers["x-discourse-trackview"]).to eq("1")
+      expect(headers["x-discourse-browserpageview"]).to eq("1")
     end
 
     it "adds the appropriate response header based on implicit tracking (HTML requests)" do
       middleware =
         Middleware::RequestTracker.new(
-          lambda { |env| [200, { "Content-Type" => "text/html" }, ["OK"]] },
+          lambda { |env| [200, { "content-type" => "text/html" }, ["OK"]] },
         )
       status, headers = middleware.call(env)
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-TrackView"]).to eq("1")
-      expect(headers["X-Discourse-BrowserPageView"]).to eq(nil)
+      expect(headers["x-discourse-trackview"]).to eq("1")
+      expect(headers["x-discourse-browserpageview"]).to eq(nil)
     end
 
     it "adds the appropriate response header based on deferred tracking (MiniProfiler piggyback, BPVs)" do
@@ -136,8 +136,8 @@ RSpec.describe Middleware::RequestTracker do
       status, headers = middleware.call(env("HTTP_DISCOURSE_TRACK_VIEW_DEFERRED" => "1"))
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-TrackView"]).to eq(nil)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
+      expect(headers["x-discourse-trackview"]).to eq(nil)
+      expect(headers["x-discourse-browserpageview"]).to eq("1")
     end
 
     it "adds the appropriate response headers for MessageBus requests with deferred tracking" do
@@ -155,7 +155,7 @@ RSpec.describe Middleware::RequestTracker do
         )
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
+      expect(headers["x-discourse-browserpageview"]).to eq("1")
     end
 
     it "adds the appropriate response headers for MessageBus requests with regular tracking" do
@@ -171,8 +171,8 @@ RSpec.describe Middleware::RequestTracker do
         middleware.call(env("HTTP_DISCOURSE_TRACK_VIEW" => "1", :path => "/message-bus/abcde/poll"))
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
-      expect(headers["X-Discourse-TrackView"]).to eq("1")
+      expect(headers["x-discourse-browserpageview"]).to eq("1")
+      expect(headers["x-discourse-trackview"]).to eq("1")
     end
 
     it "does not add these response headers when skipping the request tracker" do
@@ -194,15 +194,15 @@ RSpec.describe Middleware::RequestTracker do
         )
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq(nil)
-      expect(headers["X-Discourse-TrackView"]).to eq(nil)
+      expect(headers["x-discourse-browserpageview"]).to eq(nil)
+      expect(headers["x-discourse-trackview"]).to eq(nil)
     end
 
     it "can log requests correctly" do
       data =
         Middleware::RequestTracker.get_data(
           env("HTTP_USER_AGENT" => "AdsBot-Google (+http://www.google.com/adsbot.html)"),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
 
@@ -223,7 +223,7 @@ RSpec.describe Middleware::RequestTracker do
             "HTTP_USER_AGENT" =>
               "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4",
           ),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
 
@@ -233,7 +233,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env("HTTP_USER_AGENT" => "kube-probe/1.18", "REQUEST_URI" => "/srv/status"),
-          ["200", { "Content-Type" => "text/plain" }],
+          ["200", { "content-type" => "text/plain" }],
           0.1,
         )
 
@@ -257,7 +257,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env(:path => "/message-bus/abcde/poll", "HTTP_DISCOURSE_TRACK_VIEW_DEFERRED" => "1"),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
       Middleware::RequestTracker.log_request(data)
@@ -273,7 +273,7 @@ RSpec.describe Middleware::RequestTracker do
         data =
           Middleware::RequestTracker.get_data(
             env(path: "/t/topic-slug/1?embed_mode=true"),
-            ["200", { "Content-Type" => "text/html" }],
+            ["200", { "content-type" => "text/html" }],
             0.1,
           )
         Middleware::RequestTracker.log_request(data)
@@ -291,7 +291,7 @@ RSpec.describe Middleware::RequestTracker do
               "HTTP_DISCOURSE_TRACK_VIEW_DEFERRED" => "1",
               "HTTP_DISCOURSE_TRACK_VIEW_EMBED" => "true",
             ),
-            ["200", { "Content-Type" => "text/html" }],
+            ["200", { "content-type" => "text/html" }],
             0.1,
           )
         Middleware::RequestTracker.log_request(data)
@@ -390,7 +390,7 @@ RSpec.describe Middleware::RequestTracker do
           data =
             Middleware::RequestTracker.get_data(
               env(path: "/?foo=1&foo%5B1%5D=2"),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.1,
             )
         }.not_to raise_error
@@ -404,7 +404,7 @@ RSpec.describe Middleware::RequestTracker do
               :path => "/t/topic-slug/1?embed_mode=true",
               "HTTP_USER_AGENT" => "AdsBot-Google (+http://www.google.com/adsbot.html)",
             ),
-            ["200", { "Content-Type" => "text/html" }],
+            ["200", { "content-type" => "text/html" }],
             0.1,
           )
         Middleware::RequestTracker.log_request(data)
@@ -419,7 +419,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env("_DISCOURSE_API" => "1"),
-          ["200", { "Content-Type" => "text/json" }],
+          ["200", { "content-type" => "text/json" }],
           0.1,
         )
 
@@ -428,7 +428,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env("_DISCOURSE_API" => "1"),
-          ["404", { "Content-Type" => "text/json" }],
+          ["404", { "content-type" => "text/json" }],
           0.1,
         )
 
@@ -452,7 +452,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env("HTTP_USER_AGENT" => "DiscourseAPI Ruby Gem 0.19.0"),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
 
@@ -467,7 +467,7 @@ RSpec.describe Middleware::RequestTracker do
       data =
         Middleware::RequestTracker.get_data(
           env("HTTP_USER_AGENT" => "Mozilla/5.0 AppleWebKit/605.1.15 Mobile/15E148 DiscourseHub)"),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
 
@@ -513,7 +513,7 @@ RSpec.describe Middleware::RequestTracker do
         data =
           Middleware::RequestTracker.get_data(
             env(path: path, **headers),
-            ["200", { "Content-Type" => "text/html" }],
+            ["200", { "content-type" => "text/html" }],
             0.1,
           )
         Middleware::RequestTracker.log_request(data)
@@ -683,7 +683,7 @@ RSpec.describe Middleware::RequestTracker do
             "HTTP_USER_AGENT" =>
               "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.72 Safari/537.36",
           ),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
       end
@@ -704,7 +704,7 @@ RSpec.describe Middleware::RequestTracker do
               "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.72 Safari/537.36",
             "HTTP_COOKIE" => "_t=#{cookie};",
           ),
-          ["200", { "Content-Type" => "text/html" }],
+          ["200", { "content-type" => "text/html" }],
           0.1,
         )
       end
@@ -760,7 +760,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -789,7 +789,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -810,7 +810,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_USER_AGENT" => "A" * 5000,
                 "action_dispatch.remote_ip" => "1" * 50,
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -845,7 +845,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -865,7 +865,7 @@ RSpec.describe Middleware::RequestTracker do
           data =
             Middleware::RequestTracker.get_data(
               env("HTTP_USER_AGENT" => "Googlebot"),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -887,7 +887,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -926,7 +926,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
                 "action_dispatch.remote_ip" => "1.2.3.4",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -981,7 +981,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://www.example.com/path?utm_source=x",
                 "action_dispatch.remote_ip" => "1.2.3.4",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -1006,7 +1006,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "action_dispatch.remote_ip" => "1.2.3.4",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -1028,7 +1028,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "action_dispatch.remote_ip" => "1.2.3.4",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -1052,7 +1052,7 @@ RSpec.describe Middleware::RequestTracker do
                 "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
                 "action_dispatch.remote_ip" => "1.2.3.4",
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", { "content-type" => "text/html" }],
               0.2,
             )
 
@@ -1435,7 +1435,7 @@ RSpec.describe Middleware::RequestTracker do
         Discourse.stubs(:os_hostname).returns("backend-1")
         status, headers = middleware.call(health_check_env("1.2.3.4", subfolder: "/forum"))
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("health_check_10_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("health_check_10_secs_limit")
       end
 
       it "keeps other paths on a separate rate limit budget" do
@@ -1444,7 +1444,7 @@ RSpec.describe Middleware::RequestTracker do
 
         status, headers = middleware.call(health_check_env("1.2.3.4"))
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("health_check_10_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("health_check_10_secs_limit")
 
         status, _ = middleware.call(env("REMOTE_ADDR" => "1.2.3.4"))
         expect(status).to eq(200)
@@ -1538,7 +1538,7 @@ RSpec.describe Middleware::RequestTracker do
 
       expect(fake_logger.warnings.count { |w| w.include?("Global rate limit exceeded") }).to eq(1)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq("10")
+      expect(headers["retry-after"]).to eq("10")
     end
 
     it "does warn if rate limiter is enabled" do
@@ -1568,13 +1568,13 @@ RSpec.describe Middleware::RequestTracker do
       expect(status).to eq(200)
       status, headers = middleware.call(env1)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq("10")
+      expect(headers["retry-after"]).to eq("10")
 
       env2 = env("REMOTE_ADDR" => "1.1.1.1")
 
       status, headers = middleware.call(env2)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq("10")
+      expect(headers["retry-after"]).to eq("10")
     end
 
     it "does block if rate limiter is enabled" do
@@ -1589,7 +1589,7 @@ RSpec.describe Middleware::RequestTracker do
 
       status, headers = middleware.call(env1)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq("10")
+      expect(headers["retry-after"]).to eq("10")
 
       status, _ = middleware.call(env2)
       expect(status).to eq(200)
@@ -1615,7 +1615,7 @@ RSpec.describe Middleware::RequestTracker do
         status, headers, response = middleware.call(env)
         expect(status).to eq(429)
         expect(called).to eq(1)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("ip_10_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("ip_10_secs_limit")
 
         expect(response.first).to eq(<<~MSG)
         Slow down, you're making too many requests.
@@ -1643,7 +1643,7 @@ RSpec.describe Middleware::RequestTracker do
         status, headers, response = middleware.call(env)
         expect(status).to eq(429)
         expect(called).to eq(1)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("ip_60_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("ip_60_secs_limit")
 
         expect(response.first).to eq(<<~MSG)
         Slow down, you're making too many requests.
@@ -1672,7 +1672,7 @@ RSpec.describe Middleware::RequestTracker do
         status, headers, response = middleware.call(env)
         expect(status).to eq(429)
         expect(called).to eq(1)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("ip_assets_10_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("ip_assets_10_secs_limit")
 
         expect(response.first).to eq(<<~MSG)
         Slow down, you're making too many requests.
@@ -1717,7 +1717,7 @@ RSpec.describe Middleware::RequestTracker do
         middleware = Middleware::RequestTracker.new(app)
         status, headers, response = middleware.call(env)
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("user_60_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("user_60_secs_limit")
 
         expect(response.first).to eq(<<~MSG)
         Slow down, you're making too many requests.
@@ -1760,7 +1760,7 @@ RSpec.describe Middleware::RequestTracker do
         middleware = Middleware::RequestTracker.new(app)
         status, headers, response = middleware.call(env)
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("ip_60_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("ip_60_secs_limit")
 
         expect(response.first).to eq(<<~MSG)
         Slow down, you're making too many requests.
@@ -1800,7 +1800,7 @@ RSpec.describe Middleware::RequestTracker do
       middleware = Middleware::RequestTracker.new(app)
       status, headers, response = middleware.call(env)
       expect(status).to eq(429)
-      expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("ip_60_secs_limit")
+      expect(headers["discourse-rate-limit-error-code"]).to eq("ip_60_secs_limit")
 
       expect(response.first).to eq(<<~MSG)
       Slow down, you're making too many requests.
@@ -1840,7 +1840,7 @@ RSpec.describe Middleware::RequestTracker do
         middleware = Middleware::RequestTracker.new(app)
         status, headers, response = middleware.call(env1)
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq("crawlers_60_secs_limit")
+        expect(headers["discourse-rate-limit-error-code"]).to eq("crawlers_60_secs_limit")
 
         expect(response.first).to eq(<<~MSG)
         Slow down, you're making too many requests.
@@ -1941,15 +1941,15 @@ RSpec.describe Middleware::RequestTracker do
       expect(timing[:redis][:duration]).to be > 0
       expect(timing[:redis][:calls]).to eq 2
 
-      expect(headers["X-Queue-Time"]).to eq("60.000000")
+      expect(headers["x-queue-time"]).to eq("60.000000")
 
-      expect(headers["X-Redis-Calls"]).to eq("2")
-      expect(headers["X-Redis-Time"].to_f).to be > 0
+      expect(headers["x-redis-calls"]).to eq("2")
+      expect(headers["x-redis-time"].to_f).to be > 0
 
-      expect(headers["X-Sql-Calls"]).to eq("2")
-      expect(headers["X-Sql-Time"].to_f).to be > 0
+      expect(headers["x-sql-calls"]).to eq("2")
+      expect(headers["x-sql-time"].to_f).to be > 0
 
-      expect(headers["X-Runtime"].to_f).to be > 0
+      expect(headers["x-runtime"].to_f).to be > 0
     end
 
     it "correctly logs GC stats when `instrument_gc_stat_per_request` site setting has been enabled" do

--- a/spec/multisite/request_tracker_spec.rb
+++ b/spec/multisite/request_tracker_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "RequestTracker in multisite", type: :multisite do
             [200, {}, ["OK"]]
           end
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq(error_code)
+        expect(headers["discourse-rate-limit-error-code"]).to eq(error_code)
         expect(called[:default]).to eq(1)
       end
 
@@ -50,7 +50,7 @@ RSpec.describe "RequestTracker in multisite", type: :multisite do
             [200, {}, ["OK"]]
           end
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq(error_code)
+        expect(headers["discourse-rate-limit-error-code"]).to eq(error_code)
         expect(called[:second]).to eq(0)
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe "RequestTracker in multisite", type: :multisite do
             [200, {}, ["OK"]]
           end
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq(error_code)
+        expect(headers["discourse-rate-limit-error-code"]).to eq(error_code)
         expect(called[:default]).to eq(1)
       end
 
@@ -100,7 +100,7 @@ RSpec.describe "RequestTracker in multisite", type: :multisite do
             [200, {}, ["OK"]]
           end
         expect(status).to eq(429)
-        expect(headers["Discourse-Rate-Limit-Error-Code"]).to eq(error_code)
+        expect(headers["discourse-rate-limit-error-code"]).to eq(error_code)
         expect(called[:second]).to eq(1)
       end
     end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         events = DiscourseEvent.track_events { get "/auth/google_oauth2/callback.json" }
 
         expect(
-          response.headers["Set-Cookie"].match(%r{^authentication_data=.*; path=/forum}),
+          Array(response.headers["Set-Cookie"]).join("\n").match(%r{^authentication_data=.*; path=/forum}),
         ).not_to eq(nil)
 
         expect(events.map { |event| event[:event_name] }).to include(

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -522,7 +522,9 @@ RSpec.describe Users::OmniauthCallbacksController do
         events = DiscourseEvent.track_events { get "/auth/google_oauth2/callback.json" }
 
         expect(
-          Array(response.headers["Set-Cookie"]).join("\n").match(%r{^authentication_data=.*; path=/forum}),
+          Array(response.headers["Set-Cookie"]).join("\n").match(
+            %r{^authentication_data=.*; path=/forum},
+          ),
         ).not_to eq(nil)
 
         expect(events.map { |event| event[:event_name] }).to include(


### PR DESCRIPTION
The `< 3` pin on `rack` was added because Rack 3 broke Unicorn. Unicorn is gone and Pitchfork supports Rack 3, so this drops the pin and moves `rack-protection`, `rack-session` and `rackup` to their Rack 3 releases. Sidekiq stays on 7.

Code changes Rack 3 needs:

- `Rack::Request#[]` and `#[]=` are gone, so the API key and username lookups go through `request.params`.
- Response header names are lower-case. Headers stored by the anonymous cache come back wrapped in `Rack::Headers` so lookups stay case-insensitive, and the plain hashes we build ourselves (CORS, message bus extra headers, the 413 and missing-avatar responses) use lower-case names. Hijacked responses now write lower-case names to the socket too.
- `set-cookie` can be an array, so the test-only cookie injector appends to it instead of joining strings.
- `rack.input` is optional, so the anonymous cache guards its read.
- `Rack::Utils.build_nested_query` percent-encodes brackets, which changes the JSON:API pagination links from `page[after]=` to `page%5Bafter%5D=`.
- `Rack::Server` moved to the `rackup` gem.
