### PR TITLE
FIX: Hide childless deleted roots in nested replies

### DIFF
--- a/lib/nested_replies/tree_loader.rb
+++ b/lib/nested_replies/tree_loader.rb
@@ -44,8 +44,24 @@ module NestedReplies
           .posts
           .where("posts.reply_to_post_number IS NULL OR posts.reply_to_post_number = 1")
           .where(post_number: 2..) # exclude OP itself
-      scope = apply_visibility(scope)
+      scope = apply_root_visibility(scope)
       apply_sort(scope, sort)
+    end
+
+    def apply_root_visibility(scope)
+      scope = apply_visibility(scope)
+      return scope if guardian.is_staff?
+
+      # Keep this lookup correlated so the topic/reply index bounds each root's child search.
+      visible_children =
+        apply_visibility(Post.unscoped.from("posts child_posts"), posts_table: "child_posts")
+          .where("child_posts.topic_id = posts.topic_id")
+          .where("child_posts.reply_to_post_number = posts.post_number")
+          .where("child_posts.post_number > 1")
+          .select("1")
+          .offset(0)
+
+      scope.where("posts.deleted_at IS NULL OR EXISTS (#{visible_children.to_sql})")
     end
 
     def apply_sort(scope, sort)
@@ -66,7 +82,7 @@ module NestedReplies
       pinned_post_ids.each do |pid|
         idx = roots.index { |p| p.id == pid }
         if idx
-          pinned_in_page << roots.delete_at(idx) if roots[idx].deleted_at.nil?
+          pinned_in_page << roots.delete_at(idx) if roots[idx].deleted_at.nil? || !guardian.is_staff?
         else
           pinned_missing_ids << pid
         end
@@ -74,12 +90,12 @@ module NestedReplies
 
       if pinned_missing_ids.present?
         fetched =
-          load_posts_for_tree(apply_visibility(topic.posts.where(id: pinned_missing_ids))).index_by(
-            &:id
-          )
+          load_posts_for_tree(
+            apply_root_visibility(topic.posts.where(id: pinned_missing_ids)),
+          ).index_by(&:id)
         pinned_missing_ids.each do |pid|
           post = fetched[pid]
-          pinned_in_page << post if post && post.deleted_at.nil?
+          pinned_in_page << post if post && (post.deleted_at.nil? || !guardian.is_staff?)
         end
       end
 
@@ -93,13 +109,14 @@ module NestedReplies
       scope
     end
 
-    def apply_visibility(scope)
+    def apply_visibility(scope, posts_table: "posts")
       scope = scope.unscope(where: :deleted_at)
-      scope = scope.where(post_type: visible_post_types)
+      scope = scope.where("#{posts_table}.post_type IN (?)", visible_post_types)
       if guardian.user&.whisperer?
         scope =
           scope.where(
-            "post_type != :whisper OR action_code IS NULL OR action_code = ''",
+            "#{posts_table}.post_type != :whisper OR #{posts_table}.action_code IS NULL OR " \
+              "#{posts_table}.action_code = ''",
             whisper: Post.types[:whisper],
           )
       end

--- a/lib/nested_replies/tree_loader.rb
+++ b/lib/nested_replies/tree_loader.rb
@@ -82,7 +82,9 @@ module NestedReplies
       pinned_post_ids.each do |pid|
         idx = roots.index { |p| p.id == pid }
         if idx
-          pinned_in_page << roots.delete_at(idx) if roots[idx].deleted_at.nil? || !guardian.is_staff?
+          if roots[idx].deleted_at.nil? || !guardian.is_staff?
+            pinned_in_page << roots.delete_at(idx)
+          end
         else
           pinned_missing_ids << pid
         end

--- a/spec/lib/nested_replies/tree_loader_spec.rb
+++ b/spec/lib/nested_replies/tree_loader_spec.rb
@@ -178,10 +178,11 @@ RSpec.describe NestedReplies::TreeLoader do
       delete_post(deleted_pinned_root)
       loader = described_class.new(topic: topic, guardian: Fabricate(:admin).guardian)
 
-      promoted = loader.promote_pinned_roots(
-        [first_root, deleted_pinned_root, last_root],
-        [deleted_pinned_root.id],
-      )
+      promoted =
+        loader.promote_pinned_roots(
+          [first_root, deleted_pinned_root, last_root],
+          [deleted_pinned_root.id],
+        )
 
       expect(promoted.map(&:id)).to eq([first_root.id, deleted_pinned_root.id, last_root.id])
     end

--- a/spec/lib/nested_replies/tree_loader_spec.rb
+++ b/spec/lib/nested_replies/tree_loader_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+RSpec.describe NestedReplies::TreeLoader do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:op) { Fabricate(:post, topic: topic, user: user, post_number: 1) }
+
+  def create_root(reply_to_post_number: nil, **attributes)
+    Fabricate(
+      :post,
+      topic: topic,
+      user: user,
+      reply_to_post_number: reply_to_post_number,
+      **attributes,
+    )
+  end
+
+  def create_child(parent, **attributes)
+    Fabricate(
+      :post,
+      topic: topic,
+      user: user,
+      reply_to_post_number: parent.post_number,
+      **attributes,
+    )
+  end
+
+  def delete_post(post)
+    post.update_columns(deleted_at: Time.current)
+  end
+
+  describe "#root_posts_scope" do
+    it "filters only deleted direct leaves for anonymous and ordinary users" do
+      deleted_null_leaf = create_root
+      deleted_op_leaf = create_root(reply_to_post_number: 1)
+      deleted_root_with_live_child = create_root
+      deleted_root_with_deleted_child = create_root(reply_to_post_number: 1)
+      live_root_with_deleted_leaf = create_root
+      live_root_with_deleted_parent = create_root(reply_to_post_number: 1)
+
+      create_child(deleted_root_with_live_child)
+      deleted_child = create_child(deleted_root_with_deleted_child)
+      live_deleted_leaf = create_child(live_root_with_deleted_leaf)
+      deleted_parent = create_child(live_root_with_deleted_parent)
+      deleted_grandchild = create_child(deleted_parent)
+
+      [
+        deleted_null_leaf,
+        deleted_op_leaf,
+        deleted_root_with_live_child,
+        deleted_root_with_deleted_child,
+        deleted_child,
+        live_deleted_leaf,
+        deleted_parent,
+        deleted_grandchild,
+      ].each { |post| delete_post(post) }
+
+      stat =
+        NestedViewPostStat.create!(
+          post: deleted_root_with_live_child,
+          direct_reply_count: 0,
+          total_descendant_count: 0,
+        )
+      expect(stat.reload).to have_attributes(direct_reply_count: 0, total_descendant_count: 0)
+
+      expected_ids = [
+        deleted_root_with_live_child.id,
+        deleted_root_with_deleted_child.id,
+        live_root_with_deleted_leaf.id,
+        live_root_with_deleted_parent.id,
+      ]
+
+      [Guardian.new, user.guardian].each do |guardian|
+        loader = described_class.new(topic: topic, guardian: guardian)
+        expect(loader.root_posts_scope("old").pluck(:id)).to eq(expected_ids)
+      end
+    end
+
+    it "keeps staff root visibility unchanged" do
+      deleted_leaf = create_root
+      deleted_root_with_child = create_root(reply_to_post_number: 1)
+      create_child(deleted_root_with_child)
+      delete_post(deleted_leaf)
+      delete_post(deleted_root_with_child)
+
+      loader = described_class.new(topic: topic, guardian: Fabricate(:admin).guardian)
+
+      expect(loader.root_posts_scope("old").pluck(:id)).to eq(
+        [deleted_leaf.id, deleted_root_with_child.id],
+      )
+    end
+
+    it "uses requester-aware post type visibility for direct children" do
+      whisper_group = Fabricate(:group)
+      whisperer = Fabricate(:user, refresh_auto_groups: true)
+      whisper_group.add(whisperer)
+      SiteSetting.whispers_allowed_groups = whisper_group.id.to_s
+
+      regular_child_root = create_root
+      moderator_child_root = create_root
+      small_action_child_root = create_root
+      whisper_child_root = create_root
+      action_whisper_child_root = create_root
+
+      create_child(regular_child_root)
+      create_child(moderator_child_root, post_type: Post.types[:moderator_action])
+      create_child(small_action_child_root, post_type: Post.types[:small_action])
+      create_child(whisper_child_root, post_type: Post.types[:whisper])
+      create_child(
+        action_whisper_child_root,
+        post_type: Post.types[:whisper],
+        action_code: "assigned",
+      )
+
+      [
+        regular_child_root,
+        moderator_child_root,
+        small_action_child_root,
+        whisper_child_root,
+        action_whisper_child_root,
+      ].each { |root| delete_post(root) }
+
+      ordinary_loader = described_class.new(topic: topic, guardian: user.guardian)
+      whisperer_loader = described_class.new(topic: topic, guardian: whisperer.guardian)
+
+      expect(ordinary_loader.root_posts_scope("old").pluck(:id)).to eq(
+        [regular_child_root.id, moderator_child_root.id],
+      )
+      expect(whisperer_loader.root_posts_scope("old").pluck(:id)).to eq(
+        [regular_child_root.id, moderator_child_root.id, whisper_child_root.id],
+      )
+    end
+
+    it "filters before page boundaries for every root sort" do
+      eligible_roots = 5.times.map { |index| create_root(like_count: index + 1) }
+      hidden_roots = 4.times.map { |index| create_root(like_count: index + 10) }
+      hidden_roots.each { |root| delete_post(root) }
+      loader = described_class.new(topic: topic, guardian: user.guardian)
+
+      %w[old new top hot].each do |sort|
+        paged_ids =
+          3.times.flat_map do |page|
+            loader.root_posts_scope(sort).offset(page * 2).limit(2).pluck(:id)
+          end
+
+        expect(paged_ids).to contain_exactly(*eligible_roots.map(&:id))
+      end
+    end
+  end
+
+  describe "#promote_pinned_roots" do
+    it "uses nonstaff root eligibility for pins outside the input page" do
+      deleted_leaf = create_root
+      deleted_root_with_child = create_root(reply_to_post_number: 1)
+      child = create_child(deleted_root_with_child)
+      delete_post(deleted_leaf)
+      delete_post(deleted_root_with_child)
+      pinned_ids = [deleted_leaf.id, deleted_root_with_child.id]
+
+      ordinary_loader = described_class.new(topic: topic, guardian: user.guardian)
+      staff_loader = described_class.new(topic: topic, guardian: Fabricate(:admin).guardian)
+
+      expect(ordinary_loader.promote_pinned_roots([], pinned_ids).map(&:id)).to eq(
+        [deleted_root_with_child.id],
+      )
+      expect(ordinary_loader.promote_pinned_roots([], pinned_ids).first).to have_attributes(
+        deleted_at: be_present,
+        post_number: deleted_root_with_child.post_number,
+      )
+      expect(child.reply_to_post_number).to eq(deleted_root_with_child.post_number)
+      expect(staff_loader.promote_pinned_roots([], pinned_ids)).to eq([])
+    end
+
+    it "leaves a staff-visible deleted pin in its original input-page position" do
+      first_root = create_root
+      deleted_pinned_root = create_root
+      last_root = create_root
+      delete_post(deleted_pinned_root)
+      loader = described_class.new(topic: topic, guardian: Fabricate(:admin).guardian)
+
+      promoted = loader.promote_pinned_roots(
+        [first_root, deleted_pinned_root, last_root],
+        [deleted_pinned_root.id],
+      )
+
+      expect(promoted.map(&:id)).to eq([first_root.id, deleted_pinned_root.id, last_root.id])
+    end
+  end
+end

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -752,7 +752,9 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.status).to eq(200)
       expect(json).to have_key("post_stream")
       expect(json).not_to have_key("roots")
-      expect(json.dig("post_stream", "posts").map { |post| post["id"] }).to eq([op.id, live_reply.id])
+      expect(json.dig("post_stream", "posts").map { |post| post["id"] }).to eq(
+        [op.id, live_reply.id],
+      )
     end
 
     describe "deleted post placeholders" do

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -227,6 +227,8 @@ RSpec.describe NestedTopicsController, type: :request do
       get show_url(topic, sort: "hot")
 
       expect(response.status).to eq(200)
+      expect(response.parsed_body["sort"]).to eq("hot")
+      expect(response.parsed_body["effective_sort"]).to eq("hot")
       deleted_root_json = response.parsed_body["roots"].first
       expect(deleted_root_json["id"]).to eq(deleted_root.id)
       expect(deleted_root_json["deleted_post_placeholder"]).to eq(true)
@@ -587,25 +589,31 @@ RSpec.describe NestedTopicsController, type: :request do
       end
     end
 
-    it "paginates with has_more_roots" do
-      NestedReplies::TreeLoader::ROOTS_PER_PAGE.times do
-        Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+    it "paginates eligible roots after filtering interleaved deleted leaves" do
+      eligible_roots = []
+      deleted_leaves = []
+      23.times do |index|
+        eligible_roots << Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+        next if (index % 3).nonzero?
+
+        deleted_leaf = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+        deleted_leaf.update!(deleted_at: Time.current)
+        deleted_leaves << deleted_leaf
       end
       sign_in(user)
 
-      get show_url(topic, page: 0)
-      json = response.parsed_body
-      expect(json["has_more_roots"]).to eq(true)
-      expect(json["roots"].length).to eq(NestedReplies::TreeLoader::ROOTS_PER_PAGE)
-    end
+      get show_url(topic, page: 0, sort: "old")
+      first_page = response.parsed_body
+      get show_url(topic, page: 1, sort: "old")
+      final_page = response.parsed_body
 
-    it "returns has_more_roots false on last page" do
-      5.times { Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil) }
-      sign_in(user)
-
-      get show_url(topic, page: 0)
-      json = response.parsed_body
-      expect(json["has_more_roots"]).to eq(false)
+      expect(first_page).to include("page" => 0, "has_more_roots" => true)
+      expect(final_page).to include("page" => 1, "has_more_roots" => false)
+      expect(first_page["roots"].length).to eq(NestedReplies::TreeLoader::ROOTS_PER_PAGE)
+      returned_ids = (first_page["roots"] + final_page["roots"]).map { |root| root["id"] }
+      expect(returned_ids).to eq(eligible_roots.map(&:id))
+      expect(returned_ids.uniq).to eq(returned_ids)
+      expect(returned_ids).not_to include(*deleted_leaves.map(&:id))
     end
 
     it "validates sort parameter and falls back to default" do
@@ -731,20 +739,34 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(root_json["direct_reply_count"]).to eq(1)
     end
 
+    it "keeps the non-nested topic endpoint on the flat post stream behavior" do
+      live_reply = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      deleted_reply = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      deleted_reply.update!(deleted_at: Time.current)
+
+      expect(topic.reload.nested_view?).to eq(false)
+
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      json = response.parsed_body
+      expect(response.status).to eq(200)
+      expect(json).to have_key("post_stream")
+      expect(json).not_to have_key("roots")
+      expect(json.dig("post_stream", "posts").map { |post| post["id"] }).to eq([op.id, live_reply.id])
+    end
+
     describe "deleted post placeholders" do
-      it "shows deleted root as placeholder for non-staff" do
+      it "hides a deleted root leaf while preserving topic and OP metadata for non-staff" do
         root = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
         root.update!(deleted_at: Time.current)
-        sign_in(user)
 
         get show_url(topic)
+
         json = response.parsed_body
-        root_json = json["roots"].find { |r| r["id"] == root.id }
-        expect(root_json).to be_present
-        expect(root_json["deleted_post_placeholder"]).to eq(true)
-        expect(root_json["cooked"]).to eq("")
-        expect(root_json["raw"]).to be_nil
-        expect(root_json["actions_summary"]).to eq([])
+        expect(response.status).to eq(200)
+        expect(json["roots"].map { |json_root| json_root["id"] }).not_to include(root.id)
+        expect(json["topic"]["id"]).to eq(topic.id)
+        expect(json["op_post"]["id"]).to eq(op.id)
       end
 
       it "preserves children under deleted root for non-staff" do
@@ -754,11 +776,41 @@ RSpec.describe NestedTopicsController, type: :request do
         sign_in(user)
 
         get show_url(topic)
-        json = response.parsed_body
-        root_json = json["roots"].find { |r| r["id"] == root.id }
-        expect(root_json["children"]).to be_an(Array)
-        expect(root_json["children"].length).to eq(1)
-        expect(root_json["children"].first["id"]).to eq(child.id)
+        root_json = response.parsed_body["roots"].find { |json_root| json_root["id"] == root.id }
+        expect(root_json).to include(
+          "id" => root.id,
+          "deleted_post_placeholder" => true,
+          "cooked" => "",
+          "raw" => nil,
+          "actions_summary" => [],
+        )
+        expect(root_json["children"].map { |json_child| json_child["id"] }).to eq([child.id])
+      end
+
+      it "preserves a deleted root when its direct child is also deleted" do
+        root = Fabricate(:post, topic: topic, user: user, reply_to_post_number: 1)
+        child = Fabricate(:post, topic: topic, user: user, reply_to_post_number: root.post_number)
+        root.update!(deleted_at: Time.current)
+        child.update!(deleted_at: Time.current)
+        sign_in(user)
+
+        get show_url(topic)
+
+        root_json = response.parsed_body["roots"].find { |json_root| json_root["id"] == root.id }
+        expect(root_json).to include(
+          "id" => root.id,
+          "deleted_post_placeholder" => true,
+          "cooked" => "",
+          "raw" => nil,
+          "actions_summary" => [],
+        )
+        expect(root_json["children"].first).to include(
+          "id" => child.id,
+          "deleted_post_placeholder" => true,
+          "cooked" => "",
+          "raw" => nil,
+          "actions_summary" => [],
+        )
       end
 
       it "shows deleted root as placeholder for staff but preserves content" do
@@ -847,7 +899,7 @@ RSpec.describe NestedTopicsController, type: :request do
         expect(root_ids.first).to eq(low_post.id)
       end
 
-      it "does not promote a deleted post to pinned position" do
+      it "does not promote a deleted leaf to pinned position for non-staff" do
         low_post.update!(deleted_at: Time.current)
         pin_posts(low_post)
         sign_in(user)
@@ -855,8 +907,32 @@ RSpec.describe NestedTopicsController, type: :request do
         get show_url(topic, sort: "top")
 
         json = response.parsed_body
-        root_ids = json["roots"].map { |r| r["id"] }
-        expect(root_ids.first).not_to eq(low_post.id)
+        expect(json["roots"].map { |root| root["id"] }).not_to include(low_post.id)
+      end
+
+      it "promotes a deleted pinned root with a visible child for non-staff" do
+        child =
+          Fabricate(:post, topic: topic, user: user, reply_to_post_number: low_post.post_number)
+        low_post.update!(deleted_at: Time.current)
+        pin_posts(low_post)
+        sign_in(user)
+
+        get show_url(topic, sort: "top")
+
+        pinned_root = response.parsed_body["roots"].first
+        expect(pinned_root).to include("id" => low_post.id, "deleted_post_placeholder" => true)
+        expect(pinned_root["children"].map { |post| post["id"] }).to eq([child.id])
+      end
+
+      it "keeps deleted pins excluded for staff even when they have children" do
+        Fabricate(:post, topic: topic, user: user, reply_to_post_number: low_post.post_number)
+        low_post.update!(deleted_at: Time.current)
+        pin_posts(low_post)
+        sign_in(admin)
+
+        get show_url(topic, sort: "top")
+
+        expect(response.parsed_body["roots"].map { |root| root["id"] }).not_to include(low_post.id)
       end
 
       it "ignores a pinned post_id that does not exist" do
@@ -1479,6 +1555,22 @@ RSpec.describe NestedTopicsController, type: :request do
       sign_in(user)
       get context_url(topic, 99_999)
       expect(response.status).to eq(404)
+    end
+
+    it "retains direct context access to a deleted root leaf hidden from the root list" do
+      root = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      root.update!(deleted_at: Time.current)
+      sign_in(user)
+
+      get show_url(topic)
+      expect(response.parsed_body["roots"]).to be_empty
+
+      get context_url(topic, root.post_number)
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["target_post"]).to include(
+        "id" => root.id,
+        "deleted_post_placeholder" => true,
+      )
     end
 
     it "returns 404 when plugin disabled" do

--- a/spec/system/nested_post_lifecycle_spec.rb
+++ b/spec/system/nested_post_lifecycle_spec.rb
@@ -220,12 +220,11 @@ RSpec.describe "Nested view post lifecycle" do
     context "when logged in as regular user" do
       before { sign_in(user) }
 
-      it "does not show an eye button on deleted posts" do
+      it "hides deleted root leaves" do
         root_reply.update!(deleted_at: Time.current)
 
         nested_view.visit_nested(topic)
-        expect(nested_view).to have_deleted_placeholder_for(root_reply)
-        expect(nested_view).to have_no_toggle_deleted_content_button_for(root_reply)
+        expect(nested_view).to have_no_post(root_reply)
       end
     end
   end


### PR DESCRIPTION
Previously, nested replies showed deleted root-level replies without children to non-staff, while pin promotion excluded deleted roots even when they had replies.

This change filters childless deleted roots before pagination and pin promotion for non-staff, preserving roots with visible live or deleted replies, nested placeholders, direct context access, and existing staff behavior.