### PR TITLE
FEATURE: Surface first post likes and reactions in embed mode

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -49,6 +49,22 @@ body.embed-mode {
     display: none !important;
   }
 
+  // Like and reaction controls for the (hidden) first post
+  .embed-topic-actions {
+    &__menu {
+      padding: 0.5em 0 0.75em;
+      border-bottom: 1px solid var(--content-border-color);
+
+      nav.post-controls {
+        width: 100%;
+      }
+
+      .post-action-menu__like .d-button-label {
+        display: inline;
+      }
+    }
+  }
+
   .embed-topic-footer {
     margin-top: 1.5em;
     text-align: center;

--- a/frontend/discourse/app/components/embed-topic-actions.gjs
+++ b/frontend/discourse/app/components/embed-topic-actions.gjs
@@ -1,0 +1,76 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { getOwner } from "@ember/owner";
+import { modifier } from "ember-modifier";
+import PostMenu from "discourse/components/post/menu";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import EmbedMode from "discourse/lib/embed-mode";
+
+// Embed mode hides the first post because the embedding page already shows
+// that content. This surfaces just its like and reaction controls so readers
+// can react to the article itself without leaving the page.
+export default class EmbedTopicActions extends Component {
+  @tracked firstPost;
+
+  loadFirstPost = modifier((element, [topic]) => {
+    let cancelled = false;
+
+    topic
+      ?.firstPost()
+      .then((post) => {
+        if (!cancelled) {
+          this.firstPost = post;
+        }
+      })
+      .catch(() => {
+        // Without the first post there is nothing to react to; the bar stays hidden.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  get isEmbedMode() {
+    return EmbedMode.enabled;
+  }
+
+  @action
+  async toggleLike() {
+    const post = this.firstPost;
+    const likeAction = post.likeAction;
+
+    if (!likeAction?.canToggle) {
+      return;
+    }
+
+    try {
+      await likeAction.togglePromise(post);
+    } catch (e) {
+      popupAjaxError(e);
+    }
+  }
+
+  @action
+  showLogin() {
+    getOwner(this).lookup("route:application").send("showLogin");
+  }
+
+  <template>
+    {{#if this.isEmbedMode}}
+      <div class="embed-topic-actions" {{this.loadFirstPost @topic}}>
+        {{#if this.firstPost}}
+          <section class="embed-topic-actions__menu">
+            <PostMenu
+              @canCreatePost={{false}}
+              @post={{this.firstPost}}
+              @showLogin={{this.showLogin}}
+              @toggleLike={{this.toggleLike}}
+            />
+          </section>
+        {{/if}}
+      </div>
+    {{/if}}
+  </template>
+}

--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -8,6 +8,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { cancel, next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
+import EmbedTopicActions from "discourse/components/embed-topic-actions";
 import MoreTopics from "discourse/components/more-topics";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -852,6 +853,8 @@ export default class Nested extends Component {
         @topicCategoryChanged={{@topicCategoryChanged}}
         @topicTagsChanged={{@topicTagsChanged}}
       />
+
+      <EmbedTopicActions @topic={{@topic}} />
 
       <PluginOutlet
         @connectorTagName="div"

--- a/frontend/discourse/app/instance-initializers/embed-mode-post-menu.js
+++ b/frontend/discourse/app/instance-initializers/embed-mode-post-menu.js
@@ -1,0 +1,39 @@
+import EmbedMode from "discourse/lib/embed-mode";
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  after: "inject-objects",
+
+  initialize() {
+    if (!EmbedMode.enabled) {
+      return;
+    }
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "post-menu-buttons",
+        ({ value: dag, context: { post, buttonKeys, buttonLabels } }) => {
+          if (post.post_number !== 1) {
+            return;
+          }
+
+          // The embedding page shows the first post's content, so its menu is
+          // reduced to the like button plus summary-style controls plugins add
+          // alongside it (e.g. a reactions summary).
+          const coreKeys = Object.values(buttonKeys);
+
+          dag.entries().forEach(([key, ButtonComponent]) => {
+            const isPluginSummary =
+              !coreKeys.includes(key) && ButtonComponent.extraControls;
+
+            if (key !== buttonKeys.LIKE && !isPluginSummary) {
+              dag.delete(key);
+            }
+          });
+
+          buttonLabels.show(buttonKeys.LIKE);
+        }
+      );
+    });
+  },
+};

--- a/frontend/discourse/app/templates/topic.gjs
+++ b/frontend/discourse/app/templates/topic.gjs
@@ -8,6 +8,7 @@ import AnonymousTopicFooterButtons from "discourse/components/anonymous-topic-fo
 import DiscourseBanner from "discourse/components/discourse-banner";
 import DiscourseTopic from "discourse/components/discourse-topic";
 import EmbedModeComposer from "discourse/components/embed-mode-composer";
+import EmbedTopicActions from "discourse/components/embed-topic-actions";
 import EmbedTopicFooter from "discourse/components/embed-topic-footer";
 import MoreTopics from "discourse/components/more-topics";
 import Nested from "discourse/components/nested";
@@ -479,6 +480,8 @@ export default <template>
                       @outletArgs={{lazyHash model=@controller.model}}
                     />
                   </span>
+
+                  <EmbedTopicActions @topic={{@controller.model}} />
 
                   {{#if @controller.model.postStream.firstPostNotLoaded}}
                     {{hideScrollableContent "above"}}

--- a/spec/system/embed_mode_spec.rb
+++ b/spec/system/embed_mode_spec.rb
@@ -69,6 +69,82 @@ describe "Embed mode" do
     expect(page).to have_no_css(".embed-topic-footer")
   end
 
+  describe "first post actions" do
+    fab!(:reply) { Fabricate(:post, topic: topic) }
+
+    it "shows the first post's like count to anonymous users" do
+      PostActionCreator.like(Fabricate(:user), post)
+
+      visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+
+      expect(topic_page).to have_embed_topic_actions
+      expect(topic_page.embed_topic_actions).to have_css(".post-action-menu__like")
+      expect(topic_page.embed_topic_actions).to have_css(".like-count", text: "1")
+    end
+
+    it "only exposes like controls for the first post" do
+      visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+
+      expect(topic_page).to have_embed_topic_actions
+      expect(topic_page.embed_topic_actions).to have_css(".post-action-menu__like")
+      expect(topic_page.embed_topic_actions).to have_no_css(".post-action-menu__copy-link")
+      expect(topic_page.embed_topic_actions).to have_no_css(".post-action-menu__reply")
+      expect(topic_page.embed_topic_actions).to have_no_css(".show-more-actions")
+    end
+
+    it "prompts anonymous users to sign in when they like the first post" do
+      visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+
+      topic_page.click_embed_topic_like_button
+
+      expect(page).to have_css(".embed-auth-flow-modal")
+    end
+
+    it "does not show first post actions outside embed mode" do
+      visit("/t/#{topic.slug}/#{topic.id}")
+
+      expect(topic_page).to have_no_embed_topic_actions
+    end
+
+    context "when logged in" do
+      fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+
+      before { sign_in(user) }
+
+      it "likes and unlikes the first post" do
+        visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+
+        topic_page.click_embed_topic_like_button
+
+        expect(topic_page.embed_topic_actions).to have_css(".post-action-menu__like.has-like")
+        expect(topic_page.embed_topic_actions).to have_css(".like-count", text: "1")
+        # The button updates optimistically, so wait for the server to catch up
+        try_until_success do
+          expect(
+            PostAction.where(
+              user:,
+              post:,
+              post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+            ),
+          ).to exist
+        end
+
+        topic_page.click_embed_topic_like_button
+
+        expect(topic_page.embed_topic_actions).to have_no_css(".post-action-menu__like.has-like")
+        try_until_success do
+          expect(
+            PostAction.where(
+              user:,
+              post:,
+              post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+            ),
+          ).not_to exist
+        end
+      end
+    end
+  end
+
   context "when logged in" do
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -282,6 +282,23 @@ module PageObjects
         has_css?(".embed-mode-composer .docked-composer")
       end
 
+      def embed_topic_actions
+        find(".embed-topic-actions")
+      end
+
+      def has_embed_topic_actions?
+        has_css?(".embed-topic-actions nav.post-controls")
+      end
+
+      def has_no_embed_topic_actions?
+        has_no_css?(".embed-topic-actions")
+      end
+
+      def click_embed_topic_like_button
+        embed_topic_actions.find(".post-action-menu__like").click
+        self
+      end
+
       def has_no_docked_composer?
         has_no_css?(".embed-mode-composer .docked-composer")
       end


### PR DESCRIPTION
**Previously**, full-app embed mode hid the topic's first post entirely, so readers had no way to see or add likes and reactions to the embedded article itself.

**In this update**, added an `EmbedTopicActions` bar above the replies that renders the first post's like and reaction controls (via the post menu, so plugin reactions work too), with anonymous clicks routed through the embed sign-in flow.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/e47febbb-2329-43c7-a5c1-3c45057d140a) | ![after](https://github.com/user-attachments/assets/5baba2be-8b46-442b-8dea-7f211d1d0506) |