### PR TITLE
FIX: hide approve on reviewed user reviewables

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -311,12 +311,18 @@ class Admin::UsersController < Admin::StaffController
       ReviewableUser.find_by(target: @user) ||
         Jobs::CreateUserReviewable.new.execute(user_id: @user.id).reviewable
 
-    reviewable.perform(current_user, :approve_user)
+    reviewable.perform(current_user, :approve_user, allow_reviewed: true)
     render body: nil
   end
 
   def approve_bulk
-    Reviewable.bulk_perform_targets(current_user, :approve_user, "ReviewableUser", params[:users])
+    Reviewable.bulk_perform_targets(
+      current_user,
+      :approve_user,
+      "ReviewableUser",
+      params[:users],
+      allow_reviewed: true,
+    )
     render body: nil
   end
 

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -52,7 +52,10 @@ class ReviewableUser < Reviewable
       build_action(actions, :remove_avatar, icon: "user-xmark", secondary: true)
     end
 
-    if guardian.can_approve?(target)
+    # Reviewed items must not offer approval in the queue, but approving an
+    # unapproved user directly (e.g. from the admin user page) still goes
+    # through this action, so those callers opt in with `allow_reviewed`.
+    if (pending? || args[:allow_reviewed]) && guardian.can_approve?(target)
       actions.add(:approve_user, bundle: nil) do |a|
         a.icon = "user-plus"
         a.completed_message = "reviewables.actions.approve_user.complete"

--- a/frontend/discourse/app/models/reviewable.js
+++ b/frontend/discourse/app/models/reviewable.js
@@ -123,21 +123,12 @@ export default class Reviewable extends RestModel {
     });
   }
 
-  get #offersApproveUser() {
-    return this.bundled_actions?.some((bundle) =>
-      bundle.actions?.some((action) => action.server_action === "approve_user")
-    );
-  }
-
-  @computed("resolvedType", "reviewable_scores", "status", "bundled_actions")
+  @computed("resolvedType", "reviewable_scores", "status")
   get userReviewableContextQuestion() {
     if (this.resolvedType === "ReviewableUser") {
-      // the spam question must not outlive the pending state: its only
-      // remaining answer would be a "Yes" that approves the user
+      // in this case the only remaining action is "scrub record" so the question shouldn't show
       if (this.status !== PENDING) {
-        return this.#offersApproveUser
-          ? i18n("review.context_question.approve_user")
-          : null;
+        return null;
       }
       const isSuspectUser = this.reviewable_scores?.some(
         (score) => score.reason_type === "suspect_user"

--- a/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
@@ -132,38 +132,6 @@ module("Integration | Component | Reviewable | Item", function (hooks) {
       .exists();
   });
 
-  test("keeps asking the approve question once a user reviewable is resolved but still approvable", async function (assert) {
-    const resolved = userReviewable(this, {
-      status: REJECTED,
-      bundled_actions: [actionBundle("approve_user", "Yes")],
-    });
-
-    await render(
-      <template><ReviewableItem @reviewable={{resolved}} /></template>
-    );
-
-    assert.dom(".review-item__aside-title").hasText("Approve this user?");
-  });
-
-  test("does not reuse the spam question once a user reviewable is resolved", async function (assert) {
-    const resolved = userReviewable(this, {
-      status: REJECTED,
-      reviewable_scores: [
-        {
-          reason_type: "suspect_user",
-          score_type: { type: "needs_approval", title: "Needs approval" },
-        },
-      ],
-      bundled_actions: [actionBundle("approve_user", "Yes")],
-    });
-
-    await render(
-      <template><ReviewableItem @reviewable={{resolved}} /></template>
-    );
-
-    assert.dom(".review-item__aside-title").hasText("Approve this user?");
-  });
-
   test("falls back to the generic heading when a resolved user reviewable can only be scrubbed", async function (assert) {
     const resolved = userReviewable(this, {
       status: REJECTED,

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -111,12 +111,16 @@ RSpec.describe ReviewableUser, type: :model do
       expect(actions.has?(:delete_user_block)).to eq(false)
     end
 
-    it "still allows approving in the rejected state" do
+    it "doesn't return anything in the rejected state while the user is still unapproved" do
       reviewable.status = Reviewable.statuses[:rejected]
       actions = reviewable.actions_for(Guardian.new(moderator))
-      expect(actions.has?(:approve_user)).to eq(true)
-      expect(actions.has?(:delete_user)).to eq(false)
-      expect(actions.has?(:delete_user_block)).to eq(false)
+      expect(actions.bundles).to be_empty
+    end
+
+    it "returns only the approve action in the rejected state when reviewed items are allowed" do
+      reviewable.status = Reviewable.statuses[:rejected]
+      actions = reviewable.actions_for(Guardian.new(moderator), allow_reviewed: true)
+      expect(actions.bundles.flat_map(&:actions).map(&:server_action)).to eq(["approve_user"])
     end
 
     it "doesn't ask for a rejection reason when deleting a user who was flagged as a possible spammer" do
@@ -325,7 +329,7 @@ RSpec.describe ReviewableUser, type: :model do
           )
         reviewable.update!(status: Reviewable.statuses[:rejected])
 
-        reviewable.perform(moderator, :approve_user)
+        reviewable.perform(moderator, :approve_user, allow_reviewed: true)
 
         expect(reviewable.reload).to be_approved
         expect(score.reload.status).to eq("agreed")

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -471,6 +471,18 @@ RSpec.describe Admin::UsersController do
         evil_trout.reload
         expect(evil_trout.approved).to eq(true)
       end
+
+      it "approves a user whose previous reviewable was rejected" do
+        evil_trout.update!(active: true)
+        reviewable =
+          Fabricate(:reviewable_user, target: evil_trout, status: Reviewable.statuses[:rejected])
+
+        put "/admin/users/approve-bulk.json", params: { users: [evil_trout.id] }
+
+        expect(response.status).to eq(200)
+        expect(evil_trout.reload).to be_approved
+        expect(reviewable.reload).to be_approved
+      end
     end
 
     context "when logged in as an admin" do

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -56,6 +56,12 @@ module PageObjects
         page.has_no_css?(REVIEWABLE_ACTION_DROPDOWN)
       end
 
+      def has_no_reviewable_actions?(reviewable)
+        within(reviewable_by_id(reviewable.id)) do
+          page.has_no_css?(".reviewable-action, #{REVIEWABLE_ACTION_DROPDOWN}")
+        end
+      end
+
       def has_reviewable_items?(count:)
         page.has_css?(".review-item", count: count)
       end
@@ -69,10 +75,6 @@ module PageObjects
 
       def has_scrub_button?(reviewable)
         within(reviewable_by_id(reviewable.id)) { page.has_css?(".user-scrub") }
-      end
-
-      def has_no_scrub_button?(reviewable)
-        within(reviewable_by_id(reviewable.id)) { page.has_no_css?(".user-scrub") }
       end
 
       def click_scrub_user_button

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -164,7 +164,7 @@ describe "Reviewables" do
 
       expect(suspend_user_modal).to be_closed
       expect(review_page).to have_reviewable_with_rejected_status(suspect_reviewable)
-      expect(review_page).to have_no_scrub_button(suspect_reviewable)
+      expect(review_page).to have_no_reviewable_actions(suspect_reviewable)
       expect(suspect_user.reload).to be_suspended
       expect(
         UserHistory.find_by(


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/moderation-yes-button-after-suspending-user/411693/4 and a follow-up to https://github.com/discourse/discourse/commit/0d241b1f717cbfd0bf950794c30b4db0ffeb72a5 — that fix was in the wrong direction, it added the correct context for the "yes" button that appeared, but really the approval shouldn't be in the review queue after the user was handled at all. 

The original issue that caused the "yes" button to appear after the item was reviewed was from #40303, which fixed an issue when `must_approve_users` was on. Users whose review queue item had already been handled but who were still unapproved couldn't be approved from their admin page, because approval only worked on pending items. The fix allowed approval on handled items. That fixed the admin page, but it also left a "Yes" button on handled items in the review queue.

So this undoes that context fix from https://github.com/discourse/discourse/commit/0d241b1f717cbfd0bf950794c30b4db0ffeb72a5 for the review queue, and hides the approval button in the review queue after the item has already been handled. The original fix for the admin page is still present. 