### PR TITLE
FIX: Accept an OIDC token response that carries only an id_token

### DIFF
--- a/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
+++ b/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
@@ -254,7 +254,8 @@ module OmniAuth
         return super if options.use_userinfo
         response =
           client.request(:post, options[:client_options][:token_url], body: get_token_options)
-        ::OAuth2::AccessToken.from_hash(client, response.parsed)
+        parsed = response.parsed
+        ::OAuth2::AccessToken.new(client, parsed["id_token"].to_s, parsed)
       end
     end
   end

--- a/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
@@ -184,7 +184,7 @@ describe OmniAuth::Strategies::OpenIDConnect do
             body: hash_including("code" => "supersecretcode", "p" => "someallowedvalue"),
           ).to_return(
             status: 200,
-            body: { access_token: "AnAccessToken", id_token: @token }.to_json,
+            body: { id_token: @token }.to_json,
             headers: {
               "Content-Type" => "application/json",
             },
@@ -200,6 +200,20 @@ describe OmniAuth::Strategies::OpenIDConnect do
           expect(strategy.info[:email]).to eq("tokenemail@example.com")
           expect(strategy.extra[:id_token]).to eq(@token)
           expect(@app_called).to eq(true)
+        end
+
+        it "handles a blank access_token alongside the id_token" do
+          stub_request(:post, "https://id.example.com/token").to_return(
+            status: 200,
+            body: { access_token: "", id_token: @token }.to_json,
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+
+          expect(strategy.callback_phase[0]).to eq(200)
+          expect(strategy.uid).to eq("someuserid")
+          expect(strategy.extra[:id_token]).to eq(@token)
         end
 
         it "checks the nonce" do


### PR DESCRIPTION
Some providers return a token response with no access token at all, or with an empty `access_token` alongside the `id_token`. `oauth2` 2.x treats `id_token` as one of the keys that can hold the token value, so `AccessToken.from_hash` either takes the `id_token` and removes it from the params, leaving `access_token["id_token"]` nil and the JWT decode failing, or it takes the empty `access_token` and raises "OAuth2::AccessToken has no token".

When userinfo is disabled the strategy reads everything it needs from the `id_token`, so build the access token directly and keep the whole parsed response in the params.

- The spec for the userinfo-disabled path goes back to an `id_token`-only token response, which is what a provider with no userinfo endpoint sends.
- A new case covers a response with a blank `access_token`.