### PR TITLE
FIX: Handle missing OAuth2 state parameter more gracefully

### DIFF
--- a/lib/freedom_patches/omniauth_oauth2_state.rb
+++ b/lib/freedom_patches/omniauth_oauth2_state.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "omniauth-oauth2"
+
+# `secure_compare` calls `bytesize` on both sides, so a callback that arrives
+# with no `omniauth.state` in the session raises instead of failing the CSRF
+# check. https://github.com/omniauth/omniauth-oauth2/pull/186 fixes it upstream.
+module OmniAuthOAuth2StatePatch
+  def secure_compare(string_a, string_b)
+    return false if string_a.to_s.empty? || string_b.to_s.empty?
+    super
+  end
+end
+
+OmniAuth::Strategies::OAuth2.prepend(OmniAuthOAuth2StatePatch)

--- a/spec/integration/omniauth_state_spec.rb
+++ b/spec/integration/omniauth_state_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe "OAuth2 callback state validation" do
+  before do
+    SiteSetting.discord_client_id = "abcdef11223344"
+    SiteSetting.discord_secret = "adddcccdddd99922"
+    SiteSetting.enable_discord_logins = true
+  end
+
+  it "fails gracefully when the session has no state" do
+    post "/auth/discord/callback", params: { state: "somestate", code: "somecode" }
+
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("/auth/failure?message=csrf_detected&strategy=discord")
+  end
+end


### PR DESCRIPTION
A callback can arrive without an `omniauth.state` in the session, for example when the browser drops the cookie or the user opens a stale callback URL. `omniauth-oauth2` 1.9.0 compares the request state against the session state with `secure_compare`, which calls `bytesize` on both, so a missing session state raises `NoMethodError` and the request 500s instead of redirecting to `/auth/failure`.

Upstream issue: https://github.com/omniauth/omniauth-oauth2/issues/189
Pending fix: https://github.com/omniauth/omniauth-oauth2/pull/186