### PR TITLE
DEV: Cover staged email media exemption for logged-in users

### DIFF
--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1045,6 +1045,17 @@ RSpec.describe Email::Receiver do
       expect(reviewable.reviewable_scores.first.reason).to eq("contains_media")
     end
 
+    it "does not queue an email with media from a staged stranger when logged-in users skip media review" do
+      SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:logged_in_users]
+
+      expect { process(:new_user_with_media) }
+        .to change(Topic, :count).by(1)
+        .and not_change(ReviewableQueuedPost, :count)
+
+      user = User.find_by_email("discourse@bar.com")
+      expect(user).to be_staged
+    end
+
     it "raises an UserNotFoundError if enable_staged_users is false " do
       SiteSetting.enable_staged_users = false
       expect { process(:new_user) }.to raise_error(Email::Receiver::UserNotFoundError)


### PR DESCRIPTION
This adds regression coverage for media-containing incoming email from a newly-created staged user when `logged_in_users` is included in `skip_review_media_groups`.

This came up in Meta topic 412025 following the staged-email media handling covered by #42515.

The new spec verifies that:

- a previously unknown sender is created as a staged user;
- their media-containing email creates a topic directly when `logged_in_users` is configured to skip media review; and
- no `ReviewableQueuedPost` is created.

This complements the existing test which verifies that the same kind of staged email is queued with `contains_media` when the sender is not in an exempt group.

No production code is changed.

One slightly surprising aspect of the current behavior is that staged users match the `logged_in_users` pseudo-group for this check. This PR makes that dependency explicit for review and regression coverage.

Tests:

- `bin/rspec spec/lib/email/receiver_spec.rb` — 213 examples, 0 failures
- `bin/rubocop spec/lib/email/receiver_spec.rb` — no offenses
- `git diff --check`
