### PR TITLE
FIX: Prevent delayed scroll resets after route transitions

### DIFF
--- a/frontend/discourse/app/services/route-scroll-manager.js
+++ b/frontend/discourse/app/services/route-scroll-manager.js
@@ -1,4 +1,4 @@
-import { next } from "@ember/runloop";
+import { schedule } from "@ember/runloop";
 import Service, { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
 import { isTesting } from "discourse/lib/environment";
@@ -55,7 +55,9 @@ export default class RouteScrollManager extends Service {
 
     const scrollLocation = this.historyStore.get(STORE_KEY) || [0, 0];
 
-    next(() => this.scrollElement.scrollTo(...scrollLocation));
+    schedule("afterRender", () =>
+      this.scrollElement.scrollTo(...scrollLocation)
+    );
   }
 
   #shouldScroll(routeInfo) {

--- a/spec/system/scroll_manager_service_spec.rb
+++ b/spec/system/scroll_manager_service_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 describe "Ember route-scroll-manager service" do
+  fab!(:topic)
+
   before do
     Fabricate(:admin)
     Fabricate.times(50, :post)
+    Fabricate.times(20, :post, topic: topic)
   end
 
   let(:discovery) { PageObjects::Pages::Discovery.new }
@@ -37,6 +40,20 @@ describe "Ember route-scroll-manager service" do
 
     # Clicking site logo triggers refresh and scrolls to top
     click_logo
+    expect(current_scroll_y).to eq(0)
+  end
+
+  it "scrolls to the top when navigating from a topic to the homepage" do
+    visit("/t/#{topic.slug}/#{topic.id}")
+    expect(page).to have_css("#post_20")
+
+    page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
+    expect(current_scroll_y).to be > 0
+
+    click_logo
+
+    expect(page).to have_css("body.navigation-topics")
+    expect(discovery.topic_list).to have_topics
     expect(current_scroll_y).to eq(0)
   end
 end


### PR DESCRIPTION
**Previously**, navigating from a scrolled topic to the homepage could briefly render the topic list at the old scroll position before resetting to the top.

**In this update**, restore the destination scroll position in the current render cycle and add system coverage for topic-to-home navigation.