### PR TITLE
FIX: Make links absolute in emails rendered from Markdown

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -444,6 +444,7 @@ module Email
     def to_html
       replace_secure_uploads_urls if SiteSetting.secure_uploads?
       replace_relative_urls
+      make_all_links_absolute
       deduplicate_styles
 
       @fragment.to_html
@@ -481,14 +482,9 @@ module Email
     end
 
     def make_all_links_absolute
-      site_uri = URI(Discourse.base_url)
       @fragment
-        .css("a")
-        .each do |link|
-          link["href"] = "#{site_uri}#{link["href"]}" if URI(link["href"].to_s).host.blank?
-        rescue URI::Error
-          # leave it
-        end
+        .css("a[href]")
+        .each { |link| link["href"] = UrlHelper.absolute_without_cdn(link["href"]) }
     end
 
     private

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Email::Styles do
       expect(frag.at("img")["src"]).to eq("#{Discourse.base_url}/some-image.png")
     end
 
+    it "converts relative links to absolute links" do
+      frag = basic_fragment("<a href='/u/someone'>someone</a><a href='mailto:a@b.com'>mail</a>")
+
+      expect(frag.css("a").map { |link| link["href"] }).to eq(
+        ["#{Discourse.base_url}/u/someone", "mailto:a@b.com"],
+      )
+    end
+
     it "preserves classes and ids" do
       raw = '<div class="foo" id="bar"><div class="foo" id="bar"></div></div>'
       frag = basic_fragment(raw)


### PR DESCRIPTION
Previously, notification emails without an HTML part were rendered by cooking the Markdown body, a path that never absolutised links, so every `@mention` and `#hashtag` in them pointed at a root-relative URL and was dead in a mail client.

This change rewrites the unused `Email::Styles#make_all_links_absolute` helper in terms of `UrlHelper.absolute_without_cdn`, which only touches root-relative URLs and leaves `mailto:` alone, and calls it from `Email::Styles#to_html`.