### PR TITLE
FIX: Disambiguate tag hashtags in topic tag change posts

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -244,7 +244,10 @@ class PostRevisor
   end
 
   def self.tag_list_to_raw(tag_list)
-    tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ")
+    HashtagAutocompleteService
+      .new(Discourse.system_user.guardian)
+      .hashtags_for("tag", tag_list.sort)
+      .join(", ")
   end
 
   def self.tag_change_noop?(topic, incoming)

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -298,8 +298,8 @@ describe PostRevisor do
     end
 
     describe "when `create_post_for_category_and_tag_changes` site setting is enabled" do
-      fab!(:tag1) { Fabricate(:tag, name: "First tag") }
-      fab!(:tag2) { Fabricate(:tag, name: "Second tag") }
+      fab!(:tag1) { Fabricate(:tag, name: "first-tag") }
+      fab!(:tag2) { Fabricate(:tag, name: "second-tag") }
 
       before do
         SiteSetting.create_post_for_category_and_tag_changes = true
@@ -343,6 +343,17 @@ describe PostRevisor do
 
         expect(post.topic.ordered_posts.last.raw).to eq(
           I18n.t("topic_tag_changed.removed", removed: "##{tag1.name}, ##{tag2.name}"),
+        )
+      end
+
+      it "suffixes a tag hashtag that collides with a category slug" do
+        Fabricate(:category, slug: tag1.name)
+        post.topic.update!(tags: [])
+
+        post_revisor.revise!(admin, tags: [tag1.name])
+
+        expect(post.topic.ordered_posts.last.raw).to eq(
+          I18n.t("topic_tag_changed.added", added: "##{tag1.name}::tag"),
         )
       end
 


### PR DESCRIPTION
Previously, `PostRevisor` wrote bare `#name` hashtags into the whisper that records a topic's tag changes. Categories outrank tags when a bare hashtag is resolved, so adding a tag whose name matched a category slug produced a whisper linking to the category.

This change builds those hashtags with `HashtagAutocompleteService#hashtags_for`, which qualifies a reference a higher-priority type would otherwise claim.

Stacked on #43596.