### PR TITLE
FIX: Disambiguate tag hashtags in chat integration messages

### DIFF
--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -78,7 +78,10 @@ module DiscourseChatIntegration
     def raw
       if @raw.nil? && @kind == DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED
         tag_list_to_raw = ->(tag_list) do
-          tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ")
+          HashtagAutocompleteService
+            .new(user.guardian)
+            .hashtags_for("tag", tag_list.sort)
+            .join(", ")
         end
 
         added_tags = @context["added_tags"]


### PR DESCRIPTION
Previously, the tag-change message pushed to chat providers built its hashtags with a copy of `PostRevisor.tag_list_to_raw`. That raw is cooked before being excerpted, so a tag sharing a slug with a category announced the category to Slack, Teams and Discord.

This change resolves the references through `HashtagAutocompleteService#hashtags_for` using the acting user's guardian, the same one the excerpt is already cooked with.

Stacked on #43598.