### PR TITLE
UX: general style adjustments for livestream chat drawer

### DIFF
--- a/plugins/discourse-events/assets/stylesheets/desktop/livestream.scss
+++ b/plugins/discourse-events/assets/stylesheets/desktop/livestream.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .livestream-topic.chat-enabled.archetype-regular {
   // we need to fullscreen the header icons to match the chat panel
   // being on the right side of the screen
@@ -16,20 +18,21 @@
   }
 
   #custom-chat-container {
-    height: calc(
-      var(--composer-vh, var(--1dvh)) * 100 - var(--header-offset, 0px)
-    ) !important;
+    --1dvh: 1vh;
     grid-area: livestream;
-    border-left: 2px solid var(--primary-very-low);
     display: flex;
     position: sticky;
     top: var(--header-offset);
     background: var(--d-content-background, var(--secondary));
-
-    --1dvh: 1vh;
     align-self: start;
     overflow-y: auto;
-    margin-left: 1em;
+
+    @include viewport.from(lg) {
+      border-left: 2px solid var(--primary-very-low);
+      height: calc(
+        var(--composer-vh, var(--1dvh)) * 100 - var(--header-offset, 0px)
+      ) !important;
+    }
 
     .livestream-chat-close {
       display: none;
@@ -37,6 +40,17 @@
 
     .chat-drawer {
       height: 100%;
+    }
+  }
+
+  .d-modal__body {
+    #custom-chat-container {
+      height: 70vh;
+
+      .chat-composer__wrapper {
+        position: sticky;
+        bottom: 0;
+      }
     }
   }
 

--- a/plugins/discourse-events/assets/stylesheets/mobile/livestream.scss
+++ b/plugins/discourse-events/assets/stylesheets/mobile/livestream.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 body.livestream-topic.chat-enabled {
   .d-header-icons {
     .livestream-header-icon {
@@ -6,30 +8,14 @@ body.livestream-topic.chat-enabled {
       &::after {
         content: "";
         position: absolute;
-        top: 9px;
-        right: 16px;
-        width: 8px;
-        height: 8px;
+        top: 1px;
+        right: 0;
+        width: 14px;
+        height: 14px;
         border-radius: 50%;
-        background-color: rgb(255, 0, 0);
+        background-color: var(--danger);
         animation: pulse-circle 3s infinite;
-      }
-
-      @keyframes pulse-circle {
-        0% {
-          transform: scale(1);
-          background-color: rgb(255, 0, 0, 0.9);
-        }
-
-        50% {
-          transform: scale(1.3);
-          background-color: rgb(255, 0, 0, 0.75);
-        }
-
-        100% {
-          transform: scale(1);
-          background-color: rgb(255, 0, 0, 0.9);
-        }
+        border: 2px solid var(--header_background);
       }
     }
   }
@@ -167,19 +153,11 @@ body.livestream-topic.chat-enabled {
   }
 
   .chat-composer__outer-container {
-    gap: var(--space-2);
+    align-items: center;
   }
 
   .chat-composer-dropdown__menu-trigger {
-    padding: 0;
     margin: 0;
-    width: 3em;
-
-    .d-icon {
-      padding: var(--space-2);
-      width: 100%;
-      height: 100%;
-    }
   }
 
   .chat-composer-button__wrapper {
@@ -188,9 +166,13 @@ body.livestream-topic.chat-enabled {
   }
 
   .chat-composer-button {
-    margin: 0;
-    padding: 0.5em 0.65em;
-    height: 100%;
+    align-self: center;
+  }
+
+  @include viewport.until(sm) {
+    .chat-channel .empty-state__title {
+      font-size: var(--font-up-1);
+    }
   }
 }
 


### PR DESCRIPTION
This improves some livestream chat drawer styles — scale, alignment, positioning etc. 

Solves issues reported here, and more https://meta.discourse.org/t/mobile-event-chat-has-too-big-ui-elements/412206


Before: 
<img width="150"  alt="image" src="https://github.com/user-attachments/assets/8329d93a-58df-4107-b8f3-289f698a7748" />
<img width="450"  alt="image" src="https://github.com/user-attachments/assets/03fdea6e-bc71-4da8-b926-8fdacfadb890" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/53988478-6929-430e-a508-7d9cdde91cf3" />

After: 
<img width="200" alt="image" src="https://github.com/user-attachments/assets/50b91def-efb0-41c2-b0da-1de0783d5e51" />


<img width="450"  alt="image" src="https://github.com/user-attachments/assets/66b6072a-0b41-4b52-ac3e-f0c4c03a420b" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4b5793cb-5abb-4a76-9c83-9eac6c030f78" />
