### PR TITLE
PERF: Run MaintainBrowserPageviewRollups hourly

### DIFF
--- a/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
+++ b/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class MaintainBrowserPageviewRollups < ::Jobs::Scheduled
-    every 10.minutes
+    every 1.hour
 
     cluster_concurrency 1
 


### PR DESCRIPTION
Reduce database load while investigating slow rollup queries.