### PR TITLE
FIX: Don't wrap whitespace between tags in revision diffs

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -246,8 +246,8 @@
   }
 
   ins,
-  .diff-ins,
   del,
+  .diff-ins,
   .diff-del {
     color: var(--primary);
 
@@ -262,6 +262,11 @@
 
     a {
       text-decoration: none;
+    }
+
+    > .title,
+    > blockquote {
+      background: transparent;
     }
   }
 

--- a/lib/discourse_diff.rb
+++ b/lib/discourse_diff.rb
@@ -2,6 +2,7 @@
 
 class DiscourseDiff
   MAX_DIFFERENCE = 200
+  CLASS_ATTRIBUTE = " class=\""
 
   def initialize(before, after)
     @before = before
@@ -120,8 +121,8 @@ class DiscourseDiff
           end
           diff = ONPDiff.new(before_tokens, after_tokens).short_diff
           deleted, inserted = generate_side_by_side_markdown(diff)
-          table << "<td class=\"--previous diff-del\">#{deleted.join}</td>"
-          table << "<td class=\"--current diff-ins\">#{inserted.join}</td>"
+          table << "<td class=\"--previous\">#{deleted.join}</td>"
+          table << "<td class=\"--current\">#{inserted.join}</td>"
           i += 1
         else
           if op_code == :delete
@@ -199,41 +200,26 @@ class DiscourseDiff
   end
 
   def add_class_or_wrap_in_tags(html_or_text, klass)
+    return html_or_text if html_or_text.start_with?("</")
+
+    chevron = html_or_text.index(">")
+    return "<#{klass}>#{html_or_text}</#{klass}>" unless html_or_text.start_with?("<") && chevron
+
     result = html_or_text.dup
-    index_of_next_chevron = result.index(">")
-    if result.size > 0 && result[0] == "<" && index_of_next_chevron
-      index_of_class = result.index("class=")
-      if index_of_class.nil? || index_of_class > index_of_next_chevron
-        # we do not have a class for the current tag
-        # add it right before the ">"
-        result.insert(index_of_next_chevron, " class=\"diff-#{klass}\"")
-      else
-        # we have a class, insert it at the beginning if not already present
-        classes = result[/class=(["'])([^\1]*)\1/, 2]
-        if classes.include?("diff-#{klass}")
-          result
-        else
-          result.insert(index_of_class + "class=".size + 1, "diff-#{klass} ")
-        end
-      end
-    else
-      "<#{klass}>#{result}</#{klass}>"
+    class_index = html_or_text.index(CLASS_ATTRIBUTE)
+    if class_index.nil? || class_index > chevron
+      return result.insert(chevron, "#{CLASS_ATTRIBUTE}diff-#{klass}\"")
     end
+
+    result.insert(class_index + CLASS_ATTRIBUTE.size, "diff-#{klass} ")
   end
 
   def generate_inline_html(diff)
-    inline = []
-    diff.each do |d|
-      case d[1]
-      when :common
-        inline << d[0]
-      when :delete
-        inline << add_class_or_wrap_in_tags(d[0], "del")
-      when :add
-        inline << add_class_or_wrap_in_tags(d[0], "ins")
-      end
+    diff.map do |text, op_code|
+      next text if op_code == :common
+
+      add_class_or_wrap_in_tags(text, op_code == :delete ? "del" : "ins")
     end
-    inline
   end
 
   def generate_side_by_side_html(diff)
@@ -296,6 +282,8 @@ class DiscourseDiff
     end
 
     def characters(string)
+      return @tokens[-1] << string if string.blank? && @tokens.last&.start_with?("<")
+
       @tokens.concat string.scan(/\W|\w+[ \t]*/).map { |x| CGI.escapeHTML(x) }
     end
   end

--- a/spec/lib/discourse_diff_spec.rb
+++ b/spec/lib/discourse_diff_spec.rb
@@ -3,18 +3,18 @@
 require "discourse_diff"
 
 RSpec.describe DiscourseDiff do
+  it "does not lead to XSS" do
+    a = "<test>start</test>"
+    b = "<test>end</test>"
+    prev = "<div>#{CGI.escapeHTML(a)}</div>"
+    cur = "<div>#{CGI.escapeHTML(b)}</div>"
+
+    diff = DiscourseDiff.new(prev, cur)
+    expect(diff.inline_html).not_to match(%r{</?test>})
+    expect(diff.side_by_side_html).not_to match(%r{</?test>})
+  end
+
   describe "inline_html" do
-    it "does not lead to XSS" do
-      a = "<test>start</test>"
-      b = "<test>end</test>"
-      prev = "<div>#{CGI.escapeHTML(a)}</div>"
-      cur = "<div>#{CGI.escapeHTML(b)}</div>"
-
-      diff = DiscourseDiff.new(prev, cur)
-      expect(diff.inline_html).not_to match(%r{</?test>})
-      expect(diff.side_by_side_html).not_to match(%r{</?test>})
-    end
-
     it "returns an empty div when no content is diffed" do
       expect(DiscourseDiff.new("", "").inline_html).to eq("<div class=\"inline-diff\"></div>")
     end
@@ -92,8 +92,7 @@ RSpec.describe DiscourseDiff do
     it "adds <ins> and <del> tags on consecutive paragraphs" do
       before = "<p>this is one paragraph</p><p>here is yet another</p>"
       after = "<p>this is one great paragraph</p><p>here is another</p>"
-      got = DiscourseDiff.new(before, after).side_by_side_html
-      expect(got).to eq(
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq(
         "<div class=\"revision-content --previous\"><p>this is one paragraph</p><p>here is <del>yet </del>another</p></div><div class=\"revision-content --current\"><p>this is one <ins>great </ins>paragraph</p><p>here is another</p></div>",
       )
     end
@@ -130,11 +129,43 @@ RSpec.describe DiscourseDiff do
       )
     end
 
-    it "escapes attribute values" do
-      before = "<p data-attr='Some \"quoted\" string'></p>"
-      after = "<p data-attr='Some \"quoted\" string'></p>"
+    it "leaves formatting whitespace and closing tags undecorated" do
+      before = "<p>a paragraph</p>"
+      after = "<div class=\"grid\">\n  <span>a paragraph</span>\n</div>"
       expect(DiscourseDiff.new(before, after).side_by_side_html).to eq(
-        "<div class=\"revision-content --previous\"><p data-attr=\"Some &quot;quoted&quot; string\"></p></div><div class=\"revision-content --current\"><p data-attr=\"Some &quot;quoted&quot; string\"></p></div>",
+        "<div class=\"revision-content --previous\"><p class=\"diff-del\">a paragraph</p></div><div class=\"revision-content --current\"><div class=\"diff-ins grid\">\n  <span class=\"diff-ins\">a paragraph</span>\n</div></div>",
+      )
+    end
+
+    it "still decorates whitespace inside text" do
+      before = "<pre><code>foo\nbar</code></pre>"
+      after = "<pre><code>foo\n  bar</code></pre>"
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq(
+        "<div class=\"revision-content --previous\"><pre><code>foo\nbar</code></pre></div><div class=\"revision-content --current\"><pre><code>foo\n<ins> </ins><ins> </ins>bar</code></pre></div>",
+      )
+    end
+
+    it "ignores a class= inside an attribute value" do
+      before = "<p>x</p>"
+      after = "<p><a title=\"class=foo\">bar</a></p>"
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq(
+        "<div class=\"revision-content --previous\"><p><del>x</del></p></div><div class=\"revision-content --current\"><p><a title=\"class=foo\" class=\"diff-ins\"><ins>bar</ins></a></p></div>",
+      )
+    end
+
+    it "adds the class to the outer tag of an added block" do
+      before = "<p>keep</p>"
+      after = "<p>keep</p><div><span class=\"foo\">new</span></div>"
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq(
+        "<div class=\"revision-content --previous\"><p>keep</p></div><div class=\"revision-content --current\"><p>keep</p><div class=\"diff-ins\"><span class=\"foo\">new</span></div></div>",
+      )
+    end
+
+    it "escapes attribute values" do
+      before = "<p data-attr='Some \"quoted\" string'>x</p>"
+      after = "<p data-attr='Some \"quoted\" string'>y</p>"
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq(
+        "<div class=\"revision-content --previous\"><p data-attr=\"Some &quot;quoted&quot; string\"><del>x</del></p></div><div class=\"revision-content --current\"><p data-attr=\"Some &quot;quoted&quot; string\"><ins>y</ins></p></div>",
       )
     end
   end
@@ -165,7 +196,7 @@ RSpec.describe DiscourseDiff do
       before = "this is a paragraph"
       after = "this is a great paragraph"
       expect(DiscourseDiff.new(before, after).side_by_side_markdown).to eq(
-        "<table class=\"markdown\"><tr><td class=\"--previous diff-del\">this is a paragraph</td><td class=\"--current diff-ins\">this is a <ins>great </ins>paragraph</td></tr></table>",
+        "<table class=\"markdown\"><tr><td class=\"--previous\">this is a paragraph</td><td class=\"--current\">this is a <ins>great </ins>paragraph</td></tr></table>",
       )
     end
 
@@ -173,15 +204,15 @@ RSpec.describe DiscourseDiff do
       before = "this is a great paragraph"
       after = "this is a paragraph"
       expect(DiscourseDiff.new(before, after).side_by_side_markdown).to eq(
-        "<table class=\"markdown\"><tr><td class=\"--previous diff-del\">this is a <del>great </del>paragraph</td><td class=\"--current diff-ins\">this is a paragraph</td></tr></table>",
+        "<table class=\"markdown\"><tr><td class=\"--previous\">this is a <del>great </del>paragraph</td><td class=\"--current\">this is a paragraph</td></tr></table>",
       )
     end
 
-    it "adds .diff-ins class when a paragraph is added" do
+    it "marks only the changed words when a line is edited" do
       before = "this is the first paragraph"
       after = "this is the first paragraph\nthis is the second paragraph"
       expect(DiscourseDiff.new(before, after).side_by_side_markdown).to eq(
-        "<table class=\"markdown\"><tr><td class=\"--previous diff-del\">this is the first paragraph</td><td class=\"--current diff-ins\">this is the first paragraph<ins>\nthis is the second paragraph</ins></td></tr></table>",
+        "<table class=\"markdown\"><tr><td class=\"--previous\">this is the first paragraph</td><td class=\"--current\">this is the first paragraph<ins>\nthis is the second paragraph</ins></td></tr></table>",
       )
     end
 

--- a/spec/requests/admin/staff_action_logs_controller_spec.rb
+++ b/spec/requests/admin/staff_action_logs_controller_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Admin::StaffActionLogsController do
         parsed = response.parsed_body
 
         name_diff = <<-HTML
-          <h3>name</h3><p></p><table class="markdown"><tr><td class="--previous diff-del"><del>#{tag_group1.name}</del></td><td class="--current diff-ins"><ins>#{tag_group2.name}</ins></td></tr></table>
+          <h3>name</h3><p></p><table class="markdown"><tr><td class="--previous"><del>#{tag_group1.name}</del></td><td class="--current"><ins>#{tag_group2.name}</ins></td></tr></table>
         HTML
         expect(parsed["side_by_side"]).to include(name_diff.strip)
         expect(parsed["side_by_side"]).to include("<del>#{tag1.name}</del>")


### PR DESCRIPTION
Previously, `DiscourseDiff` wrapped every added text token in `<ins>`, including the formatting whitespace between tags. Inside a GitHub onebox, whose body is a CSS grid with `display: contents` rows, those extra elements became grid items and displaced the title into the 2.5em icon column, where it wrapped one character per line.

This change appends whitespace-only text nodes to the preceding tag token so they can never become elements.

It also fixes three things found alongside it:

- closing tags were given a class, emitting `</h4 class="diff-ins">`
- `class=` was matched inside attribute values, so `[text](url "class=foo")` raised `NoMethodError` and returned a 500 from the revisions endpoint
- the raw view tinted the whole cell even when only some words changed, hiding the word-level markers underneath, and quote backgrounds hid the highlight on an inserted or removed quote

Reported in https://meta.discourse.org/t/appearance-of-a-onebox-in-the-edit-history/412207
